### PR TITLE
docs(json): say that opencode's session path is its project directory

### DIFF
--- a/cmd/deja/session_path_contract_test.go
+++ b/cmd/deja/session_path_contract_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docs/json-output.md is the published contract for the session fields, and it
+// says `path` is the file the session was read from. opencode's is the project
+// directory instead (#2033), so the sentence has to name that (#2077).
+func TestTheDocumentedPathNamesTheOpencodeException(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "docs", "json-output.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := ""
+	for _, l := range strings.Split(string(b), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "| `path` |") {
+			line = strings.TrimSpace(l)
+			break
+		}
+	}
+	if line == "" {
+		t.Fatal("docs/json-output.md no longer describes `path`, so this pins nothing")
+	}
+	if !strings.Contains(line, "opencode") {
+		t.Errorf("the contract does not say opencode's path is its project directory: %s", line)
+	}
+}
+
+// And the behaviour the sentence describes, measured rather than assumed: one
+// harness hands back a directory where the others hand back a file.
+func TestTheOpencodePathIsAProjectDirectory(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	hermeticEnv(t)
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	proj := filepath.Join(tmp, "app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sql := `create table session (id text primary key, directory text, time_created integer, time_updated integer);
+create table message (id text primary key, session_id text, data text, time_created integer);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('s1','` + proj + `',1767268800000,1767268800000);
+insert into message values ('m1','s1','{"role":"user"}',1767268800000);
+insert into part values ('p1','m1',json_object('type','text','text','the pool was exhausted'));`
+	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "show", "s1", "--json", "--harness", "opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Session struct {
+			Path string `json:"path"`
+		} `json:"session"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("show --json: %v: %s", err, out)
+	}
+	fi, err := os.Stat(got.Session.Path)
+	if err != nil {
+		t.Fatalf("the path deja published does not exist: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Skip("opencode now records a file, so the documented exception can go")
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -146,7 +146,7 @@ when empty:
 
 | Field | Meaning |
 |---|---|
-| `path` | file the session was read from |
+| `path` | file the session was read from — the transcript, or the store for the database-backed harnesses; opencode is the exception and gives the project directory it ran in |
 | `title` | first user turn, elided to terminal width |
 | `agent_title` | `title` came from the assistant because the session has no user turn |
 | `touched` | the few files this session worked on most |


### PR DESCRIPTION
Part of #2077. `docs/json-output.md` says the session's `path` is "file the session was read from". It is, for every source but opencode, which puts the project directory there (#2033), so a caller that opens what the contract invites it to open gets a directory for one harness in twenty:

```json
{"session":{"harness":"opencode","path":"/private/tmp/.../app", ...}}
{"session":{"harness":"claude","path":"/private/tmp/.../projects/-tmp-app/s1.jsonl", ...}}
```

This is the small half: the sentence now names the exception, with a test that pins it and a second test that measures the behaviour rather than assuming it — it indexes an opencode fixture, reads `show --json`, and asserts the published path exists and is a directory. If opencode ever starts recording the store, that test skips and the docs line can go with it.

The other half — making opencode record the store path like cursor, goose, grok and zed — is on the issue. It touches record retention, `fromDatabase`, `wholeStoresThisPass` and `sessionInStore`, which is the code that produced #2025, #2033 and #2073, so it wants its own change.
