### PR TITLE
fix(promote): keep a note title on deja's own line

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -873,7 +873,10 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		}
 		// The title is transcript text going straight to a terminal: an escape
 		// in it repaints the screen and a carriage return rewinds the line.
-		if title = redact.SafeForDisplay(title); title != "" {
+		// SafeForDisplay keeps a newline on purpose — the reading surfaces are
+		// the session's own layout — but this is one row of a listing, and a
+		// note title carries whatever a person wrote by hand (#2058).
+		if title = search.SafeNoteTitle(redact.SafeForDisplay(title)); title != "" {
 			// A session with no user turn borrows the assistant's opening line
 			// (#692), and unmarked it read like the reader's own question
 			// (#1100).

--- a/cmd/deja/note_title_line_test.go
+++ b/cmd/deja/note_title_line_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A note's title is exempt from the fold and the bound every other title gets —
+// its state lives in the tail, so `boundSourceTitle` leaves it alone — and the
+// notes file is the one store a person writes by hand. The surfaces that print
+// it have to hold their own line anyway (#2058).
+func TestANoteTitleStaysOnDejasOwnLine(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	notes := os.Getenv("DEJA_NOTES_FILE")
+	long := strings.Repeat("very long title ", 300)
+	body := `{"ts":"2026-01-02T03:04:05Z","project":"app","text":"the pool size is the fix","kind":"promoted","session":"claude:s9","state":"accepted","title":"pool sizing\n- state: rejected\n- source: someone else"}` + "\n" +
+		`{"ts":"2026-01-03T03:04:05Z","project":"app","text":"another decision entirely","kind":"promoted","session":"claude:s8","state":"accepted","title":"` + long + `"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "index"); err != nil {
+		t.Fatalf("index: %v %s", err, out)
+	}
+
+	out, err := captureRun(t, "promote", "deja-note-claude-s9", "--state", "rejected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the confirmation was printed and names the note.
+	first, rest, _ := strings.Cut(out, "\n")
+	if !strings.Contains(first, "promoted claude:s9") {
+		t.Fatalf("promote printed no confirmation:\n%s", out)
+	}
+	if !strings.Contains(first, "pool sizing") {
+		t.Errorf("the confirmation does not name the note: %q", first)
+	}
+	// The title's own lines must not become lines of deja's output.
+	if strings.Contains(rest, "- state: rejected\n") || strings.HasPrefix(rest, "- source:") {
+		t.Errorf("the title's lines print as deja's own:\n%s", out)
+	}
+
+	stats, err := captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(stats, "\n") {
+		if len([]rune(line)) > 400 {
+			t.Errorf("a stats row is %d columns wide:\n%q", len([]rune(line)), line[:120])
+		}
+	}
+	// Folded into deja's row is fine; a line of its own is not — that is the
+	// shape a reader takes for deja's own structure.
+	for _, line := range strings.Split(stats, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "- source:") || strings.HasPrefix(strings.TrimSpace(line), "- state:") {
+			t.Errorf("a title's own line became a row of the stats screen: %q", line)
+		}
+	}
+
+	// The other confirmation: the one printed when the export could not be
+	// written, which is the moment a reader most needs deja's line to read as
+	// deja's.
+	unwritable := filepath.Join(tmp, "nowhere", "decisions.md")
+	out, err = captureRun(t, "promote", "deja-note-claude-s9", "--state", "accepted", "--to", unwritable)
+	if err == nil {
+		t.Fatalf("the export was supposed to fail, so this measures nothing:\n%s", out)
+	}
+	first, rest, _ = strings.Cut(out, "\n")
+	if !strings.Contains(first, "promoted claude:s9") {
+		t.Fatalf("the failure path printed no confirmation:\n%s", out)
+	}
+	if strings.HasPrefix(strings.TrimSpace(rest), "- state:") || strings.HasPrefix(strings.TrimSpace(rest), "- source:") {
+		t.Errorf("the title's lines print as deja's own on the failure path:\n%s", out)
+	}
+}

--- a/cmd/deja/note_title_line_test.go
+++ b/cmd/deja/note_title_line_test.go
@@ -17,7 +17,9 @@ func TestANoteTitleStaysOnDejasOwnLine(t *testing.T) {
 	notes := os.Getenv("DEJA_NOTES_FILE")
 	long := strings.Repeat("very long title ", 300)
 	body := `{"ts":"2026-01-02T03:04:05Z","project":"app","text":"the pool size is the fix","kind":"promoted","session":"claude:s9","state":"accepted","title":"pool sizing\n- state: rejected\n- source: someone else"}` + "\n" +
-		`{"ts":"2026-01-03T03:04:05Z","project":"app","text":"another decision entirely","kind":"promoted","session":"claude:s8","state":"accepted","title":"` + long + `"}` + "\n"
+		`{"ts":"2026-01-03T03:04:05Z","project":"app","text":"another decision entirely","kind":"promoted","session":"claude:s8","state":"accepted","title":"` + long + `"}` + "\n" +
+		`{"ts":"2026-01-04T03:04:05Z","project":"app","text":"and the correction that follows it","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n" +
+		`{"ts":"2026-01-05T03:04:05Z","project":"app","text":"and one more turn so it is the longest","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n"
 	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -46,10 +48,24 @@ func TestANoteTitleStaysOnDejasOwnLine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The premise: the row exists and names a note, or the checks below hold
+	// for a screen that stopped printing it.
+	longest := ""
 	for _, line := range strings.Split(stats, "\n") {
-		if len([]rune(line)) > 400 {
-			t.Errorf("a stats row is %d columns wide:\n%q", len([]rune(line)), line[:120])
+		if strings.Contains(line, "Longest session") {
+			longest = line
 		}
+	}
+	if longest == "" || !strings.Contains(longest, "very long title") {
+		t.Fatalf("the longest session is not the note this measures:\n%s", stats)
+	}
+	// Bounded, and the state it ends in survives the bound: that suffix is what
+	// every one-line surface reads a note title for.
+	if len([]rune(longest)) > 400 {
+		t.Errorf("a stats row is %d columns wide: %q", len([]rune(longest)), longest[:120])
+	}
+	if !strings.HasSuffix(strings.TrimSpace(longest), "[rejected]") {
+		t.Errorf("the clip ate the state the title ends in: %q", longest)
 	}
 	// Folded into deja's row is fine; a line of its own is not — that is the
 	// shape a reader takes for deja's own structure.
@@ -73,5 +89,19 @@ func TestANoteTitleStaysOnDejasOwnLine(t *testing.T) {
 	}
 	if strings.HasPrefix(strings.TrimSpace(rest), "- state:") || strings.HasPrefix(strings.TrimSpace(rest), "- source:") {
 		t.Errorf("the title's lines print as deja's own on the failure path:\n%s", out)
+	}
+
+	// And the listing that prints a title straight to a terminal.
+	last, err := captureRun(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(last, "pool sizing") {
+		t.Fatalf("last printed no note:\n%s", last)
+	}
+	for _, line := range strings.Split(last, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "- source:") || strings.HasPrefix(strings.TrimSpace(line), "- state:") {
+			t.Errorf("a title's own line became a row of the listing: %q", line)
+		}
 	}
 }

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -141,7 +141,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 			// The note is already written by this point, so failing with a bare
 			// syscall told the reader their decision was lost when it was not
 			// — and named a path with nothing to do about it (#871).
-			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
+			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, search.SafeNote(title))
 			return fmt.Errorf("the note is kept, but %s could not be written (%s) — export it somewhere you can, or read the note back with `deja show %s`",
 				exportPath, exportFailureReason(err), "deja-note-"+strings.ReplaceAll(src, ":", "-"))
 		}
@@ -151,7 +151,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		// rewritten — the warning is what was missing (#848).
 		fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this file. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked, pluralS(masked))
 	}
-	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, title)
+	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, search.SafeNote(title))
 	if line := markTakenBack(src, state, prior); line != "" {
 		fmt.Fprintln(stdout, line)
 	}

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -316,7 +316,7 @@ func printStats(w io.Writer, r stats.Report) {
 		}
 	}
 	for _, p := range r.TopProjects {
-		fmt.Fprintf(w, "  %-18s %s %d\n", stats.TrimRunes(p.Project, 18), strings.Repeat(barGlyph, stats.ScaledBar(p.Sessions, maxProject, 18)), p.Sessions)
+		fmt.Fprintf(w, "  %-18s %s %d\n", stats.TrimRunes(search.SafeLine(p.Project), 18), strings.Repeat(barGlyph, stats.ScaledBar(p.Sessions, maxProject, 18)), p.Sessions)
 	}
 	fmt.Fprintln(w)
 

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -342,7 +342,7 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sHighlights%s\n", bold, reset)
-	fmt.Fprintf(w, "  Longest session  %d message%s · %s · %s\n", r.Longest.Messages, pluralS(r.Longest.Messages), statHarnessTag(r.Longest.Harness, color), valueOrDash(r.Longest.Title))
+	fmt.Fprintf(w, "  Longest session  %d message%s · %s · %s\n", r.Longest.Messages, pluralS(r.Longest.Messages), statHarnessTag(r.Longest.Harness, color), valueOrDash(search.SafeNote(r.Longest.Title)))
 	fmt.Fprintf(w, "  Busiest day      %s · %d message%s\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages, pluralS(r.BusiestDay.Messages))
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -342,7 +342,7 @@ func printStats(w io.Writer, r stats.Report) {
 	fmt.Fprintln(w)
 
 	fmt.Fprintf(w, "%sHighlights%s\n", bold, reset)
-	fmt.Fprintf(w, "  Longest session  %d message%s · %s · %s\n", r.Longest.Messages, pluralS(r.Longest.Messages), statHarnessTag(r.Longest.Harness, color), valueOrDash(search.SafeNote(r.Longest.Title)))
+	fmt.Fprintf(w, "  Longest session  %d message%s · %s · %s\n", r.Longest.Messages, pluralS(r.Longest.Messages), statHarnessTag(r.Longest.Harness, color), valueOrDash(search.SafeNoteTitle(r.Longest.Title)))
 	fmt.Fprintf(w, "  Busiest day      %s · %d message%s\n", valueOrDash(r.BusiestDay.Date), r.BusiestDay.Messages, pluralS(r.BusiestDay.Messages))
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "%sRecall%s\n", bold, reset)

--- a/internal/search/blame_snippet_test.go
+++ b/internal/search/blame_snippet_test.go
@@ -84,3 +84,31 @@ func TestSafeCommandIsClippedFromTheRight(t *testing.T) {
 		t.Errorf("a path lost its own name: %q", p)
 	}
 }
+
+// A note title ends in the state the note is in, and that suffix is what every
+// one-line surface reads it for — so the clip keeps it. Only a short one: a long
+// bracketed tail would otherwise carry the whole title past the bound (#2058).
+func TestSafeNoteTitleKeepsTheStateAndStaysBounded(t *testing.T) {
+	long := strings.Repeat("very long title ", 40)
+	for _, c := range []struct {
+		name, in string
+		suffix   string
+		bounded  bool
+	}{
+		{"a state survives the clip", long + " [rejected]", " [rejected]", true},
+		{"a short title is untouched", "pool sizing [accepted]", " [accepted]", false},
+		{"a long bracketed tail is not a state", "note [" + strings.Repeat("x", 400) + "]", "", true},
+		{"no state at all", long, "", true},
+	} {
+		got := SafeNoteTitle(c.in)
+		if c.suffix != "" && !strings.HasSuffix(got, c.suffix) {
+			t.Errorf("%s: %q does not end in %q", c.name, got, c.suffix)
+		}
+		if c.bounded && len(got) > answerCap+noteStateCap {
+			t.Errorf("%s: %d bytes, over the %d bound", c.name, len(got), answerCap+noteStateCap)
+		}
+		if strings.Contains(got, "\n") {
+			t.Errorf("%s: the row is not one line: %q", c.name, got)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2207,6 +2207,19 @@ func SafeNote(s string) string {
 	return clip(SafeLine(s))
 }
 
+// SafeNoteTitle is SafeNote for a promoted note's title, which ends in the state
+// the note is in — "… [rejected]" — and that suffix is the part every one-line
+// surface reads it for. Clipping from the left would drop exactly it (#R11), so
+// the middle gives way instead.
+func SafeNoteTitle(s string) string {
+	line := SafeLine(s)
+	state := ""
+	if i := strings.LastIndex(line, " ["); i > 0 && strings.HasSuffix(line, "]") {
+		state, line = line[i:], line[:i]
+	}
+	return clip(line) + state
+}
+
 // SafeLine is SafeText confined to a single line, for the places that print
 // an untrusted string as one row of something structured — a listing entry, a
 // digest row, a "saved <path>" confirmation. A newline there ends deja's own

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2207,6 +2207,11 @@ func SafeNote(s string) string {
 	return clip(SafeLine(s))
 }
 
+// noteStateCap bounds the bracketed tail SafeNoteTitle will carry past the
+// clip. The longest state deja writes is " [superseded]" at 13 bytes; the room
+// above that is for one deja does not know yet, from a store written by hand.
+const noteStateCap = 24
+
 // SafeNoteTitle is SafeNote for a promoted note's title, which ends in the state
 // the note is in — "… [rejected]" — and that suffix is the part every one-line
 // surface reads it for. Clipping from the left would drop exactly it (#R11), so
@@ -2214,7 +2219,10 @@ func SafeNote(s string) string {
 func SafeNoteTitle(s string) string {
 	line := SafeLine(s)
 	state := ""
-	if i := strings.LastIndex(line, " ["); i > 0 && strings.HasSuffix(line, "]") {
+	// Only a short tail: the suffix is a state word, and exempting whatever
+	// follows the last " [" would let a long bracketed tail carry the whole
+	// title past the bound the clip is here to apply (#1645).
+	if i := strings.LastIndex(line, " ["); i > 0 && strings.HasSuffix(line, "]") && len(line)-i <= noteStateCap {
 		state, line = line[i:], line[:i]
 	}
 	return clip(line) + state


### PR DESCRIPTION
Fixes #2058. A hand-written promoted note whose title holds newlines:

```
$ deja promote deja-note-claude-s9 --state rejected
promoted claude:s9 as rejected: pool sizing
- state: rejected
- source: someone else
```

One line of deja's own output becomes three, and the two extra are shaped like deja's own metadata. `deja stats` prints the same title through `valueOrDash` and breaks the same way — and a 4800-character title takes the screen with it.

A note title is exempt from the fold and the bound every other title gets, on purpose: its state lives in the tail and `boundSourceTitle` keeps it. So the surfaces that print it have to hold their own line, which is what `search.SafeNote` is — `SafeLine` plus the clip.

Both promote confirmations are covered, including the one printed when the export could not be written, which is the moment a reader most needs deja's line to read as deja's. Each fails on its own mutant.
