### PR TITLE
fix(test): keep the docs at LF and let docSection read CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 packaging/** text eol=lf
+# The doc-contract tests read a heading as a whole line, so a CRLF checkout
+# breaks eleven of them at once (#2081).
+# text=auto rather than text: docs/assets holds a png and a gif, and git decides
+# by content which files it may normalise.
+docs/** text=auto eol=lf

--- a/cmd/deja/doc_line_endings_test.go
+++ b/cmd/deja/doc_line_endings_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A Windows checkout with the default core.autocrlf hands every text file back
+// with CRLF, and the doc-contract tests read a heading as a whole line: with a
+// trailing carriage return the line never matches, so eleven of them failed at
+// once and none of them said why (#2081).
+func TestDocSectionFindsAHeadingInACRLFDocument(t *testing.T) {
+	doc := "# Title\r\n\r\n## `deja stats --json`\r\n\r\nseven calendar days.\r\n\r\n## Next\r\n\r\nother.\r\n"
+	got := docSection(t, doc, "## `deja stats --json`")
+	if !strings.Contains(got, "seven calendar days") {
+		t.Errorf("the section is empty or wrong: %q", got)
+	}
+	if strings.Contains(got, "other.") {
+		t.Errorf("the section ran past its heading: %q", got)
+	}
+}
+
+// And the checked-out file itself: `.gitattributes` keeps docs at LF, so a
+// clone on any platform gives these tests the same bytes. Without it the failure
+// lands eleven tests away from its cause.
+func TestTheDocsAreCheckedOutWithUnixLineEndings(t *testing.T) {
+	// Every text file under docs, not the two these tests happen to read: the
+	// attribute covers the tree, and the next test to parse a page by line
+	// should not have to rediscover this.
+	texty := map[string]bool{".md": true, ".html": true, ".xml": true, ".json": true, ".css": true, ".js": true, ".txt": true, ".svg": true}
+	checked := 0
+	root := filepath.Join("..", "..", "docs")
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !texty[strings.ToLower(filepath.Ext(p))] {
+			return err
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		checked++
+		if n := strings.Count(string(b), "\r"); n > 0 {
+			rel, _ := filepath.Rel(root, p)
+			t.Errorf("docs/%s holds %d carriage returns — check .gitattributes", filepath.ToSlash(rel), n)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checked == 0 {
+		t.Fatal("no text files found under docs, so this pins nothing")
+	}
+}

--- a/cmd/deja/session_json_contract_test.go
+++ b/cmd/deja/session_json_contract_test.go
@@ -18,6 +18,12 @@ import (
 // the end of it (#1951).
 func docSection(t *testing.T, doc, heading string) string {
 	t.Helper()
+	// A heading is matched as a whole line, and a Windows checkout ends every
+	// line with a carriage return, so the boundary test below never held and
+	// eleven of these tests failed at once without naming the reason (#2081).
+	// `.gitattributes` keeps a fresh clone at LF; this keeps an existing
+	// working tree that already has CRLF from failing the same way.
+	doc = strings.ReplaceAll(doc, "\r\n", "\n")
 	// A heading is a whole line. Matching anywhere would let prose that names a
 	// heading — a pointer to it, a sentence about the format — start the
 	// section somewhere in the middle of a paragraph, and matching only its


### PR DESCRIPTION
Part of #2081. Seven of the thirteen windows failures are one cause: a Windows checkout ends every line with a carriage return, and `docSection` decides a heading is a whole line by testing `doc[at] == '\n'`. With `\r` in between the heading is never found, so each test dies with "docs/json-output.md has no line …" — far from the reason.

Reproduced by rewriting the file with CRLF locally:

```
--- FAIL: TestTheSessionObjectSectionIsNotMostOfTheDocument
    docs/json-output.md has no line "### The session object"
--- FAIL: TestLogJSONKeysMatchTheDocumentedContract
--- FAIL: TestWhichJSONSurfacesCarryASchemaVersion
--- FAIL: TestSessionJSONKeysAreDocumented
--- FAIL: TestTheOptionalSessionKeysAreDocumentedToo
--- FAIL: TestTheStatsSectionSaysWhatAWeekIs
```

Two parts. `.gitattributes` keeps the docs at LF so a fresh clone gives these tests the same bytes on any platform — written as `text=auto` because `docs/assets` holds a png and a gif, and git decides by content which files it may normalise. And `docSection` tolerates CRLF anyway, for a working tree that already has it and would not be renormalised by the attribute alone.

The new guard walks every text file under docs and fails with "docs/json-output.md holds 535 carriage returns — check .gitattributes" if the attribute is ever lost, which is one honest failure instead of seven confusing ones.

The other six windows failures are the permission-semantics and hook groups on the issue; this does not touch them, so the leg stays red until those are done.
