### PR TITLE
fix(digest): keep the worktree root when the caller is below it

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -303,10 +303,32 @@ func gitWorktreeRoots(cwd string) []string {
 			roots = append(roots, strings.TrimSpace(p))
 		}
 	}
-	if len(roots) < 2 {
-		return nil // a single worktree adds nothing beyond cwd's own names
+	// A single worktree adds nothing beyond cwd's own names only when cwd is
+	// that worktree. From a package directory inside it, the root is the one
+	// name the caller does not already have — and it is the project recall is
+	// scoped by, so dropping it left an agent started anywhere but the top of
+	// its repository with no memory at all (#2037).
+	if len(roots) == 1 && sameDir(roots[0], cwd) {
+		return nil
 	}
 	return roots
+}
+
+// sameDir compares two paths as directories, so a symlinked or unclean spelling
+// of the same place does not read as a different one.
+func sameDir(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		ra = filepath.Clean(a)
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		rb = filepath.Clean(b)
+	}
+	return ra == rb
 }
 
 // agentArtifactMarkers flag transcript entries that are tool output or

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -297,38 +297,29 @@ func gitWorktreeRoots(cwd string) []string {
 	if err != nil {
 		return nil
 	}
+	// Every root, including a lone one. It used to be dropped as "nothing
+	// beyond cwd's own names", which holds only when the caller is standing at
+	// that root: from a package directory inside it the root is the one name
+	// the caller does not have, and it is the project recall is scoped by — so
+	// an agent started anywhere but the top of its repository had no memory at
+	// all (#2037). At the root itself the names are the same computation on the
+	// same path and dedupe away, and a root spelled differently — through a
+	// symlink — is a spelling recall wants to see.
 	var roots []string
 	for _, line := range strings.Split(string(out), "\n") {
-		if p, ok := strings.CutPrefix(line, "worktree "); ok && strings.TrimSpace(p) != "" {
-			roots = append(roots, strings.TrimSpace(p))
+		p, ok := strings.CutPrefix(line, "worktree ")
+		p = strings.TrimSpace(p)
+		if !ok || p == "" {
+			continue
 		}
-	}
-	// A single worktree adds nothing beyond cwd's own names only when cwd is
-	// that worktree. From a package directory inside it, the root is the one
-	// name the caller does not already have — and it is the project recall is
-	// scoped by, so dropping it left an agent started anywhere but the top of
-	// its repository with no memory at all (#2037).
-	if len(roots) == 1 && sameDir(roots[0], cwd) {
-		return nil
+		// Inside a submodule git names the gitdir rather than the working tree,
+		// and ".git/modules/sub" is not a project anybody worked in.
+		if strings.Contains(filepath.ToSlash(p), "/.git/") {
+			continue
+		}
+		roots = append(roots, p)
 	}
 	return roots
-}
-
-// sameDir compares two paths as directories, so a symlinked or unclean spelling
-// of the same place does not read as a different one.
-func sameDir(a, b string) bool {
-	if a == b {
-		return true
-	}
-	ra, err := filepath.EvalSymlinks(a)
-	if err != nil {
-		ra = filepath.Clean(a)
-	}
-	rb, err := filepath.EvalSymlinks(b)
-	if err != nil {
-		rb = filepath.Clean(b)
-	}
-	return ra == rb
 }
 
 // agentArtifactMarkers flag transcript entries that are tool output or

--- a/internal/digest/subdir_candidates_test.go
+++ b/internal/digest/subdir_candidates_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -49,4 +50,49 @@ func has(names []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// Inside a submodule git names the gitdir rather than the working tree, so the
+// root it reports is ".git/modules/<name>" — a path nobody worked in. Dropping
+// the single root used to hide that; keeping it made the junk a candidate.
+func TestProjectNameCandidatesSkipTheSubmoduleGitdir(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "work", "parent")
+	child := filepath.Join(tmp, "work", "child")
+	for _, d := range []string{parent, child} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{{"init", "-q"}, {"config", "user.email", "t@t"}, {"config", "user.name", "t"}} {
+			if out, err := exec.Command("git", append([]string{"-C", d}, args...)...).CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v %s", args, err, out)
+			}
+		}
+	}
+	if err := os.WriteFile(filepath.Join(child, "f.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "f.txt"}, {"commit", "-q", "-m", "seed"}} {
+		if out, err := exec.Command("git", append([]string{"-C", child}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+	add := exec.Command("git", "-C", parent, "-c", "protocol.file.allow=always", "submodule", "add", "-q", child, "sub")
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Skipf("submodules unavailable here: %v %s", err, out)
+	}
+
+	got := ProjectNameCandidates(filepath.Join(parent, "sub"))
+	for _, n := range got {
+		if strings.Contains(n, "modules/") {
+			t.Errorf("the gitdir reached the candidates as a project: %v", got)
+		}
+	}
+	// The submodule is still a place someone works in, under its own name.
+	if !has(got, "parent/sub") {
+		t.Errorf("the submodule lost its own name: %v", got)
+	}
 }

--- a/internal/digest/subdir_candidates_test.go
+++ b/internal/digest/subdir_candidates_test.go
@@ -1,0 +1,52 @@
+package digest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// An agent started in a package directory is standing in the project all the
+// same, and the project is what recall is scoped by. The worktree roots are
+// what carry that — except a repository with one worktree dropped its root,
+// which is the only name a subdirectory does not already have (#2037).
+func TestProjectNameCandidatesNameTheRepositoryFromASubdirectory(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "work", "repo")
+	sub := filepath.Join(repo, "cmd", "deja")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v %s", err, out)
+	}
+
+	// The premise: standing at the root, the project's own names are there.
+	atRoot := ProjectNameCandidates(repo)
+	if !has(atRoot, "work/repo") {
+		t.Fatalf("the root does not name its own project: %v", atRoot)
+	}
+
+	got := ProjectNameCandidates(sub)
+	if !has(got, "work/repo") {
+		t.Errorf("a subdirectory of the repository does not name the project it is in: %v", got)
+	}
+	// And its own names stay: a session recorded against the subdirectory
+	// before it was re-projected is still that session's.
+	if !has(got, "cmd/deja") {
+		t.Errorf("the subdirectory lost its own name: %v", got)
+	}
+}
+
+func has(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #2037. A session recorded in a repository root, and a hook standing in `<repo>/cmd/deja` — in a real git repo and in a plain directory alike:

```
root        : digest=163 bytes, mentions pool=true  candidates=[repo work/repo]
subdirectory: digest=0 bytes,   mentions pool=false candidates=[deja cmd/deja]
```

Inside a repo the candidate list is supposed to carry the project: `ProjectNameCandidates` adds the names of every worktree root. It didn't, because `gitWorktreeRoots` ends with

```go
if len(roots) < 2 {
    return nil // a single worktree adds nothing beyond cwd's own names
}
```

which holds only when the caller is standing at the root. From a subdirectory the single root is exactly the name that is missing — so an agent started in a package directory, which is ordinary in a Go or monorepo layout, got no memory on session start at all.

The root is kept now whenever the caller is not standing on it (compared through `EvalSymlinks`, so a symlinked spelling of the same place still counts as standing on it). After:

```
root        : digest=163 bytes, mentions pool=true
subdirectory: digest=163 bytes, mentions pool=true
```

The test asserts the subdirectory keeps its own names too: a session recorded against it before the project was re-derived is still that session's.
