### PR TITLE
fix(test): split the index-lock helper per platform

### DIFF
--- a/cmd/deja/index_lock_unix_test.go
+++ b/cmd/deja/index_lock_unix_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// holdIndexLock takes the index lock the way another deja process would, so a
+// tool that waits for it waits for this test instead.
+//
+// Split by platform for the same reason internal/index splits lockDir: flock is
+// Unix's and LockFileEx is Windows's. Keeping only the first in a plain _test.go
+// file stopped cmd/deja compiling on Windows at all, so the leg that runs there
+// failed before it reached a single test (#2079).
+func holdIndexLock(t *testing.T, dir string) func() {
+	t.Helper()
+	f, err := os.OpenFile(dir+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+}

--- a/cmd/deja/index_lock_windows_test.go
+++ b/cmd/deja/index_lock_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+const lockfileExclusiveLock = 0x2
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = kernel32.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
+)
+
+// holdIndexLock takes the index lock the way another deja process would, so a
+// tool that waits for it waits for this test instead.
+//
+// The Windows half of the pair, taking the same lock internal/index takes here
+// — one byte through LockFileEx — so the tests that need a held lock run on
+// this platform rather than being tagged out of it (#2079).
+func holdIndexLock(t *testing.T, dir string) func() {
+	t.Helper()
+	f, err := os.OpenFile(dir+".lock", os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := syscall.Handle(f.Fd())
+	var ol syscall.Overlapped
+	if r1, _, e1 := procLockFileEx.Call(uintptr(h), uintptr(lockfileExclusiveLock), 0, 1, 0, uintptr(unsafe.Pointer(&ol))); r1 == 0 {
+		_ = f.Close()
+		t.Fatalf("lock %s: %v", dir+".lock", e1)
+	}
+	// The same Overlapped the lock was taken with, as lockDir does: the offset
+	// it carries is what names the byte range being released.
+	return func() {
+		_, _, _ = procUnlockFileEx.Call(uintptr(h), 0, 1, 0, uintptr(unsafe.Pointer(&ol)))
+		_ = f.Close()
+	}
+}

--- a/cmd/deja/mcp_nonblocking_test.go
+++ b/cmd/deja/mcp_nonblocking_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -58,23 +57,6 @@ func TestRememberAnswersWhileTheIndexIsLocked(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "wobble pool cap") {
 		t.Errorf("the note is missing from %s:\n%s", notes, body)
-	}
-}
-
-// holdIndexLock takes the index lock the way another deja process would, so a
-// tool that waits for it waits for this test instead.
-func holdIndexLock(t *testing.T, dir string) func() {
-	t.Helper()
-	f, err := os.OpenFile(dir+".lock", os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
-	return func() {
-		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		_ = f.Close()
 	}
 }
 


### PR DESCRIPTION
Fixes #2079. `cmd/deja` did not compile on Windows, so the windows leg failed at vet before it reached a test:

```
vet.exe: cmd\deja\mcp_nonblocking_test.go:72:20: undefined: syscall.Flock
```

The helper that takes the index lock the way another deja process would lived in a plain `_test.go` file and used flock. It moves into two tagged files, the way `internal/index` already splits `lockDir` — flock on Unix, `LockFileEx` on Windows, one byte, same as the real lock takes — so the tests that need a held lock run on both platforms instead of being tagged out of one.

`GOOS=windows GOARCH=amd64 go vet ./...` is clean now and was the reproduction before; it is the whole repo, and this was its only break.

The leg is opt-in per pull request, which is why this sat: labelling a PR to check Windows gave a red leg for a reason unrelated to the change under review.
