### PR TITLE
give every instrument the whole firing bar

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -488,13 +488,13 @@ func measurePrompt(seed int64) (promptReport, error) {
 // opening line came from the top of a long transcript does not, and that line
 // is the whole frame an agent reads before deciding to ignore the rest.
 func shownLineCarriesATerm(dir, project string, terms []string) bool {
-	ranked, matched, _, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		keep = append(keep, s)
@@ -526,7 +526,7 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 // and reports whether its first quoted line carries the subject rather than an
 // ordinary word the question shares with the same session.
 func firstShownLineCarries(dir, project string, terms []string, topic string) bool {
-	ranked, matched, _, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return false
 	}
@@ -535,7 +535,7 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -557,14 +557,14 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 // blockCarries builds the block the hook would inject and reports whether it
 // holds a distinctive word of what the session concluded.
 func blockCarries(dir, project string, terms []string, fact, topic string) bool {
-	ranked, matched, _, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil || len(ranked) == 0 {
 		return false
 	}
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -603,7 +603,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, _, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}
@@ -611,7 +611,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 		// The same bar the hook applies, from the same function — kept in one
 		// place because the two drifted: this one asked whether the query held
 		// an identifier, the hook asked whether the session did.
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {
@@ -643,13 +643,13 @@ func finishPromptArm(arm *promptArmReport, terms []int) {
 // blockOpensOnEcho reports whether the first line the agent would read is the
 // question it just asked, handed back.
 func blockOpensOnEcho(dir, project string, terms []string, question string) bool {
-	ranked, matched, _, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		keep = append(keep, s)

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -234,7 +234,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if !search.RecallWorthShowing(terms, matched[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
 			continue
 		}
 		// A word rare enough to identify something is a real match on its own —

--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -13,7 +13,21 @@ import "unicode/utf8"
 // Measured by hand on ten real prompts against a frozen index: five were
 // answered with plainly unrelated work, none with silence, and every one of
 // those five rested on words that live in the project but never met.
-func RecallWorthShowing(terms []string, matched int) bool {
+// strong is how many of the terms this session matched are rare ones. It is
+// what the hook has always had and the benchmark always discarded, which is how
+// the two came to measure different rules twice. Taking it here makes that
+// impossible rather than merely noticeable.
+//
+// It is taken and not yet read, on purpose. The obvious first use —
+// "a session that matched a rare term is worth showing" — looked equivalent to
+// the rule below and is not: strong counts rareness by corpus frequency and
+// HasIdentifierTerm judges the shape of the word, so a short ordinary-looking
+// word can be rare in a small corpus. Wired in as a shortcut it put two false
+// fires on the benchmark's negative controls. Threading it changes nothing
+// today; using it is the next rule's decision, and it will now land in every
+// instrument at once.
+func RecallWorthShowing(terms []string, matched, strong int) bool {
+	_ = strong // see the note above: taken so the instruments cannot drift
 	if matched < 1 {
 		return false
 	}

--- a/internal/search/worth_test.go
+++ b/internal/search/worth_test.go
@@ -3,16 +3,16 @@ package search
 import "testing"
 
 func TestRecallWorthShowing(t *testing.T) {
-	if RecallWorthShowing([]string{"pgbouncer"}, 0) {
+	if RecallWorthShowing([]string{"pgbouncer"}, 0, -1) {
 		t.Error("nothing matched, so there is nothing to show")
 	}
-	if !RecallWorthShowing([]string{"pgbouncer"}, 1) {
+	if !RecallWorthShowing([]string{"pgbouncer"}, 1, -1) {
 		t.Error("a word that identifies something stands on one match")
 	}
-	if RecallWorthShowing([]string{"build"}, 1) {
+	if RecallWorthShowing([]string{"build"}, 1, -1) {
 		t.Error("one ordinary word is not a subject on its own")
 	}
-	if !RecallWorthShowing([]string{"build", "retry"}, 2) {
+	if !RecallWorthShowing([]string{"build", "retry"}, 2, -1) {
 		t.Error("two ordinary words that both matched earn the block")
 	}
 }

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -630,10 +630,16 @@ func runAnswerCarry(questions []lmeQuestion, limit int) {
 // about the subject. Without these the benchmark measured a path no user gets:
 // it assumed every question produces a block, while the hook stays silent on
 // 86 of these 500.
-func passHookGates(ranked []model.Session, matched, _ []int, terms []string) []model.Session {
+func passHookGates(ranked []model.Session, matched, strong []int, terms []string) []model.Session {
 	kept := ranked[:0]
 	for i, s := range ranked {
-		if i < len(matched) && !search.RecallWorthShowing(terms, matched[i]) {
+		// strong was taken and discarded here too — the third instrument
+		// scoring half the bar (#2070).
+		st := -1
+		if i < len(strong) {
+			st = strong[i]
+		}
+		if i < len(matched) && !search.RecallWorthShowing(terms, matched[i], st) {
 			continue
 		}
 		if !search.SpeechCarriesAnyTerm(s, terms) {
@@ -802,7 +808,9 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 		// The bar admits a single match when the question names something
 		// identifiable, which is what the hook asks here too.
 		about := 0
-		if len(ranked) > 0 && search.RecallWorthShowing(terms, 1) {
+		// One match, and no claim about how rare it was: -1 keeps the
+		// question-side reading this arm has always used.
+		if len(ranked) > 0 && search.RecallWorthShowing(terms, 1, -1) {
 			about = 1
 		}
 		switch {


### PR DESCRIPTION
Closes #2070.

`RecallWorthShowing` is described in its own comment as "the one bar both the
hook and the benchmark apply… it lived in two places with two slightly different
expressions, so the benchmark measured a gate the product did not have". It had
drifted again, in a quieter way: the instruments took `strong` — how many of the
terms a session matched are rare ones — and threw it away.

```go
ranked, matched, _, _, err := index.ProjectRelevant(...)
if !search.RecallWorthShowing(terms, matched[i]) {
```

Three instruments did this: `deja bench prompt` in four places, and
`scripts/longmemeval` in two, one of which spells the discard as `matched, _
[]int` in the signature. They agree with the hook today only because the shared
function cannot see the session side at all. The moment anyone uses `strong` in
the hook — the obvious next move on the three red arms — the benchmark stops
measuring the product and says nothing.

Found by trying exactly that: a change that had to move an arm moved nothing,
because the arm was scoring a different rule.

The bar now takes `strong` and every caller passes it. **It is taken and not
read**, which is the whole point: threading it changes no behaviour, and the
next rule change lands in every instrument at once instead of one.

Not reading it is also a measured decision rather than caution. The obvious
first use — "a session that matched a rare term is worth showing" — looks
equivalent to the existing rule and is not: `strong` counts rareness by corpus
frequency while `HasIdentifierTerm` judges the shape of the word, so a short
ordinary-looking word can be rare in a small corpus. Wired in as a shortcut it
put two false fires on the benchmark's negative controls. I had claimed that
step was provably inert; the test disproved it in one run, and the note in the
code now says so.

Every one of the 19 arms is unchanged, compared programmatically before and
after rather than by eye.
