### PR TITLE
stop matching the transcript's record of a deja call

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -224,7 +224,12 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			if o.Role != "" && !roleMatches(m.Role, o.Role) {
 				continue
 			}
-			low := strings.ToLower(m.Text)
+			// The transcript's own record of a call to deja is not something
+			// anyone said, and a question matches the log of that question
+			// being asked (#2067). Removed from matching only; the line stays
+			// in the transcript for `deja how` and `deja fix`.
+			text := withoutOwnCallLog(m.Text)
+			low := strings.ToLower(text)
 			c := 0
 			// windowText and windowToks are the pair proximity is measured on: the
 			// surface text and the query's own words, except where the match came from
@@ -232,9 +237,9 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			// genuine match as words that never meet.
 			windowText, windowToks := low, qtoks
 			if re != nil {
-				c = countRegex(re, m.Text)
+				c = countRegex(re, text)
 			} else {
-				c = countIn(m.Text, low, qtoks, phrases, o.FuzzyVariants)
+				c = countIn(text, low, qtoks, phrases, o.FuzzyVariants)
 				// Postings are keyed on Traditional-folded CJK, so a query in
 				// one script legitimately reaches a record in the other. This
 				// counting pass works on surface text and would score that
@@ -242,7 +247,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				// already found — retry with both sides folded.
 				if c == 0 && queryCJK {
 					foldedLow := cjkfold.String(low)
-					c = countIn(cjkfold.String(m.Text), foldedLow, qtoksFolded,
+					c = countIn(cjkfold.String(text), foldedLow, qtoksFolded,
 						phrasesFolded, o.FuzzyVariants)
 					if c > 0 {
 						windowText, windowToks = foldedLow, qtoksFolded
@@ -259,7 +264,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				// first three showed wherever a word happened to appear early
 				// rather than the passage that carries the answer.
 				w := tokenWindow(windowText, windowToks)
-				snipCands = append(snipCands, snipCand{text: m.Text, weight: c, window: w})
+				snipCands = append(snipCands, snipCand{text: text, weight: c, window: w})
 				if w > 0 && (doc.minWindow == 0 || w < doc.minWindow) {
 					doc.minWindow = w
 				}
@@ -2137,7 +2142,11 @@ func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]fl
 		}
 		best := make([]msgScore, 0, 8)
 		for mi, m := range s.Messages {
-			low := strings.ToLower(m.Text)
+			// The same rule the scoring loop applies: a transcript's record of
+			// a call to deja is not something anyone said, and this tier is
+			// where the live miss came through — the scoring loop was fixed
+			// first and the hit arrived here instead (#2067).
+			low := strings.ToLower(withoutOwnCallLog(m.Text))
 			var foldedLow string
 			distinct := 0
 			weighted := 0.0

--- a/internal/search/toolcall.go
+++ b/internal/search/toolcall.go
@@ -1,0 +1,65 @@
+package search
+
+import "strings"
+
+// dejaCallNames are the tools an agent calls to reach deja. A transcript line
+// carrying one of them beside a JSON argument object is the record of a call,
+// not something anyone said.
+var dejaCallNames = []string{
+	"deja_recall_context", "deja_recall", "deja_remember",
+	"deja_blame", "deja_fix", "deja_how",
+	"recall_context",
+}
+
+// withoutOwnCallLog removes the lines where a transcript recorded a call to
+// deja, so a question does not match the log of that same question being asked.
+//
+// An agent run from inside a session writes its stdout into that session's
+// transcript, tool-call lines and all, and those lines carry the queries it
+// sent. Asked which wording option had been chosen, recall led with
+// `⚙ deja_recall {"query":"deja-vu repository description…"}` from a real
+// working session, and the agent answered with an invented phrase (#2067).
+//
+// The lines are removed from matching only. The fact that a call happened stays
+// in the transcript, which is what `deja how` and `deja fix` are built on —
+// dropping it at ingest would buy this at their cost.
+//
+// Deliberately narrow: deja's own tool names beside a JSON object. A general
+// rule about tool logs would have to guess at every harness's formatting, and
+// the echo that matters is the one deja creates for itself.
+func withoutOwnCallLog(text string) string {
+	if !strings.Contains(text, `{"`) {
+		return text
+	}
+	lines := strings.Split(text, "\n")
+	kept := lines[:0:0]
+	for _, line := range lines {
+		if isOwnCallLine(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	if len(kept) == len(lines) {
+		return text
+	}
+	return strings.Join(kept, "\n")
+}
+
+// isOwnCallLine reports whether a line records a call to deja: one of its tool
+// names, and a JSON argument object after it.
+func isOwnCallLine(line string) bool {
+	low := strings.ToLower(line)
+	for _, name := range dejaCallNames {
+		at := strings.Index(low, name)
+		if at < 0 {
+			continue
+		}
+		// The arguments follow the name — a line merely discussing the tool
+		// ("recall_context returns a digest") has no object after it and is
+		// ordinary prose worth keeping.
+		if strings.Contains(low[at+len(name):], `{"`) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/search/toolcall_test.go
+++ b/internal/search/toolcall_test.go
@@ -1,0 +1,100 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An agent run from inside a session writes its stdout into that session's
+// transcript, tool-call lines included, and those lines carry the queries it
+// sent. Asked which wording option had been chosen, recall led with the log of
+// that very question being asked and the agent answered with an invented
+// phrase (#2067).
+func TestTheLogOfACallDoesNotAnswerTheQuestionItAsked(t *testing.T) {
+	now := time.Now()
+	// A real working session that happens to contain the log.
+	logged := model.Session{
+		ID: "logged", Harness: "claude", Project: "deja-vu",
+		Path: "/Users/x/.claude/projects/deja-vu/logged.jsonl", Started: now, Updated: now,
+		Messages: []model.Message{
+			{Role: "assistant", Text: "> builder · gpt-5.6-luna\n" +
+				`⚙ deja_recall {"query":"repository description wording","limit":10}` + "\n" +
+				"ran the sweep and moved on", Time: now},
+		},
+	}
+	answered := model.Session{
+		ID: "answered", Harness: "claude", Project: "deja-vu",
+		Path: "/Users/x/.claude/projects/deja-vu/answered.jsonl", Started: now, Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "which repository description wording did we pick", Time: now},
+			{Role: "assistant", Text: "You picked the task-first option, so it now opens with Search your past AI coding sessions.", Time: now},
+		},
+	}
+
+	hits, err := Run([]model.Session{logged, answered}, Options{Query: "repository description wording", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("nothing matched at all")
+	}
+	if hits[0].Session.ID != "answered" {
+		t.Errorf("the log of the call outranked the answer: %s", hits[0].Session.ID)
+	}
+	for _, h := range hits {
+		for _, sn := range h.Snippets {
+			if strings.Contains(sn, "deja_recall {") {
+				t.Errorf("a call log was quoted back as a snippet: %q", sn)
+			}
+		}
+	}
+}
+
+// The fact that a call happened stays in the transcript — `deja how` and
+// `deja fix` are built on exactly that — so only matching is affected.
+func TestTheCallItselfIsStillInTheTranscript(t *testing.T) {
+	line := `⚙ deja_how {"what":"go test"}`
+	s := model.Session{
+		ID: "kept", Harness: "claude", Project: "p",
+		Messages: []model.Message{{Role: "assistant", Text: line}},
+	}
+	if got := s.Messages[0].Text; got != line {
+		t.Fatalf("the transcript was rewritten: %q", got)
+	}
+	if withoutOwnCallLog(line) != "" {
+		t.Errorf("the line was not removed from matching: %q", withoutOwnCallLog(line))
+	}
+}
+
+// Prose about the tools is ordinary text and has to stay searchable, or a
+// session explaining how recall works becomes unfindable.
+func TestProseAboutTheToolsIsKept(t *testing.T) {
+	for _, text := range []string{
+		"recall_context returns a digest of the best matching session",
+		"we should call deja_recall before debugging anything",
+		"deja_fix takes the failing output verbatim",
+	} {
+		if got := withoutOwnCallLog(text); got != text {
+			t.Errorf("prose was treated as a call log: %q -> %q", text, got)
+		}
+	}
+}
+
+// Only the log lines go; the rest of the message is still matched.
+func TestOnlyTheCallLinesAreRemoved(t *testing.T) {
+	text := "looked at the release\n" +
+		`⚙ deja_recall {"query":"release discussion permission"}` + "\n" +
+		"the missing permission was discussions: write"
+	got := withoutOwnCallLog(text)
+	if strings.Contains(got, "deja_recall {") {
+		t.Errorf("the call line survived: %q", got)
+	}
+	for _, want := range []string{"looked at the release", "discussions: write"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q was removed with it", want)
+		}
+	}
+}


### PR DESCRIPTION
Part of #2067, and only part — said up front.

An agent run from inside a session writes its stdout into that session's
transcript, tool-call lines included, and those lines carry the queries it sent.
A later question then matches the record of that question being asked. Live on
opencode with gpt-5.6-luna, asked which wording option had been picked for the
repository description, recall led with

```
> builder · gpt-5.6-luna ⚙ deja_recall {"query":"deja-vu repository descriptio…
```

and the agent answered with a phrase that was never used.

Lines carrying one of deja's own tool names beside a JSON argument object no
longer match and are no longer quoted as snippets. The line stays in the
transcript: `deja how` and `deja fix` are built on the fact that a call
happened, and dropping it at ingest would buy this at their cost.

Applied in two places because the first was not enough. The scoring loop was the
obvious one; the live hit came through the relevance tier, which builds its own
excerpts and never reaches that loop. That is the third time this session a
filter has been placed in one path of several — worth knowing before adding a
fourth.

**What this does not close.** The top hit for that query is now the output of a
diagnostic script that printed the query as a header — captured stdout again,
without a tool name in it. The family is "a transcript quoting text that echoes
the query", and deja's own call lines are the one shape narrow enough to
recognise without guessing. #2067 stays open with that written down.

Guards: prose about the tools stays searchable ("we should call deja_recall
before debugging anything"), only the log lines are removed from a mixed
message, and the reproduction fails without the fix in either path.
