### PR TITLE
fix(completion): complete --json and --from for deja last

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -113,7 +113,7 @@ _deja_completion() {
             elif [[ "$prev" == "--role" ]]; then
                 COMPREPLY=( $(compgen -W "%ROLES%" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--harness --project --since --role" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--json --from --harness --project --since --role" -- "$cur") )
             fi
             ;;
         remember)
@@ -240,7 +240,7 @@ _deja() {
       _arguments '--no-guidance[skip guidance files]' "1:target:($install_targets)"
       ;;
     last)
-      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
+      _arguments '--json[print JSON]' '--from=[start from a session]:session:' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
       ;;
     remember)
       _arguments '--project=[note project]:project:' '1:text:'
@@ -315,6 +315,8 @@ complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
 complete -c deja -n '__fish_seen_subcommand_from index' -l rebuild
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a '%INSTALL_TARGETS% --all --auto'
 complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidance
+complete -c deja -n '__fish_seen_subcommand_from last' -l json
+complete -c deja -n '__fish_seen_subcommand_from last' -l from -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
@@ -398,7 +400,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
             'last' {
                 if ($previous -eq '--harness') { $harnesses }
                 elseif ($previous -eq '--role') { @('user', 'assistant', 'tool') }
-                else { @('--harness', '--project', '--since', '--role') }
+                else { @('--json', '--from', '--harness', '--project', '--since', '--role') }
             }
             'remember' { @('--project') }
             'resume' { @('--exec') }


### PR DESCRIPTION
Closes #1925.

## The change

`deja last` accepts `--json` and `--from` (parser at `cmd/deja/main.go:1668`), but all four completion blocks listed only the other four flags. Added both to each:

| Shell | Location |
|---|---|
| bash | `completion.go:110` |
| zsh | `:242` |
| fish | `:318` |
| powershell | `:398` |

`--from` takes a value, so it is declared as value-taking (`-r` in fish, `=[…]` in zsh) rather than as a bare switch — otherwise Tab would stop dead after the flag.

## Verified

Built the binary and checked each shell names both new flags:

```
  bash        --json=ok --from=ok
  zsh         --json=ok --from=ok
  powershell  --json=ok --from=ok
  fish        --json=ok --from=ok
```

Note for anyone scripting this check: fish declares options as `-l json`, not `--json`, so grepping for `--json` reports a false miss on fish. The verification above accounts for that.

`go build ./...` and `go vet ./cmd/deja/` pass.
