### PR TITLE
fix(index): stamp each store with its own watermark

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -380,7 +380,12 @@ func TestLowLevelIndexHelpers(t *testing.T) {
 		t.Fatalf("carryRedactions=%#v", m)
 	}
 	files := map[string]FileState{"db": {Path: "db"}}
-	setStoreLastUpdated(files, map[string]SessionMeta{"x": {Harness: "h", Updated: time.Unix(0, 7)}}, "h", "db")
+	// Path names the store the row came from, which is what the stamp is
+	// about: a row from another store must not raise this one's watermark.
+	setStoreLastUpdated(files, map[string]SessionMeta{
+		"x":     {Harness: "h", Path: "db", Updated: time.Unix(0, 7)},
+		"other": {Harness: "h", Path: "another-db", Updated: time.Unix(0, 900)},
+	}, "h", "db")
 	if files["db"].LastUpdated != 7 {
 		t.Fatalf("LastUpdated=%d", files["db"].LastUpdated)
 	}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2872,8 +2872,25 @@ func setOpencodeLastUpdated(files map[string]FileState, sessions map[string]Sess
 	}
 }
 
+// sessionInStore reports whether a row came from the store being stamped.
+//
+// Cursor keeps one database per workspace, and both it and goose record the
+// store path in Path, so the row says which one it came from. opencode records
+// the project directory instead (#2033) — and has a single database, so there
+// the harness is the store.
+func sessionInStore(s SessionMeta, harness, db string) bool {
+	if harness == "opencode" {
+		return true
+	}
+	return s.Path == db
+}
+
 // setStoreLastUpdated stamps a database-backed store with the newest session
 // time so incremental passes can query only newer content.
+//
+// The newest session in THAT store: taking the newest across the harness
+// stamped a quiet Cursor workspace with the busy one's time, and a turn the
+// quiet store gained below that line was never asked for again (#2071).
 func setStoreLastUpdated(files map[string]FileState, sessions map[string]SessionMeta, harness, db string) {
 	f, ok := files[db]
 	if !ok {
@@ -2881,7 +2898,10 @@ func setStoreLastUpdated(files map[string]FileState, sessions map[string]Session
 	}
 	var latest int64
 	for _, s := range sessions {
-		if s.Harness == harness && s.Updated.UnixNano() > latest {
+		if s.Harness != harness || !sessionInStore(s, harness, db) {
+			continue
+		}
+		if s.Updated.UnixNano() > latest {
 			latest = s.Updated.UnixNano()
 		}
 	}

--- a/internal/index/store_watermark_test.go
+++ b/internal/index/store_watermark_test.go
@@ -1,0 +1,152 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// seedCursorStore writes one composer and its bubbles into a Cursor store.
+func seedCursorStore(t *testing.T, db, composer string, bubbles [][2]any) {
+	t.Helper()
+	var last int64
+	headers := ""
+	for i, b := range bubbles {
+		if ts := b[1].(int64); ts > last {
+			last = ts
+		}
+		if i > 0 {
+			headers += ","
+		}
+		headers += fmt.Sprintf(`{"bubbleId":"b%d","type":1}`, i)
+	}
+	stmts := "create table if not exists cursorDiskKV (key text primary key, value text);\n"
+	stmts += fmt.Sprintf("insert or replace into cursorDiskKV values ('composerData:%[1]s', json('{\"composerId\":\"%[1]s\",\"name\":\"work\",\"createdAt\":%[2]d,\"lastUpdatedAt\":%[2]d,\"fullConversationHeadersOnly\":[%[3]s]}'));\n", composer, last, headers)
+	for i, b := range bubbles {
+		stmts += fmt.Sprintf("insert or replace into cursorDiskKV values ('bubbleId:%s:b%d', json('{\"type\":1,\"text\":\"%s\",\"timestamp\":%d,\"workspaceProjectDir\":\"/tmp/app\"}'));\n",
+			composer, i, b[0].(string), b[1].(int64))
+	}
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// A store's watermark is what deja asks it for next time, so it has to be the
+// newest session in THAT store. Taking the newest across the harness stamped a
+// quiet Cursor workspace with the busy one's time, and everything the quiet
+// store gained below that line was skipped for ever (#2071).
+func TestEachCursorStoreKeepsItsOwnWatermark(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	root := filepath.Join(tmp, "Cursor", "User")
+	busy := filepath.Join(root, "globalStorage")
+	quiet := filepath.Join(root, "workspaceStorage", "ws1")
+	for _, d := range []string{busy, quiet} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CURSOR_ROOT", root)
+	busyDB := filepath.Join(busy, "state.vscdb")
+	quietDB := filepath.Join(quiet, "state.vscdb")
+
+	const base = int64(1767268800000) // 2026-01-01 12:00, in milliseconds
+	const hour = int64(3600000)
+	seedCursorStore(t, busyDB, "comp-busy", [][2]any{{"marker-busy-one", base + 10*hour}})
+	seedCursorStore(t, quietDB, "comp-quiet", [][2]any{{"marker-quiet-one", base}})
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	hits := func(marker string) int {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: marker, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(got)
+	}
+	// The premise: both stores were read, so the watermarks below are about
+	// two stores that each hold something.
+	if hits("marker-busy-one") != 1 || hits("marker-quiet-one") != 1 {
+		t.Fatalf("the two stores were not both indexed, so this measures nothing")
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files[quietDB].LastUpdated > m.Files[busyDB].LastUpdated {
+		t.Fatalf("the quiet store is stamped later than the busy one: %d vs %d",
+			m.Files[quietDB].LastUpdated, m.Files[busyDB].LastUpdated)
+	}
+	if m.Files[quietDB].LastUpdated == m.Files[busyDB].LastUpdated {
+		t.Errorf("both stores carry one watermark (%d), so the quiet one is stamped with the busy one's newest",
+			m.Files[quietDB].LastUpdated)
+	}
+
+	// A turn lands in the quiet workspace: newer than anything that store
+	// holds, older than the busy store's newest.
+	seedCursorStore(t, quietDB, "comp-quiet", [][2]any{
+		{"marker-quiet-one", base}, {"marker-quiet-two", base + hour},
+	})
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits("marker-quiet-two"); n != 1 {
+		t.Errorf("the turn added to the quiet store is not indexed: %d hits", n)
+	}
+}
+
+// opencode is the exception the rule above has to keep: its rows carry the
+// project directory in Path, not the store path, so filtering on Path would
+// zero its watermark and re-read the whole database on every pass.
+func TestTheOpencodeStoreStillGetsAWatermark(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	stamped := `create table session (id text primary key, directory text, time_created integer, time_updated integer);
+create table message (id text primary key, session_id text, data text, time_created integer);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('s1','/tmp/app',1767268800000,1767268800000);
+insert into message values ('m1','s1','{"role":"user"}',1767268800000);
+insert into part values ('p1','m1',json_object('type','text','text','the pool was exhausted'));`
+	if out, err := exec.Command("sqlite3", db, stamped).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the row really does name the project rather than the store.
+	if s := m.Sessions["opencode:s1"]; s.Path == db {
+		t.Fatalf("opencode now records the store path, so this measures nothing: %s", s.Path)
+	}
+	if m.Files[db].LastUpdated == 0 {
+		t.Error("the opencode store carries no watermark, so every pass reads it whole")
+	}
+}


### PR DESCRIPTION
Fixes #2071. The watermark that decides what an incremental pass asks a store for is stamped per file but was computed across the whole harness. Cursor keeps one `state.vscdb` per workspace plus the global one, so a quiet workspace was stamped with the busy store's newest bubble:

```
built: globalStorage LastUpdated=1767304800000000000
built: ws1           LastUpdated=1767304800000000000   # its own newest is 10h older
after: incremental index changed_files=1 removed_files=0 sessions=0
after: marker-quiet-two -> 0 hits                      # the turn added to ws1
```

The file changed, deja re-queried it, and asked for nothing that exists. Nothing is printed and only a rebuild recovers it — a store restored from a backup or synced from another machine is enough to hit it, since the path is already known and so it is read from the watermark rather than whole.

A store's watermark is now the newest session in that store. cursor and goose record the store path in `Path`; opencode records the project directory (#2033) and has a single database, so there the harness is the store — with a test guarding that exception, because filtering it on `Path` would zero its watermark and re-read the whole database every pass.
