### PR TITLE
fix(opencode): compare the watermark in the unit the row is stamped in

### DIFF
--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -72,8 +72,9 @@ func ParseOpencodeDBSince(db string, t time.Time) ([]model.Session, error) {
 		return ParseOpencodeDBWhere(db, "", 0)
 	}
 	rfc := sqlEscape(t.UTC().Format(time.RFC3339Nano))
-	ms := t.UnixMilli()
-	where := fmt.Sprintf(" and (m.time_created > %d or m.time_created > '%s' or json_extract(p.data,'$.time.start') > %d or json_extract(p.data,'$.time.start') > '%s')", ms, rfc, ms, rfc)
+	where := fmt.Sprintf(" and (%s or m.time_created > '%s' or %s or json_extract(p.data,'$.time.start') > '%s')",
+		newerThanEpoch("m.time_created", t), rfc,
+		newerThanEpoch("json_extract(p.data,'$.time.start')", t), rfc)
 	return ParseOpencodeDBWhere(db, where, 0)
 }
 

--- a/internal/sources/since_units_test.go
+++ b/internal/sources/since_units_test.go
@@ -1,0 +1,85 @@
+package sources
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// parseTimeAny takes a stamp in either unit, so a since clause may not assume
+// one. opencode's compared everything against milliseconds, which puts every
+// seconds-stamped row below the watermark for ever: the store is read once and
+// then never updated again, silently (#2064).
+func TestOpencodeSinceTakesASecondsStampedRow(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	// The turn is newer than the watermark. Written in seconds, which is what
+	// unixGuess's lower branch exists for.
+	newer := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	watermark := newer.Add(-time.Hour)
+	stmts := fmt.Sprintf(`
+create table session (id text primary key, directory text, time_created integer, time_updated integer);
+create table message (id text primary key, session_id text, data text, time_created integer);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('s1','/tmp/app',%[1]d,%[1]d);
+insert into message values ('m1','s1','{"role":"user"}',%[1]d);
+insert into part values ('p1','m1',json_object('type','text','text','the autovacuum thread stalls'));
+`, newer.Unix())
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	// The premise: a full read does take this row, so a since clause that
+	// drops it is losing something the reader understands.
+	whole, err := ParseOpencodeDBSince(db, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(whole) != 1 {
+		t.Fatalf("the fixture is not readable at all, so this measures nothing: %d sessions", len(whole))
+	}
+
+	ss, err := ParseOpencodeDBSince(db, watermark)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("a turn stamped %s in seconds did not come back for a watermark of %s: %d sessions",
+			newer.Format(time.RFC3339), watermark.Format(time.RFC3339), len(ss))
+	}
+}
+
+// The other half: a millisecond store must still be filtered, or the watermark
+// buys nothing on the multi-GB stores it exists for.
+func TestOpencodeSinceStillFiltersAMillisecondStore(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	older := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	watermark := older.Add(time.Hour)
+	stmts := fmt.Sprintf(`
+create table session (id text primary key, directory text, time_created integer, time_updated integer);
+create table message (id text primary key, session_id text, data text, time_created integer);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('s1','/tmp/app',%[1]d,%[1]d);
+insert into message values ('m1','s1','{"role":"user"}',%[1]d);
+insert into part values ('p1','m1',json_object('type','text','text','the autovacuum thread stalls'));
+`, older.UnixMilli())
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	if whole, err := ParseOpencodeDBSince(db, time.Time{}); err != nil || len(whole) != 1 {
+		t.Fatalf("the fixture is not readable at all: %d sessions err=%v", len(whole), err)
+	}
+	ss, err := ParseOpencodeDBSince(db, watermark)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Errorf("a turn older than the watermark came back anyway: %d sessions", len(ss))
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -93,8 +93,25 @@ func parseTimeAny(v any) time.Time {
 	return time.Time{}
 }
 
+// newerThanEpoch is the SQL for "this numeric stamp is after t", for a column
+// deja reads through unixGuess and so accepts in either unit.
+//
+// A since clause that picks one unit is wrong in one direction or the other: a
+// seconds row is below every millisecond watermark, so the store is read once
+// and then never updated again with nothing printed (#2064); a millisecond row
+// is above every seconds watermark, so the store comes back whole on every
+// pass. Comparing against both unconditionally is the second of those. The
+// split is unixGuess's own, applied to the row rather than to the watermark.
+func newerThanEpoch(expr string, t time.Time) string {
+	return fmt.Sprintf("(%[1]s > %[2]d or (%[1]s <= %[4]d and %[1]s > %[3]d))",
+		expr, t.UnixMilli(), t.Unix(), epochMilliCutoff)
+}
+
+// Above this a stamp is milliseconds, below it seconds.
+const epochMilliCutoff = int64(1e12)
+
 func unixGuess(n int64) time.Time {
-	if n > 1e12 {
+	if n > epochMilliCutoff {
 		return time.UnixMilli(n)
 	}
 	if n > 0 {


### PR DESCRIPTION
Fixes #2064. `unixGuess` takes a numeric timestamp in either unit — above 1e12 it is milliseconds, below it seconds — but opencode's since clause compared every row against `t.UnixMilli()`. A seconds-stamped row sits below every watermark, so a store like that is read once and then never updated again, with nothing printed:

```
after: marker-echo    -> [s4(1 msgs)]     # first build sees the session
third: incremental index changed_files=1 removed_files=0 sessions=0
third: marker-foxtrot -> []               # the turn added since never arrives
```

The clause now compares each row in the unit it is written in, using unixGuess's own split. Comparing against both unconditionally would be worse than the bug: every millisecond row passes a seconds test, so the watermark stops filtering on exactly the multi-GB stores it exists for. There is a test for each half.

Cursor reads with `epochMS`, milliseconds only, so its clause matches its reader and is left alone. hermes has the mirror (a seconds watermark against a dual-unit reader, so a millisecond store comes back whole every pass) — that costs work rather than data and is a separate call.
