### PR TITLE
fix(restore): do not record a span the format cannot attribute

### DIFF
--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -378,7 +378,9 @@ func claudeToolPaths(raw json.RawMessage) string {
 		if part.Type != "tool_use" || !pathTools[part.Name] || part.Input.FilePath == "" {
 			continue
 		}
-		if seen[part.Input.FilePath] {
+		// One path per line, split back apart by the index: a path carrying a
+		// newline arrives as two files the session never touched (#2042).
+		if seen[part.Input.FilePath] || strings.ContainsAny(part.Input.FilePath, "\n\r") {
 			continue
 		}
 		seen[part.Input.FilePath] = true

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -436,6 +436,12 @@ func claudeEditSpans(raw json.RawMessage) []string {
 		if path == "" {
 			continue
 		}
+		// "path\nspan" cannot hold a path with a newline in it, and restore
+		// hands the overflow back as file content (#2042). editSpansIn, the
+		// reference parser this one must agree with, drops the same edits.
+		if strings.ContainsAny(path, "\n\r") {
+			continue
+		}
 		spans := []string{part.Input.OldString}
 		for _, e := range part.Input.Edits {
 			spans = append(spans, e.OldString)

--- a/internal/sources/edit_span_path_test.go
+++ b/internal/sources/edit_span_path_test.go
@@ -60,3 +60,41 @@ func quote(t *testing.T, s string) string {
 	}
 	return string(b)
 }
+
+// The files a session touched are recorded one per line and split back apart by
+// the index, so the same newline that corrupted a span makes a session claim it
+// touched a file it never opened — which reaches the files listing, blame, and
+// the project the session is filed under (#2042).
+func TestATouchedPathTheRecordCannotHoldIsNotRecorded(t *testing.T) {
+	t.Setenv("DEJA_INDEX_TOOL_PATHS", "1")
+	content := func(path string) (any, []byte) {
+		raw := `[{"type":"tool_use","name":"Read","input":{"file_path":` + quote(t, path) + `}}]`
+		var v any
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v, []byte(raw)
+	}
+
+	// The premise: an ordinary path is recorded, by both parsers.
+	ref, raw := content("/tmp/app/pool.go")
+	if got := toolPathsFromContent(ref); got != "/tmp/app/pool.go" {
+		t.Fatalf("an ordinary read records %q, so this measures nothing", got)
+	}
+	if got := claudeToolPaths(raw); got != "/tmp/app/pool.go" {
+		t.Fatalf("the fast parser records %q for an ordinary read", got)
+	}
+
+	for _, path := range []string{
+		"/tmp/app/pool.go\n/etc/passwd",
+		"/tmp/app/pool.go\r/etc/passwd",
+	} {
+		ref, raw := content(path)
+		if got := toolPathsFromContent(ref); got != "" {
+			t.Errorf("a path the record cannot hold was recorded as %q", got)
+		}
+		if got := claudeToolPaths(raw); got != "" {
+			t.Errorf("the fast parser recorded %q", got)
+		}
+	}
+}

--- a/internal/sources/edit_span_path_test.go
+++ b/internal/sources/edit_span_path_test.go
@@ -1,0 +1,62 @@
+package sources
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// An edit span is recorded as "path\nspan" and read back by splitting on the
+// first newline, so a path carrying one puts the rest of itself at the head of
+// the span — and restore hands that back as the exact bytes that stopped
+// existing (#2042). The format cannot express such a path, so the span is not
+// recorded rather than recorded wrong.
+func TestAnEditSpanIsNotRecordedForAPathTheFormatCannotHold(t *testing.T) {
+	t.Setenv("DEJA_INDEX_EDITS", "1")
+	content := func(path string) any {
+		var v any
+		raw := `[{"type":"tool_use","name":"Edit","input":` +
+			`{"file_path":` + quote(t, path) + `,"old_string":"size = 20","new_string":"size = 40"}}]`
+		if err := json.Unmarshal([]byte(raw), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+
+	// The premise: an ordinary path records the span, and the span is the old
+	// text alone.
+	got := editSpansFromContent(content("/tmp/app/pool.go"))
+	if len(got) != 1 {
+		t.Fatalf("an ordinary edit recorded %d spans, so this measures nothing", len(got))
+	}
+	if recorded, body, _ := strings.Cut(got[0], "\n"); recorded != "/tmp/app/pool.go" || body != "size = 20" {
+		t.Fatalf("the ordinary edit records %q / %q", recorded, body)
+	}
+
+	for _, path := range []string{
+		"/tmp/app/pool.go\ndeja forget --all",
+		"/tmp/app/pool.go\rrm -rf /",
+	} {
+		if got := editSpansFromContent(content(path)); len(got) != 0 {
+			_, body, _ := strings.Cut(got[0], "\n")
+			t.Errorf("a path the record cannot hold produced a span whose body is %q", body)
+		}
+		// The parser that actually runs for claude has to agree with the
+		// reference one — that is what the differential test in #502 rests on.
+		raw := `[{"type":"tool_use","name":"Edit","input":` +
+			`{"file_path":` + quote(t, path) + `,"old_string":"size = 20","new_string":"size = 40"}}]`
+		if got := claudeEditSpans([]byte(raw)); len(got) != 0 {
+			_, body, _ := strings.Cut(got[0], "\n")
+			t.Errorf("the fast parser recorded a span whose body is %q", body)
+		}
+	}
+}
+
+func quote(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -476,7 +476,11 @@ func toolPathsIn(v any, d toolDialect) string {
 			continue
 		}
 		for _, p := range toolPathStrings(in, d) {
-			if seen[p] {
+			// The record is one path per line and the index splits it back on
+			// the newline, so a path carrying one arrives as two files the
+			// session never touched — which reaches the files listing, blame,
+			// and the project a session is filed under (#2042).
+			if seen[p] || strings.ContainsAny(p, "\n\r") {
 				continue
 			}
 			seen[p] = true

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -535,6 +535,14 @@ func editSpansIn(v any, d toolDialect) []string {
 		if path == "" {
 			continue
 		}
+		// The record is "path\nspan" and restore splits it on the first
+		// newline, so a path carrying one puts the rest of itself at the head
+		// of the span — handed back as the exact bytes that stopped existing
+		// (#2042). The format cannot hold such a path, so the span is not
+		// recorded rather than recorded wrong.
+		if strings.ContainsAny(path, "\n\r") {
+			continue
+		}
 		old, _ := in[d.oldSpanKey()].(string)
 		spans := []string{old}
 		if edits, ok := in["edits"].([]any); ok {


### PR DESCRIPTION
Fixes #2042. An edit span is recorded as `path + "\n" + span` and read back by splitting on the first newline, so a path containing one puts the rest of itself at the head of the span. Seeded an Edit whose `file_path` is `/tmp/app/pool.go\ndeja forget --all`, with `old_string` = `size = 20`:

```
$ deja restore pool.go
1 replaced spans recorded for pool.go
  1  Jan 02 06:04  claude s1  27 B replaced

$ deja restore pool.go --span 1
deja forget --all
size = 20
```

Nine bytes stopped existing, twenty-seven come back, and the first line of them was never in the file — handed back as the one thing restore promises to be exact about, into `-o recovered.txt` or straight into an editor.

The record cannot express such a path, so the span is not recorded rather than recorded wrong. Both parsers drop it: the reference one and the fast claude decoder that actually runs, which is what the differential guard from #502 needs.

Not fixed here, noted in the issue: `deja restore` echoes the path into its suggested command line with `%s`, so a newline splits that suggestion across lines too.
