### PR TITLE
fix(promote): redact the title and the body separately

### DIFF
--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -288,12 +288,22 @@ func firstLine(s string) string {
 // how many secrets the redaction pass replaced on the way out — the same floor
 // `share` and `sync export` print, on the path that had none (#848).
 func exportPromoted(path, title, text, src, state string, updated time.Time) (int, error) {
-	body, counts := redact.Text(title + "\n" + text)
-	masked := strings.Count(body, redact.Marker)
-	for _, n := range counts {
+	// Separately, not packed and cut apart on the first newline: a title can
+	// hold one — a note's is exempt from the bound every other title gets, and
+	// the notes file is the one store a person writes by hand — and its tail
+	// then arrived at the head of the body, beside deja's own "- state:" and
+	// "- source:" lines (#2056).
+	title, titleCounts := redact.Text(title)
+	text, textCounts := redact.Text(text)
+	masked := strings.Count(title, redact.Marker) + strings.Count(text, redact.Marker)
+	for _, n := range titleCounts {
 		masked += n
 	}
-	title, text, _ = strings.Cut(body, "\n")
+	for _, n := range textCounts {
+		masked += n
+	}
+	// One line, because it is written as a heading.
+	title = strings.Join(strings.Fields(title), " ")
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
 	if err != nil {
 		return 0, err

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -305,7 +305,14 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 		context = context[i+1:]
 	}
 	withContext, textCounts := redact.Text(context + "\n" + text)
-	_, text, _ = strings.Cut(withContext, "\n")
+	if head, rest, ok := strings.Cut(withContext, "\n"); ok && head == context {
+		text = rest
+	} else {
+		// The pass swallowed the boundary — a private key spans it, and its
+		// marker replaces the newline too. Keeping the joined text loses
+		// nothing: by then the context line is inside the marker.
+		text = withContext
+	}
 	masked := strings.Count(title, redact.Marker) + strings.Count(text, redact.Marker)
 	for _, n := range titleCounts {
 		masked += n

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -293,8 +293,19 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 	// the notes file is the one store a person writes by hand — and its tail
 	// then arrived at the head of the body, beside deja's own "- state:" and
 	// "- source:" lines (#2056).
+	//
+	// The body still sees the title's last line, because a credential can be
+	// written with its key word at the end of one field and its value at the
+	// start of the next, and the patterns for those allow a newline between the
+	// two. That line is one line by construction, so the split below is exact
+	// however many the title has.
 	title, titleCounts := redact.Text(title)
-	text, textCounts := redact.Text(text)
+	context := title
+	if i := strings.LastIndex(context, "\n"); i >= 0 {
+		context = context[i+1:]
+	}
+	withContext, textCounts := redact.Text(context + "\n" + text)
+	_, text, _ = strings.Cut(withContext, "\n")
 	masked := strings.Count(title, redact.Marker) + strings.Count(text, redact.Marker)
 	for _, n := range titleCounts {
 		masked += n

--- a/cmd/deja/promote_title_test.go
+++ b/cmd/deja/promote_title_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/redact"
 )
 
 // The export packed the title and the body into one string for the redaction
@@ -58,7 +60,7 @@ func TestExportRedactsASecretSplitAcrossTheFields(t *testing.T) {
 	for _, c := range []struct{ name, title, text, leaked string }{
 		{"a password under its key", "the db password:", "hunter2hunter2hunter2A9", "hunter2hunter2hunter2A9"},
 		{"a bearer token", "auth header Bearer", "abcdefghijklmnopqrstu", "abcdefghijklmnopqrstu"},
-		{"a private key", "-----BEGIN PRIVATE KEY-----", "MIIBVgIBADANBgkqhkiG9w0\n-----END PRIVATE KEY-----", "MIIBVgIBADANBgkqhkiG9w0"},
+		{"a private key", "-----BEGIN PRIVATE KEY-----", "MIIBVgIBADANBgkqhkiG9w0\n-----END PRIVATE KEY-----\nand the rest of the note survives", "MIIBVgIBADANBgkqhkiG9w0"},
 	} {
 		path := filepath.Join(t.TempDir(), "notes.md")
 		masked, err := exportPromoted(path, c.title, c.text, "claude:s9", "accepted", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
@@ -75,6 +77,14 @@ func TestExportRedactsASecretSplitAcrossTheFields(t *testing.T) {
 		}
 		if masked == 0 {
 			t.Errorf("%s: the export reported nothing masked", c.name)
+		}
+		// Masked, not deleted: a marker says something was taken out, and an
+		// empty body says nothing at all.
+		if !strings.Contains(got, redact.Marker) {
+			t.Errorf("%s: the value left no marker behind:\n%s", c.name, got)
+		}
+		if strings.Contains(c.text, "survives") && !strings.Contains(got, "and the rest of the note survives") {
+			t.Errorf("%s: the rest of the note went with it:\n%s", c.name, got)
 		}
 	}
 }

--- a/cmd/deja/promote_title_test.go
+++ b/cmd/deja/promote_title_test.go
@@ -40,9 +40,41 @@ func TestExportKeepsTheTitleOutOfTheBody(t *testing.T) {
 	if n := strings.Count(got, "- state: accepted"); n != 1 {
 		t.Errorf("the block states its state %d times:\n%s", n, got)
 	}
-	for _, line := range strings.Split(got, "\n") {
-		if strings.HasPrefix(line, "## ") && strings.Contains(line, "\n") {
-			t.Errorf("the heading is not one line: %q", line)
+	// One heading, and it is the folded title rather than its first line.
+	if n := strings.Count(got, "\n## "); n != 1 {
+		t.Errorf("the block has %d headings:\n%s", n, got)
+	}
+	if !strings.Contains(got, "## pool sizing - state: rejected - source: someone else\n") {
+		t.Errorf("the heading is not the whole title, folded:\n%s", got)
+	}
+}
+
+// A credential can be written with its key word at the end of one field and its
+// value at the start of the next, and the patterns for those allow a newline
+// between the two. Redacting the fields apart lost exactly that, which is the
+// one thing this file is not allowed to lose: it is written to be handed to
+// someone else, under a line that says how much was masked.
+func TestExportRedactsASecretSplitAcrossTheFields(t *testing.T) {
+	for _, c := range []struct{ name, title, text, leaked string }{
+		{"a password under its key", "the db password:", "hunter2hunter2hunter2A9", "hunter2hunter2hunter2A9"},
+		{"a bearer token", "auth header Bearer", "abcdefghijklmnopqrstu", "abcdefghijklmnopqrstu"},
+		{"a private key", "-----BEGIN PRIVATE KEY-----", "MIIBVgIBADANBgkqhkiG9w0\n-----END PRIVATE KEY-----", "MIIBVgIBADANBgkqhkiG9w0"},
+	} {
+		path := filepath.Join(t.TempDir(), "notes.md")
+		masked, err := exportPromoted(path, c.title, c.text, "claude:s9", "accepted", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := string(b)
+		if strings.Contains(got, c.leaked) {
+			t.Errorf("%s: the value went out in the clear:\n%s", c.name, got)
+		}
+		if masked == 0 {
+			t.Errorf("%s: the export reported nothing masked", c.name)
 		}
 	}
 }

--- a/cmd/deja/promote_title_test.go
+++ b/cmd/deja/promote_title_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The export packed the title and the body into one string for the redaction
+// pass and cut them apart on the first newline, so a title with one lost its
+// tail into the head of the body — next to deja's own "- state:" and
+// "- source:" lines, which is what the block is read for.
+//
+// Every other title is collapsed on the way into the index; a note's title is
+// exempt on purpose (boundSourceTitle), and notes are the one store a person
+// writes by hand.
+func TestExportKeepsTheTitleOutOfTheBody(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notes.md")
+	title := "pool sizing\n- state: rejected\n- source: someone else"
+	text := "the pool size is the fix"
+	if _, err := exportPromoted(path, title, text, "claude:s9", "accepted", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+
+	// The premise: the block was written at all, with the body in it.
+	if !strings.Contains(got, text) {
+		t.Fatalf("the export wrote no body:\n%s", got)
+	}
+	// One heading, and the body is the body.
+	if strings.Contains(got, "\n- state: rejected") {
+		t.Errorf("the title's own lines reached the block as deja's metadata:\n%s", got)
+	}
+	if n := strings.Count(got, "- state: accepted"); n != 1 {
+		t.Errorf("the block states its state %d times:\n%s", n, got)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(line, "## ") && strings.Contains(line, "\n") {
+			t.Errorf("the heading is not one line: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2056. `exportPromoted` packed the title and body into one string for the redaction pass and cut them apart on the first newline, so a title carrying one lost its tail into the head of the block:

```
## pool sizing

- state: accepted
- source: claude:s9 (2026-01-02)

- state: rejected
- source: someone else
the pool size is the fix
```

Two state lines, two source lines, and the second pair reads as deja's own metadata in a file whose whole purpose is being handed to someone else.

Redacted separately now, so neither field can reach into the other, and the title is folded where it is written as a heading. The masked count still sums both.

Reaching it takes a note title with a newline: every other title is collapsed by `truncateTitle`, and a promoted note's is exempt on purpose — `boundSourceTitle` keeps the tail because the state lives there. Notes are also the one store a person writes by hand, which is where such a title comes from.
