### PR TITLE
fix(hook): read the exit status as the suffix it is written as

### DIFF
--- a/cmd/deja/compact.go
+++ b/cmd/deja/compact.go
@@ -54,7 +54,7 @@ func compactEvidence(dir, sessionID, cwd string) string {
 	// wrote into the payload, escape bytes included (#2000).
 	files := lastDistinct(s.Messages, "files", compactEvidenceFiles,
 		func(text string) []string { return strings.Split(text, "\n") },
-		func(p string) string { return search.SafeLine(trimPath(p)) })
+		func(p string) string { return search.SafePath(trimPath(p)) })
 	commands := lastDistinct(s.Messages, "command", compactEvidenceCommands,
 		func(text string) []string {
 			// A multi-line command is a heredoc or a pasted script. Truncated to

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -570,7 +570,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 		// A store path can come from the environment (DEJA_NOTES_FILE) or from
 		// disk. On a fixed-width row a newline in it prints a line of its own
 		// that reads as one of doctor's.
-		line := fmt.Sprintf("  %-12s %-9s %s", name, status, search.SafeLine(path))
+		line := fmt.Sprintf("  %-12s %-9s %s", name, status, search.SafePath(path))
 		if detail != "" {
 			line += "  (" + detail + ")"
 		}

--- a/cmd/deja/exit_marker_test.go
+++ b/cmd/deja/exit_marker_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+// The exit status is a suffix a source appends — two spaces, the marker, digits,
+// end of string. Reading it back with a search for the marker anywhere cut a
+// command that merely mentioned it, and called the command a failure because the
+// code it parsed was `0"` (#2048).
+func TestTheExitMarkerIsReadAsASuffix(t *testing.T) {
+	for _, c := range []struct {
+		name, cmd, want string
+		ok              bool
+	}{
+		{"a recorded success", "go test ./...  → exit 0", "go test ./...", true},
+		{"a recorded failure", "go test ./...  → exit 1", "go test ./...", false},
+		{"nothing recorded", "go test ./...", "go test ./...", true},
+		{"the command says it", `echo "→ exit 0"`, `echo "→ exit 0"`, true},
+		{"and says it while failing", `echo "→ exit 0"  → exit 1`, `echo "→ exit 0"`, false},
+		{"a grep for the marker", `grep -n "→ exit " log.txt  → exit 0`, `grep -n "→ exit " log.txt`, true},
+		{"a code that is not a number", "go test ./...  → exit later", "go test ./...  → exit later", true},
+		{"a many-digit code", "go test ./...  → exit 130", "go test ./...", false},
+	} {
+		got, ok := withoutFailedExit(c.cmd)
+		if got != c.want || ok != c.ok {
+			t.Errorf("%s: withoutFailedExit(%q) = %q, %v; want %q, %v", c.name, c.cmd, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/cmd/deja/exit_marker_test.go
+++ b/cmd/deja/exit_marker_test.go
@@ -11,11 +11,14 @@ func TestTheExitMarkerIsReadAsASuffix(t *testing.T) {
 		name, cmd, want string
 		ok              bool
 	}{
+		// Neither writer emits a zero — both guard on code > 0 — so this row
+		// pins the reader's rule rather than a shape found on disk.
 		{"a recorded success", "go test ./...  → exit 0", "go test ./...", true},
 		{"a recorded failure", "go test ./...  → exit 1", "go test ./...", false},
 		{"nothing recorded", "go test ./...", "go test ./...", true},
 		{"the command says it", `echo "→ exit 0"`, `echo "→ exit 0"`, true},
 		{"and says it while failing", `echo "→ exit 0"  → exit 1`, `echo "→ exit 0"`, false},
+		// This one held before the fix too: LastIndex already found the suffix.
 		{"a grep for the marker", `grep -n "→ exit " log.txt  → exit 0`, `grep -n "→ exit " log.txt`, true},
 		{"a code that is not a number", "go test ./...  → exit later", "go test ./...  → exit later", true},
 		{"a many-digit code", "go test ./...  → exit 130", "go test ./...", false},

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -419,7 +419,7 @@ var repoCheck sync.Map
 // and those bytes print as nothing, so measuring the path with them still in
 // it spends the budget the file name needs.
 func filesRowPath(p string, col int) string {
-	return trimPathTo(search.SafeLine(trimPath(p)), col)
+	return trimPathTo(search.SafePath(trimPath(p)), col)
 }
 
 // trimPathTo bounds a path to a column width, cutting from the left so the

--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -413,7 +413,7 @@ var repoCheck sync.Map
 // filesRowPath is what one row shows: the head removed, what the terminal acts
 // on removed, and the rest bounded to the column.
 //
-// SafeLine comes before the bound, not after. A file name can hold an escape
+// SafePath comes before the bound, not after. A file name can hold an escape
 // or a carriage return — recorded from the tool call verbatim, and #1090
 // stripped them from the other reading surfaces while this row was missed —
 // and those bytes print as nothing, so measuring the path with them still in

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -307,7 +307,7 @@ func fileHookLine(dir, path string) string {
 	// The line-safe form: the name lands inside the hook's own sentence, and a
 	// newline in it would end that sentence and start one that reads as deja
 	// speaking to the agent (#1863).
-	name := search.SafeLine(baseName(path))
+	name := search.SafePath(baseName(path))
 	head := fmt.Sprintf("%s has been worked on in %s%s", name, toolSessionCount(sessions), when)
 	// The measured difference between a nudge that changes what an agent does
 	// and one it ignores is whether it carries the decision or only points at

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -302,13 +302,31 @@ func fixLine(p index.FixPair) string {
 	return "deja: this error came up here before" + when + " — what followed it: " + cmd
 }
 
+// exitMarker is the shape a source appends when it knows what a command
+// returned: two spaces, the marker, the digits, end of string
+// (internal/sources/codex.go:259, internal/sources/opencode.go:202).
+const exitMarker = "  → exit "
+
 // withoutFailedExit drops the recorded exit status from a command, and reports
 // false when that status says the command failed.
+//
+// Only a suffix of that exact shape counts. Looking for the marker anywhere cut
+// `echo "→ exit 0"` down to `echo "` and called it a failure, because the code
+// it read was `0"` — a command that mentions deja's own marker is still just a
+// command (#2048).
 func withoutFailedExit(cmd string) (string, bool) {
-	i := strings.LastIndex(cmd, "→ exit ")
+	i := strings.LastIndex(cmd, exitMarker)
 	if i < 0 {
 		return cmd, true
 	}
-	code := strings.TrimSpace(cmd[i+len("→ exit "):])
+	code := cmd[i+len(exitMarker):]
+	if code == "" {
+		return cmd, true
+	}
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			return cmd, true
+		}
+	}
 	return strings.TrimSpace(cmd[:i]), code == "0"
 }

--- a/cmd/deja/path_round_trip_test.go
+++ b/cmd/deja/path_round_trip_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// What deja prints for a file has to be what deja can find again. A name with
+// two spaces came back with one, and restoring the printed path found nothing
+// deja had just listed (#2044).
+func TestAPrintedPathFindsItsOwnSpan(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	dir := filepath.Join(claude, "-tmp-app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_INDEX_TOOL_PATHS", "1")
+	t.Setenv("DEJA_INDEX_EDITS", "1")
+
+	path := "/tmp/app/two  spaces.go"
+	rec := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	body := rec(map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:05Z",
+		"message":   map[string]any{"role": "user", "content": "raise the pool size"},
+	}) + "\n" + rec(map[string]any{
+		"type": "assistant", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:06Z",
+		"message": map[string]any{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "Read", "input": map[string]any{"file_path": path}},
+			map[string]any{"type": "tool_use", "name": "Edit", "input": map[string]any{
+				"file_path": path, "old_string": "size = 20", "new_string": "size = 40"}},
+		}},
+	}) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "index"); err != nil {
+		t.Fatalf("index: %v %s", err, out)
+	}
+
+	blamed, err := captureRun(t, "blame", "two  spaces.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: blame found the file at all, or there is no printed path to
+	// carry anywhere.
+	printed := ""
+	for _, line := range strings.Split(blamed, "\n") {
+		if f := strings.TrimSpace(line); strings.HasSuffix(f, "spaces.go") {
+			printed = f
+			break
+		}
+	}
+	if printed == "" {
+		t.Fatalf("blame printed no path for the file:\n%s", blamed)
+	}
+
+	out, err := captureRun(t, "restore", printed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "1 replaced spans recorded") {
+		t.Errorf("restoring the path blame printed (%q) found nothing:\n%s", printed, out)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -179,7 +179,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if exportPath != "" {
 		// The path is whatever the caller passed. A newline in it ends this
 		// line and starts one of the caller's that reads as deja's own output.
-		fmt.Fprintf(stdout, "exported to %s\n", search.SafeLine(exportPath))
+		fmt.Fprintf(stdout, "exported to %s\n", search.SafePath(exportPath))
 	}
 	// The id deja resolved, not the one the reader typed: a prefix that stood
 	// for several sessions would send the correction to whichever is newest —

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -193,7 +193,7 @@ func runStats(dir string, args []string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stdout, search.SafeLine(path))
+		fmt.Fprintln(os.Stdout, search.SafePath(path))
 		return nil
 	}
 	if jsonOut {

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -185,7 +185,7 @@ func runStats(dir string, args []string) error {
 			return err
 		}
 		base := filepath.Base(path)
-		fmt.Fprintf(os.Stdout, "saved %s\n\nshare it — paste into a README or post:\n  ![deja](%s)\n", search.SafeLine(path), search.SafeLine(base))
+		fmt.Fprintf(os.Stdout, "saved %s\n\nshare it — paste into a README or post:\n  ![deja](%s)\n", search.SafePath(path), search.SafePath(base))
 		return nil
 	}
 	if htmlPath != "" {

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -133,21 +133,21 @@ func runSync(dir string, args []string) error {
 			if p := deniedPath(err); p != "" && !strings.HasPrefix(p, out) &&
 				(errors.Is(err, fs.ErrPermission) || writeFailureReason(err) != err.Error()) {
 				if n > 0 {
-					return fmt.Errorf("%d records are written into %s, but deja could not record that they went: %w; the next export sends them again", n, search.SafeLine(out), ensureError(dir, err))
+					return fmt.Errorf("%d records are written into %s, but deja could not record that they went: %w; the next export sends them again", n, search.SafePath(out), ensureError(dir, err))
 				}
 				return ensureError(dir, err)
 			}
 			if parent := filepath.Dir(out); !dirExists(out) && !dirExists(parent) {
-				return fmt.Errorf("cannot write the export into %s — %s is not there; the disk it lives on may have been unmounted", search.SafeLine(out), search.SafeLine(parent))
+				return fmt.Errorf("cannot write the export into %s — %s is not there; the disk it lives on may have been unmounted", search.SafePath(out), search.SafePath(parent))
 			}
 			if errors.Is(err, fs.ErrPermission) {
-				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", search.SafeLine(out))
+				return fmt.Errorf("cannot write the export into %s — check that directory's permissions, or choose one you can write", search.SafePath(out))
 			}
 			// A full or vanished disk in the same words as everywhere else
 			// (#906); anything deja does not recognise still comes through
 			// whole rather than being guessed at.
 			if reason := writeFailureReason(err); reason != err.Error() {
-				return fmt.Errorf("cannot write the export into %s — %s", search.SafeLine(out), reason)
+				return fmt.Errorf("cannot write the export into %s — %s", search.SafePath(out), reason)
 			}
 			return err
 		}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -716,7 +716,7 @@ func restoreMap[V any](live, saved map[string]V) {
 // fail (#1847). The directory beside it has been sanitised since it was first
 // printed; the file was not.
 func batchName(path string) string {
-	return search.SafeLine(filepath.Base(path))
+	return search.SafePath(filepath.Base(path))
 }
 
 // skippedError reports the files an import could not read, after the ones it

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -162,7 +162,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			return mentions[i].count > mentions[j].count
 		})
 		for i := 0; i < len(mentions) && i < 2; i++ {
-			hit.Snippets = append(hit.Snippets, blameSnippet(mentions[i].text, mentions[i].role, target.Base))
+			hit.Snippets = append(hit.Snippets, blameSnippet(mentions[i].text, mentions[i].role, target))
 		}
 		if hit.Count == 0 {
 			continue
@@ -345,16 +345,46 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 // came back with one and then found nothing when it was pasted into restore
 // (#2044). A files record is a list of paths, so the line that names the file is
 // printed as a path instead.
-func blameSnippet(text, role, base string) string {
-	if role != "files" {
-		return snippet(text, base, nil)
-	}
-	for _, line := range strings.Split(text, "\n") {
-		if strings.Contains(line, base) {
+func blameSnippet(text, role string, target BlameTarget) string {
+	switch role {
+	case "files":
+		if line := pathLineFor(text, target); line != "" {
 			return SafePath(line)
 		}
+	case "edit":
+		// An edit is "path\nspan": the first line is the file, the rest is what
+		// stopped existing and is prose as far as a snippet goes.
+		path, span, _ := strings.Cut(text, "\n")
+		if pathLineFor(path, target) != "" {
+			return strings.TrimSpace(SafePath(path) + " " + snippet(span, target.Base, nil))
+		}
 	}
-	return snippet(text, base, nil)
+	return snippet(text, target.Base, nil)
+}
+
+// pathLineFor picks the line of a record that names the file blame was asked
+// about. By the file's own name, not by containing it: "mypool.go" contains
+// "pool.go", and printing a sibling as the answer is the same wrong-path bug
+// this renderer exists to fix. The full path wins over a bare match, so a
+// vendored copy does not stand in for the file itself.
+func pathLineFor(text string, target BlameTarget) string {
+	base := strings.ToLower(target.Base)
+	full := strings.ToLower(filepath.ToSlash(target.FullPath))
+	fallback := ""
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		slashed := strings.ToLower(filepath.ToSlash(trimmed))
+		if full != "" && slashed == full {
+			return line
+		}
+		if strings.ToLower(filepath.Base(trimmed)) == base && fallback == "" {
+			fallback = line
+		}
+	}
+	return fallback
 }
 
 // BlameLifecycleLine words a withdrawn decision for blame the way search words

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -138,6 +138,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			text  string
 			count int
 			level float64
+			role  string
 		}
 		var mentions []mention
 		for _, message := range session.Messages {
@@ -149,7 +150,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			if level > specificity {
 				specificity = level
 			}
-			mentions = append(mentions, mention{message.Text, count, level})
+			mentions = append(mentions, mention{message.Text, count, level, message.Role})
 		}
 		// A path-shaped mention outranks a bare filename however often the bare
 		// name is repeated; among equally specific ones, the message that keeps
@@ -161,7 +162,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			return mentions[i].count > mentions[j].count
 		})
 		for i := 0; i < len(mentions) && i < 2; i++ {
-			hit.Snippets = append(hit.Snippets, snippet(mentions[i].text, target.Base, nil))
+			hit.Snippets = append(hit.Snippets, blameSnippet(mentions[i].text, mentions[i].role, target.Base))
 		}
 		if hit.Count == 0 {
 			continue
@@ -337,6 +338,23 @@ func PrintBlame(w io.Writer, hits []BlameHit, jsonOutput bool) {
 			}
 		}
 	}
+}
+
+// blameSnippet renders one mention. The prose path collapses runs of whitespace
+// — right for a sentence, wrong for a file whose name holds two spaces, which
+// came back with one and then found nothing when it was pasted into restore
+// (#2044). A files record is a list of paths, so the line that names the file is
+// printed as a path instead.
+func blameSnippet(text, role, base string) string {
+	if role != "files" {
+		return snippet(text, base, nil)
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.Contains(line, base) {
+			return SafePath(line)
+		}
+	}
+	return snippet(text, base, nil)
 }
 
 // BlameLifecycleLine words a withdrawn decision for blame the way search words

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -369,22 +369,38 @@ func blameSnippet(text, role string, target BlameTarget) string {
 // vendored copy does not stand in for the file itself.
 func pathLineFor(text string, target BlameTarget) string {
 	base := strings.ToLower(target.Base)
-	full := strings.ToLower(filepath.ToSlash(target.FullPath))
+	full := crossSlash(target.FullPath)
 	fallback := ""
 	for _, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
 			continue
 		}
-		slashed := strings.ToLower(filepath.ToSlash(trimmed))
+		slashed := crossSlash(trimmed)
 		if full != "" && slashed == full {
 			return line
 		}
-		if strings.ToLower(filepath.Base(trimmed)) == base && fallback == "" {
+		if crossBase(trimmed) == base && fallback == "" {
 			fallback = line
 		}
 	}
 	return fallback
+}
+
+// crossSlash and crossBase read a path the way the rest of deja does: a store
+// synced from Windows holds "C:\\src\\app\\x.go", and on a unix host
+// filepath sees one segment — which made the picker miss the line and fall back
+// to the prose renderer, quietly bringing the collapsing back (#2044).
+func crossSlash(p string) string {
+	return strings.ToLower(strings.ReplaceAll(p, "\\", "/"))
+}
+
+func crossBase(p string) string {
+	s := crossSlash(p)
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 // BlameLifecycleLine words a withdrawn decision for blame the way search words

--- a/internal/search/blame_snippet_test.go
+++ b/internal/search/blame_snippet_test.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line a blame snippet shows has to be the file that was asked about. A
+// substring match printed a sibling — "mypool.go" contains "pool.go" — as the
+// answer, and pasted into restore that is a different file's spans (#2044).
+func TestBlameSnippetNamesTheFileThatWasAskedAbout(t *testing.T) {
+	target := BlameTarget{Base: "pool.go", FullPath: "/tmp/app/pool.go"}
+	for _, c := range []struct{ name, text, want string }{
+		{"a sibling whose name contains it",
+			"/tmp/app/mypool.go\n/tmp/app/pool.go", "/tmp/app/pool.go"},
+		{"the full path beats a bare match",
+			"/tmp/app/vendor/pool.go\n/tmp/app/pool.go", "/tmp/app/pool.go"},
+		{"spelled in another case",
+			"/tmp/app/Pool.go", "/tmp/app/Pool.go"},
+		{"its own spaces kept",
+			"/tmp/app/two  spaces.go\n/tmp/app/pool.go", "/tmp/app/pool.go"},
+	} {
+		if got := blameSnippet(c.text, "files", target); got != c.want {
+			t.Errorf("%s: blameSnippet = %q, want %q", c.name, got, c.want)
+		}
+	}
+
+	// An edit record is "path\nspan": the path is a path, the span is prose.
+	spaces := BlameTarget{Base: "two  spaces.go", FullPath: "/tmp/app/two  spaces.go"}
+	got := blameSnippet("/tmp/app/two  spaces.go\nsize = 20", "edit", spaces)
+	if !strings.HasPrefix(got, "/tmp/app/two  spaces.go") {
+		t.Errorf("an edit snippet lost the file's spaces: %q", got)
+	}
+	if !strings.Contains(got, "size = 20") {
+		t.Errorf("an edit snippet lost the span: %q", got)
+	}
+
+	// Anything else is prose, and prose is what snippet() is for.
+	if got := blameSnippet("we changed pool.go twice today", "user", target); got == "" {
+		t.Error("a prose mention produced no snippet")
+	}
+}
+
+// A path is bounded like anything else that reaches a terminal or an MCP
+// payload, and bounded from the left: the tail is what names the file.
+func TestSafePathIsBoundedFromTheLeft(t *testing.T) {
+	long := "/tmp/" + strings.Repeat("deep/", 200) + "pool.go"
+	got := SafePath(long)
+	if len([]rune(got)) > pathCap {
+		t.Errorf("SafePath returned %d runes, over the %d cap", len([]rune(got)), pathCap)
+	}
+	if !strings.HasSuffix(got, "pool.go") {
+		t.Errorf("the clip dropped the file's own name: %q", got)
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("a clipped path does not say it was clipped: %q", got)
+	}
+}

--- a/internal/search/blame_snippet_test.go
+++ b/internal/search/blame_snippet_test.go
@@ -19,6 +19,10 @@ func TestBlameSnippetNamesTheFileThatWasAskedAbout(t *testing.T) {
 			"/tmp/app/Pool.go", "/tmp/app/Pool.go"},
 		{"its own spaces kept",
 			"/tmp/app/two  spaces.go\n/tmp/app/pool.go", "/tmp/app/pool.go"},
+		// A store synced from Windows: on a unix host filepath sees one
+		// segment, and missing the line here drops back to the renderer that
+		// collapses the spaces.
+		{"a windows path", `C:\src\app\pool.go`, `C:\src\app\pool.go`},
 	} {
 		if got := blameSnippet(c.text, "files", target); got != c.want {
 			t.Errorf("%s: blameSnippet = %q, want %q", c.name, got, c.want)
@@ -27,6 +31,10 @@ func TestBlameSnippetNamesTheFileThatWasAskedAbout(t *testing.T) {
 
 	// An edit record is "path\nspan": the path is a path, the span is prose.
 	spaces := BlameTarget{Base: "two  spaces.go", FullPath: "/tmp/app/two  spaces.go"}
+	if got := blameSnippet(`C:\src\app\two  spaces.go`, "files", BlameTarget{Base: "two  spaces.go"}); got != `C:\src\app\two  spaces.go` {
+		t.Errorf("a windows path lost its spaces: %q", got)
+	}
+
 	got := blameSnippet("/tmp/app/two  spaces.go\nsize = 20", "edit", spaces)
 	if !strings.HasPrefix(got, "/tmp/app/two  spaces.go") {
 		t.Errorf("an edit snippet lost the file's spaces: %q", got)

--- a/internal/search/safe_path_test.go
+++ b/internal/search/safe_path_test.go
@@ -1,0 +1,29 @@
+package search
+
+import "testing"
+
+// A path is an identifier, not prose: what deja prints has to be what deja can
+// find again. SafeLine collapses runs of whitespace, which is right for a digest
+// row and wrong here — blame printed "/tmp/app/two spaces.go" for a file named
+// with two, and restoring that printed path found nothing (#2044).
+func TestSafePathKeepsTheSpacesInAName(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"/tmp/app/two  spaces.go", "/tmp/app/two  spaces.go"},
+		{"/tmp/app/one space.go", "/tmp/app/one space.go"},
+		{"/tmp/app/pool.go", "/tmp/app/pool.go"},
+		// Still one line, and still free of what a terminal would obey.
+		// A control byte becomes a space rather than vanishing, which is what
+		// SafeText has done since #1090: a name is easier to recognise with a
+		// gap where the byte was than silently shortened.
+		{"/tmp/app/pool\x1b[31m.go", "/tmp/app/pool [31m.go"},
+		{"/tmp/app/a\nb.go", "/tmp/app/a b.go"},
+		{"/tmp/app/a\tb.go", "/tmp/app/a b.go"},
+		{"/tmp/app/a\r\nb.go", "/tmp/app/a  b.go"},
+		{"  /tmp/app/pool.go  ", "/tmp/app/pool.go"},
+		{"", ""},
+	} {
+		if got := SafePath(c.in); got != c.want {
+			t.Errorf("SafePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/search/safe_path_test.go
+++ b/internal/search/safe_path_test.go
@@ -18,6 +18,8 @@ func TestSafePathKeepsTheSpacesInAName(t *testing.T) {
 		{"/tmp/app/pool\x1b[31m.go", "/tmp/app/pool [31m.go"},
 		{"/tmp/app/a\nb.go", "/tmp/app/a b.go"},
 		{"/tmp/app/a\tb.go", "/tmp/app/a b.go"},
+		// SafeText has already turned the carriage return into a space by the
+		// time SafePath maps the newline, so a CRLF costs two.
 		{"/tmp/app/a\r\nb.go", "/tmp/app/a  b.go"},
 		{"  /tmp/app/pool.go  ", "/tmp/app/pool.go"},
 		{"", ""},

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2215,6 +2215,24 @@ func SafeLine(s string) string {
 	return strings.Join(strings.Fields(SafeText(s)), " ")
 }
 
+// SafePath is SafeLine for a path, which is an identifier rather than prose: it
+// strips what a terminal would obey and keeps the result on one line, but the
+// spaces inside a name are part of the name. Collapsing them made blame print
+// "/tmp/app/two spaces.go" for a file with two, and restoring that printed path
+// found nothing (#2044).
+func SafePath(s string) string {
+	if s == "" {
+		return ""
+	}
+	cleaned := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' || r == '\r' {
+			return ' '
+		}
+		return r
+	}, SafeText(s))
+	return strings.Trim(cleaned, " ")
+}
+
 func unsafeForTerminal(r rune) bool {
 	if r == '\n' || r == '\t' {
 		return false

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2224,13 +2224,30 @@ func SafePath(s string) string {
 	if s == "" {
 		return ""
 	}
+	// SafeText leaves only newline and tab standing, and both have to go: this
+	// is one row of something structured. One space each rather than a run
+	// collapsed, which is the whole point.
 	cleaned := strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\t' || r == '\r' {
+		if r == '\n' || r == '\t' {
 			return ' '
 		}
 		return r
 	}, SafeText(s))
-	return strings.Trim(cleaned, " ")
+	return clipPath(strings.Trim(cleaned, " "))
+}
+
+// pathCap bounds a printed path. Long enough for any real one, short enough
+// that a transcript-supplied string cannot fill a terminal or an MCP payload.
+const pathCap = 300
+
+// clipPath bounds a path the way clip bounds an answer, from the left: a path
+// is recognised by its tail, and the head is what a reader gives up first.
+func clipPath(s string) string {
+	r := []rune(s)
+	if len(r) <= pathCap {
+		return s
+	}
+	return "…" + string(r[len(r)-pathCap+1:])
 }
 
 func unsafeForTerminal(r rune) bool {


### PR DESCRIPTION
Fixes #2048. A recorded command carries its exit status as `"  → exit %d"`, appended by codex and opencode. `withoutFailedExit` looked for the marker anywhere in the string:

```
"echo \"→ exit 0\""                       -> "echo \"" ok=false
"grep -n \"→ exit \" log.txt  → exit 0"   -> "grep -n \"→ exit \" log.txt" ok=true
"echo \"→ exit 0\"  → exit 1"             -> "echo \"→ exit 0\"" ok=false
```

The first is the bug: nothing appended a status, so the whole string is the command — but it was cut at the marker, offered as `echo "` in the line the tool hook shows after a repeated error, and judged a failure because the code parsed was `0"`.

Only the shape a source actually writes counts now: two spaces, the marker, digits, end of string. A command that mentions the marker keeps it; a status of `later` is not a status; `130` still is one.
