### PR TITLE
fix(completion): offer --tag for deja remember

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -117,7 +117,7 @@ _deja_completion() {
             fi
             ;;
         remember)
-            COMPREPLY=( $(compgen -W "--project" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--project --tag" -- "$cur") )
             ;;
         resume)
             COMPREPLY=( $(compgen -W "--exec" -- "$cur") )
@@ -243,7 +243,7 @@ _deja() {
       _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
       ;;
     remember)
-      _arguments '--project=[note project]:project:' '1:text:'
+      _arguments '--project=[note project]:project:' '*--tag=[tag the note, repeatable]:tag:' '1:text:'
       ;;
     resume)
       _arguments '--exec[launch the native harness]' '1:session ID prefix:'
@@ -320,6 +320,7 @@ complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l role -r -a '%ROLES%'
 complete -c deja -n '__fish_seen_subcommand_from remember' -l project -r
+complete -c deja -n '__fish_seen_subcommand_from remember' -l tag -r
 complete -c deja -n '__fish_seen_subcommand_from resume' -l exec
 complete -c deja -n '__fish_seen_subcommand_from stats' -l json
 complete -c deja -n '__fish_seen_subcommand_from stats' -l impact
@@ -400,7 +401,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
                 elseif ($previous -eq '--role') { @('user', 'assistant', 'tool') }
                 else { @('--harness', '--project', '--since', '--role') }
             }
-            'remember' { @('--project') }
+            'remember' { @('--project', '--tag') }
             'resume' { @('--exec') }
             'stats' {
                 if ($previous -eq '--harness') { $harnesses }


### PR DESCRIPTION
Closes #1928.

## The change

`deja remember` takes `--tag`, and tags are how a note is found again later — so it is arguably the more important of its two flags. Completion offered only `--project`. Added `--tag` to all four blocks: bash (`completion.go:119`), zsh (`:245`), fish (`:322`), powershell (`:403`).

## One detail worth flagging

`--tag` is **repeatable** — `remember.go:44` does `tags = append(tags, args[i+1])`, so `--tag a --tag b` is valid. In zsh, a plain `'--tag=…'` in `_arguments` means "at most once", and zsh stops offering it after the first use. It is declared `'*--tag=…'` here so it keeps being offered:

```
'*--tag=[tag the note, repeatable]:tag:'
```

The other three shells have no equivalent notion, so they are plain value-taking flags.

## Verified

```
  bash        ok
  zsh         ok
  powershell  ok
  fish        ok
```

`go build ./...`, `go test ./cmd/deja/` and `go vet ./cmd/deja/` pass.
