### PR TITLE
test(goose): write the incremental fixture the way goose writes a store

### DIFF
--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // seedOpencodeSession adds one session with one text part to an opencode store,
@@ -150,5 +152,46 @@ func TestAGooseSessionThatContinuesIsNotCountedTwice(t *testing.T) {
 		if got := clipped(); got != 1 {
 			t.Fatalf("one long message in the store, pass %d says %d clipped", i+1, got)
 		}
+	}
+}
+
+// The other side of handing back only the new turns: what the index already
+// holds has to survive it. A partial return that replaced the session would
+// drop every turn it did not include (#2032).
+func TestAGooseSessionKeepsItsEarlierTurns(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "goose.db")
+	t.Setenv("DEJA_GOOSE_DB", db)
+
+	seedGooseTurn(t, db, "g1", "user", "why does pgbouncer time out", 1785166187)
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
+		t.Fatalf("the first turn is not in the index (%d hits, %v), so this measures nothing", len(hits), err)
+	}
+
+	seedGooseTurn(t, db, "g1", "assistant", "the pool was too small", 1785166787)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	s, ok, err := FindByIdentity(dir, "goose", "g1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || len(s.Messages) != 2 {
+		t.Fatalf("the session came back with %d messages (found=%v): the new turn replaced what was there", len(s.Messages), ok)
+	}
+	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
+		t.Errorf("the first turn is gone from the index after the session continued (%d hits, %v)", len(hits), err)
 	}
 }

--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -94,8 +94,8 @@ func seedGooseTurn(t *testing.T, db, session, role, text string, created int64) 
 	stmts := fmt.Sprintf(`
 create table if not exists sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
 create table if not exists messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
-insert or ignore into sessions values ('%[1]s','g','a goose session','/tmp/app', strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch'), strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch'));
-update sessions set updated_at = strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ',%[4]d,'unixepoch') where id='%[1]s';
+insert or ignore into sessions values ('%[1]s','g','a goose session','/tmp/app', datetime(%[4]d,'unixepoch'), datetime(%[4]d,'unixepoch'));
+update sessions set updated_at = datetime(%[4]d,'unixepoch') where id='%[1]s';
 insert into messages (session_id,role,content_json,created_timestamp) values ('%[1]s','%[2]s',json_array(json_object('type','text','text','%[3]s')),%[4]d);
 `, session, role, text, created)
 	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
@@ -108,10 +108,9 @@ insert into messages (session_id,role,content_json,created_timestamp) values ('%
 // nothing resetting a database's counts (#2025) those turns were counted again
 // on every pass — a store in daily use would report clips in the thousands.
 //
-// The timestamps here are RFC3339, which is what goose writes: the since clause
-// compares s.updated_at against an RFC3339 string, and sqlite's own
-// datetime() format ("2026-01-02 03:00:00") never compares greater, so a
-// fixture written that way never re-reads the session and measures nothing.
+// The timestamps are sqlite's own format, which is what a real store holds; the
+// since clause puts both sides through datetime(), so the format no longer
+// decides the comparison (#2030).
 func TestAGooseSessionThatContinuesIsNotCountedTwice(t *testing.T) {
 	if _, err := exec.LookPath("sqlite3"); err != nil {
 		t.Skip("sqlite3 CLI not available")
@@ -181,8 +180,12 @@ func TestAGooseSessionKeepsItsEarlierTurns(t *testing.T) {
 	}
 
 	seedGooseTurn(t, db, "g1", "assistant", "the pool was too small", 1785166787)
-	if err := Ensure(dir, "", false, nil); err != nil {
+	var out strings.Builder
+	if err := Ensure(dir, "", false, &out); err != nil {
 		t.Fatal(err)
+	}
+	if said := out.String(); !strings.Contains(said, "incremental index") {
+		t.Fatalf("this was not the merge path, so it does not measure what it is about: %q", said)
 	}
 	s, ok, err := FindByIdentity(dir, "goose", "g1")
 	if err != nil {

--- a/internal/index/goose_incremental_test.go
+++ b/internal/index/goose_incremental_test.go
@@ -13,6 +13,12 @@ import (
 
 // A goose session untouched since the watermark must survive an incremental
 // pass triggered by a change to the shared sessions.db.
+//
+// The timestamps are written the way a real store writes them: sqlite's own
+// format for updated_at, agreeing with the message timestamps to the second,
+// because goose writes both from the same turn commit. The fixture used to put
+// updated_at a week ahead of its messages and in RFC3339, a shape goose does not
+// produce, and that gap decided what the since clause could be (#2032).
 func TestGooseIncrementalKeepsUntouchedSessions(t *testing.T) {
 	if _, err := exec.LookPath("sqlite3"); err != nil {
 		t.Skip("sqlite3 not available")
@@ -27,7 +33,7 @@ func TestGooseIncrementalKeepsUntouchedSessions(t *testing.T) {
 	seed := func(extra string) {
 		schema := `create table if not exists sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
 create table if not exists messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
-insert or replace into sessions values ('20250724_old','old','Old chat','/w/app','2026-07-24T10:00:00Z','2026-07-24T10:00:01Z');
+insert or replace into sessions values ('20250724_old','old','Old chat','/w/app',datetime(1784278801,'unixepoch'),datetime(1784278802,'unixepoch'));
 insert or replace into messages values (1,'20250724_old','user','[{"type":"text","text":"oldgoosefact about the pager"}]',1784278801);
 insert or replace into messages values (2,'20250724_old','assistant','[{"type":"text","text":"oldgoose reply"}]',1784278802)` + extra + `;`
 		if out, err := exec.Command("sqlite3", db, schema).CombinedOutput(); err != nil {
@@ -42,7 +48,7 @@ insert or replace into messages values (2,'20250724_old','assistant','[{"type":"
 		t.Fatal("old goose session not indexed on first pass")
 	}
 	seed(`;
-insert or replace into sessions values ('20250724_new','new','New chat','/w/app','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z');
+insert or replace into sessions values ('20250724_new','new','New chat','/w/app',datetime(1784282401,'unixepoch'),datetime(1784282402,'unixepoch'));
 insert or replace into messages values (3,'20250724_new','user','[{"type":"text","text":"newgoosefact about caching"}]',1784282401);
 insert or replace into messages values (4,'20250724_new','assistant','[{"type":"text","text":"newgoose reply"}]',1784282402)`)
 	future := time.Now().Add(time.Hour)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1995,6 +1995,17 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
+// rereadsWholeSessions marks a store whose cursor selects sessions rather than
+// messages: goose asks for every message of any session touched since the
+// stamp, so a continued session hands back turns already counted, and adding
+// them again grew the count on every pass. Starting the file over is the lesser
+// wrong — it loses what an untouched session held, which is #2025 again for
+// this one store, rather than a number that only climbs. Narrowing the clause
+// instead costs the session its earlier turns (#2033), so the re-reading stays.
+func rereadsWholeSessions(p string) bool {
+	return harnessForPath(p) == "goose-db"
+}
+
 // fullyReadFiles drops the files a pass reads only part of. LastUpdated is
 // stamped for database-backed stores alone (setStoreLastUpdated), and it is
 // exactly what makes their parse partial: parseChangedFile hands it to the kind
@@ -2008,16 +2019,6 @@ func fullyReadFiles(changed, old map[string]FileState) map[string]FileState {
 		out[p] = f
 	}
 	return out
-}
-
-// rereadsWholeSessions marks a store whose cursor selects sessions rather than
-// messages: goose asks for every message of any session touched since the
-// stamp, so a continued session hands back turns already counted, and adding
-// them again grew the count on every pass. Starting the file over is the lesser
-// wrong of the two — it loses what an untouched session held, which is #2025
-// again for this one store, rather than reporting a number that only climbs.
-func rereadsWholeSessions(p string) bool {
-	return harnessForPath(p) == "goose-db"
 }
 
 // copyIngestFiles hands the new manifest its own map: the old one belongs to

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -169,6 +169,11 @@ func ParseGooseDBSince(db string, t time.Time) ([]model.Session, error) {
 	// same day — including a turn goose stored without a timestamp of its own,
 	// which is reachable only through its session — and matched every session
 	// touched on a later date, handing back all of it (#2030).
+	//
+	// A matching session comes back whole, which is work repeated on every pass
+	// over an active store (#2030) — but it is also what keeps the session
+	// whole in the index: a partial return replaces what goose already had
+	// there, where the same partial return from opencode merges (#2033).
 	where := fmt.Sprintf(" and (m.created_timestamp > %d or datetime(s.updated_at) > datetime('%s'))", sec, rfc)
 	return parseGooseDBWhere(db, where, 0)
 }


### PR DESCRIPTION
Fixes #2032's first half. The goose incremental fixture put its message timestamps a week behind `updated_at`, and wrote `updated_at` in RFC3339:

```
messages 1784278801/2 -> 2026-07-17 09:00:01/02
sessions updated_at   -> 2026-07-24T10:00:01Z
```

A real store writes both from the same turn commit and they agree to the second, in sqlite's own format. The fixture now does the same.

The second half — narrowing the since clause so a matched session stops coming back whole — does not follow, and the measurement is why. With the corrected fixture the narrow clause passes every existing test, and then this happens:

```
opencode: the parse returns 1 message  ->  the index ends with 2   (merged)
goose:    the parse returns 1 message  ->  the index ends with 1   (replaced)
```

So goose's whole-session return is load-bearing: it is what keeps the session whole in the index. Narrowing the clause costs the session its earlier turns, which is worse than the repeated work it saves. Filed as #2033, with the two stores' disagreement as the thing to settle first.

`rereadsWholeSessions` stays for the same reason, with the comment updated to say what it now rests on.
