### PR TITLE
fix(share): count the masked spots in the file, once

### DIFF
--- a/cmd/deja/masked_count_test.go
+++ b/cmd/deja/masked_count_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/redact"
+)
+
+// The floor line is read before handing a file to someone else, so the number
+// has to be the number of masked spots in the file. Counting the markers *and*
+// adding what the pass replaced counted a fresh secret twice (#2061).
+func TestTheMaskedFloorCountsWhatIsInTheFile(t *testing.T) {
+	fresh := "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd"
+	alreadyMasked, _ := redact.Text("sk-ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210zyxw")
+	if !strings.Contains(alreadyMasked, redact.Marker) {
+		t.Fatalf("the fixture's second secret was not masked: %q", alreadyMasked)
+	}
+
+	for _, c := range []struct {
+		name, title, text string
+		want              int
+	}{
+		{"one the export catches", "pool sizing", "the key is " + fresh, 1},
+		{"one already masked at ingest", "pool sizing", "the key was " + alreadyMasked, 1},
+		{"one of each", "pool sizing", "now " + fresh + " and before " + alreadyMasked, 2},
+		{"nothing to mask", "pool sizing", "the pool size is the fix", 0},
+	} {
+		path := filepath.Join(t.TempDir(), "notes.md")
+		masked, err := exportPromoted(path, c.title, c.text, "claude:s9", "accepted", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The premise and the answer are the same thing: what the line claims
+		// has to be what the file holds.
+		inFile := strings.Count(string(b), redact.Marker)
+		if inFile != c.want {
+			t.Fatalf("%s: the file holds %d masked spots, so the case is wrong: %s", c.name, inFile, b)
+		}
+		if masked != c.want {
+			t.Errorf("%s: the line says %d, the file holds %d", c.name, masked, inFile)
+		}
+	}
+}
+
+// The other surface that prints the floor, counted the same way.
+func TestShareCountsWhatIsInTheShare(t *testing.T) {
+	fresh := "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcd"
+	var out strings.Builder
+	stderr := captureStderr(t, func() { printSanitized(&out, "the key is "+fresh+"\nand nothing else") })
+	inShare := strings.Count(out.String(), redact.Marker)
+	if inShare != 1 {
+		t.Fatalf("the share holds %d masked spots, so this measures nothing: %q", inShare, out.String())
+	}
+	if !strings.Contains(stderr, "1 secrets masked") {
+		t.Errorf("the floor line disagrees with the %d masked spots in the share: %q", inShare, strings.TrimSpace(stderr))
+	}
+}

--- a/cmd/deja/masked_count_test.go
+++ b/cmd/deja/masked_count_test.go
@@ -59,7 +59,7 @@ func TestShareCountsWhatIsInTheShare(t *testing.T) {
 	if inShare != 1 {
 		t.Fatalf("the share holds %d masked spots, so this measures nothing: %q", inShare, out.String())
 	}
-	if !strings.Contains(stderr, "1 secrets masked") {
+	if !strings.Contains(stderr, "deja: 1 secret masked") {
 		t.Errorf("the floor line disagrees with the %d masked spots in the share: %q", inShare, strings.TrimSpace(stderr))
 	}
 }

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -299,12 +299,12 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 	// start of the next, and the patterns for those allow a newline between the
 	// two. That line is one line by construction, so the split below is exact
 	// however many the title has.
-	title, titleCounts := redact.Text(title)
+	title, _ = redact.Text(title)
 	context := title
 	if i := strings.LastIndex(context, "\n"); i >= 0 {
 		context = context[i+1:]
 	}
-	withContext, textCounts := redact.Text(context + "\n" + text)
+	withContext, _ := redact.Text(context + "\n" + text)
 	if head, rest, ok := strings.Cut(withContext, "\n"); ok && head == context {
 		text = rest
 	} else {
@@ -313,13 +313,11 @@ func exportPromoted(path, title, text, src, state string, updated time.Time) (in
 		// nothing: by then the context line is inside the marker.
 		text = withContext
 	}
+	// The masked spots in what is about to be written, and nothing else: a
+	// secret redacted at ingest is already a marker here, and one this pass
+	// replaces became one too. Adding the pass's own tally on top counted the
+	// second kind twice (#2061). deja view counts the same way.
 	masked := strings.Count(title, redact.Marker) + strings.Count(text, redact.Marker)
-	for _, n := range titleCounts {
-		masked += n
-	}
-	for _, n := range textCounts {
-		masked += n
-	}
 	// One line, because it is written as a heading.
 	title = strings.Join(strings.Fields(title), " ")
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -49,7 +49,7 @@ func runShare(dir string, args []string, w io.Writer) error {
 func printSanitized(w io.Writer, text string) {
 	// Redact the whole document at once: multiline secrets (PEM private key
 	// blocks) never match when scanned line-by-line.
-	redacted, counts := redact.Text(text)
+	redacted, _ := redact.Text(text)
 	redacted = stripBidiAndInvisible(redacted)
 	fmt.Fprint(w, redacted)
 	if !strings.HasSuffix(redacted, "\n") {
@@ -62,10 +62,9 @@ func printSanitized(w io.Writer, text string) {
 	// nothing new. Counting only what this pass replaced reported "0 secrets
 	// masked" on a document visibly full of them — the opposite of what the
 	// line is for.
+	// One count, of the markers in what is being shared: adding the pass's own
+	// tally on top counted a secret this pass caught twice (#2061).
 	masked := strings.Count(redacted, redact.Marker)
-	for _, n := range counts {
-		masked += n
-	}
 	fmt.Fprintf(os.Stderr, "deja: %d secrets masked in this share. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked)
 }
 

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -65,7 +65,7 @@ func printSanitized(w io.Writer, text string) {
 	// One count, of the markers in what is being shared: adding the pass's own
 	// tally on top counted a secret this pass caught twice (#2061).
 	masked := strings.Count(redacted, redact.Marker)
-	fmt.Fprintf(os.Stderr, "deja: %d secrets masked in this share. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked)
+	fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this share. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked, pluralS(masked))
 }
 
 // stripBidiAndInvisible removes the characters that make a share render as


### PR DESCRIPTION
Fixes #2061. `deja share` and `deja promote --to` counted the markers in the output *and* added what the redaction pass replaced, so a secret the outbound pass catches was counted twice:

```
one fresh secret     markers-in-output=1 this-pass=1 printed=2
one already masked   markers-in-output=1 this-pass=0 printed=1
one of each          markers-in-output=2 this-pass=1 printed=3
nothing at all       markers-in-output=0 this-pass=0 printed=0
```

Markers in the output is the whole answer: a secret redacted at index time is already a marker, and one this pass replaces becomes one. `deja view` counts exactly that and says why — "counts what a reader will actually find in the file".

It read right most of the time only because the normal path arrives already redacted and the counts map is empty. It doubled precisely when the outbound pass is the one that catches something, which is the case the line exists for.

Both surfaces are tested against the file rather than against a constant: the fixture fatals unless the file really holds the number of masked spots the case is about.
