### PR TITLE
fix(how): hand back the command that ran

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -85,7 +85,7 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			when = " · " + p.When.Local().Format("2006-01-02")
 		}
 		fmt.Fprintf(stdout, "%s%s\n", search.SafeLine(p.Error), when)
-		fmt.Fprintf(stdout, "  ran next: %s\n", search.SafeLine(p.Command))
+		fmt.Fprintf(stdout, "  ran next: %s\n", search.SafeCommand(p.Command))
 	}
 	return nil
 }

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
@@ -221,12 +222,24 @@ func pluralSessions(n int) string {
 // name the halves of a hyphenated tool.
 // A term that itself carries a separator (`go test`, `./x`) is matched as
 // written: it is already more specific than one word.
+func fold(s string) string { return strings.Join(strings.Fields(s), " ") }
+
 func commandMentions(low, term string) bool {
 	if term == "" {
 		return false
 	}
 	if strings.ContainsFunc(term, func(r rune) bool { return !isCommandWordRune(r) }) {
-		return strings.Contains(low, term)
+		if strings.Contains(low, term) {
+			return true
+		}
+		// Matching folds the whitespace the command keeps. The record holds
+		// what ran, spacing and all (#2052), so `deja how "pool size"` stopped
+		// finding a command written `"Pool  Size"` — the answer is to compare a
+		// folded copy, not to print one.
+		if strings.ContainsFunc(term, unicode.IsSpace) {
+			return strings.Contains(fold(low), fold(term))
+		}
+		return false
 	}
 	for at := 0; ; {
 		i := strings.Index(low[at:], term)

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -28,6 +28,21 @@ import (
 
 const howCommandMax = 200
 
+// firstCommandLine is firstLine for a command: the first line, bounded, and
+// otherwise left alone. firstLine collapses runs of whitespace, which is right
+// for the note titles it was written for and wrong here — `-run "Pool  Size"`
+// came back as a different test filter (#2052).
+func firstCommandLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i > 0 {
+		s = s[:i]
+	}
+	r := []rune(s)
+	if len(r) <= 80 {
+		return s
+	}
+	return string(r[:80]) + "…"
+}
+
 type howEntry struct {
 	Command  string
 	Runs     int
@@ -99,7 +114,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		if !e.Last.IsZero() {
 			when = " · last " + e.Last.Local().Format("2006-01-02")
 		}
-		fmt.Fprintf(stdout, "%s\n", search.SafeLine(e.Command))
+		fmt.Fprintf(stdout, "%s\n", search.SafeCommand(e.Command))
 		fmt.Fprintf(stdout, "  ran %s in %s%s\n",
 			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
 	}
@@ -137,7 +152,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		if project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(project)) {
 			return
 		}
-		cmd := strings.TrimSpace(firstLine(r.Text))
+		cmd := strings.TrimSpace(firstCommandLine(r.Text))
 		if cmd == "" || len(cmd) > howCommandMax {
 			return
 		}

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -210,6 +210,10 @@ func pluralSessions(n int) string {
 	return fmt.Sprintf("%d sessions", n)
 }
 
+// fold collapses runs of whitespace, for comparing a query against a command
+// without touching the command itself.
+func fold(s string) string { return strings.Join(strings.Fields(s), " ") }
+
 // commandMentions is the membership test for `how`: the term has to appear in
 // the command as a word, not inside a longer one. A raw substring test answered
 // `how go` with `golangci-lint run ./...`, and ranked it first (#1630) — and the
@@ -222,8 +226,6 @@ func pluralSessions(n int) string {
 // name the halves of a hyphenated tool.
 // A term that itself carries a separator (`go test`, `./x`) is matched as
 // written: it is already more specific than one word.
-func fold(s string) string { return strings.Join(strings.Fields(s), " ") }
-
 func commandMentions(low, term string) bool {
 	if term == "" {
 		return false

--- a/cmd/deja/how_spacing_test.go
+++ b/cmd/deja/how_spacing_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `deja how` exists to hand back a command to run, so the command it prints has
+// to be the command that ran. SafeLine collapsed runs of whitespace, and
+// `-run "Pool  Size"` came back as `-run "Pool Size"` — a different test filter
+// (#2052).
+func TestHowPrintsTheCommandThatRan(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	dir := filepath.Join(claude, "-tmp-app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_INDEX_COMMANDS", "1")
+
+	cmd := `go test ./... -run "Pool  Size"`
+	rec := func(v any) string {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	body := rec(map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:05Z",
+		"message":   map[string]any{"role": "user", "content": "the pgbouncer pool times out"},
+	}) + "\n" + rec(map[string]any{
+		"type": "assistant", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": "2026-01-02T03:04:06Z",
+		"message": map[string]any{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "Bash", "input": map[string]any{"command": cmd}},
+		}},
+	}) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "index"); err != nil {
+		t.Fatalf("index: %v %s", err, out)
+	}
+
+	out, err := captureRun(t, "how", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: how found the command at all. A `grep` would not have been
+	// indexed, and an empty answer would pass the check below for free.
+	if !strings.Contains(out, "go test") {
+		t.Fatalf("how found no command to print:\n%s", out)
+	}
+	if !strings.Contains(out, cmd) {
+		t.Errorf("how printed a command that is not the one that ran:\n%s\nwanted: %s", out, cmd)
+	}
+}

--- a/cmd/deja/how_spacing_test.go
+++ b/cmd/deja/how_spacing_test.go
@@ -61,6 +61,16 @@ func TestHowPrintsTheCommandThatRan(t *testing.T) {
 		t.Errorf("how printed a command that is not the one that ran:\n%s\nwanted: %s", out, cmd)
 	}
 
+	// A quoted phrase still finds it: the record keeps the spacing that ran, and
+	// matching folds its own copy rather than the record's (#2052).
+	quoted, err := captureRun(t, "how", "pool size")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(quoted, cmd) {
+		t.Errorf("a quoted phrase no longer finds the command it names:\n%s", quoted)
+	}
+
 	// The same answer through MCP, which is the half an agent runs without a
 	// person reading it first.
 	got, err := callMCPTool(os.Getenv("DEJA_INDEX_DIR"), "how", json.RawMessage(`{"what":"test"}`))

--- a/cmd/deja/how_spacing_test.go
+++ b/cmd/deja/how_spacing_test.go
@@ -60,4 +60,17 @@ func TestHowPrintsTheCommandThatRan(t *testing.T) {
 	if !strings.Contains(out, cmd) {
 		t.Errorf("how printed a command that is not the one that ran:\n%s\nwanted: %s", out, cmd)
 	}
+
+	// The same answer through MCP, which is the half an agent runs without a
+	// person reading it first.
+	got, err := callMCPTool(os.Getenv("DEJA_INDEX_DIR"), "how", json.RawMessage(`{"what":"test"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "go test") {
+		t.Fatalf("the MCP tool found no command to print:\n%s", got)
+	}
+	if !strings.Contains(got, cmd) {
+		t.Errorf("the MCP tool handed back a command that is not the one that ran:\n%s\nwanted: %s", got, cmd)
+	}
 }

--- a/cmd/deja/listing_row_test.go
+++ b/cmd/deja/listing_row_test.go
@@ -45,8 +45,11 @@ func TestTheListingRowsUseTheLineSafeForm(t *testing.T) {
 		if m := rows.FindString(body); m != "" {
 			t.Errorf("%s prints a row with SafeText, so a newline in the value forges a line: %s", file, m)
 		}
-		if !strings.Contains(body, "search.SafeLine(") {
-			t.Errorf("%s no longer uses the line-safe form at all", file)
+		// SafeLine for prose, SafeCommand for the command itself — the second
+		// keeps the spacing a person copies (#2052) and folds a newline the
+		// same way, which is what this guard is about.
+		if !strings.Contains(body, "search.SafeLine(") && !strings.Contains(body, "search.SafeCommand(") {
+			t.Errorf("%s no longer uses a line-safe form at all", file)
 		}
 	}
 }

--- a/cmd/deja/listing_row_test.go
+++ b/cmd/deja/listing_row_test.go
@@ -36,7 +36,7 @@ func TestSafeLineIsTheOneThatCannotStartALine(t *testing.T) {
 // (#1863).
 func TestTheListingRowsUseTheLineSafeForm(t *testing.T) {
 	rows := regexp.MustCompile(`Fprintf\((?:stdout|w),\s*"[^"]*\\n"[^)]*search\.SafeText\(`)
-	for _, file := range []string{"fix.go", "how.go"} {
+	for _, file := range []string{"fix.go", "how.go", "mcp.go"} {
 		src, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -418,7 +418,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if !p.When.IsZero() {
 				when = " (" + p.When.Local().Format("2006-01-02") + ")"
 			}
-			fmt.Fprintf(&fb, "%s%s\n  ran next: %s\n", recallListingLine(p.Error), when, recallListingLine(p.Command))
+			fmt.Fprintf(&fb, "%s%s\n  ran next: %s\n", recallListingLine(p.Error), when, commandListingLine(p.Command))
 		}
 		return strings.TrimRight(fb.String(), "\n"), nil
 	case "how":
@@ -466,7 +466,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if !e.Last.IsZero() {
 				when = ", last " + e.Last.Local().Format("2006-01-02")
 			}
-			fmt.Fprintf(&hb, "%s\n  ran %s in %s%s\n", recallListingLine(e.Command), pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
+			fmt.Fprintf(&hb, "%s\n  ran %s in %s%s\n", commandListingLine(e.Command), pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
 		}
 		return strings.TrimRight(hb.String(), "\n"), nil
 	case "remember":
@@ -833,6 +833,10 @@ const sameFactFloor = 40
 // row of a numbered list: a project name or an answer spanning two lines
 // forges a second result, which is the shape #1080 fixed on the sync path.
 func recallListingLine(s string) string { return search.SafeLine(s) }
+
+// commandListingLine is recallListingLine for a command, which an agent runs
+// rather than reads: the spacing inside it is part of it (#2052).
+func commandListingLine(s string) string { return search.SafeCommand(s) }
 
 func recallText(dir, q, harness string, limit, budget int) (string, error) {
 	text, _, _, _, err := recallTextResult(dir, q, harness, limit, 0, budget)

--- a/internal/search/blame_snippet_test.go
+++ b/internal/search/blame_snippet_test.go
@@ -64,3 +64,23 @@ func TestSafePathIsBoundedFromTheLeft(t *testing.T) {
 		t.Errorf("a clipped path does not say it was clipped: %q", got)
 	}
 }
+
+// A command is clipped from the other end than a path: what identifies it is
+// the program it runs, so the head is what survives (#2052).
+func TestSafeCommandIsClippedFromTheRight(t *testing.T) {
+	long := "go test ./internal/index -run " + strings.Repeat("A", 400)
+	got := SafeCommand(long)
+	if len([]rune(got)) > pathCap {
+		t.Errorf("SafeCommand returned %d runes, over the %d cap", len([]rune(got)), pathCap)
+	}
+	if !strings.HasPrefix(got, "go test ./internal/index -run ") {
+		t.Errorf("the clip dropped the command itself: %q", got[:40])
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("a clipped command does not say it was clipped: %q", got[len(got)-10:])
+	}
+	// A path keeps the other end, and both stay under the cap.
+	if p := SafePath("/tmp/" + strings.Repeat("deep/", 200) + "pool.go"); !strings.HasSuffix(p, "pool.go") {
+		t.Errorf("a path lost its own name: %q", p)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2220,7 +2220,17 @@ func SafeLine(s string) string {
 // spaces inside a name are part of the name. Collapsing them made blame print
 // "/tmp/app/two spaces.go" for a file with two, and restoring that printed path
 // found nothing (#2044).
-func SafePath(s string) string {
+func SafePath(s string) string { return safeVerbatim(s) }
+
+// SafeCommand is the same treatment for a command, which is the other thing on
+// these screens that a person copies and runs rather than reads. `deja how`
+// printed `-run "Pool Size"` for a command that ran `-run "Pool  Size"`, which
+// is a different test filter (#2052).
+func SafeCommand(s string) string { return safeVerbatim(s) }
+
+// safeVerbatim keeps what was recorded, minus what a terminal would obey and
+// minus the line breaks that would let one row become two.
+func safeVerbatim(s string) string {
 	if s == "" {
 		return ""
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2220,17 +2220,20 @@ func SafeLine(s string) string {
 // spaces inside a name are part of the name. Collapsing them made blame print
 // "/tmp/app/two spaces.go" for a file with two, and restoring that printed path
 // found nothing (#2044).
-func SafePath(s string) string { return safeVerbatim(s) }
+func SafePath(s string) string { return safeVerbatim(s, clipPath) }
 
 // SafeCommand is the same treatment for a command, which is the other thing on
 // these screens that a person copies and runs rather than reads. `deja how`
 // printed `-run "Pool Size"` for a command that ran `-run "Pool  Size"`, which
 // is a different test filter (#2052).
-func SafeCommand(s string) string { return safeVerbatim(s) }
+//
+// Clipped from the other end than a path: a path is recognised by its tail, a
+// command by the program it runs.
+func SafeCommand(s string) string { return safeVerbatim(s, clipCommand) }
 
 // safeVerbatim keeps what was recorded, minus what a terminal would obey and
 // minus the line breaks that would let one row become two.
-func safeVerbatim(s string) string {
+func safeVerbatim(s string, clip func(string) string) string {
 	if s == "" {
 		return ""
 	}
@@ -2243,15 +2246,25 @@ func safeVerbatim(s string) string {
 		}
 		return r
 	}, SafeText(s))
-	return clipPath(strings.Trim(cleaned, " "))
+	return clip(strings.Trim(cleaned, " "))
 }
 
 // pathCap bounds a printed path. Long enough for any real one, short enough
 // that a transcript-supplied string cannot fill a terminal or an MCP payload.
 const pathCap = 300
 
-// clipPath bounds a path the way clip bounds an answer, from the left: a path
-// is recognised by its tail, and the head is what a reader gives up first.
+// clipCommand bounds a command from the right: what identifies a command is the
+// program it runs, so the head is the part a reader cannot give up.
+func clipCommand(s string) string {
+	r := []rune(s)
+	if len(r) <= pathCap {
+		return s
+	}
+	return string(r[:pathCap-1]) + "…"
+}
+
+// clipPath bounds a path from the left: a path is recognised by its tail, and
+// the head is what a reader gives up first.
 func clipPath(s string) string {
 	r := []rune(s)
 	if len(r) <= pathCap {


### PR DESCRIPTION
Fixes #2052. A session ran `go test ./... -run "Pool  Size"`:

```
$ deja show s1
  $ go test ./... -run "Pool  Size"     ← right

$ deja how test
  $ go test ./... -run "Pool Size"      ← one space
```

`deja how` exists to hand back a command to run, and the one it handed back runs a different test filter.

Two places collapsed it, which is why the first fix did not take. The row printed through `SafeLine`; and before that the aggregation keyed and stored the command through `firstLine`, whose `trimRunes` is `Fields`-joined — right for the note titles it was written for, wrong for a command. `deja how` now bounds the first line without touching what is inside it, and prints through `SafeCommand`, the same one-line, no-collapse treatment `SafePath` got in #2046. `deja fix`'s "ran next:" line prints the remedy the same way; the error text beside it stays prose.

The row guard from #1863 wanted `SafeLine` by name in both files; it now accepts either one-line-safe form, with the reason written down.
