### PR TITLE
fix(index): a database that grows adds to its counts instead of resetting them

### DIFF
--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -84,3 +84,71 @@ func TestADatabaseThatGrowsKeepsItsIngestCounts(t *testing.T) {
 		t.Errorf("the clipped message is still in the database and the count is %d", got)
 	}
 }
+
+// seedGooseTurn adds one message to a goose store, creating the tables if the
+// file is new and moving the session's updated_at with it.
+func seedGooseTurn(t *testing.T, db, session, role, text string, created int64) {
+	t.Helper()
+	stmts := fmt.Sprintf(`
+create table if not exists sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
+create table if not exists messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
+insert or ignore into sessions values ('%[1]s','g','a goose session','/tmp/app', strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch'), strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch'));
+update sessions set updated_at = strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch') where id='%[1]s';
+insert into messages (session_id,role,content_json,created_timestamp) values ('%[1]s','%[2]s',json_array(json_object('type','text','text','%[3]s')),%[4]d);
+`, session, role, text, created)
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// goose asks for everything in a session that was touched, not only the new
+// messages, so a continued session hands back turns already counted. With
+// nothing resetting a database's counts (#2025) those turns were counted again
+// on every pass — a store in daily use would report clips in the thousands.
+//
+// The timestamps here are RFC3339, which is what goose writes: the since clause
+// compares s.updated_at against an RFC3339 string, and sqlite's own
+// datetime() format ("2026-01-02 03:00:00") never compares greater, so a
+// fixture written that way never re-reads the session and measures nothing.
+func TestAGooseSessionThatContinuesIsNotCountedTwice(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "goose.db")
+	t.Setenv("DEJA_GOOSE_DB", db)
+
+	long := strings.Repeat("pgbouncer pool timed out and the retry took a second ", 1600)
+	seedGooseTurn(t, db, "g1", "user", long, 1767322800)
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	clipped := func() int {
+		t.Helper()
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.IngestHealth["goose-db"].ClippedMessages
+	}
+	if got := clipped(); got != 1 {
+		t.Fatalf("the build clipped %d messages, so this measures nothing", got)
+	}
+
+	// The session carries on. Each pass hands the long message back again.
+	for i, ts := range []int64{1767326400, 1767330000} {
+		seedGooseTurn(t, db, "g1", "assistant", "a short answer", ts)
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := clipped(); got != 1 {
+			t.Fatalf("one long message in the store, pass %d says %d clipped", i+1, got)
+		}
+	}
+}

--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -35,7 +35,6 @@ func TestADatabaseThatGrowsKeepsItsIngestCounts(t *testing.T) {
 	}
 	tmp := t.TempDir()
 	setHome(t, tmp)
-	t.Setenv("USERPROFILE", tmp)
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))

--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -1,0 +1,87 @@
+package index
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedOpencodeSession adds one session with one text part to an opencode store,
+// creating the tables if the file is new.
+func seedOpencodeSession(t *testing.T, db, session, text string, createdMillis int64) {
+	t.Helper()
+	stmts := fmt.Sprintf(`
+create table if not exists session (id text primary key, directory text, time_created integer, time_updated integer);
+create table if not exists message (id text primary key, session_id text, data text, time_created integer);
+create table if not exists part (id text primary key, message_id text, data text);
+insert into session values ('%[1]s','/tmp/app',%[2]d,%[2]d);
+insert into message values ('m-%[1]s','%[1]s','{"role":"user","time":{"created":%[2]d}}',%[2]d);
+insert into part values ('p-%[1]s','m-%[1]s',json_object('type','text','text','%[3]s','time',json_object('start',%[2]d)));
+`, session, createdMillis, text)
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// A database-backed store reads only what is new — the since cursor the index
+// stamps as LastUpdated — but it changes like any other file, so the merge
+// branch treated it as re-read whole and started its ingest counts over. The
+// database growing by one session threw away what the rest of it holds (#2025).
+func TestADatabaseThatGrowsKeepsItsIngestCounts(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+
+	long := strings.Repeat("pgbouncer pool timed out and the retry took a second ", 1600)
+	if len(long) < maxIndexedText {
+		t.Fatalf("the fixture message is %d bytes, under the %d that gets it clipped", len(long), maxIndexedText)
+	}
+	seedOpencodeSession(t, db, "s1", long, 1767322800000)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	clipped := func() int {
+		t.Helper()
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.IngestHealth["opencode"].ClippedMessages
+	}
+	if got := clipped(); got != 1 {
+		t.Fatalf("the build clipped %d messages, so this measures nothing", got)
+	}
+
+	// The store grows by a session that has nothing wrong with it. The pass
+	// reads only that session, so it cannot speak for the rest of the store.
+	seedOpencodeSession(t, db, "s2", "a short second session", 1767326400000)
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatal(err)
+	}
+	if said := out.String(); !strings.Contains(said, "incremental index") {
+		t.Fatalf("this was not the merge path, so it does not measure what it is about: %q", said)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Sessions) != 2 {
+		t.Fatalf("the pass ended with %d sessions, so the store did not grow the way this expects", len(m.Sessions))
+	}
+	if got := clipped(); got != 1 {
+		t.Errorf("the clipped message is still in the database and the count is %d", got)
+	}
+}

--- a/internal/index/health_carry_test.go
+++ b/internal/index/health_carry_test.go
@@ -357,3 +357,45 @@ func TestAClipSurvivesAPassOverAnotherFile(t *testing.T) {
 		t.Errorf("one long message, count says %d", got)
 	}
 }
+
+// A pass that could not read a file keeps what that file already held: it is
+// the one pass with nothing to say about it. The merge branch decides which
+// files it re-read after the parse loop for this reason — the loop drops the
+// ones it failed on.
+func TestAFileThePassCouldNotReadKeepsItsCounts(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("file permissions do not stop a read here")
+	}
+	dir, proj, turn := healthFixture(t)
+	long := strings.Repeat("pgbouncer pool timed out and the retry took a second ", 1600)
+	a := filepath.Join(proj, "a.jsonl")
+	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", long)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := clippedFor(t, dir, "claude"); got != 1 {
+		t.Fatalf("the build clipped %d messages, so this measures nothing", got)
+	}
+
+	// The file changes and becomes unreadable in the same breath, which is what
+	// a store being rewritten under a lock looks like.
+	if err := os.WriteFile(a, []byte(turn("a", "2026-01-02T03:04:05Z", "user", long+" and more")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(a, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(a, 0o644) })
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatal(err)
+	}
+	if said := out.String(); !strings.Contains(said, "skipping") {
+		t.Fatalf("the pass read the file after all, so it does not measure what it is about: %q", said)
+	}
+	if got := clippedFor(t, dir, "claude"); got != 1 {
+		t.Errorf("the pass could not read the file and dropped its count anyway: %d", got)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1995,11 +1995,26 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
+// fullyReadFiles drops the files a pass reads only part of. LastUpdated is
+// stamped for database-backed stores alone (setStoreLastUpdated), and it is
+// exactly what makes their parse partial: parseChangedFile hands it to the kind
+// as the since cursor.
+func fullyReadFiles(changed, old map[string]FileState) map[string]FileState {
+	out := make(map[string]FileState, len(changed))
+	for p, f := range changed {
+		if old[p].LastUpdated > 0 {
+			continue
+		}
+		out[p] = f
+	}
+	return out
+}
+
 // copyIngestFiles hands the new manifest its own map: the old one belongs to
-// the manifest this build read, which is still in use while the build runs.
-// The files this pass will re-read arrive with their clip count zeroed: the
-// pass records its own as it goes, and adding it to what the last pass found
-// counted one long message twice.
+// the manifest this build read, which is still in use while the build runs. The
+// files this pass will re-read arrive with their clip count zeroed — the pass
+// records its own as it goes, and adding it to what the last pass found counted
+// one long message twice.
 func copyIngestFiles(old map[string]FileIngest, reread map[string]FileState) map[string]FileIngest {
 	out := make(map[string]FileIngest, len(old))
 	for p, e := range old {
@@ -2173,7 +2188,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
-	parsedThisPass(changed)
+	// A database-backed store reads only what is newer than the cursor the last
+	// pass stamped, so this pass cannot speak for the rest of it: it adds to
+	// what the store holds, the way an append does (#2025).
+	reread := fullyReadFiles(changed, old.Files)
+	parsedThisPass(reread)
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
 		if err != nil {
@@ -2235,7 +2254,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// doctor forgot a store's unreadable file because an unrelated
 		// transcript changed (#2015). A store this pass re-read starts over,
 		// because a file rewritten clean has to be able to clear its count.
-		IngestFiles: copyIngestFiles(old.IngestFiles, changed)}
+		IngestFiles: copyIngestFiles(old.IngestFiles, reread)}
 	skipRedactions := map[string]bool{}
 	for p := range changed {
 		skipRedactions[p] = true

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2002,12 +2002,22 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 func fullyReadFiles(changed, old map[string]FileState) map[string]FileState {
 	out := make(map[string]FileState, len(changed))
 	for p, f := range changed {
-		if old[p].LastUpdated > 0 {
+		if old[p].LastUpdated > 0 && !rereadsWholeSessions(p) {
 			continue
 		}
 		out[p] = f
 	}
 	return out
+}
+
+// rereadsWholeSessions marks a store whose cursor selects sessions rather than
+// messages: goose asks for every message of any session touched since the
+// stamp, so a continued session hands back turns already counted, and adding
+// them again grew the count on every pass. Starting the file over is the lesser
+// wrong of the two — it loses what an untouched session held, which is #2025
+// again for this one store, rather than reporting a number that only climbs.
+func rereadsWholeSessions(p string) bool {
+	return harnessForPath(p) == "goose-db"
 }
 
 // copyIngestFiles hands the new manifest its own map: the old one belongs to

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2188,11 +2188,6 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	emptied.Store(0)
 	collisions.Store(0)
 	lastIngestFiles = len(changed)
-	// A database-backed store reads only what is newer than the cursor the last
-	// pass stamped, so this pass cannot speak for the rest of it: it adds to
-	// what the store holds, the way an append does (#2025).
-	reread := fullyReadFiles(changed, old.Files)
-	parsedThisPass(reread)
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
 		if err != nil {
@@ -2213,6 +2208,19 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		replacements = append(replacements, sources.FilterSessions(filterTombstoned(ss))...)
 		files[p] = f
 	}
+	// After the loop, because a file whose parse failed is dropped from
+	// `changed` there and keeps what it already held — starting it over would
+	// throw the counts away on the one pass that could not read it.
+	//
+	// A database-backed store reads only what is newer than the cursor the last
+	// pass stamped, so this pass cannot speak for the rest of it either: it adds
+	// to what the store holds, the way an append does (#2025). The trade is the
+	// append path's — a db's counts can only grow until a full rebuild.
+	reread := fullyReadFiles(changed, old.Files)
+	parsedThisPass(reread)
+	// A file the pass read is a file that opens, whether or not it read all of
+	// it, so an error recorded when it did not has to go.
+	readThisPass(changed)
 	replaceKeys := map[string]bool{}
 	for _, s := range replacements {
 		replaceKeys[s.Harness+":"+s.ID] = true


### PR DESCRIPTION
Fixes #2025. An opencode store with one message stored short:

```
build                              opencode clipped=1 files=1
after an unrelated store changes   opencode clipped=1 files=1
after the database grows           opencode clipped=0 files=0
```

The clipped message is still in the database. A db-backed store reads only what is newer than the cursor the last pass stamped, but it changes like any other file, so the merge branch declared it re-read and started its ingest counts over — throwing away a number it only partly re-derives.

The index already knows which files these are: `LastUpdated` is stamped for database-backed stores alone, and it is exactly what makes the parse partial — `parseChangedFile` hands it to the kind as the since cursor. Those files are left out of the re-read set, so they add to what the store holds, the way the append path already does.

Test seeds a real opencode sqlite store (skips without the `sqlite3` CLI), grows it by a clean session, and requires the count for the rest of the store to survive. It also checks the pass took the merge path, since a rewrite that only grows is an append.
