### PR TITLE
say no session is about it when nothing matched

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -964,7 +964,13 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	} else if result.Tier == search.TierError {
 		fmt.Fprintln(&b, "No exact match; these sessions hit the same error (matched by signature).")
 	} else if result.Tier == search.TierRelevance {
-		fmt.Fprintln(&b, "No exact match; sessions ranked by relevance to the whole query.")
+		// Not "ranked by relevance", which reads as "here is what I found
+		// about it". Nothing matched: these are the nearest sessions by
+		// wording, and an agent handed them under the old line answered
+		// questions about subjects this machine has never held — eight of
+		// eight came back with sessions rather than nothing, and the tool
+		// description promises an empty result means no record (#2074).
+		fmt.Fprintln(&b, "No session is about this. Nothing matched the query, so the sessions below are the nearest by wording — treat them as leads to check, not as a record, and say plainly if none of them answers.")
 	}
 	if note := demotedNote(hits, demoted); note != "" {
 		fmt.Fprintln(&b, note+" — read the order as the user's judgement, not as recency.")

--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -96,7 +96,9 @@ func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
 	// A fixture that stops reaching the tier makes this test guard nothing,
 	// and skipping there hides that: the query above stopped reaching it once
 	// already, and the test went quiet instead of saying so.
-	if !strings.Contains(text, "ranked by relevance") {
+	// The sentinel is the tier's own words, and they changed when the line
+	// stopped reading as "here is what I found about it" (#2074).
+	if !strings.Contains(text, "nearest by wording") {
 		t.Fatalf("the fixture no longer reaches the relevance tier, so this test guards nothing:\n%s", firstLines(text, 3))
 	}
 	if strings.Contains(text, "matched)") {


### PR DESCRIPTION
Part of #2074, the cheaper of the two directions in it.

`recall` cannot return nothing. Empty happens only when the query has no
indexable words at all — `zzzqqq wwwxxx vvvbbb` returns 0 hits. Eight questions
about subjects this machine has never held, each written the way a person asks,
all came back with 39–50 hits on the relevance tier. The tool description
handed to every agent ends "An empty result means this machine has no record of
that", so an agent is entitled to read anything non-empty as a record.

The line above those sessions used to read:

> No exact match; sessions ranked by relevance to the whole query.

"Ranked by relevance" is what a search engine says when it found your thing.
Followed by `deja recall for "<query>"` and three real sessions, it reads as an
answer. It now says no session is about this, that these are the nearest by
wording, and that saying so plainly is the right move when none of them
answers.

**Measured live, and the measurement is small — say so before the numbers.**
Four questions about absent subjects through opencode on gpt-5.6-luna, one run
each build, a non-deterministic model:

```
                      honest    invented
old framing             2/4         2/4
new framing             3/4         1/4
```

The case that moved is the clearest one. Old: *"Deja search is still indexing,
so I could not retrieve that decision"* — an excuse deja never emits, invented
whole. New: *"I couldn't recover a genuine decision. The only match appears to
be synthetic test data, not an actual negotiation record."* The agent read the
hits, judged them, and said so.

The one still wrong is wrong in both arms and for a different reason: the query
reaches a genuine session about token bucketing and the agent transplants it.
That is the relevance tier working as designed, and it belongs to the other
direction in #2074 — whether these sessions should be returned at all — which
needs `bench recall` before anyone believes it.

n=4 on a non-deterministic model is a direction, not a proof. What is solid is
the mechanism: the old line claimed relevance to the query, and nothing was.

`TestRelevanceHitsAreNotCalledMatches` keyed on the old wording and now keys on
the new; it exists to fail loudly when the fixture stops reaching this tier, and
it still does.
