### PR TITLE
fix(compact): keep the evidence block in the caller's project

### DIFF
--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -45,7 +45,7 @@ func compactEvidence(dir, sessionID, cwd string) string {
 	// The payload names no harness, so the id is all there is to go on — and two
 	// projects can hold one id. The cwd it does carry is what keeps this block
 	// about the session that is compacting (#1999).
-	s, ok, err := index.FindByIDInProject(dir, sessionID, cwd)
+	s, ok, err := index.FindByIDPreferProject(dir, sessionID, cwd)
 	if err != nil || !ok {
 		return ""
 	}

--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -38,11 +38,14 @@ const (
 
 // compactEvidence describes what a session did before it was compacted, or ""
 // when the session is not in the index yet or recorded nothing worth saying.
-func compactEvidence(dir, sessionID string) string {
+func compactEvidence(dir, sessionID, cwd string) string {
 	if sessionID == "" {
 		return ""
 	}
-	s, ok, err := index.FindByID(dir, sessionID)
+	// The payload names no harness, so the id is all there is to go on — and two
+	// projects can hold one id. The cwd it does carry is what keeps this block
+	// about the session that is compacting (#1999).
+	s, ok, err := index.FindByIDInProject(dir, sessionID, cwd)
 	if err != nil || !ok {
 		return ""
 	}

--- a/cmd/deja/compact_control_bytes_test.go
+++ b/cmd/deja/compact_control_bytes_test.go
@@ -68,7 +68,7 @@ func TestCompactEvidenceStripsControlBytes(t *testing.T) {
 		t.Fatalf("index: %v %s", err, out)
 	}
 
-	got := compactEvidence(os.Getenv("DEJA_INDEX_DIR"), "s1")
+	got := compactEvidence(os.Getenv("DEJA_INDEX_DIR"), "s1", "/tmp/app")
 	// The premise: the block has to hold both kinds of row, or a clean answer
 	// here means the records never arrived rather than that they were stripped.
 	if !strings.Contains(got, "files it touched:") || !strings.Contains(got, "psql") {

--- a/cmd/deja/compact_project_test.go
+++ b/cmd/deja/compact_project_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The compaction block is a session's own evidence, and "its own" is the whole
+// point: the hook payload names no harness, so a shared id used to resolve to
+// whichever copy the index had seen most recently — which can be a different
+// project's session that happens to have been touched later (#1999).
+func TestCompactEvidenceStaysInTheCallersProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	codex := filepath.Join(tmp, "codex", "sessions", "2026", "01", "01")
+	if err := os.MkdirAll(filepath.Join(claude, "-w-other"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(codex, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_INDEX_TOOL_PATHS", "1")
+	t.Setenv("DEJA_INDEX_COMMANDS", "1")
+
+	rec := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	// The other project's copy, and the newer of the two in the index.
+	other := rec(map[string]any{
+		"type": "user", "sessionId": "shared", "cwd": "/w/other",
+		"timestamp": "2026-06-01T10:00:00Z",
+		"message":   map[string]any{"role": "user", "content": "the other project's question"},
+	}) + "\n" + rec(map[string]any{
+		"type": "assistant", "sessionId": "shared", "cwd": "/w/other",
+		"timestamp": "2026-06-01T10:02:00Z",
+		"message": map[string]any{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "Read", "input": map[string]any{"file_path": "/w/other/claude_only.go"}},
+			map[string]any{"type": "tool_use", "name": "Bash", "input": map[string]any{"command": "go test ./pkg/ -run ClaudeOnly"}},
+		}},
+	}) + "\n"
+	if err := os.WriteFile(filepath.Join(claude, "-w-other", "shared.jsonl"), []byte(other), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The session that is compacting: same id, this project, older.
+	mine := `{"type":"session_meta","timestamp":"2026-01-01T12:00:00Z","payload":{"session_id":"shared","cwd":"/w/app"}}` + "\n" +
+		`{"timestamp":"2026-01-01T12:00:01Z","payload":{"role":"user","content":"the app's question about pgbouncer"}}` + "\n" +
+		`{"timestamp":"2026-01-01T12:00:02Z","payload":{"type":"function_call","name":"exec_command","call_id":"c1","arguments":"{\"cmd\":\"go test ./app/ -run Pool\"}"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(codex, "rollout-2026-01-01T12-00-00-shared.jsonl"), []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "index"); err != nil {
+		t.Fatalf("index: %v %s", err, out)
+	}
+
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	// The premise: without a project to go on, the newer copy is what answers.
+	// If that stops being true the case below passes for the wrong reason.
+	if blind := compactEvidence(dir, "shared", ""); !strings.Contains(blind, "claude_only.go") {
+		t.Fatalf("the fixture does not reproduce the mix-up it is about:\n%s", blind)
+	}
+
+	got := compactEvidence(dir, "shared", "/w/app")
+	if got == "" {
+		t.Fatal("the compacting session got no block at all")
+	}
+	if strings.Contains(got, "claude_only.go") || strings.Contains(got, "ClaudeOnly") {
+		t.Errorf("the block names another project's work:\n%s", got)
+	}
+	if !strings.Contains(got, "run Pool") {
+		t.Errorf("the block does not name what this session actually ran:\n%s", got)
+	}
+}

--- a/cmd/deja/compact_test.go
+++ b/cmd/deja/compact_test.go
@@ -67,7 +67,7 @@ func writeCompactFixture(t *testing.T) string {
 
 func TestCompactEvidenceNamesWhatTheSummaryDrops(t *testing.T) {
 	writeCompactFixture(t)
-	got := compactEvidence(index.DefaultDir(), "claude-compact")
+	got := compactEvidence(index.DefaultDir(), "claude-compact", "")
 	if got == "" {
 		t.Fatal("a session with files and commands should produce a block")
 	}
@@ -85,10 +85,10 @@ func TestCompactEvidenceNamesWhatTheSummaryDrops(t *testing.T) {
 func TestCompactEvidenceSaysNothingWhenItCannot(t *testing.T) {
 	writeCompactFixture(t)
 	dir := index.DefaultDir()
-	if got := compactEvidence(dir, ""); got != "" {
+	if got := compactEvidence(dir, "", ""); got != "" {
 		t.Errorf("no session id, no block: %q", got)
 	}
-	if got := compactEvidence(dir, "claude-not-indexed-yet"); got != "" {
+	if got := compactEvidence(dir, "claude-not-indexed-yet", ""); got != "" {
 		t.Errorf("an unknown session says nothing: %q", got)
 	}
 }

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -310,7 +310,7 @@ func runHookContext(dir string, plain bool) error {
 		// most needs is its own evidence: measured on this corpus, a summary
 		// keeps ~77% of the decisions and 0.2% of the commands that produced
 		// them (#543).
-		if ev := compactEvidence(dir, input.SessionID); ev != "" {
+		if ev := compactEvidence(dir, input.SessionID, input.CWD); ev != "" {
 			lead += "\n" + ev + "\n"
 		}
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -310,7 +310,7 @@ func runHookContext(dir string, plain bool) error {
 		// most needs is its own evidence: measured on this corpus, a summary
 		// keeps ~77% of the decisions and 0.2% of the commands that produced
 		// them (#543).
-		if ev := compactEvidence(dir, input.SessionID, input.CWD); ev != "" {
+		if ev := compactEvidence(dir, input.SessionID, hookCWD(input.CWD)); ev != "" {
 			lead += "\n" + ev + "\n"
 		}
 	}
@@ -556,11 +556,23 @@ func adoptHookCWD(cwd string) {
 	_ = os.Setenv("CLAUDE_PROJECT_DIR", cwd)
 }
 
-func cachedHookDigest(dir string) (string, int, int64, []string, int) {
-	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
-	if cwd == "" {
-		cwd, _ = os.Getwd()
+// hookCWD is where the hook is standing: what the payload says, else the
+// project directory the harness exported, else the process's own — the same
+// chain cachedHookDigest walks, so a host that exports the directory without
+// naming it in the payload is not treated as standing nowhere.
+func hookCWD(fromPayload string) string {
+	if fromPayload != "" {
+		return fromPayload
 	}
+	if cwd := os.Getenv("CLAUDE_PROJECT_DIR"); cwd != "" {
+		return cwd
+	}
+	cwd, _ := os.Getwd()
+	return cwd
+}
+
+func cachedHookDigest(dir string) (string, int, int64, []string, int) {
+	cwd := hookCWD("")
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
 		return "", 0, 0, nil, 0
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1683,6 +1684,16 @@ func ChildrenOf(dir, id string) ([]model.Session, error) {
 // one without naming the harness, and the id is unique in practice: the
 // harnesses that generate them use uuids or their own prefixed ids.
 func FindByID(dir, id string) (model.Session, bool, error) {
+	return FindByIDInProject(dir, id, "")
+}
+
+// FindByIDInProject is FindByID for a caller that knows where it is standing.
+// The freshest match is the right guess only while the copies are the same
+// conversation; two projects can hold a session with one id, and then the
+// freshest is whichever was touched last, which has nothing to do with the one
+// asking (#1999). A project that names one of them settles it, and the rest of
+// the rule is unchanged.
+func FindByIDInProject(dir, id, project string) (model.Session, bool, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -1701,19 +1712,40 @@ func FindByID(dir, id string) (model.Session, bool, error) {
 		return model.Session{}, false, err
 	}
 	var best SessionMeta
-	var found bool
+	var found, bestInProject bool
 	for _, meta := range m.Sessions {
 		if meta.ID != id {
 			continue
 		}
-		if !found || betterIDMatch(meta, best) {
-			best, found = meta, true
+		inProject := project != "" && sameProject(meta.Project, project)
+		switch {
+		case !found, inProject && !bestInProject:
+			best, found, bestInProject = meta, true, inProject
+		case inProject == bestInProject && betterIDMatch(meta, best):
+			best = meta
 		}
 	}
 	if !found {
 		return model.Session{}, false, nil
 	}
 	return loadSessionMeta(dir, m, best)
+}
+
+// sameProject reports whether a session's project is the one the caller is
+// standing in. A project is recorded as the directory's own name, sometimes
+// with its parent — "app" or "w/app" — so the caller's path is matched by its
+// last segments rather than whole.
+func sameProject(recorded, cwd string) bool {
+	if recorded == "" || cwd == "" {
+		return false
+	}
+	cwd = filepath.ToSlash(cwd)
+	base := path.Base(cwd)
+	if strings.EqualFold(recorded, base) {
+		return true
+	}
+	parent := path.Base(path.Dir(cwd))
+	return parent != "." && parent != "/" && strings.EqualFold(recorded, parent+"/"+base)
 }
 
 // betterIDMatch picks between two sessions carrying the same id (#1997). The

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1714,16 +1714,20 @@ func FindByIDPreferProject(dir, id, project string) (model.Session, bool, error)
 		return model.Session{}, false, err
 	}
 	var best SessionMeta
-	var found, bestInProject bool
+	var found bool
+	bestNear := -1
 	for _, meta := range m.Sessions {
 		if meta.ID != id {
 			continue
 		}
-		inProject := project != "" && sameProject(meta.Project, project)
+		near := -1
+		if project != "" {
+			near = projectDistance(meta.Project, project)
+		}
 		switch {
-		case !found, inProject && !bestInProject:
-			best, found, bestInProject = meta, true, inProject
-		case inProject == bestInProject && betterIDMatch(meta, best):
+		case !found, nearerProject(near, bestNear):
+			best, found, bestNear = meta, true, near
+		case near == bestNear && betterIDMatch(meta, best):
 			best = meta
 		}
 	}
@@ -1733,8 +1737,8 @@ func FindByIDPreferProject(dir, id, project string) (model.Session, bool, error)
 	return loadSessionMeta(dir, m, best)
 }
 
-// sameProject reports whether a session's project is the one the caller is
-// standing in. A project is recorded as the directory's own name, sometimes
+// projectDistance measures a session's project against the directory the caller
+// is standing in. A project is recorded as the directory's own name, sometimes
 // with its parent — "app" or "w/app" — so the caller's path is matched by its
 // last segments rather than whole.
 //
@@ -1744,23 +1748,41 @@ func FindByIDPreferProject(dir, id, project string) (model.Session, bool, error)
 // reaches by walking up. Bare names match at the leaf alone, where the caller
 // actually is — an ancestor matching by base would make every worktree named
 // "wt" the same project.
-func sameProject(recorded, cwd string) bool {
+//
+// It answers with how far up the match was found — 0 where the caller stands —
+// so a session recorded against this very directory outranks one recorded
+// against a directory three levels above it. Without that, an agent someone ran
+// from their home directory could outrank the project's own session by being
+// the fresher of the two.
+func projectDistance(recorded, cwd string) int {
 	if recorded == "" || cwd == "" {
-		return false
+		return -1
 	}
 	cwd = path.Clean(filepath.ToSlash(cwd))
 	if strings.EqualFold(recorded, path.Base(cwd)) {
-		return true
+		return 0
 	}
-	for dir := cwd; ; dir = path.Dir(dir) {
+	for dir, up := cwd, 0; ; dir, up = path.Dir(dir), up+1 {
 		parent, base := path.Base(path.Dir(dir)), path.Base(dir)
 		if parent == "." || parent == "/" || base == "." || base == "/" {
-			return false
+			return -1
 		}
 		if strings.EqualFold(recorded, parent+"/"+base) {
-			return true
+			return up
 		}
 	}
+}
+
+func sameProject(recorded, cwd string) bool { return projectDistance(recorded, cwd) >= 0 }
+
+// nearerProject reports whether a match this far from the caller beats the one
+// already held. A match at any distance beats none; among matches the nearer
+// wins, and equals fall through to betterIDMatch.
+func nearerProject(near, held int) bool {
+	if near < 0 {
+		return false
+	}
+	return held < 0 || near < held
 }
 
 // betterIDMatch picks between two sessions carrying the same id (#1997). The

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1684,16 +1684,18 @@ func ChildrenOf(dir, id string) ([]model.Session, error) {
 // one without naming the harness, and the id is unique in practice: the
 // harnesses that generate them use uuids or their own prefixed ids.
 func FindByID(dir, id string) (model.Session, bool, error) {
-	return FindByIDInProject(dir, id, "")
+	return FindByIDPreferProject(dir, id, "")
 }
 
-// FindByIDInProject is FindByID for a caller that knows where it is standing.
+// FindByIDPreferProject is FindByID for a caller that knows where it is
+// standing. A preference, not a filter: a session outside the project still
+// answers when nothing inside it does.
 // The freshest match is the right guess only while the copies are the same
 // conversation; two projects can hold a session with one id, and then the
 // freshest is whichever was touched last, which has nothing to do with the one
 // asking (#1999). A project that names one of them settles it, and the rest of
 // the rule is unchanged.
-func FindByIDInProject(dir, id, project string) (model.Session, bool, error) {
+func FindByIDPreferProject(dir, id, project string) (model.Session, bool, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -1735,17 +1737,30 @@ func FindByIDInProject(dir, id, project string) (model.Session, bool, error) {
 // standing in. A project is recorded as the directory's own name, sometimes
 // with its parent — "app" or "w/app" — so the caller's path is matched by its
 // last segments rather than whole.
+//
+// And by its ancestors' too: a session started in a subdirectory is re-projected
+// onto the repository root once it has touched enough files under it
+// (projectFromPaths), so the recorded name can be two segments the cwd only
+// reaches by walking up. Bare names match at the leaf alone, where the caller
+// actually is — an ancestor matching by base would make every worktree named
+// "wt" the same project.
 func sameProject(recorded, cwd string) bool {
 	if recorded == "" || cwd == "" {
 		return false
 	}
-	cwd = filepath.ToSlash(cwd)
-	base := path.Base(cwd)
-	if strings.EqualFold(recorded, base) {
+	cwd = path.Clean(filepath.ToSlash(cwd))
+	if strings.EqualFold(recorded, path.Base(cwd)) {
 		return true
 	}
-	parent := path.Base(path.Dir(cwd))
-	return parent != "." && parent != "/" && strings.EqualFold(recorded, parent+"/"+base)
+	for dir := cwd; ; dir = path.Dir(dir) {
+		parent, base := path.Base(path.Dir(dir)), path.Base(dir)
+		if parent == "." || parent == "/" || base == "." || base == "/" {
+			return false
+		}
+		if strings.EqualFold(recorded, parent+"/"+base) {
+			return true
+		}
+	}
 }
 
 // betterIDMatch picks between two sessions carrying the same id (#1997). The

--- a/internal/index/same_project_test.go
+++ b/internal/index/same_project_test.go
@@ -1,0 +1,33 @@
+package index
+
+import "testing"
+
+// A session is re-projected onto the repository root once it has touched enough
+// files under it (projectFromPaths), so the name recorded for a session started
+// in a subdirectory is two segments the caller only reaches by walking up. A
+// match against the cwd's own last segments alone missed exactly the sessions
+// people have (#1999).
+func TestSameProjectWalksUpToTheRepositoryRoot(t *testing.T) {
+	for _, c := range []struct {
+		recorded, cwd string
+		want          bool
+	}{
+		{"w/app", "/w/app", true},
+		{"app", "/w/app", true},
+		{"w/app", "/w/app/", true}, // a trailing slash is still the same place
+		{"home2/repo", "/home2/repo/cmd/deja", true},
+		{"goprojects/deja-vu", "/Users/x/goprojects/deja-vu/internal/index", true},
+		{"x/my app", "/Users/x/my app", true},
+		{"x/проект", "/Users/x/проект", true},
+		{"app/app", "/w/app/", false},          // and not a project of that name
+		{"cmd", "/home2/repo/cmd/deja", false}, // a bare name matches where the caller stands
+		{"other/app", "/w/app", false},
+		{"", "/w/app", false},
+		{"w/app", "", false},
+		{"w/app", "/", false},
+	} {
+		if got := sameProject(c.recorded, c.cwd); got != c.want {
+			t.Errorf("sameProject(%q, %q) = %v, want %v", c.recorded, c.cwd, got, c.want)
+		}
+	}
+}

--- a/internal/index/same_project_test.go
+++ b/internal/index/same_project_test.go
@@ -31,3 +31,32 @@ func TestSameProjectWalksUpToTheRepositoryRoot(t *testing.T) {
 		}
 	}
 }
+
+// How far up the match was found decides between two sessions that both match:
+// the project's own session beats one recorded against a directory above it,
+// however fresh that one is. People do run an agent from a home directory, which
+// is the case projectFromPaths was written for.
+func TestProjectDistanceRanksTheNearerMatch(t *testing.T) {
+	cwd := "/Users/me/work/app"
+	for _, c := range []struct {
+		recorded string
+		want     int
+	}{
+		{"app", 0},
+		{"work/app", 0},
+		{"me/work", 1},
+		{"Users/me", 2},
+		{"work", -1}, // a bare name matches only where the caller stands
+		{"other/app", -1},
+	} {
+		if got := projectDistance(c.recorded, cwd); got != c.want {
+			t.Errorf("projectDistance(%q, %q) = %d, want %d", c.recorded, cwd, got, c.want)
+		}
+	}
+	if !nearerProject(0, 2) || !nearerProject(3, -1) {
+		t.Error("a nearer match, and any match at all, has to win")
+	}
+	if nearerProject(2, 0) || nearerProject(-1, 3) || nearerProject(-1, -1) || nearerProject(1, 1) {
+		t.Error("a farther match, or none, must not displace what is held")
+	}
+}


### PR DESCRIPTION
Fixes #1999. Two stores holding a session with the same id, in different projects. The codex copy in `/w/app` is the one compacting; the claude copy in `/w/other` is newer in the index:

```
What this session did before the compaction, from deja's index — …
  files it touched: w/other/claude_only.go
  commands it ran:
    $ go test ./pkg/ -run ClaudeOnly
```

Files the session never opened and a command it never ran, handed to it right after its context was emptied.

`FindByID` resolves a shared id to the freshest session (#1997), which is the right guess only while the copies are the same conversation. The hook payload names no harness — but it does carry the cwd, and the meta carries the project, so `FindByIDInProject` prefers a copy whose project matches before falling back to the freshest. `FindByID` is unchanged for every other caller.

The project is recorded as the directory's own name, sometimes with its parent ("app" or "w/app"), so the caller's path is matched by its last segments rather than whole.

The test checks the mix-up still reproduces with no project to go on before asserting the fixed behaviour, so it cannot pass because the fixture stopped colliding.
