### PR TITLE
fix(goose): let the database own a session that survived the migration

### DIFF
--- a/cmd/deja/goose_migration_line_test.go
+++ b/cmd/deja/goose_migration_line_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A goose session that came back from both of that harness's stores is one
+// conversation, so the id-collision warning is wrong about it — but the
+// per-harness line still counted it twice, and the totals that reconcile the
+// two used to print only alongside that warning (#2066, #1091).
+func TestAMigratedGooseSessionSaysTheTotalsWithoutTheWarning(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	hermeticEnv(t)
+	root := filepath.Join(t.TempDir(), "goose")
+	sessions := filepath.Join(root, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GOOSE_ROOT", root)
+	db := filepath.Join(sessions, "sessions.db")
+	t.Setenv("DEJA_GOOSE_DB", db)
+
+	jsonl := `{"id":"20260101_120000","description":"pgbouncer pool","working_dir":"/tmp/app"}
+{"role":"user","content":[{"type":"text","text":"why does pgbouncer time out"}],"created":1767268800}
+`
+	if err := os.WriteFile(filepath.Join(sessions, "20260101_120000.jsonl"), []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sql := `create table sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
+create table messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
+insert into sessions values ('20260101_120000','n','pgbouncer pool','/tmp/app','2026-01-01 12:00:00','2026-01-01 12:05:00');
+insert into messages values (1,'20260101_120000','user','[{"type":"text","text":"why does pgbouncer time out"}]',1767268800);
+insert into messages values (2,'20260101_120000','user','[{"type":"text","text":"and after the restart"}]',1767269100);`
+	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+
+	var err error
+	stderr := captureStderr(t, func() { _, err = captureRun(t, "index") })
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the per-harness line really did count both copies, so the
+	// reconciling line has something to reconcile.
+	if !strings.Contains(stderr, "goose: 2 sessions") {
+		t.Fatalf("the two stores were not both read, so this measures nothing: %q", stderr)
+	}
+	if strings.Contains(stderr, "an id with another transcript") {
+		t.Errorf("a migrated session was reported as an id collision: %q", strings.TrimSpace(stderr))
+	}
+	if !strings.Contains(stderr, "count transcripts, not rows") {
+		t.Errorf("the per-harness line says 2 sessions and nothing says the index holds 1: %q", strings.TrimSpace(stderr))
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -377,14 +377,18 @@ func cmdIndex(dir string, rest []string) error {
 	}
 	if n := index.ReportCollisions(); n > 0 {
 		fmt.Fprintf(os.Stderr, "deja: %d session%s %s an id with another transcript — each pair is filed under one project, the one whose file sorts first\n", n, pluralS(n), verbShare(n))
-		// The per-harness lines above count transcripts, so once any of them
-		// merged, those lines add up to more than the index holds — and the
-		// reconciling line below is TTY-only, which is not where anyone is
-		// counting. Say the real totals whenever the sums have parted (#1091).
-		if b := index.LastBuild; b.Messages > 0 {
-			fmt.Fprintf(os.Stderr, "deja: indexed %d session%s, %d message%s — the per-harness lines above count transcripts, not rows\n",
-				b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
-		}
+	}
+	// The per-harness lines above count transcripts, so once any of them
+	// merged, those lines add up to more than the index holds — and the
+	// reconciling line below is TTY-only, which is not where anyone is
+	// counting. Say the real totals whenever the sums have parted (#1091).
+	//
+	// Every merge, not only the ones deja warns about: a goose session that
+	// came back from both of that harness's stores is one conversation and
+	// gets no warning, but it is still two transcripts against one row (#2066).
+	if b := index.LastBuild; index.ReportMerged() > 0 && b.Messages > 0 {
+		fmt.Fprintf(os.Stderr, "deja: indexed %d session%s, %d message%s — the per-harness lines above count transcripts, not rows\n",
+			b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
 	}
 	// A machine with no agent history built an empty index and said nothing:
 	// the step whose whole job is filling memory returned to the prompt after

--- a/internal/index/goose_migration_test.go
+++ b/internal/index/goose_migration_test.go
@@ -1,0 +1,110 @@
+package index
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goose 1.10 moved its sessions into sessions.db and left the JSONL files
+// behind, so the same conversation is in both stores under one id. That is a
+// migration, not two transcripts clashing: the database is the live copy, and
+// deja used to report every migrated session as an id collision and file the
+// row under the superseded file, because the file name sorts first (#2066).
+func TestAMigratedGooseSessionIsNotACollision(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	root := filepath.Join(tmp, "goose")
+	sessions := filepath.Join(root, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GOOSE_ROOT", root)
+	db := filepath.Join(sessions, "sessions.db")
+	t.Setenv("DEJA_GOOSE_DB", db)
+
+	jsonl := `{"id":"20260101_120000","description":"pgbouncer pool","working_dir":"/tmp/app"}
+{"role":"user","content":[{"type":"text","text":"why does pgbouncer time out"}],"created":1767268800}
+`
+	if err := os.WriteFile(filepath.Join(sessions, "20260101_120000.jsonl"), []byte(jsonl), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sql := `create table sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text);
+create table messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
+insert into sessions values ('20260101_120000','n','pgbouncer pool','/tmp/app','2026-01-01 12:00:00','2026-01-01 12:05:00');
+insert into messages values (1,'20260101_120000','user','[{"type":"text","text":"why does pgbouncer time out"}]',1767268800);
+insert into messages values (2,'20260101_120000','user','[{"type":"text","text":"and after the restart"}]',1767269100);`
+	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: both copies really did reach the same row, so the pair is
+	// the one the fix is about.
+	s, ok, err := FindByIdentity(dir, "goose", "20260101_120000")
+	if err != nil || !ok {
+		t.Fatalf("the session is not indexed at all, so this measures nothing: ok=%v err=%v", ok, err)
+	}
+	if len(s.Messages) != 2 {
+		t.Fatalf("the two stores did not merge into one session: %d messages", len(s.Messages))
+	}
+
+	if n := ReportCollisions(); n != 0 {
+		t.Errorf("a migrated session was counted as %d id collision(s)", n)
+	}
+	if !strings.HasSuffix(s.Path, "sessions.db") {
+		t.Errorf("the row is filed under %s, not the live store", s.Path)
+	}
+	if shared := HarnessSharedCounts(dir)["goose"]; shared != 0 {
+		t.Errorf("doctor reports %d shared goose session(s)", shared)
+	}
+}
+
+// A genuine clash between two transcripts must still be reported: two JSONL
+// files under one id are two conversations, whatever the migration looks like.
+func TestTwoGooseFilesUnderOneIDStillCollide(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	root := filepath.Join(tmp, "goose")
+	sessions := filepath.Join(root, "sessions", "archive")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GOOSE_ROOT", root)
+	for i, dirName := range []string{"a", "b"} {
+		d := filepath.Join(sessions, dirName)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"id":"20260101_120000","description":"pgbouncer pool","working_dir":"/tmp/app` + dirName + `"}
+{"role":"user","content":[{"type":"text","text":"conversation ` + dirName + `"}],"created":176726880` + string(rune('0'+i)) + `}
+`
+		if err := os.WriteFile(filepath.Join(d, "20260101_120000.jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := ReportCollisions(); n == 0 {
+		t.Error("two transcripts sharing an id were not reported at all")
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -402,6 +402,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	beginPass()
 	emptied.Store(0)
 	collisions.Store(0)
+	merged.Store(0)
 	// A rebuild evicts nothing, but a number left by an earlier build must not
 	// outlive it (#1861).
 	evicted.Store(0)
@@ -734,6 +735,11 @@ func ReportCollisions() int {
 	return int(collisions.Swap(0))
 }
 
+// ReportMerged is ReportCollisions plus the pairs deja merges without warning.
+func ReportMerged() int {
+	return int(merged.Swap(0))
+}
+
 // markShared records that a manifest row covers more than one conversation, so
 // a later forget can say what it is about to take (#970).
 func markShared(sessions map[string]SessionMeta, key string) {
@@ -806,6 +812,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	// why it showed in the test binary first.
 	emptied.Store(0)
 	collisions.Store(0)
+	merged.Store(0)
 	initialBuild := !HasManifest(dir)
 	writtenMessages := 0
 	lastIngestFiles = len(files)
@@ -1699,6 +1706,14 @@ func sortedKeys[V any](m map[string]V) []string {
 // current build. The two full-build paths index sessions in parallel, so the
 // counter is atomic.
 var collisions atomic.Int64
+
+// merged counts every pair of transcripts that became one row, including the
+// ones deja does not warn about — a goose session present in both of that
+// harness's stores is a migration, not a clash, but the per-harness lines
+// still count it twice. The reconciling totals key on this, so they appear
+// whenever the sums have parted rather than only when there is a warning
+// (#1091, #2066).
+var merged atomic.Int64
 var emptied atomic.Int64
 
 // evicted counts the indexed files that left because their store went away —
@@ -1720,7 +1735,29 @@ func attributeSession(held SessionMeta, s model.Session) (owns, collided bool) {
 	if held.Path == "" || s.Path == "" || held.Path == s.Path {
 		return true, false
 	}
+	merged.Add(1)
+	// goose 1.10 moved its sessions into sessions.db and left the JSONL files
+	// where they were, so after a migration the same conversation is in both
+	// stores under one id — the db row keeps the id the file was named after.
+	// That is one conversation across two storage generations, not two
+	// transcripts clashing, and sort order decided it: `<stamp>.jsonl` sorts
+	// below `sessions.db`, so every migrated session was filed under the
+	// superseded copy and counted as a collision the reader can do nothing
+	// about (#2066). The live store owns the row and the pair is not reported.
+	if s.Harness == "goose" {
+		if newIsDB, heldIsDB := isGooseStore(s.Path), isGooseStore(held.Path); newIsDB != heldIsDB {
+			return newIsDB, false
+		}
+	}
 	return s.Path < held.Path, true
+}
+
+// isGooseStore reports whether a path is goose's database rather than one of
+// the JSONL files beside it. Named, not compared against sources.GooseDB(),
+// because the row deja already holds was written by an earlier pass that may
+// have read a differently configured root.
+func isGooseStore(path string) bool {
+	return strings.EqualFold(filepath.Base(path), "sessions.db")
 }
 
 // pluralS keeps "1 sessions" off the first line anyone sees from deja (#737).
@@ -2282,6 +2319,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// This pass's counts, like every other build path (#1850).
 	emptied.Store(0)
 	collisions.Store(0)
+	merged.Store(0)
 	lastIngestFiles = len(changed)
 	for p, f := range changed {
 		ss, err := parseChangedFile(harness, p, old.Files[p])
@@ -2596,6 +2634,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	// ones before it (#1850).
 	emptied.Store(0)
 	collisions.Store(0)
+	merged.Store(0)
 	lastIngestFiles = len(changed)
 	readThisPass(changed)
 	// Deliberately not parsedThisPass: this path reads the appended tail, not


### PR DESCRIPTION
Fixes #2066. goose 1.10 moved its sessions into `sessions.db` and left the JSONL files where they were, so after a migration the same conversation is in both stores under one id. `attributeSession` saw two paths and did the only thing it could: reported an id collision and filed the row under whichever name sorts first, which is always the superseded file.

```
before: 1 session shares an id with another transcript — ...
        row path=.../sessions/20260101_120000.jsonl   shared per harness: map[goose:1]
after:  row path=.../sessions/sessions.db             shared per harness: map[]
```

The content was never wrong — the two copies merge and the duplicated turns dedup. What was wrong is the diagnosis (a warning about a project choice that was never made, once per migrated session, plus the same count in `doctor`) and the attribution: `Path` is what `--json` hands callers, what `forget` names, and where blame attributes from, so the live store lost to the frozen one.

The reconciling totals moved with it. They used to print inside the collision branch, so silencing the warning would have left the per-harness line saying 2 sessions with nothing saying the index holds 1. They now key on a merge counter that counts every pair that became one row, warned about or not.

Two goose JSONL files under one id still collide and still say so — there is a test for that alongside the migration one.
