### PR TITLE
fix(completion): offer --all-matches for deja forget

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -89,7 +89,7 @@ _deja_completion() {
             COMPREPLY=( $(compgen -W "--json --offline --deep" -- "$cur") )
             ;;
         forget)
-            COMPREPLY=( $(compgen -W "--list --dry-run --session --project --before --unforget" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--list --dry-run --session --project --before --unforget --all-matches" -- "$cur") )
             ;;
         handoff)
             if [[ "$prev" == "--to" ]]; then
@@ -225,7 +225,7 @@ _deja() {
       _arguments '--json[print JSON]' '--offline[skip version check]' '--deep[verify index against sources]'
       ;;
     forget)
-      _arguments '--list[list tombstones]' '--dry-run[show changes without applying]' '--session=[session ID prefix]:session:' '--project=[project substring]:project:' '--before=[duration or date]:time:' '--unforget=[tombstone ID]:ID:'
+      _arguments '--list[list tombstones]' '--dry-run[show changes without applying]' '--session=[session ID prefix]:session:' '--project=[project substring]:project:' '--before=[duration or date]:time:' '--unforget=[tombstone ID]:ID:' '--all-matches[act on every match]'
       ;;
     handoff)
       _arguments '--to=[target agent]:agent:(%HANDOFF_TARGETS%)' '--exec[launch the target agent]' '1:session ID prefix:'
@@ -309,6 +309,7 @@ complete -c deja -n '__fish_seen_subcommand_from forget' -l session -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l before -r
 complete -c deja -n '__fish_seen_subcommand_from forget' -l unforget -r
+complete -c deja -n '__fish_seen_subcommand_from forget' -l all-matches
 complete -c deja -n '__fish_seen_subcommand_from handoff' -l to -r -a '%HANDOFF_TARGETS%'
 complete -c deja -n '__fish_seen_subcommand_from handoff' -l exec
 complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
@@ -387,7 +388,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
             }
             'completion' { @('bash', 'zsh', 'fish', 'powershell', 'pwsh') }
             'doctor' { @('--json', '--offline', '--deep') }
-            'forget' { @('--list', '--dry-run', '--session', '--project', '--before', '--unforget') }
+            'forget' { @('--list', '--dry-run', '--session', '--project', '--before', '--unforget', '--all-matches') }
             'handoff' {
                 if ($previous -eq '--to') { $handoffTargets }
                 else { @('--to', '--exec') }


### PR DESCRIPTION
Closes #1927.

## The change

`deja forget` refuses an ambiguous prefix with a message telling you to pass `--all-matches` (`cmd/deja/main.go:2345`), and accepts it (`:2359`) — but no shell offered it. Being told to use a flag that Tab does not know is the sharpest version of this gap, since the user has already been sent looking for it.

Added to all four blocks: bash (`completion.go:91`), zsh (`:227`), fish (`:306`), powershell (`:390`).

It is a boolean switch, so it is declared as a bare flag — no value completion.

## Verified

```
  bash        1 occurrence(s)
  zsh         1 occurrence(s)
  powershell  1 occurrence(s)
  fish        1 occurrence(s)
```

(fish declares it as `-l all-matches`; the check accounts for that spelling.)

`go build ./...` and `go vet ./cmd/deja/` pass.
