### PR TITLE
fix(test): marshal the hook payload instead of pasting the path into it

### DIFF
--- a/cmd/deja/hook_context_into_test.go
+++ b/cmd/deja/hook_context_into_test.go
@@ -70,7 +70,7 @@ func TestHookContextRecordsTheSessionItStarted(t *testing.T) {
 	// longer exists — and the second run below would keep this one's.
 	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
-	withHookStdin(t, `{"source":"startup","session_id":"ses_from_harness","cwd":"`+cwd+`"}`)
+	withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "ses_from_harness", "cwd": cwd}))
 	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
 		t.Fatalf("the hook injected nothing, so there is no record to check:\n%q", out)
 	}
@@ -103,7 +103,7 @@ func TestBothHooksRecordTheSameSessionForOneSession(t *testing.T) {
 	t.Chdir(cwd)
 	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
-	withHookStdin(t, `{"source":"startup","session_id":"ses_both","cwd":"`+cwd+`"}`)
+	withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "ses_both", "cwd": cwd}))
 	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
 		t.Fatalf("the session-start hook injected nothing:\n%q", out)
 	}

--- a/cmd/deja/hook_payload_test.go
+++ b/cmd/deja/hook_payload_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// hookPayload builds what a harness writes to a hook's stdin.
+//
+// Pasting a path into a JSON string with `+` breaks the moment the path holds a
+// backslash — every Windows path does — and the payload a test then feeds the
+// hook is not JSON at all. Nothing says so: the hook reads no session id and
+// the assertion fails several steps later, about a session that was never in a
+// payload deja could parse (#2081).
+func hookPayload(t *testing.T, fields map[string]string) string {
+	t.Helper()
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// The escaping itself, so the helper cannot quietly stop doing it.
+func TestAHookPayloadSurvivesAWindowsPath(t *testing.T) {
+	payload := hookPayload(t, map[string]string{
+		"source": "startup", "session_id": "ses1", "cwd": `C:\Users\me\work\api`,
+	})
+	var got map[string]string
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("the payload is not JSON: %v: %s", err, payload)
+	}
+	if got["cwd"] != `C:\Users\me\work\api` {
+		t.Errorf("the path did not survive: %q", got["cwd"])
+	}
+	if got["session_id"] != "ses1" {
+		t.Errorf("the session id did not survive: %q", got["session_id"])
+	}
+	// And the shape a hand-built payload had: a bare backslash run, which is
+	// what made it unparseable.
+	if !strings.Contains(payload, `\\Users`) {
+		t.Errorf("the backslashes are not escaped: %s", payload)
+	}
+}

--- a/cmd/deja/kimi_doctor_test.go
+++ b/cmd/deja/kimi_doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -17,14 +18,12 @@ func writeKimiPlugin(t *testing.T, home string, enabled bool) {
 	if err := os.WriteFile(filepath.Join(root, "kimi.plugin.json"), []byte(`{"name":"deja"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	record := `{"version":1,"plugins":[{"id":"deja","root":` + strconvQuote(root) +
+	record := `{"version":1,"plugins":[{"id":"deja","root":` + strconv.Quote(root) +
 		`,"source":"local-path","enabled":` + boolText(enabled) + `,"installedAt":"2026-08-23T00:00:00Z"}]}`
 	if err := os.WriteFile(filepath.Join(home, "plugins", "installed.json"), []byte(record), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
-
-func strconvQuote(s string) string { return `"` + strings.ReplaceAll(s, `\`, `\\`) + `"` }
 
 func boolText(b bool) string {
 	if b {


### PR DESCRIPTION
Closes the last group of #2081. The two hook tests build the hook's stdin by pasting the cwd into a JSON string:

```go
withHookStdin(t, `{"source":"startup","session_id":"ses_both","cwd":"`+cwd+`"}`)
```

Every Windows path holds backslashes, so what the hook reads is not JSON — `\U` is not an escape — and it gets no session id at all. The failure lands several steps later, about a session that was never in a payload deja could parse:

```
the session-start injection went to "", not to the session in the payload
one session was recorded under two names: session start wrote "", deja vu wrote "ses_both"
```

Reproduced on macOS by putting a backslash in the cwd's name: same empty id.

The payload is marshalled now, through a helper with the reason on it, and a test pins the escaping so the helper cannot quietly stop doing it. `hook_worktree_test.go` had already worked around the same hazard with `filepath.ToSlash`; this fixes the cause rather than the path.

One more site of the same family came out of review: `kimi_doctor_test.go` had a local `strconvQuote` that escapes backslashes and nothing else, under a name that reads like the standard library's. It uses `strconv.Quote` now. The remaining hand-built payloads pass paths through `filepath.ToSlash`, which is JSON-safe unless a path holds a quote — worth a sweep of its own, not this change.
