### PR TITLE
fix(test): ask the filesystem whether the denial took

### DIFF
--- a/cmd/deja/doctor_peers_unreadable_test.go
+++ b/cmd/deja/doctor_peers_unreadable_test.go
@@ -167,6 +167,14 @@ func TestAFileDejaCannotOpenIsReportedToo(t *testing.T) {
 			t.Skipf("cannot drop permissions here: %v", err)
 		}
 		t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+		// Chmod reports success on Windows and leaves the file readable — it
+		// only toggles the read-only attribute — so the case this test is about
+		// never existed there and the assertion failed instead of skipping
+		// (#2081). Ask the filesystem rather than the call.
+		if f, err := os.Open(path); err == nil {
+			_ = f.Close()
+			t.Skip("this platform reads the file anyway, so there is no denial to report")
+		}
 		got := collectDoctorSync(t.TempDir())
 		if got.State != "unreadable" || !strings.Contains(got.Error, "permission denied") {
 			t.Errorf("a file deja may not read reports %#v", got)

--- a/internal/index/sync_dir_name_test.go
+++ b/internal/index/sync_dir_name_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -12,7 +13,13 @@ import (
 // reaches a terminal through main, which prints an error as it is (#1857).
 func TestEverySentenceAboutTheDirectoryIsSafeToPrint(t *testing.T) {
 	base := t.TempDir()
-	const odd = "batch\x1b[31mHACK\rrewound"
+	// Windows refuses every control character in a name, so the odd name there
+	// is the other half of what assertPrintable guards: a bidi override, which
+	// the filesystem accepts and a terminal obeys (#2081).
+	odd := "batch\x1b[31mHACK\rrewound"
+	if runtime.GOOS == "windows" {
+		odd = "batch\u202eHACK-rewound"
+	}
 
 	t.Run("a file where the directory should be", func(t *testing.T) {
 		path := filepath.Join(base, odd)
@@ -31,8 +38,11 @@ func TestEverySentenceAboutTheDirectoryIsSafeToPrint(t *testing.T) {
 			t.Skip("root reads anything")
 		}
 		dir := filepath.Join(base, odd+"-dir")
+		// The name carries an escape and a carriage return on purpose, and not
+		// every filesystem takes one — Windows refuses the whole class. Its
+		// siblings above already skip on that; this one failed instead (#2081).
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatal(err)
+			t.Skipf("the filesystem refused the name: %v", err)
 		}
 		if err := os.Chmod(dir, 0o000); err != nil {
 			t.Skipf("cannot drop permissions: %v", err)


### PR DESCRIPTION
Part of #2081, the permission group. Two windows failures, neither about the product:

```
doctor_peers_unreadable_test.go:172: a file deja may not read reports {State:"ok", Error:""}
sync_dir_name_test.go:35: mkdir ...\batch<ESC>[31mHACK<CR>rewound-dir:
                          The filename, directory name, or volume label syntax is incorrect.
```

`chmod(path, 0o000)` returns nil on Windows and leaves the file readable — it only toggles the read-only attribute — so the case the first test is about never existed there and it asserted instead of skipping. It asks the filesystem now: if the file still opens, there is no denial to report and the test says so. On Unix the denial takes and the subtest runs as before.

The second builds a directory whose name carries an ESC and a CR on purpose, which Windows refuses outright. Its two siblings in the same test already skip on a refused name; this one called `t.Fatal`. It skips like them now — and rather than losing the case there, the odd name on Windows becomes a bidi override, which the filesystem accepts and a terminal obeys, so `assertPrintable` still has something to guard.

Nothing here changes what the tests check where they can check it — both subtests still PASS rather than SKIP on this machine.
