### PR TITLE
carry the injection cooldown across agent sessions

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -176,8 +176,19 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// questions in a day, and what stops it repeating itself is the block
 	// fingerprint below, not a ban on where it came from.
 	recent := recentlyInjected(dir, input.SessionID, injectionCooldown)
-	skip := make(map[string]bool, len(recent)+1)
+	// The same cooldown across agent sessions in this project. Without it the
+	// window reset every time a new agent session opened, which is how one
+	// marathon reached 110 servings (#2038).
+	projectKey := ""
+	if cands := digest.ProjectNameCandidates(cwd); len(cands) > 0 {
+		projectKey = cands[0]
+	}
+	inProject := recentlyInjectedInProject(dir, projectKey, injectionCooldown)
+	skip := make(map[string]bool, len(recent)+len(inProject)+1)
 	for id := range recent {
+		skip[id] = true
+	}
+	for id := range inProject {
 		skip[id] = true
 	}
 	if input.SessionID != "" {
@@ -342,7 +353,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	out := frameRecall(body)
 	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
-	rememberInjected(dir, input.SessionID, ss)
+	rememberInjectedFor(dir, input.SessionID, projectKey, ss)
 	usage.RecordDigestInto(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
 		terms, sessionIDs(ss)...)
 	if plain {
@@ -496,6 +507,45 @@ func blockFingerprint(body string) string {
 // again. Ten is the length of a short stretch of work.
 const injectionCooldown = 10
 
+// recentlyInjectedInProject is the same cooldown counted across agent sessions
+// rather than inside one, because the cooldown above only ever saw the session
+// it was called from and every new agent session started blank.
+//
+// Measured over six weeks of a real log: per-prompt recall made 937 injections
+// drawn from 74 distinct sessions, 92% of them repeats, with ten sessions
+// carrying 80% of the total — the two commonest being marathons of 2.6M and
+// 1.4M words, which match nearly any prompt. The agent is told to say nothing
+// about a recall that did not help, so the hundredth serving of the same
+// session is correctly met with silence, and `stats --impact` counts that
+// silence against us (#2038).
+//
+// Scoped to the project on purpose: the same session answering the same
+// question in a different repository is not the repetition being fixed here.
+func recentlyInjectedInProject(dir, project string, window int) map[string]bool {
+	out := map[string]bool{}
+	if project == "" || window <= 0 {
+		return out
+	}
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		return out
+	}
+	lines := strings.Split(string(b), "\n")
+	kept := 0
+	for i := len(lines) - 1; i >= 0 && kept < window; i-- {
+		// Four fields since this cooldown was added; lines written before it
+		// carry no project and match nothing, which is the right answer for
+		// them rather than a guess.
+		parts := strings.Fields(lines[i])
+		if len(parts) < 4 || parts[3] != project {
+			continue
+		}
+		kept++
+		out[parts[1]] = true
+	}
+	return out
+}
+
 // recentlyInjected is alreadyInjected narrowed to the last few things this
 // agent session was shown.
 func recentlyInjected(dir, sid string, window int) map[string]bool {
@@ -553,6 +603,14 @@ func forgetInjected(dir, sid string) {
 }
 
 func rememberInjected(dir, sid string, ss []model.Session) {
+	rememberInjectedFor(dir, sid, "", ss)
+}
+
+// rememberInjectedFor is rememberInjected with the project the injection went
+// to, so recentlyInjectedInProject can count across agent sessions. Callers
+// that have no project pass the empty string and write the old three-field
+// line.
+func rememberInjectedFor(dir, sid, project string, ss []model.Session) {
 	if sid == "" {
 		return
 	}
@@ -579,7 +637,13 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 	}
 	stamp := time.Now().UTC().Format(time.RFC3339)
 	for _, s := range ss {
-		fmt.Fprintf(f, "%s %s %s\n", sid, s.ID, stamp)
+		if project == "" {
+			fmt.Fprintf(f, "%s %s %s\n", sid, s.ID, stamp)
+			continue
+		}
+		// The project has no spaces by the time it gets here — it is one
+		// candidate name, not a path — so the line stays field-separated.
+		fmt.Fprintf(f, "%s %s %s %s\n", sid, s.ID, stamp, project)
 	}
 }
 

--- a/cmd/deja/hook_prompt_project_cooldown_test.go
+++ b/cmd/deja/hook_prompt_project_cooldown_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func sessionsWithIDs(ids ...string) []model.Session {
+	out := make([]model.Session, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, model.Session{ID: id})
+	}
+	return out
+}
+
+// The per-prompt cooldown only ever counted the agent session it was called
+// from, so every new agent session started blank and the same past session was
+// served again. Measured over six weeks of a real log: 937 injections drawn
+// from 74 distinct sessions, 92% repeats, ten sessions carrying 80% of the
+// total (#2038).
+//
+// This pins the part that was missing rather than the ranking: what one agent
+// session was shown has to be visible to the next one working in the same
+// project.
+func TestTheCooldownOutlivesTheAgentSession(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	const project = "deja-vu"
+
+	rememberInjectedFor(dir, "agent-one", project, sessionsWithIDs("marathon", "other"))
+
+	// The next agent session knows nothing of the first one — that is the bug.
+	if got := recentlyInjected(dir, "agent-two", injectionCooldown); len(got) != 0 {
+		t.Fatalf("a fresh agent session already had a cooldown: %v", got)
+	}
+
+	got := recentlyInjectedInProject(dir, project, injectionCooldown)
+	if !got["marathon"] || !got["other"] {
+		t.Errorf("the project cooldown lost what the previous agent session was shown: %v", got)
+	}
+
+	// A different project is not the repetition being fixed, and must not be
+	// suppressed by it.
+	if other := recentlyInjectedInProject(dir, "some-other-repo", injectionCooldown); len(other) != 0 {
+		t.Errorf("the cooldown reached into another project: %v", other)
+	}
+}
+
+// Lines written before the project field existed carry three fields. They have
+// to be read past rather than guessed at, or every old entry would match the
+// first project asked about.
+func TestOldSeenLinesCarryNoProject(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	if err := os.WriteFile(dir+".hookseen", []byte("agent-one marathon 2026-08-01T00:00:00Z\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := recentlyInjectedInProject(dir, "deja-vu", injectionCooldown); len(got) != 0 {
+		t.Errorf("a line with no project matched a project: %v", got)
+	}
+	// The per-session cooldown still reads it, so nothing regresses for the
+	// agent session that wrote it.
+	if got := recentlyInjected(dir, "agent-one", injectionCooldown); !got["marathon"] {
+		t.Errorf("the old line stopped working for its own agent session: %v", got)
+	}
+}
+
+// The window is a window: a session shown long enough ago comes back, because
+// the same past work answers many questions across a day.
+func TestTheProjectCooldownIsAWindowNotABan(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	const project = "deja-vu"
+	rememberInjectedFor(dir, "agent-one", project, sessionsWithIDs("marathon"))
+	for i := 0; i < injectionCooldown; i++ {
+		rememberInjectedFor(dir, "agent-one", project, sessionsWithIDs("filler"))
+	}
+	if got := recentlyInjectedInProject(dir, project, injectionCooldown); got["marathon"] {
+		t.Error("a session pushed out of the window is still being skipped")
+	}
+}
+
+func TestTheSeenLineStaysFieldSeparated(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	rememberInjectedFor(dir, "agent-one", "deja-vu", sessionsWithIDs("marathon"))
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(b))
+	if n := len(strings.Fields(line)); n != 4 {
+		t.Fatalf("the line has %d fields, not four: %q", n, line)
+	}
+}

--- a/cmd/deja/hook_prompt_repeat_test.go
+++ b/cmd/deja/hook_prompt_repeat_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The repetition #2038 measured, at the level it actually happens: two agent
+// sessions asking the same thing in the same project. The cooldown used to be
+// keyed on the agent session id alone, so the second one started blank and was
+// handed the same past session again — 92% of per-prompt injections in six
+// weeks of a real log were repeats of 74 sessions.
+//
+// End-to-end rather than on the helpers, because the helpers passed with the
+// cooldown unwired.
+func TestASecondAgentSessionIsNotHandedTheSameMemory(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "repeatterm", []string{
+		`{"type":"user","sessionId":"repeatterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	ask := func(agentSession string) string {
+		t.Helper()
+		var out bytes.Buffer
+		in := strings.NewReader(`{"prompt":"do we need pgbouncer here","session_id":"` + agentSession + `"}`)
+		if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	first := ask("agent-one")
+	if !strings.Contains(first, "transaction mode") {
+		t.Fatalf("the first agent session got no memory, so there is nothing to repeat:\n%q", first)
+	}
+
+	second := ask("agent-two")
+	if strings.Contains(second, "transaction mode") {
+		t.Errorf("a second agent session in the same project was handed the same session again:\n%q", second)
+	}
+}

--- a/cmd/deja/hook_prompt_test.go
+++ b/cmd/deja/hook_prompt_test.go
@@ -175,14 +175,27 @@ func TestHookPromptCitationAndDedupe(t *testing.T) {
 	if out2.Len() != 0 {
 		t.Fatalf("repeat injection for same session: %q", out2.String())
 	}
-	// A different agent session still gets it.
+	// A different agent session in the same project does not get it again.
+	//
+	// This assertion used to read the other way, and that is what #2038
+	// measured: the cooldown was keyed on the agent session id alone, so every
+	// new session started blank and asked for the same memory. Six weeks of a
+	// real log showed 937 per-prompt injections drawn from 74 distinct
+	// sessions — 92% repeats, one session served 110 times. The agent is told
+	// to say nothing about a recall that did not help, so those servings bought
+	// silence.
 	var out3 bytes.Buffer
 	if err := runHookPrompt(index.DefaultDir(), strings.NewReader(`{"prompt":"exporter_batch utc_midnight rows again","session_id":"agent-2"}`), &out3); err != nil {
 		t.Fatal(err)
 	}
-	if out3.Len() == 0 {
-		t.Fatal("fresh session should still receive the memory")
+	if out3.Len() != 0 {
+		t.Fatalf("a second agent session in the same project was handed the same memory: %q", out3.String())
 	}
+
+	// The cooldown not reaching into another project is pinned as a unit in
+	// TestTheCooldownOutlivesTheAgentSession; it cannot be shown here, because
+	// per-prompt recall is project-scoped and a different directory has no
+	// matching history to withhold in the first place.
 }
 
 func TestAgentCreditsCountedFromIndex(t *testing.T) {


### PR DESCRIPTION
Closes #2038.

The per-prompt cooldown only ever counted the agent session it was called from
(`recentlyInjected` matched on `sid`), so a new agent session started blank and
asked for the same memory again. Six weeks of a real log: 937 per-prompt
injections drawn from **74 distinct sessions**, 92% repeats, one session served
110 times, ten sessions carrying 80% of the total. The two commonest are
marathons of 2.6M and 1.4M words, which match nearly any prompt.

That is not merely noise. The skill and both hook leads tell the agent to say
nothing about a recall that did not help, so the hundredth serving of the same
session buys silence — and `stats --impact` counts that silence as memory served
but not credited.

The cooldown now also counts what this **project** was served, across agent
sessions, over the same ten-injection window. Scoped to the project on purpose:
the same session answering in a different repository is not the repetition being
fixed.

Measured on the same corpus and the same twelve prompts, each from its own agent
session in one project:

```
before   12 injections   23 servings    3 distinct   87.0% repeats
after    11 injections   18 servings   13 distinct   27.8% repeats
```

Distinct sessions served went from 3 to 13. The cost is visible in the same
table and worth stating: one injection fewer and five servings fewer — we serve
slightly less, and what we serve is four times more varied.

`.hookseen` lines gain a fourth field. Lines written before this carry three and
match no project, which is the right answer for them rather than a guess.

`TestHookPromptCitationAndDedupe` asserted the old rule — "a different agent
session still gets it" — and now asserts the new one, with the measurement in
the comment rather than a silent flip. The end-to-end guard fails without the
wiring; the unit tests alone did not, which is why it exists.

Still open from #2038: the session-start hook writes no session ids to the log,
so its repetition cannot be measured at all.
