### PR TITLE
keep an agent's own scratch sessions out of recall

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -963,7 +963,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// Before ranking, not after: the cap is applied while ranking, so a rule
 	// that runs later still lets denied sessions occupy the result slots and
 	// the allowed ones never reach the page (#1060).
-	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, result.Sessions)
+	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, search.WithoutScratch(result.Sessions))
 	o.PolicyWithheld = policyHidden
 	o.Tier = result.Tier
 	if result.Neighbour {

--- a/internal/search/scratch.go
+++ b/internal/search/scratch.go
@@ -1,0 +1,59 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// scratchRoots are directories an agent runtime owns rather than a person: a
+// background job's own temp tree. A session recorded there is the tool being
+// driven, not work being done.
+//
+// Measured on a real store: 207 of the 300 most recent sessions sat under
+// .claude/jobs/<id>/tmp with a median of 42 words, and one of them — a one-shot
+// transcript of a question — outranked the session that had settled that
+// question, because a repeated question matches word for word (#2050).
+//
+// The system temp directory is deliberately absent. It looked like the same
+// thing and is not: every Go test's t.TempDir() lands under /var/folders on
+// macOS, so including it hid four hook fixtures the moment it ran, and a person
+// who starts an agent in a mktemp -d is doing real work in a real directory.
+var scratchRoots = []string{
+	"/.claude/jobs/",
+}
+
+// WithoutScratch drops the sessions an agent runtime recorded in its own
+// scratch tree.
+//
+// Applied where sessions enter a search rather than inside the scorer: the
+// error-signature and relevance tiers build their hits without going through
+// it, so a filter there covered one path of three and the transcript still came
+// back (#2050).
+func WithoutScratch(ss []model.Session) []model.Session {
+	out := ss[:0:0]
+	for _, s := range ss {
+		if isScratchSession(s) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// isScratchSession reports whether a session was recorded inside a directory an
+// agent runtime made for itself.
+//
+// Both fields are checked rather than chosen between: opencode keeps one
+// database for every session, so its Path is the store and the Project carries
+// the working directory, while the file-per-session harnesses put the directory
+// in the Path.
+func isScratchSession(s model.Session) bool {
+	hay := s.Path + " " + s.Project
+	for _, root := range scratchRoots {
+		if strings.Contains(hay, root) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/search/scratch_test.go
+++ b/internal/search/scratch_test.go
@@ -1,0 +1,84 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A one-shot transcript recorded in an agent runtime's scratch tree repeats the
+// question word for word, which is the strongest lexical match there is, and
+// every one of those words is user text carrying the user-role boost. It beat
+// the session that had actually settled the question (#2050).
+//
+// Measured at Run rather than on the live store on purpose: the store has been
+// reindexed since and those transcripts have aged out of the top, so only a
+// fixture can hold the case still.
+func TestAScratchTranscriptDoesNotOutrankTheAnswer(t *testing.T) {
+	now := time.Now()
+	answered := model.Session{
+		ID: "answered", Harness: "claude", Project: "deja-vu",
+		Path:    "/Users/x/.claude/projects/deja-vu/answered.jsonl",
+		Started: now, Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "who should send the claudeworkshop email", Time: now},
+			{Role: "assistant", Text: "You send it yourself — the site has no repository, so there is no pull request to open.", Time: now},
+		},
+	}
+	// The same question, asked of an agent in a job's temp tree and answered
+	// with nothing.
+	echo := model.Session{
+		ID: "echo", Harness: "opencode", Project: "neutral",
+		Path:    "/Users/x/.claude/jobs/9f0aa059/tmp/ab2/neutral",
+		Started: now, Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "who should send the claudeworkshop email about their outdated article", Time: now},
+			{Role: "assistant", Text: "I will look into that.", Time: now},
+		},
+	}
+
+	hits, err := Run(WithoutScratch([]model.Session{echo, answered}), Options{Query: "who should send the claudeworkshop email", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.Session.ID == "echo" {
+			t.Errorf("a transcript from a job's scratch tree was returned: %+v", h.Session.Path)
+		}
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "answered" {
+		t.Fatalf("the session that answered did not lead: %+v", hits)
+	}
+}
+
+// The rule has to stay narrower than "anything temporary": people do real work
+// in /tmp and in a mktemp -d, and a repository whose name contains "jobs" is
+// not a runtime directory.
+func TestOrdinaryWorkIsNotMistakenForScratch(t *testing.T) {
+	now := time.Now()
+	for _, where := range []struct{ name, path, project string }{
+		{"a project under /tmp", "/tmp/spike/session.jsonl", "spike"},
+		{"a system temp directory", "/var/folders/jn/T/spike/s.jsonl", "spike"},
+		{"a repository with jobs in the name", "/Users/x/code/jobs-api/s.jsonl", "jobs-api"},
+		{"a project named tmp-something", "/Users/x/code/tmp-migrations/s.jsonl", "tmp-migrations"},
+	} {
+		t.Run(where.name, func(t *testing.T) {
+			s := model.Session{
+				ID: "real", Harness: "claude", Project: where.project, Path: where.path,
+				Started: now, Updated: now,
+				Messages: []model.Message{
+					{Role: "user", Text: "the exporter drops rows at utc midnight", Time: now},
+					{Role: "assistant", Text: "Root cause was the batch cutoff timezone. We pinned it to UTC.", Time: now},
+				},
+			}
+			hits, err := Run(WithoutScratch([]model.Session{s}), Options{Query: "exporter drops rows midnight", All: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(hits) == 0 {
+				t.Error("ordinary work was treated as a runtime's scratch tree")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2050.

A session an agent runtime recorded in its own scratch tree is the tool being
driven, not work being done, and those sessions now dominate this store: 207 of
the 300 most recent sit under `.claude/jobs/<id>/tmp`, median 42 words.

They win searches because of what they are. A one-shot transcript of a question
repeats that question word for word — the strongest lexical match there is — and
every one of those words is user text, so `userRoleBoost` applies to all of
them. The session that *answered* uses different words, because that is what an
answer is. The reproduction is now a test, and without the filter it fails with
the original numbers: the echo scores 1.345 against the answering session's
1.202.

Live, on the store the bug was found on:

```
claudeworkshop email               old  50 hits / 1 scratch   new  49 hits / 0
repository description wording     old  50 hits / 1 scratch   new  49 hits / 0
session start candidate pool       old  50 hits / 1 scratch   new  49 hits / 0
windows flock build                old  50 hits / 0 scratch   new  50 hits / 0
```

Placed where sessions enter a search, beside the trust-policy filter, rather
than inside the scorer. That was the third attempt and the first that worked:
the error-signature and relevance tiers build their hits without going through
the scoring loop, so a filter there covered one path of three and the transcript
still came back — the live measurement said "no change" twice while the unit
test passed.

Two things deliberately left out, both because they were tried and were wrong:

- `/var/folders/` as a scratch root. Every Go test's `t.TempDir()` lands there
  on macOS, so it hid four hook fixtures the moment it ran, and a person who
  starts an agent in a `mktemp -d` is doing real work in a real directory. One
  session of the 207 came from there.
- Gating on `!o.All`. `All` means "return every result", not "include what the
  tool wrote about itself", and the CLI search path sets it on every call — the
  gate disabled the filter entirely.

Guards cover the other side: `/tmp/spike`, a `mktemp -d` path, `tmp-migrations`
and a repository called `jobs-api` all stay searchable.
