### PR TITLE
fix(index): judge a record by the store it came from

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1995,28 +1995,69 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
-// fromSharedStore reports whether a record came out of a database rather than a
-// file of its own. The source path answers that for goose and cursor, which name
-// the database as the session's path — but opencode names the project directory,
-// so its records looked like a per-file harness whose file had not changed and
-// were kept beside the ones the pass had just re-read. A store read whole then
-// grew by a copy of every session on every pass (#2033).
-func fromSharedStore(r Record) bool {
-	switch harnessForPath(r.SourcePath) {
+// fromDatabase reports whether a record came out of a shared store rather than
+// a file of its own, which is what exempts it from the changed-file rule: the
+// database changes whenever any session in it does, and dropping every record
+// that names it would take the untouched sessions along.
+//
+// The path settles it for goose and cursor, which name the database as the
+// session's path. opencode names the project directory, so nothing about its
+// path says "database" — the key names the harness, and opencode has no
+// per-file kind to confuse it with (#2033).
+func fromDatabase(r Record) bool {
+	switch h := harnessForPath(r.SourcePath); h {
 	case "opencode", "cursor-db", "goose-db":
 		return true
+	default:
+		if h != "" {
+			// A path that names a per-file kind settles it: two transcripts in
+			// different projects can share a filename-derived id, and judging
+			// those by key erased the sibling that was never re-read (#699).
+			return false
+		}
 	}
-	// The key names the harness the session belongs to, which settles it when
-	// the path cannot.
 	harness, _, ok := strings.Cut(r.Key, ":")
-	if !ok {
+	return ok && harness == "opencode"
+}
+
+// readWholeThisPass reports whether the pass re-read this record's store in
+// full. Only then may an old record be dropped because its key came back: a
+// store read from a watermark hands back the new turns alone, and dropping the
+// rest by key would take the earlier turns of a continued session with them.
+func readWholeThisPass(r Record) bool {
+	if len(passWholeStores) == 0 {
 		return false
 	}
-	switch harness {
-	case "opencode", "cursor", "goose":
-		return true
+	harness, _, ok := strings.Cut(r.Key, ":")
+	return ok && passWholeStores[harness]
+}
+
+// passWholeStores names the database-backed stores this pass read whole, by
+// harness. Package state for the same reason passParsed is: a pass holds the
+// directory lock.
+var passWholeStores map[string]bool
+
+// wholeStoresThisPass records them. A kind is the fine-grained name for a path
+// and a record carries the harness its session belongs to, so the two are
+// matched up here rather than at every record.
+func wholeStoresThisPass(changed, old map[string]FileState) {
+	passWholeStores = map[string]bool{}
+	for p := range changed {
+		harness := ""
+		switch harnessForPath(p) {
+		case "opencode":
+			harness = "opencode"
+		case "cursor-db":
+			harness = "cursor"
+		case "goose-db":
+			harness = "goose"
+		default:
+			continue
+		}
+		if old[p].LastUpdated == 0 || rereadsWholeSessions(p) {
+			passWholeStores[harness] = true
+		}
 	}
-	return false
 }
 
 // rereadsWholeSessions marks a store whose cursor selects sessions rather than
@@ -2074,6 +2115,7 @@ func beginPass() {
 	sources.DiagSnapshot()
 	passParsed = nil
 	passRead = nil
+	passWholeStores = nil
 }
 
 // passParsed is the set of files the pass in progress re-read. Package state
@@ -2253,6 +2295,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// append path's — a db's counts can only grow until a full rebuild.
 	reread := fullyReadFiles(changed, old.Files)
 	parsedThisPass(reread)
+	wholeStoresThisPass(changed, old.Files)
 	// A file the pass read is a file that opens, whether or not it read all of
 	// it, so an error recorded when it did not has to go.
 	readThisPass(changed)
@@ -2361,7 +2404,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// watermark, so their untouched sessions are NOT re-emitted on a
 		// change — they must be retained, not dropped, or they vanish.
 		// Superseded sessions are handled by replaceKeys.
-		sharedStore := fromSharedStore(r)
+		sharedStore := fromDatabase(r)
 		// replaceKeys is scoped to shared stores. A shared store is parsed since
 		// a watermark, so a superseded session's old record is not re-read and
 		// clause two never reaches it — replaceKeys is what drops it. For a
@@ -2370,7 +2413,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// hurts: two transcripts in different projects can share a filename-derived
 		// id, and dropping by key alone erased the sibling that was never re-read
 		// (#699). The record's own SourcePath decides its fate for those.
-		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !sharedStore) || (sharedStore && replaceKeys[r.Key]) {
+		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !sharedStore) || (sharedStore && readWholeThisPass(r) && replaceKeys[r.Key]) {
 			return
 		}
 		recErr = addRec(r)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2005,19 +2005,23 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 // path says "database" — the key names the harness, and opencode has no
 // per-file kind to confuse it with (#2033).
 func fromDatabase(r Record) bool {
+	// The key first, and only for opencode: it has one store and no per-file
+	// kind, so nothing else carries an "opencode:" key and no path can
+	// contradict it. Asking the path first got this wrong for an opencode
+	// project that lives inside another harness's root — a versioned ~/.claude,
+	// say — where harnessForPath answers with that harness's kind.
+	if h, _, ok := strings.Cut(r.Key, ":"); ok && h == "opencode" {
+		return true
+	}
 	switch h := harnessForPath(r.SourcePath); h {
-	case "opencode", "cursor-db", "goose-db":
+	case "cursor-db", "goose-db":
 		return true
 	default:
-		if h != "" {
-			// A path that names a per-file kind settles it: two transcripts in
-			// different projects can share a filename-derived id, and judging
-			// those by key erased the sibling that was never re-read (#699).
-			return false
-		}
+		// A path that names a per-file kind settles it: two transcripts in
+		// different projects can share a filename-derived id, and judging those
+		// by key erased the sibling that was never re-read (#699).
+		return false
 	}
-	harness, _, ok := strings.Cut(r.Key, ":")
-	return ok && harness == "opencode"
 }
 
 // readWholeThisPass reports whether the pass re-read this record's store in
@@ -2418,7 +2422,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// watermark, so their untouched sessions are NOT re-emitted on a
 		// change — they must be retained, not dropped, or they vanish.
 		// Superseded sessions are handled by replaceKeys.
-		sharedStore := fromDatabase(r)
+		fromStore := fromDatabase(r)
 		// replaceKeys is scoped to shared stores. A shared store is parsed since
 		// a watermark, so a superseded session's old record is not re-read and
 		// clause two never reaches it — replaceKeys is what drops it. For a
@@ -2427,7 +2431,11 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// hurts: two transcripts in different projects can share a filename-derived
 		// id, and dropping by key alone erased the sibling that was never re-read
 		// (#699). The record's own SourcePath decides its fate for those.
-		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !sharedStore) || (sharedStore && readWholeThisPass(r) && replaceKeys[r.Key]) {
+		//
+		// And only when the pass read that store whole: a store read from its
+		// watermark hands back the new turns alone, so dropping the rest by key
+		// would take the earlier turns of every continued session (#2033).
+		if removed[r.SourcePath] || (changed[r.SourcePath].Path != "" && !fromStore) || (fromStore && readWholeThisPass(r) && replaceKeys[r.Key]) {
 			return
 		}
 		recErr = addRec(r)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2024,9 +2024,18 @@ func fromDatabase(r Record) bool {
 // full. Only then may an old record be dropped because its key came back: a
 // store read from a watermark hands back the new turns alone, and dropping the
 // rest by key would take the earlier turns of a continued session with them.
+//
+// By store rather than by harness where the record names one: cursor keeps a
+// database per workspace as well as the global one, and a first sight of a new
+// workspace — opening a project — has no watermark, so a harness-wide flag let
+// that pass replace sessions in the store it had only read the tail of.
 func readWholeThisPass(r Record) bool {
 	if len(passWholeStores) == 0 {
 		return false
+	}
+	switch harnessForPath(r.SourcePath) {
+	case "cursor-db", "goose-db":
+		return passWholeStores[r.SourcePath]
 	}
 	harness, _, ok := strings.Cut(r.Key, ":")
 	return ok && passWholeStores[harness]
@@ -2037,9 +2046,13 @@ func readWholeThisPass(r Record) bool {
 // directory lock.
 var passWholeStores map[string]bool
 
-// wholeStoresThisPass records them. A kind is the fine-grained name for a path
-// and a record carries the harness its session belongs to, so the two are
-// matched up here rather than at every record.
+// wholeStoresThisPass records them, under both the store path and the harness:
+// a record names the first where it can and the second otherwise.
+//
+// Only these three stores are stamped with a watermark (setStoreLastUpdated).
+// Everything else is read whole on every pass and judged by its path, which is
+// why it needs none of this — a watermark added to another database later would
+// have to join fromDatabase and this function in the same change.
 func wholeStoresThisPass(changed, old map[string]FileState) {
 	passWholeStores = map[string]bool{}
 	for p := range changed {
@@ -2056,6 +2069,7 @@ func wholeStoresThisPass(changed, old map[string]FileState) {
 		}
 		if old[p].LastUpdated == 0 || rereadsWholeSessions(p) {
 			passWholeStores[harness] = true
+			passWholeStores[p] = true
 		}
 	}
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1995,6 +1995,30 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 }
 
+// fromSharedStore reports whether a record came out of a database rather than a
+// file of its own. The source path answers that for goose and cursor, which name
+// the database as the session's path — but opencode names the project directory,
+// so its records looked like a per-file harness whose file had not changed and
+// were kept beside the ones the pass had just re-read. A store read whole then
+// grew by a copy of every session on every pass (#2033).
+func fromSharedStore(r Record) bool {
+	switch harnessForPath(r.SourcePath) {
+	case "opencode", "cursor-db", "goose-db":
+		return true
+	}
+	// The key names the harness the session belongs to, which settles it when
+	// the path cannot.
+	harness, _, ok := strings.Cut(r.Key, ":")
+	if !ok {
+		return false
+	}
+	switch harness {
+	case "opencode", "cursor", "goose":
+		return true
+	}
+	return false
+}
+
 // rereadsWholeSessions marks a store whose cursor selects sessions rather than
 // messages: goose asks for every message of any session touched since the
 // stamp, so a continued session hands back turns already counted, and adding
@@ -2337,8 +2361,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		// watermark, so their untouched sessions are NOT re-emitted on a
 		// change — they must be retained, not dropped, or they vanish.
 		// Superseded sessions are handled by replaceKeys.
-		h := harnessForPath(r.SourcePath)
-		sharedStore := h == "opencode" || h == "cursor-db" || h == "goose-db"
+		sharedStore := fromSharedStore(r)
 		// replaceKeys is scoped to shared stores. A shared store is parsed since
 		// a watermark, so a superseded session's old record is not re-read and
 		// clause two never reaches it — replaceKeys is what drops it. For a

--- a/internal/index/opencode_duplicate_test.go
+++ b/internal/index/opencode_duplicate_test.go
@@ -1,0 +1,86 @@
+package index
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// seedTimelessOpencodeSession writes a session with nothing for the index to
+// stamp as a watermark: no time on the part, none on the message. A store like
+// this is re-read whole on every pass, which is the case that showed the
+// records piling up (#2033).
+func seedTimelessOpencodeSession(t *testing.T, db, id, text string) {
+	t.Helper()
+	stmts := fmt.Sprintf(`
+create table if not exists session (id text primary key, directory text, time_created integer, time_updated integer);
+create table if not exists message (id text primary key, session_id text, data text, time_created integer);
+create table if not exists part (id text primary key, message_id text, data text);
+insert into session values ('%[1]s','/tmp/app',0,0);
+insert into message values ('m-%[1]s','%[1]s','{"role":"user"}',0);
+insert into part values ('p-%[1]s','m-%[1]s',json_object('type','text','text','%[2]s'));
+`, id, text)
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// A session that comes back from the store again must replace what the index
+// holds, not join it. opencode's records escaped that rule because it is keyed
+// on the record's source path and opencode puts the project directory there,
+// so a store re-read whole grew by a copy of every session on every pass.
+func TestAnOpencodeSessionReadAgainDoesNotDouble(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+
+	seedTimelessOpencodeSession(t, db, "s1", "why does pgbouncer time out")
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	messages := func() int {
+		t.Helper()
+		s, ok, err := FindByIdentity(dir, "opencode", "s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("the session is not in the index")
+		}
+		return len(s.Messages)
+	}
+	if got := messages(); got != 1 {
+		t.Fatalf("the build indexed %d messages for a one-turn session, so this measures nothing", got)
+	}
+	// The premise: nothing to stamp, so the next pass reads the whole store
+	// rather than the part that changed.
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stamp := m.Files[db].LastUpdated; stamp != 0 {
+		t.Fatalf("the store stamped a watermark of %d, so the pass below will not re-read it whole", stamp)
+	}
+
+	// Two more passes, each triggered by a session that has nothing to do with
+	// the first one.
+	for i, id := range []string{"s2", "s3"} {
+		seedTimelessOpencodeSession(t, db, id, "an unrelated session")
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := messages(); got != 1 {
+			t.Fatalf("one turn on disk, %d in the index after pass %d", got, i+1)
+		}
+	}
+}

--- a/internal/index/opencode_duplicate_test.go
+++ b/internal/index/opencode_duplicate_test.go
@@ -2,10 +2,12 @@ package index
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -145,5 +147,85 @@ update session set time_updated=1785166787000 where id='s1';`
 	}
 	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
 		t.Errorf("the first turn is no longer searchable (%d hits, %v)", len(hits), err)
+	}
+}
+
+// cursor keeps a database per workspace beside the global one, so "this pass
+// read the store whole" is a fact about a store, not about the harness. A
+// workspace seen for the first time has no watermark; a harness-wide flag let
+// that pass replace sessions in the global store, which it had only read the
+// tail of (#2033).
+func TestANewCursorWorkspaceDoesNotTruncateTheGlobalStore(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	root := filepath.Join(tmp, "cursor")
+	t.Setenv("DEJA_CURSOR_ROOT", root)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	global := filepath.Join(root, "globalStorage", "state.vscdb")
+	if err := os.MkdirAll(filepath.Dir(global), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(db, sql string) {
+		t.Helper()
+		if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+			t.Fatalf("sqlite3: %v %s", err, out)
+		}
+	}
+	run(global, `create table if not exists cursorDiskKV (key text primary key, value text);
+insert or replace into cursorDiskKV values
+ ('composerData:cu1', json('{"composerId":"cu1","name":"Chat","createdAt":1752600000000,"lastUpdatedAt":1752600100000,"fullConversationHeadersOnly":[{"bubbleId":"b1","type":1}]}')),
+ ('bubbleId:cu1:b1', json('{"type":1,"text":"the first turn is about pgbouncer","timestamp":1752600001000,"workspaceProjectDir":"/w/app"}'));`)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
+		t.Fatalf("the first turn is not in the index (%d hits, %v), so this measures nothing", len(hits), err)
+	}
+
+	// One pass, two things: a workspace store deja has never seen, and a second
+	// turn in the global conversation.
+	ws := filepath.Join(root, "workspaceStorage", "w1", "state.vscdb")
+	if err := os.MkdirAll(filepath.Dir(ws), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(ws, `create table if not exists cursorDiskKV (key text primary key, value text);
+insert or replace into cursorDiskKV values
+ ('composerData:cu2', json('{"composerId":"cu2","name":"Workspace chat","createdAt":1752700000000,"lastUpdatedAt":1752700100000,"fullConversationHeadersOnly":[{"bubbleId":"c1","type":1}]}')),
+ ('bubbleId:cu2:c1', json('{"type":1,"text":"a workspace turn about caching","timestamp":1752700001000,"workspaceProjectDir":"/w/other"}'));`)
+	run(global, `insert or replace into cursorDiskKV values
+ ('composerData:cu1', json('{"composerId":"cu1","name":"Chat","createdAt":1752600000000,"lastUpdatedAt":1752600200000,"fullConversationHeadersOnly":[{"bubbleId":"b1","type":1},{"bubbleId":"b2","type":2}]}')),
+ ('bubbleId:cu1:b2', json('{"type":2,"text":"the second turn is the answer","timestamp":1752600150000,"workspaceProjectDir":"/w/app"}'));`)
+	future := time.Now().Add(time.Hour)
+	_ = os.Chtimes(global, future, future)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	s, ok, err := FindByIdentity(dir, "cursor", "cu1")
+	if err != nil || !ok {
+		t.Fatalf("the global session did not come back: %v %v", ok, err)
+	}
+	if len(s.Messages) != 2 {
+		texts := []string{}
+		for _, msg := range s.Messages {
+			texts = append(texts, msg.Text)
+		}
+		t.Errorf("the global conversation came back with %d turns after a new workspace appeared: %v", len(s.Messages), texts)
+	}
+	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
+		t.Errorf("the first turn is no longer searchable (%d hits, %v)", len(hits), err)
+	}
+	if hits, err := Search(dir, search.Options{Query: "caching", All: true}); err != nil || len(hits) == 0 {
+		t.Errorf("the new workspace store was not indexed (%d hits, %v)", len(hits), err)
 	}
 }

--- a/internal/index/opencode_duplicate_test.go
+++ b/internal/index/opencode_duplicate_test.go
@@ -206,7 +206,9 @@ insert or replace into cursorDiskKV values
  ('composerData:cu1', json('{"composerId":"cu1","name":"Chat","createdAt":1752600000000,"lastUpdatedAt":1752600200000,"fullConversationHeadersOnly":[{"bubbleId":"b1","type":1},{"bubbleId":"b2","type":2}]}')),
  ('bubbleId:cu1:b2', json('{"type":2,"text":"the second turn is the answer","timestamp":1752600150000,"workspaceProjectDir":"/w/app"}'));`)
 	future := time.Now().Add(time.Hour)
-	_ = os.Chtimes(global, future, future)
+	if err := os.Chtimes(global, future, future); err != nil {
+		t.Fatal(err)
+	}
 	if err := Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -227,5 +229,71 @@ insert or replace into cursorDiskKV values
 	}
 	if hits, err := Search(dir, search.Options{Query: "caching", All: true}); err != nil || len(hits) == 0 {
 		t.Errorf("the new workspace store was not indexed (%d hits, %v)", len(hits), err)
+	}
+}
+
+// opencode names the project directory as the session's path, and a project can
+// live inside another harness's root — a versioned ~/.claude is the obvious one.
+// Asking the path what store a record came from answers with that harness there,
+// which put opencode's records back among the per-file ones and brought #2033
+// back with them.
+func TestAnOpencodeProjectInsideAnotherHarnessRootStillCounts(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	claudeRoot := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	project := filepath.Join(claudeRoot, "myconfig")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	seed := func(id, text string) {
+		t.Helper()
+		stmts := fmt.Sprintf(`
+create table if not exists session (id text primary key, directory text, time_created integer, time_updated integer);
+create table if not exists message (id text primary key, session_id text, data text, time_created integer);
+create table if not exists part (id text primary key, message_id text, data text);
+insert into session values ('%[1]s','%[3]s',0,0);
+insert into message values ('m-%[1]s','%[1]s','{"role":"user"}',0);
+insert into part values ('p-%[1]s','m-%[1]s',json_object('type','text','text','%[2]s'));
+`, id, text, project)
+		if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+			t.Fatalf("sqlite3 seed: %v %s", err, out)
+		}
+	}
+	seed("s1", "why does pgbouncer time out")
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	messages := func() int {
+		t.Helper()
+		s, ok, err := FindByIdentity(dir, "opencode", "s1")
+		if err != nil || !ok {
+			t.Fatalf("the session is not in the index: %v %v", ok, err)
+		}
+		return len(s.Messages)
+	}
+	if got := messages(); got != 1 {
+		t.Fatalf("the build indexed %d messages for a one-turn session, so this measures nothing", got)
+	}
+
+	for i, id := range []string{"s2", "s3"} {
+		seed(id, "an unrelated session")
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := messages(); got != 1 {
+			t.Fatalf("one turn on disk, %d in the index after pass %d", got, i+1)
+		}
 	}
 }

--- a/internal/index/opencode_duplicate_test.go
+++ b/internal/index/opencode_duplicate_test.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // seedTimelessOpencodeSession writes a session with nothing for the index to
@@ -82,5 +85,65 @@ func TestAnOpencodeSessionReadAgainDoesNotDouble(t *testing.T) {
 		if got := messages(); got != 1 {
 			t.Fatalf("one turn on disk, %d in the index after pass %d", got, i+1)
 		}
+	}
+}
+
+// The other side of the same rule: a store read from a watermark hands back the
+// new turns alone, so dropping its old records by key would take the rest of the
+// session with them. This is the common case — every continued opencode session.
+func TestAContinuedOpencodeSessionKeepsItsEarlierTurns(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+
+	seedOpencodeSession(t, db, "s1", "the first turn is about pgbouncer", 1785166187000)
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise, and the difference from the case above: this store has a
+	// watermark, so the next pass reads only what is newer than it.
+	if m.Files[db].LastUpdated == 0 {
+		t.Fatal("the store has no watermark, so the pass below reads it whole and measures the other case")
+	}
+
+	stmts := `insert into message values ('m2-s1','s1','{"role":"assistant","time":{"created":1785166787000}}',1785166787000);
+insert into part values ('p2-s1','m2-s1',json_object('type','text','text','the second turn is the answer','time',json_object('start',1785166787000)));
+update session set time_updated=1785166787000 where id='s1';`
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3: %v %s", err, out)
+	}
+	var said strings.Builder
+	if err := Ensure(dir, "", false, &said); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(said.String(), "incremental index") {
+		t.Fatalf("this was not the merge path, so it does not measure what it is about: %q", said.String())
+	}
+	s, ok, err := FindByIdentity(dir, "opencode", "s1")
+	if err != nil || !ok {
+		t.Fatalf("the session did not come back: %v %v", ok, err)
+	}
+	if len(s.Messages) != 2 {
+		texts := []string{}
+		for _, msg := range s.Messages {
+			texts = append(texts, msg.Text)
+		}
+		t.Errorf("the session continued and came back with %d turns: %v", len(s.Messages), texts)
+	}
+	if hits, err := Search(dir, search.Options{Query: "pgbouncer", All: true}); err != nil || len(hits) == 0 {
+		t.Errorf("the first turn is no longer searchable (%d hits, %v)", len(hits), err)
 	}
 }


### PR DESCRIPTION
Fixes #2033. An opencode store whose sessions carry no usable time — nothing for the watermark to be stamped from, so every pass re-reads the whole store:

```
after the first build          s1 messages=1 stamp=0 sessions=1
after the store grows          s1 messages=2 stamp=0 sessions=2
after it grows again           s1 messages=3 stamp=0 sessions=3
```

One turn on disk, a copy added on every pass.

The retention rule read the harness off the record's source path, and the source path is the session's `Path`: goose and cursor name the database there, opencode names the project directory. So opencode's records looked like a per-file harness whose file had not changed, and the old copies were kept beside the ones the pass had just re-read — the shared-store branch the comment above the rule describes was dead code for them.

The record's key names its harness, which settles it when the path cannot.

The dedup that would otherwise have caught this (`seenMsgs`) is fresh per pass and never sees carried records, which is why nothing noticed.
