### PR TITLE
let the policy file name the directories deja skips

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -830,6 +830,9 @@ func doctorPolicy(w io.Writer, dir string) {
 			return
 		}
 		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", policy.Path())
+		// Except one thing, which is in force with or without a file and is
+		// the reason a directory can be missing from recall (#2050).
+		printIgnored(w, policy.Load())
 		return
 	}
 	if err != nil {
@@ -851,6 +854,7 @@ func doctorPolicy(w io.Writer, dir string) {
 		}
 		fmt.Fprintf(w, "  %-12s %s\n", activation, line)
 	}
+	printIgnored(w, pol)
 	for _, u := range unknown {
 		fmt.Fprintf(w, "  %-12s %q is not an activation or origin deja consults — this rule does nothing\n", "ignored", u)
 	}
@@ -1281,4 +1285,20 @@ func doctorExists(path string) bool {
 func doctorFilePresent(path string) bool {
 	fi, err := os.Stat(path)
 	return err == nil && fi.Size() > 0
+}
+
+// printIgnored says which directories deja does not recall from. A rule that
+// silently drops history is indistinguishable from history that was never
+// there, so it is printed whether it came from the policy file or from the
+// built-in default (#2050).
+func printIgnored(w io.Writer, pol policy.Policy) {
+	pats := pol.IgnorePatterns()
+	if len(pats) == 0 {
+		return
+	}
+	what := "default"
+	if len(pol.Ignore) > 0 {
+		what = "from the file"
+	}
+	fmt.Fprintf(w, "  %-12s %s (%s)\n", "not recalled", strings.Join(pats, ", "), what)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -963,7 +963,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// Before ranking, not after: the cap is applied while ranking, so a rule
 	// that runs later still lets denied sessions occupy the result slots and
 	// the allowed ones never reach the page (#1060).
-	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, search.WithoutScratch(result.Sessions))
+	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, search.WithoutIgnored(result.Sessions))
 	o.PolicyWithheld = policyHidden
 	o.Tier = result.Tier
 	if result.Neighbour {

--- a/internal/policy/ignore.go
+++ b/internal/policy/ignore.go
@@ -1,0 +1,73 @@
+package policy
+
+import (
+	"path"
+	"strings"
+)
+
+// defaultIgnore is the one directory deja never recalls from without being
+// asked: the temp tree a background agent's own runtime makes for itself.
+//
+// Measured on a real store, 207 of the 300 most recent sessions sat under
+// .claude/jobs/<id>/tmp with a median of 42 words, and one of them — a one-shot
+// transcript of a question — outranked the session that had settled that
+// question, because a repeated question matches word for word (#2050).
+//
+// The system temp directory is deliberately not here. Every Go test's
+// t.TempDir() lands under /var/folders on macOS, and a person who starts an
+// agent in a mktemp -d is doing real work in a real directory; anyone who wants
+// it excluded can say so in the file.
+var defaultIgnore = []string{"*/.claude/jobs/*"}
+
+// Ignored reports whether a session recorded at this path, in this project,
+// should stay out of recall.
+//
+// Patterns are shell globs matched against the path and against the project,
+// because the harnesses disagree about which one carries the working directory:
+// opencode keeps a single database, so its path is the store and the project is
+// the directory, while the file-per-session harnesses put the directory in the
+// path.
+//
+// A pattern in the file replaces the default rather than adding to it. Someone
+// who writes the key has an opinion about what deja should skip, and silently
+// keeping a rule they did not write is the kind of surprise that makes a config
+// file untrustworthy — `deja doctor` prints what is in force.
+func (p Policy) Ignored(sessionPath, project string) bool {
+	pats := p.Ignore
+	if len(pats) == 0 {
+		pats = defaultIgnore
+	}
+	for _, pat := range pats {
+		if matchesAnywhere(pat, sessionPath) || matchesAnywhere(pat, project) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesAnywhere is path.Match with the leniency a person expects from a
+// directory rule: a bare fragment matches anywhere in the string, so
+// "*/.claude/jobs/*" catches the tree wherever the home directory sits.
+func matchesAnywhere(pattern, s string) bool {
+	if s == "" {
+		return false
+	}
+	if ok, err := path.Match(pattern, s); err == nil && ok {
+		return true
+	}
+	// A glob only matches the whole string, and a session path is longer than
+	// the rule that describes it. Fall back to the literal middle of the
+	// pattern, which is what a directory rule means.
+	if lit := strings.Trim(pattern, "*"); lit != "" && !strings.ContainsAny(lit, "*?[") {
+		return strings.Contains(s, lit)
+	}
+	return false
+}
+
+// IgnorePatterns is what is in force, for doctor to print.
+func (p Policy) IgnorePatterns() []string {
+	if len(p.Ignore) == 0 {
+		return defaultIgnore
+	}
+	return p.Ignore
+}

--- a/internal/policy/ignore_test.go
+++ b/internal/policy/ignore_test.go
@@ -1,0 +1,71 @@
+package policy
+
+import "testing"
+
+// The default is the one directory nobody works in: the temp tree a background
+// agent's runtime makes for itself. Measured on a real store, 207 of the 300
+// most recent sessions sat there (#2050).
+func TestTheDefaultIgnoresAnAgentsScratchTree(t *testing.T) {
+	var p Policy
+	for _, c := range []struct {
+		name, path, project string
+		want                bool
+	}{
+		{"a job's temp tree", "/Users/x/.claude/jobs/9f0aa059/tmp/ab2/neutral", "neutral", true},
+		{"opencode, which carries the directory in the project",
+			"/Users/x/.local/share/opencode/db", "/Users/x/.claude/jobs/abc/tmp/run", true},
+		{"a real project", "/Users/x/code/deja-vu/s.jsonl", "deja-vu", false},
+		{"a system temp directory, where a person may genuinely work",
+			"/var/folders/jn/T/spike/s.jsonl", "spike", false},
+		{"a repository with jobs in the name", "/Users/x/code/jobs-api/s.jsonl", "jobs-api", false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := p.Ignored(c.path, c.project); got != c.want {
+				t.Errorf("Ignored(%q, %q) = %v, want %v", c.path, c.project, got, c.want)
+			}
+		})
+	}
+}
+
+// Someone who writes the key has an opinion about what deja should skip.
+// Keeping the built-in rule alongside theirs would mean a config file that does
+// not say what it does.
+func TestAWrittenListReplacesTheDefault(t *testing.T) {
+	p := Policy{Ignore: []string{"*/ci-checkout/*"}}
+	if !p.Ignored("/build/ci-checkout/repo/s.jsonl", "repo") {
+		t.Error("the pattern from the file did not match")
+	}
+	if p.Ignored("/Users/x/.claude/jobs/abc/tmp/run", "run") {
+		t.Error("the default is still in force after the file named its own rules")
+	}
+}
+
+// A directory rule is written as a fragment, and a session path is longer than
+// the rule that describes it.
+func TestAFragmentMatchesAnywhereInThePath(t *testing.T) {
+	p := Policy{Ignore: []string{"*/eval-harness/*"}}
+	for _, s := range []string{
+		"/home/runner/work/eval-harness/case-3/s.jsonl",
+		"/Users/x/eval-harness/s.jsonl",
+	} {
+		if !p.Ignored(s, "") {
+			t.Errorf("%q was not matched", s)
+		}
+	}
+	if p.Ignored("/Users/x/code/harness/s.jsonl", "") {
+		t.Error("a shorter name matched a longer rule")
+	}
+}
+
+// What is in force has to be printable, or a rule that silently drops history
+// is indistinguishable from history that was never there.
+func TestWhatIsInForceCanBeShown(t *testing.T) {
+	var p Policy
+	if got := p.IgnorePatterns(); len(got) != 1 || got[0] != defaultIgnore[0] {
+		t.Errorf("the default is not reportable: %v", got)
+	}
+	p.Ignore = []string{"*/x/*"}
+	if got := p.IgnorePatterns(); len(got) != 1 || got[0] != "*/x/*" {
+		t.Errorf("the file's own rules are not reportable: %v", got)
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -32,6 +32,12 @@ const (
 // displayed and never matched (#955). Most specific wins.
 type Policy struct {
 	Activations map[string]map[string]bool `json:"activations,omitempty"`
+	// Ignore lists the directories deja does not recall from: an agent
+	// runtime's scratch tree, a CI checkout, an evaluation harness. Without it
+	// the only way to keep such sessions out was `deja forget`, which removes
+	// what exists and says nothing about what the same directory writes
+	// tomorrow (#2050). Empty means the default in ignore.go.
+	Ignore []string `json:"ignore,omitempty"`
 }
 
 func Path() string {

--- a/internal/search/scratch.go
+++ b/internal/search/scratch.go
@@ -1,59 +1,26 @@
 package search
 
 import (
-	"strings"
-
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
-// scratchRoots are directories an agent runtime owns rather than a person: a
-// background job's own temp tree. A session recorded there is the tool being
-// driven, not work being done.
+// WithoutIgnored drops the sessions the trust policy says deja does not recall
+// from: by default an agent runtime's own scratch tree, and whatever else the
+// policy file names.
 //
-// Measured on a real store: 207 of the 300 most recent sessions sat under
-// .claude/jobs/<id>/tmp with a median of 42 words, and one of them — a one-shot
-// transcript of a question — outranked the session that had settled that
-// question, because a repeated question matches word for word (#2050).
-//
-// The system temp directory is deliberately absent. It looked like the same
-// thing and is not: every Go test's t.TempDir() lands under /var/folders on
-// macOS, so including it hid four hook fixtures the moment it ran, and a person
-// who starts an agent in a mktemp -d is doing real work in a real directory.
-var scratchRoots = []string{
-	"/.claude/jobs/",
-}
-
-// WithoutScratch drops the sessions an agent runtime recorded in its own
-// scratch tree.
-//
-// Applied where sessions enter a search rather than inside the scorer: the
+// Applied where sessions enter a search rather than inside the scorer. The
 // error-signature and relevance tiers build their hits without going through
-// it, so a filter there covered one path of three and the transcript still came
-// back (#2050).
-func WithoutScratch(ss []model.Session) []model.Session {
+// the scoring loop, so a filter there covered one path of three and the
+// transcript still came back (#2050).
+func WithoutIgnored(ss []model.Session) []model.Session {
+	p := policy.Load()
 	out := ss[:0:0]
 	for _, s := range ss {
-		if isScratchSession(s) {
+		if p.Ignored(s.Path, s.Project) {
 			continue
 		}
 		out = append(out, s)
 	}
 	return out
-}
-
-// isScratchSession reports whether a session was recorded inside a directory an
-// agent runtime made for itself.
-//
-// Both fields are checked rather than chosen between: opencode keeps one
-// database for every session, so its Path is the store and the Project carries
-// the working directory, while the file-per-session harnesses put the directory
-// in the Path.
-func isScratchSession(s model.Session) bool {
-	hay := s.Path + " " + s.Project
-	for _, root := range scratchRoots {
-		if strings.Contains(hay, root) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/search/scratch_test.go
+++ b/internal/search/scratch_test.go
@@ -38,7 +38,7 @@ func TestAScratchTranscriptDoesNotOutrankTheAnswer(t *testing.T) {
 		},
 	}
 
-	hits, err := Run(WithoutScratch([]model.Session{echo, answered}), Options{Query: "who should send the claudeworkshop email", All: true})
+	hits, err := Run(WithoutIgnored([]model.Session{echo, answered}), Options{Query: "who should send the claudeworkshop email", All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestOrdinaryWorkIsNotMistakenForScratch(t *testing.T) {
 					{Role: "assistant", Text: "Root cause was the batch cutoff timezone. We pinned it to UTC.", Time: now},
 				},
 			}
-			hits, err := Run(WithoutScratch([]model.Session{s}), Options{Query: "exporter drops rows midnight", All: true})
+			hits, err := Run(WithoutIgnored([]model.Session{s}), Options{Query: "exporter drops rows midnight", All: true})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Stacked on #2054, which is where the hardcoded root came from.

That PR keeps one directory out of recall because measurement said it had to.
This turns it into something a user can say for themselves, because the same
problem has other shapes on other machines: a CI checkout, an evaluation
harness, a scratch clone.

The gap it closes: today the only way to keep such sessions out is `deja
forget`, and forget removes what exists. It says nothing about what the same
directory writes tomorrow, so anyone running agents in a fixed scratch path
would have to run it forever.

```json
{ "ignore": ["*/ci-checkout/*", "*/eval-harness/*"] }
```

Empty means the built-in default, `*/.claude/jobs/*`. A list in the file
replaces it rather than adding to it — someone who writes the key has an opinion
about what deja should skip, and silently keeping a rule they did not write is
what makes a config file untrustworthy.

Verified end to end rather than by unit test alone: pointing the file at this
repository's worktree took a search from 50 hits to 42, and doctor reported the
rule that did it.

```
$ deja doctor
Trust policy:
  default      no file at ~/.config/deja/policy.json — every origin activates everywhere
  not recalled */pin-manifests/*, */worktrees/* (from the file)
```

That line is printed whether the rule came from the file or from the default,
including on the no-file path where most people are. A rule that silently drops
history is indistinguishable from history that was never there, and this is the
one setting that can make a directory vanish from recall.

Patterns match the path and the project, because the harnesses disagree about
which one carries the working directory: opencode keeps one database, so its
path is the store and the project is the directory, while the file-per-session
harnesses put the directory in the path. A bare fragment matches anywhere in
either, which is what a directory rule means to the person writing it.

`ignore` is a name, not a decision — say the word if you want a different one.
