### PR TITLE
fix(goose): compare the session cursor in one format

### DIFF
--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -162,7 +162,14 @@ func ParseGooseDBSince(db string, t time.Time) ([]model.Session, error) {
 	}
 	sec := t.Unix()
 	rfc := sqlEscape(t.UTC().Format(time.RFC3339Nano))
-	where := fmt.Sprintf(" and (m.created_timestamp > %d or s.updated_at > '%s')", sec, rfc)
+	// Compared through datetime() because the two sides are written in
+	// different formats: a real store keeps updated_at as sqlite's own
+	// "2026-07-27 15:29:47", and a space sorts below the T of an RFC3339
+	// string, so a plain text comparison missed every session touched later the
+	// same day — including a turn goose stored without a timestamp of its own,
+	// which is reachable only through its session — and matched every session
+	// touched on a later date, handing back all of it (#2030).
+	where := fmt.Sprintf(" and (m.created_timestamp > %d or datetime(s.updated_at) > datetime('%s'))", sec, rfc)
 	return parseGooseDBWhere(db, where, 0)
 }
 

--- a/internal/sources/goose_since_test.go
+++ b/internal/sources/goose_since_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -64,11 +65,17 @@ func TestGooseSinceStillFindsATurnWithNoTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n := 0
+	// The turn itself, not just something: a clause that handed back the
+	// session's other message and stopped would answer this with the wrong one.
+	found := false
 	for _, s := range got {
-		n += len(s.Messages)
+		for _, msg := range s.Messages {
+			if strings.Contains(msg.Text, "the pool is too small") {
+				found = true
+			}
+		}
 	}
-	if n == 0 {
-		t.Errorf("a turn with no timestamp of its own is reachable only through its session, and nothing came back")
+	if !found {
+		t.Errorf("a turn with no timestamp of its own is reachable only through its session, and it did not come back")
 	}
 }

--- a/internal/sources/goose_since_test.go
+++ b/internal/sources/goose_since_test.go
@@ -1,0 +1,74 @@
+package sources
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// gooseStore writes a store the way goose writes one: sessions.updated_at in
+// sqlite's CURRENT_TIMESTAMP format ("2026-07-27 15:29:47"), messages carrying
+// unix seconds for the same instant. Measured on a real store.
+func gooseStore(t *testing.T, db string, turns []struct {
+	Session, Role, Text string
+	At                  int64
+}) {
+	t.Helper()
+	stmts := `create table if not exists sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
+create table if not exists messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
+`
+	for _, turn := range turns {
+		stmts += fmt.Sprintf(
+			"insert or ignore into sessions values ('%[1]s','n','a goose session','/tmp/app',datetime(%[3]d,'unixepoch'),datetime(%[3]d,'unixepoch'));\n"+
+				"update sessions set updated_at = datetime(%[3]d,'unixepoch') where id='%[1]s';\n"+
+				"insert into messages (session_id,role,content_json,created_timestamp) values ('%[1]s','%[2]s',json_array(json_object('type','text','text','%[4]s')),%[3]d);\n",
+			turn.Session, turn.Role, turn.At, turn.Text)
+	}
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// A turn goose stored without a timestamp of its own is reachable only through
+// its session, so the session-level half of the since clause is what finds it —
+// and it has to compare two timestamps written in the same format. A real store
+// keeps updated_at as sqlite's own "2026-07-27 15:29:47", which never compares
+// greater than an RFC3339 string within the same day, so the turn was invisible
+// to every incremental pass until the store was touched on a later date
+// (#2030).
+func TestGooseSinceStillFindsATurnWithNoTimestamp(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	db := filepath.Join(t.TempDir(), "sessions.db")
+	type turn = struct {
+		Session, Role, Text string
+		At                  int64
+	}
+	first := int64(1785166187)
+	gooseStore(t, db, []turn{{"g1", "user", "why does pgbouncer time out", first}})
+
+	// A turn goose stored without a usable timestamp, on a session whose
+	// updated_at moved a few minutes later — the same day.
+	later := first + 600
+	stmts := fmt.Sprintf(
+		"insert into messages (session_id,role,content_json,created_timestamp) values ('g1','assistant',json_array(json_object('type','text','text','the pool is too small')),0);\n"+
+			"update sessions set updated_at = datetime(%d,'unixepoch') where id='g1';\n", later)
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+
+	got, err := ParseGooseDBSince(db, time.Unix(first, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, s := range got {
+		n += len(s.Messages)
+	}
+	if n == 0 {
+		t.Errorf("a turn with no timestamp of its own is reachable only through its session, and nothing came back")
+	}
+}


### PR DESCRIPTION
Part of #2030, measured on a real goose store (`~/.local/share/goose/sessions/sessions.db`):

```
updated_at / created_at   "2026-07-27 15:29:47"   sqlite CURRENT_TIMESTAMP
created_timestamp         1785166187              unix seconds, same wall time
```

The since clause compared that text against an RFC3339 string:

```
select '2026-07-27 15:29:47' > '2026-07-27T15:29:00Z'          -> 0
select '2026-07-28 09:00:00' > '2026-07-27T15:29:00Z'          -> 1
select datetime('2026-07-27 15:29:47') > datetime('...15:29:00Z') -> 1
```

A space sorts below `T`, so the session-level half of the clause missed every session touched later the same day and fired for every session touched on a later date. Two consequences, both real: a turn goose stores without a timestamp of its own — reachable only through its session — stayed invisible to incremental passes until the next calendar day, and once a day boundary was crossed the whole session came back.

Both sides go through `datetime()` now. The new test covers the first half; it fails against the old comparison with "a turn with no timestamp of its own … nothing came back".

What this does not do is stop a matching session coming back whole. The narrow version of the clause — rescue only rows with no usable timestamp — indexes nothing at all on a store whose message timestamps disagree with the session's, which is how this repo's own goose fixture is written (`TestGooseIncrementalKeepsUntouchedSessions` fails on it). So goose keeps the ingest-count reset from #2029, and the re-reading stays open in #2030 with the timestamp question answered for one real store.
