### PR TITLE
fix(opencode): date a message by whatever carries the stamp

### DIFF
--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -104,7 +104,11 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		`then json_extract(p.data,'$.state.output') end as out,` +
 		`json_extract(p.data,'$.state.metadata.exit') as exit,` +
 		`json_extract(p.data,'$.time.start') as pt,` +
-		`json_extract(m.data,'$.time.created') as mt ` +
+		`json_extract(m.data,'$.time.created') as mt,` +
+		// The row's own column, which is what the since clause filters on. A
+		// store that fills it and leaves the blob's time out handed back
+		// messages dated to the year zero (#2086).
+		`m.time_created as mc ` +
 		`from session s join message m on m.session_id=s.id join part p on p.message_id=m.id ` +
 		// The type test is written twice on purpose. json_extract on its own
 		// parses every blob in the table — parts average ~12 KB and are mostly
@@ -225,9 +229,20 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 			continue
 		}
 		txt = capParsedMessage(txt)
+		// Whatever carries the stamp: the part's, then the message blob's, then
+		// the message row's column — and failing all three the conversation's
+		// own start, which is the fallback cursor takes for a bubble without a
+		// stamp. The year zero is not a time anyone asked deja to record, and
+		// it reaches `show --json` as it is.
 		t := parseTimeAny(r["pt"])
 		if t.IsZero() {
 			t = parseTimeAny(r["mt"])
+		}
+		if t.IsZero() {
+			t = parseTimeAny(r["mc"])
+		}
+		if t.IsZero() {
+			t = s.Started
 		}
 		s.Touch(t)
 		s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})

--- a/internal/sources/opencode_message_time_test.go
+++ b/internal/sources/opencode_message_time_test.go
@@ -1,0 +1,58 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// The since clause filters on the message row's column and the reader dated the
+// message from the blob, so a row stamped in the column alone came back with no
+// time at all — the year zero, published as it is by `show --json` and treated
+// as one turn by an index that keys duplicates on (role, time, text) (#2086).
+func TestAnOpencodeMessageIsDatedByWhateverCarriesTheStamp(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	started := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	inColumn := time.Date(2026, 1, 1, 12, 30, 0, 0, time.UTC)
+	inBlob := time.Date(2026, 1, 1, 13, 0, 0, 0, time.UTC)
+	sql := `create table session (id text primary key, directory text, time_created integer, time_updated integer);
+create table message (id text primary key, session_id text, data text, time_created integer);
+create table part (id text primary key, message_id text, data text);
+insert into session values ('s1','/tmp/app',` + ms(started) + `,` + ms(inBlob) + `);
+insert into message values ('m1','s1','{"role":"user"}',` + ms(inColumn) + `);
+insert into part values ('p1','m1',json_object('type','text','text','the column carries this one'));
+insert into message values ('m2','s1','{"role":"user","time":{"created":` + ms(inBlob) + `}}',` + ms(inBlob) + `);
+insert into part values ('p2','m2',json_object('type','text','text','the blob carries this one'));
+insert into message values ('m3','s1','{"role":"user"}',0);
+insert into part values ('p3','m3',json_object('type','text','text','nothing carries this one'));`
+	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	ss, err := ParseOpencodeDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 3 {
+		t.Fatalf("the fixture did not come back whole, so this measures nothing: %#v", ss)
+	}
+	want := map[string]time.Time{
+		"the column carries this one": inColumn,
+		"the blob carries this one":   inBlob,
+		// Neither has one, so it belongs to its conversation — the fallback
+		// cursor has taken since bubbles without stamps turned up there.
+		"nothing carries this one": started,
+	}
+	for _, m := range ss[0].Messages {
+		if got := m.Time.UTC(); !got.Equal(want[m.Text]) {
+			t.Errorf("%q is dated %s, want %s", m.Text, got, want[m.Text].UTC())
+		}
+	}
+}
+
+// ms is what opencode writes: epoch milliseconds.
+func ms(t time.Time) string { return strconv.FormatInt(t.UnixMilli(), 10) }


### PR DESCRIPTION
Fixes #2086. opencode's since clause filters on the message row's column and the reader dated the message from the blob, so a row stamped in the column alone came back with no time at all:

```
session started=2026-01-01 12:00:00 UTC updated=2026-01-01 13:00:00 UTC
  user  column only, no blob time      time=0001-01-01 00:00:00 UTC
  user  blob time too                  time=2026-01-01 13:00:00 UTC
```

The zero is not internal: `deja show --json` publishes it as `"time":"0001-01-01T00:00:00Z"`, and the index keys its duplicate test on (role, time, text), so two undated turns of the same role and text are one turn to it.

The chain is now the part's stamp, then the message blob's, then the row's column — one more scalar in a projection that is deliberately narrow, and the column is already in the joined table — and failing all three the conversation's own start, which is the fallback cursor has taken for a stampless bubble all along.

A column authoritative enough to decide what comes back is authoritative enough to date what it returned. I have not established that a real opencode store ever leaves the blob time out; the argument is that one.
