### PR TITLE
fix(packaging): pin the manifests to 0.19.0

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,12 +1,12 @@
 {
     "architecture": {
         "64bit": {
-            "hash": "e2c5a442afb3f208aa1389be031b2ac595de3c79b1179856fb843a1f1b042391",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip"
+            "hash": "c64f1b538f38774114e6f704807908de39c2f4eb41531f319d61925f1847ad57",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip"
         },
         "arm64": {
-            "hash": "f814fe2117f69ae1d2cc2202e6c3d37e90ef7cde705c3e3c6de1dfdfa4743b25",
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip"
+            "hash": "2e06405f2cf509d6eb20a1099fcef5ac0e02d19f525f1e3a1bd5dfe66eac7119",
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip"
         }
     },
     "autoupdate": {
@@ -24,5 +24,5 @@
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
-    "version": "0.18.0"
+    "version": "0.19.0"
 }

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_amd64.zip
-  InstallerSha256: E2C5A442AFB3F208AA1389BE031B2AC595DE3C79B1179856FB843A1F1B042391
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_amd64.zip
+  InstallerSha256: C64F1B538F38774114E6F704807908DE39C2F4EB41531F319D61925F1847AD57
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.18.0/deja-vu_0.18.0_windows_arm64.zip
-  InstallerSha256: F814FE2117F69AE1D2CC2202E6C3D37E90EF7CDE705C3E3C6DE1DFDFA4743B25
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.0/deja-vu_0.19.0_windows_arm64.zip
+  InstallerSha256: 2E06405F2CF509D6EB20A1099FCEF5AC0E02D19F525F1E3A1BD5DFE66EAC7119
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.18.0/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.0/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.16.1
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.18.0
+PackageVersion: 0.19.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -193,7 +193,10 @@ func renderCodexPlugin(p pins) ([]byte, error) {
 
 var (
 	versionLine = regexp.MustCompile(`(?m)^PackageVersion: .*$`)
-	tagRefs     = regexp.MustCompile(`/v\d+\.\d+\.\d+(/|$)`)
+	// (?m) because a tag reference is often the last thing on its line: the
+	// ReleaseNotesUrl in the winget locale sat at v0.16.1 through three
+	// releases while every reference followed by a slash moved (#2088).
+	tagRefs     = regexp.MustCompile(`(?m)/v\d+\.\d+\.\d+(/|$)`)
 	fileRefs    = regexp.MustCompile(`deja-vu_\d+\.\d+\.\d+_windows`)
 	jsonVersion = regexp.MustCompile(`(?m)^(\s*"version":\s*)"[^"]*"`)
 	amdSha      = regexp.MustCompile(`(?m)^(\s*InstallerSha256: )[0-9A-Fa-f]{64}(\s*)$`)

--- a/scripts/pinmanifests/main_test.go
+++ b/scripts/pinmanifests/main_test.go
@@ -142,3 +142,37 @@ func TestRenderScoopIsStableAndComplete(t *testing.T) {
 		t.Fatal("arm64 hash is not the arm64 one")
 	}
 }
+
+// A tag reference at the end of a line is still a tag reference. `$` without
+// the multiline flag matches only the end of the whole file, so the
+// ReleaseNotesUrl in the winget locale — the last thing on its line — kept
+// pointing at v0.16.1 through three releases while every other reference moved
+// (#2088).
+func TestEditMovesATagReferenceAtTheEndOfALine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "locale.yaml")
+	original := `PackageIdentifier: vshulcz.deja-vu
+PackageVersion: 0.0.1
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.0.1/LICENSE
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.0.1
+ShortDescription: memory for coding agents
+`
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, err := parse("1.2.3", sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := edit(path, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "/releases/tag/v1.2.3") {
+		t.Errorf("the release notes still point at the old tag:\n%s", got)
+	}
+	if strings.Contains(got, "v0.0.1") {
+		t.Errorf("a stale tag reference is left behind:\n%s", got)
+	}
+}


### PR DESCRIPTION
Fixes #2088. `windows manifests` has failed on every pull request since v0.19.0 was published, because scoop, winget and the Codex plugin still carried 0.18.0 and its hashes. This is the pin the release skipped — `go run ./scripts/pinmanifests -version 0.19.0 -checksums <the release's checksums.txt>`, nothing edited by hand. The hashes come from the release's own checksums.txt, and I verified the amd64 one by downloading the zip and hashing it.

The tool had a hole of its own, which is why the winget locale's `ReleaseNotesUrl` still pointed at v0.16.1 three releases later:

```go
tagRefs = regexp.MustCompile(`/v\d+\.\d+\.\d+(/|$)`)
```

Without `(?m)` the `$` matches the end of the file, not the end of a line — so a tag reference followed by a slash moved and one at the end of its line did not. It is the last thing on that line. Fixed, with a test.

The other half of #2088 is yours: a check that means "someone owes the release a step" is red for days on pull requests that cannot fix it, and that teaches people to ignore a red check.
