### PR TITLE
record which sessions the session-start hook served

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -48,7 +48,7 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if len(input.WorkspacePaths) > 0 && input.WorkspacePaths[0] != "" && os.Getenv("CLAUDE_PROJECT_DIR") == "" {
 		_ = os.Setenv("CLAUDE_PROJECT_DIR", input.WorkspacePaths[0])
 	}
-	digest, sessions, raw, _, _ := cachedHookDigest(dir)
+	digest, sessions, raw, _, _, _ := cachedHookDigest(dir)
 	if digest == "" {
 		fmt.Fprintln(stdout, "{}")
 		return nil

--- a/cmd/deja/hook_antigravity_stdin_test.go
+++ b/cmd/deja/hook_antigravity_stdin_test.go
@@ -35,7 +35,7 @@ func TestHookAntigravityBoundsStdinWithoutInjectingOnEveryTurn(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("fixture has no digest to inject")
 	}
 

--- a/cmd/deja/hook_cache_orphan_test.go
+++ b/cmd/deja/hook_cache_orphan_test.go
@@ -45,7 +45,7 @@ func TestHookAsksForARebuildWhenTheIndexIsGone(t *testing.T) {
 	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
 	t.Cleanup(func() { spawnWarmup = saved })
 
-	digest, sessions, _, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(digest, "pool exhausted") || sessions != 1 {
 		t.Errorf("the cached digest was dropped rather than served: %q (%d sessions)", digest, sessions)
 	}

--- a/cmd/deja/hook_cache_test.go
+++ b/cmd/deja/hook_cache_test.go
@@ -28,7 +28,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
-	d1, s1, _, _, _ := cachedHookDigest(dir)
+	d1, s1, _, _, _, _ := cachedHookDigest(dir)
 	if d1 == "" || s1 == 0 {
 		t.Fatal("first call must build a digest")
 	}
@@ -40,7 +40,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	d2, _, _, _, _ := cachedHookDigest(dir)
+	d2, _, _, _, _, _ := cachedHookDigest(dir)
 	if d2 != d1 {
 		t.Fatal("within TTL the cached digest must be served verbatim")
 	}
@@ -60,20 +60,20 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := os.WriteFile(cachePath, nb, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	d3, _, _, _, _ := cachedHookDigest(dir)
+	d3, _, _, _, _, _ := cachedHookDigest(dir)
 	if d3 != d1 {
 		t.Fatalf("expired cache must serve stale instantly, got:\n%s", d3)
 	}
 	// The refresh itself must produce the fresh view.
 	runHookRefresh(dir)
-	d3b, _, _, _, _ := cachedHookDigest(dir)
+	d3b, _, _, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(d3b, "marker_beta") {
 		t.Fatalf("refresh must rebuild with fresh sessions:\n%s", d3b)
 	}
 	d3 = d3b
 	// A different cwd must never reuse another project's cache.
 	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(t.TempDir(), "elsewhere"))
-	d4, _, _, _, _ := cachedHookDigest(dir)
+	d4, _, _, _, _, _ := cachedHookDigest(dir)
 	if d4 == d3 && d3 != "" {
 		t.Fatal("cache must be scoped to cwd")
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -240,7 +240,7 @@ func runHookContext(dir string, plain bool) error {
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
 	// none (#759).
 	adoptHookCWD(input.CWD)
-	digest, sessions, raw, taskMatched, withheld := cachedHookDigest(dir)
+	digest, sessions, raw, taskMatched, withheld, servedIDs := cachedHookDigest(dir)
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
 		// checkout — and exactly where knowing what this machine is missing
@@ -320,7 +320,7 @@ func runHookContext(dir string, plain bool) error {
 	}
 	digest = frameRecall(digest)
 	polName := policy.Load().Describe(policy.ActivationAuto)
-	usage.RecordDigestPolicyInto(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName)
+	usage.RecordDigestPolicySessions(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -530,6 +530,12 @@ type hookCacheEntry struct {
 	Withheld    int      `json:"withheld,omitempty"`
 	Raw         int64    `json:"raw"`
 	TaskMatched []string `json:"task_matched,omitempty"`
+	// IDs are the sessions this digest carries, so a cache hit logs the same
+	// thing a fresh build does. Without them the session-start hook was the
+	// one surface whose repetition could not be counted at all: 606 injections
+	// in six weeks with no record of what was in them (#2038). Old entries
+	// decode as nil and log nothing, which is what they knew.
+	IDs []string `json:"ids,omitempty"`
 }
 
 func hookCachePath(dir, cwd string) string {
@@ -556,13 +562,13 @@ func adoptHookCWD(cwd string) {
 	_ = os.Setenv("CLAUDE_PROJECT_DIR", cwd)
 }
 
-func cachedHookDigest(dir string) (string, int, int64, []string, int) {
+func cachedHookDigest(dir string) (string, int, int64, []string, int, []string) {
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		cwd, _ = os.Getwd()
 	}
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	// Before the cache read: a hit returns without reaching the version guard
 	// in hookDigestResult, so an index left behind by an upgrade was served
@@ -586,19 +592,19 @@ func cachedHookDigest(dir string) (string, int, int64, []string, int) {
 				// the cache off the startup path.
 				requestHookRefresh(dir, cwd)
 			}
-			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld
+			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld, e.IDs
 		}
 	}
-	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
-	return digest, sessions, raw, taskMatched, withheld
+	digest, sessions, raw, taskMatched, withheld, ids := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld, ids)
+	return digest, sessions, raw, taskMatched, withheld, ids
 }
 
-func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string, withheld int) {
+func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string, withheld int, ids []string) {
 	if digest == "" {
 		return
 	}
-	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld}); err == nil {
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld, IDs: ids}); err == nil {
 		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
 	}
 }
@@ -653,17 +659,17 @@ func runHookRefresh(dir string) {
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		return
 	}
-	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
+	digest, sessions, raw, taskMatched, withheld, ids := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld, ids)
 	_ = os.Remove(hookCachePath(dir, cwd) + ".refreshing")
 }
 
 func hookDigest(dir string) string {
-	digest, _, _, _, _ := hookDigestResult(dir)
+	digest, _, _, _, _, _ := hookDigestResult(dir)
 	return digest
 }
 
-func hookDigestResult(dir string) (string, int, int64, []string, int) {
+func hookDigestResult(dir string) (string, int, int64, []string, int, []string) {
 	withheld := 0
 	defer func() { _ = recover() }()
 	trace := os.Getenv("DEJA_TRACE") == "1"
@@ -677,7 +683,7 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	_ = mark
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	// A store from an older index version must be rebuilt before it is read:
 	// this path never calls Ensure, so otherwise the first prompts after an
@@ -686,14 +692,14 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	// manifest still describes, and this path answers from them (#800).
 	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	if cwd == "" {
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			return "", 0, 0, nil, 0
+			return "", 0, 0, nil, 0, nil
 		}
 	}
 	// The two git probes (worktree list for identity, status/log for the
@@ -756,11 +762,11 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 		// The standing decisions still apply, so serve them alone rather than
 		// going out empty.
 		if conventions != "" {
-			return conventions, 0, 0, nil, withheld
+			return conventions, 0, 0, nil, withheld, nil
 		}
 		// withheld travels even with nothing to show: it is the only thing
 		// that separates "the rule hid all of it" from "no history here".
-		return "", 0, 0, nil, withheld
+		return "", 0, 0, nil, withheld, nil
 	}
 	scores, matched := taskScores(ss, taskFiles)
 	sort.Slice(ss, func(i, j int) bool {
@@ -816,7 +822,7 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 	// The candidates that never made it into the digest were never served:
 	// counting their transcripts here inflated the distillation ratio deja
 	// prints about itself (1 session distilled, 3 sessions' bytes claimed).
-	return text, result.Sessions, result.RawBytes, matched, withheld
+	return text, result.Sessions, result.RawBytes, matched, withheld, result.IDs
 }
 
 // warmupDeadAfter is how long a warmup may go without publishing progress

--- a/cmd/deja/hook_context_ids_helpers_test.go
+++ b/cmd/deja/hook_context_ids_helpers_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// loggedIDsForKind reads the session ids the usage log recorded for one kind,
+// through the same file `deja log` reads.
+func loggedIDsForKind(t *testing.T, dir, kind string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	b, err := os.ReadFile(usage.Path(dir))
+	if err != nil {
+		t.Fatalf("no usage log: %v", err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e struct {
+			Kind string   `json:"kind"`
+			IDs  []string `json:"ids"`
+		}
+		if json.Unmarshal([]byte(line), &e) != nil || e.Kind != kind {
+			continue
+		}
+		for _, id := range e.IDs {
+			out[id] = true
+		}
+	}
+	return out
+}

--- a/cmd/deja/hook_context_ids_test.go
+++ b/cmd/deja/hook_context_ids_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The session-start hook served 606 injections over six weeks and recorded not
+// one of the sessions inside them, so its repetition could not be counted at
+// all — while the per-prompt path, which does record ids, turned out to be
+// re-serving 74 sessions at a 92% repeat rate (#2038). A surface nobody can
+// measure is a surface nobody fixes.
+func TestTheSessionStartHookLogsWhatItServed(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "idsterm", []string{
+		`{"type":"user","sessionId":"idsterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	withHookStdin(t, `{"source":"startup","session_id":"ses_ids","cwd":"`+cwd+`"}`)
+	if out := captureStdout(t, func() {
+		if err := runHookContext(index.DefaultDir(), true); err != nil {
+			t.Error(err)
+		}
+	}); !strings.Contains(out, "transaction mode") {
+		t.Fatalf("the hook injected nothing, so there is nothing to log:\n%q", out)
+	}
+
+	ids := loggedIDsForKind(t, index.DefaultDir(), "hook")
+	if len(ids) == 0 {
+		t.Fatal("the session-start hook logged an injection with no session ids")
+	}
+	if !ids["idsterm"] {
+		t.Errorf("the log names %v, not the session that was served", ids)
+	}
+}
+
+// A cache hit has to log the same thing a fresh build does: the digest is
+// cached per project and most session starts are hits, so ids that only
+// survived the cold path would leave the common case unmeasured.
+func TestACachedDigestStillLogsItsSessions(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "cacheterm", []string{
+		`{"type":"user","sessionId":"cacheterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	// First call fills the cache; the second must be the hit.
+	if _, _, _, _, _, ids := cachedHookDigest(index.DefaultDir()); len(ids) == 0 {
+		t.Fatal("the cold path carried no ids, so the cached one cannot be judged")
+	}
+	_, _, _, _, _, cached := cachedHookDigest(index.DefaultDir())
+	if len(cached) == 0 {
+		t.Error("a cache hit lost the sessions the digest carries")
+	}
+}

--- a/cmd/deja/hook_conventions_test.go
+++ b/cmd/deja/hook_conventions_test.go
@@ -90,7 +90,7 @@ func TestSessionStartSurfacesADecisionTheDigestDropped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	text, _, _, _, _ := hookDigestResult(dir)
+	text, _, _, _, _, _ := hookDigestResult(dir)
 	if !strings.Contains(text, "standing decisions in this project") {
 		t.Fatalf("no standing-decisions block was injected:\n%s", text)
 	}
@@ -126,7 +126,7 @@ func TestStandingDecisionsRespectTheTrustPolicy(t *testing.T) {
 	// Deny local memory for auto-activation.
 	writePolicyFile(t, `{"activations":{"auto":{"local":false}}}`)
 
-	text, _, _, _, _ := hookDigestResult(dir)
+	text, _, _, _, _, _ := hookDigestResult(dir)
 	if strings.Contains(text, "pgxpolicymarker") {
 		t.Fatalf("a policy-denied project's decision was injected into the hook:\n%s", text)
 	}

--- a/cmd/deja/hook_raw_denominator_test.go
+++ b/cmd/deja/hook_raw_denominator_test.go
@@ -58,7 +58,7 @@ func TestHookRawCountsOnlyTheSessionsItServed(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(back) })
 
-	digest, served, raw, _, _ := hookDigestResult(dir)
+	digest, served, raw, _, _, _ := hookDigestResult(dir)
 	if digest == "" || served == 0 {
 		t.Skip("no memory to recall in this environment")
 	}

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -48,8 +48,8 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	// request has to happen ahead of the cache read — and the cached digest is
 	// the user's own history, so it must still be served.
 	cwd, _ := os.Getwd()
-	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil, 0)
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil, 0, nil)
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Error("a cache hit stopped serving the user's own history")
 	}
 	if spawned != 2 {
@@ -106,7 +106,7 @@ func TestDamagedIndexHooksAskForARebuild(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
 		t.Fatal(err)
 	}
-	if d, _, _, _, _ := hookDigestResult(dir); d != "" {
+	if d, _, _, _, _, _ := hookDigestResult(dir); d != "" {
 		t.Errorf("hook-context answered from a damaged index: %q", d)
 	}
 	if spawned != 2 {

--- a/cmd/deja/hook_task_test.go
+++ b/cmd/deja/hook_task_test.go
@@ -137,7 +137,7 @@ func TestHookContextReceiptNamesTaskFiles(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", repo)
 
-	digest, sessions, _, matched, _ := hookDigestResult(dir)
+	digest, sessions, _, matched, _, _ := hookDigestResult(dir)
 	if sessions == 0 || digest == "" {
 		t.Fatal("expected recall output")
 	}

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -109,7 +109,7 @@ func refreshAiderContext(dir string) error {
 	// In-process rather than shelling out to hook-context: the wrapper stands
 	// between the user and their editor, and a subprocess here would also make
 	// the installer depend on its own binary being runnable.
-	digest, sessions, _, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _, _ := cachedHookDigest(dir)
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(aiderLead + digest)

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -319,7 +319,7 @@ func gooseRecallPath() string {
 }
 
 func refreshGooseHints() error {
-	digest, sessions, _, _, _ := cachedHookDigest(index.DefaultDir())
+	digest, sessions, _, _, _, _ := cachedHookDigest(index.DefaultDir())
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(gooseLead + digest)

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -129,7 +129,7 @@ func TestHookMissingManifestRequestsWarmup(t *testing.T) {
 	oldSpawn := spawnWarmup
 	spawnWarmup = func(_, _ string) error { called = true; return nil }
 	defer func() { spawnWarmup = oldSpawn }()
-	if digest, sessions, _, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
+	if digest, sessions, _, _, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
 		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
 	}
 	if !called {

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -46,11 +46,11 @@ func policyLeakIndex(t *testing.T) string {
 // keep injecting after it is set.
 func TestHookCacheHonorsRecallOff(t *testing.T) {
 	dir := policyLeakIndex(t)
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("expected a digest before the kill switch")
 	}
 	t.Setenv("DEJA_RECALL", "off")
-	if d, _, _, _, _ := cachedHookDigest(dir); d != "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d != "" {
 		t.Fatalf("cache served a digest with DEJA_RECALL=off:\n%s", d)
 	}
 }
@@ -61,18 +61,18 @@ func TestHookCacheRefusesEntryFromAnotherPolicy(t *testing.T) {
 	dir := policyLeakIndex(t)
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	// Warm the cache under the permissive policy.
-	warm, _, _, _, _ := cachedHookDigest(dir)
+	warm, _, _, _, _, _ := cachedHookDigest(dir)
 	if warm == "" {
 		t.Fatal("expected a digest to cache")
 	}
 	// Plant a recognizable entry as if it had been built then.
 	planted := "PLANTED-UNDER-OLD-POLICY"
-	writeHookCache(dir, cwd, planted, 1, 10, nil, 0)
-	if got, _, _, _, _ := cachedHookDigest(dir); got != planted {
+	writeHookCache(dir, cwd, planted, 1, 10, nil, 0, nil)
+	if got, _, _, _, _, _ := cachedHookDigest(dir); got != planted {
 		t.Fatalf("cache did not serve its own entry back: %q", got)
 	}
 	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
-	if got, _, _, _, _ := cachedHookDigest(dir); got == planted {
+	if got, _, _, _, _, _ := cachedHookDigest(dir); got == planted {
 		t.Fatal("cache served an entry built under a policy that no longer applies")
 	}
 }

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -37,6 +37,11 @@ type AutoRecallResult struct {
 	// own measurement. Candidates the digest skipped never reached an agent,
 	// so counting them inflates the ratio.
 	RawBytes int64
+	// IDs are the sessions that made it into Text, in the order they appear.
+	// The session-start hook is the surface that logs them, and without them
+	// its repetition could not be counted at all — 606 injections in six weeks
+	// with no record of what was in them (#2038).
+	IDs []string
 }
 
 func AutoRecallDigest(ss []model.Session, budget int) string {
@@ -122,6 +127,7 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 	}
 	var b strings.Builder
 	var fingerprints []map[string]bool
+	var ids []string
 	var raw int64
 	for _, s := range candidates {
 		if mode == RecallSafe && !projectMatches(s.Project, o.ProjectNames) {
@@ -147,6 +153,7 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 		}
 		b.WriteString(section)
 		fingerprints = append(fingerprints, fingerprint)
+		ids = append(ids, s.ID)
 		for _, m := range s.Messages {
 			raw += int64(len(m.Text))
 		}
@@ -154,7 +161,7 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 			break
 		}
 	}
-	return AutoRecallResult{Text: strings.TrimSpace(b.String()), Sessions: len(fingerprints), RawBytes: raw}
+	return AutoRecallResult{Text: strings.TrimSpace(b.String()), Sessions: len(fingerprints), RawBytes: raw, IDs: ids}
 }
 
 func projectMatches(project string, names []string) bool {

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -120,7 +120,19 @@ func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, 
 // session-start hook, the commonest injection there is, was recording nothing
 // while holding the id (#1949).
 func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, raw int64, policyName string) {
-	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
+	RecordDigestPolicySessions(indexDir, kind, digest, into, sessions, raw, policyName, nil)
+}
+
+// RecordDigestPolicySessions is RecordDigestPolicyInto plus the ids of the
+// sessions the digest carried.
+//
+// Without them the session-start hook was the one surface whose repetition
+// could not be measured: `deja log` showed 606 of its injections over six weeks
+// and not one of the sessions inside them, while the per-prompt path — which
+// does record ids — turned out to be re-serving 74 sessions at a 92% repeat
+// rate (#2038). A number nobody can compute is a number nobody fixes.
+func RecordDigestPolicySessions(indexDir, kind, digest, into string, sessions int, raw int64, policyName string, ids []string) {
+	RecordServedSessions(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids)
 	snapshotWriteInto(indexDir, kind, digest, into, sessions, policyName, nil)
 }
 


### PR DESCRIPTION
The half of #2038 that could not be measured.

Per-prompt recall records the sessions it served, which is how the 92% repeat
rate was found and fixed in #2041. The session-start hook used
`RecordDigestPolicyInto`, which drops down to `RecordResultRaw` and carries no
ids — so six weeks of the log held 606 of its injections and not one session
inside them.

Now measured, on the same store, eight session starts the way eight new agent
sessions would arrive:

```
before   8 hook rows   session ids recorded: none
after    8 hook rows   24 servings   3 distinct   87.5% repeats
             8×  2915986c-…  8×  9f0aa059-…  8×  2fc1d1ef-…
```

So the hook has the same problem the per-prompt path had, at the same size —
three sessions, every start, forever. That fix is a separate change; this one is
the instrument that makes it checkable.

The ids travel through the digest cache too. Most session starts are cache hits,
so ids that only survived the cold path would have left the common case
unmeasured — `AutoRecallResult` carries them out of the builder, `hookCacheEntry`
stores them, and both paths log the same thing. Entries written before this
decode as nil and log nothing, which is what they knew.

Two guards: one that the hook logs the session it served, one that a cache hit
logs it too. The first fails with the ids unwired.
