### PR TITLE
fix(html): scrub the pages the way every printed row is scrubbed

### DIFF
--- a/cmd/deja/html_safe_text_test.go
+++ b/cmd/deja/html_safe_text_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+// hostile is what a transcript or a hand-written note can put in a name:
+// markup, an escape byte and a bidi override, which reverses the rendering of
+// everything after it.
+const hostile = "</script><img src=x onerror=alert(1)> [31m & <b>bold‮"
+
+// Every terminal row deja prints scrubs these; the pages did not, and a page is
+// where a bidi override actually reverses a line for a reader (#2090).
+func TestTheStatsPageDoesNotCarryControlOrBidiCharacters(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "s1", Project: hostile, Title: hostile,
+		Started:  time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+		Updated:  time.Date(2026, 1, 2, 3, 5, 5, 0, time.UTC),
+		Messages: []model.Message{{Role: "user", Text: hostile}},
+	}
+	report := stats.Report{
+		TotalSessions: 1, TotalMessages: 1,
+		Longest:     stats.SessionStat{ID: "s1", Messages: 1, Harness: "claude", Project: hostile, Title: hostile},
+		Harnesses:   []stats.HarnessStats{{Harness: "claude", Sessions: 1, Messages: 1}},
+		TopProjects: []stats.ProjectStats{{Project: hostile, Sessions: 1}},
+	}
+	page, err := newStatsHTMLPage(report, []model.Session{s})
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(page.SessionsJSON)
+	// The premise: the row reached the page, so this is about what it carried
+	// rather than about an empty table.
+	if !strings.Contains(js, "bold") {
+		t.Fatalf("the session did not reach the page at all: %s", js)
+	}
+	assertNoControlOrBidi(t, "the stats page", js)
+}
+
+// `deja view` is the browsing page, and a promoted note is text a person wrote,
+// so it reaches the page the way a transcript's title does.
+func TestTheViewPageDoesNotCarryControlOrBidiCharacters(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	line, err := json.Marshal(map[string]any{
+		"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
+		"session": "claude:s1", "state": "accepted",
+		"title":   "pool sizing " + hostile,
+		"text":    "the pool was exhausted\n" + hostile,
+		"project": "app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notes, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, err := captureRun(t, "view", "--no-open", "--out", out); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := string(b)
+	if !strings.Contains(page, "pool sizing") {
+		t.Fatalf("the note did not reach the page at all")
+	}
+	assertNoControlOrBidi(t, "the view page", page)
+}
+
+func assertNoControlOrBidi(t *testing.T, what, s string) {
+	t.Helper()
+	for _, bad := range []struct{ name, text string }{
+		{"an escape byte", ""},
+		{"a bidi override", "‮"},
+		{"a carriage return", "\r"},
+	} {
+		if strings.Contains(s, bad.text) {
+			t.Errorf("%s carries %s", what, bad.name)
+		}
+	}
+}

--- a/cmd/deja/html_safe_text_test.go
+++ b/cmd/deja/html_safe_text_test.go
@@ -15,7 +15,7 @@ import (
 // hostile is what a transcript or a hand-written note can put in a name:
 // markup, an escape byte and a bidi override, which reverses the rendering of
 // everything after it.
-const hostile = "</script><img src=x onerror=alert(1)> [31m & <b>bold‮"
+const hostile = "</script><img src=x onerror=alert(1)> \x1b[31m & <b>bold\u202e"
 
 // Every terminal row deja prints scrubs these; the pages did not, and a page is
 // where a bidi override actually reverses a line for a reader (#2090).
@@ -85,8 +85,8 @@ func TestTheViewPageDoesNotCarryControlOrBidiCharacters(t *testing.T) {
 func assertNoControlOrBidi(t *testing.T, what, s string) {
 	t.Helper()
 	for _, bad := range []struct{ name, text string }{
-		{"an escape byte", ""},
-		{"a bidi override", "‮"},
+		{"an escape byte", "\x1b"},
+		{"a bidi override", "\u202e"},
 		{"a carriage return", "\r"},
 	} {
 		if strings.Contains(s, bad.text) {

--- a/cmd/deja/statshtml.go
+++ b/cmd/deja/statshtml.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/stats"
 )
 
@@ -86,9 +87,13 @@ func newStatsHTMLPage(report stats.Report, sessions []model.Session) (statsHTMLP
 		if project == "" {
 			project = "-"
 		}
+		// The same scrub the terminal rows get: a project or a title carries
+		// whatever the transcript held, and a bidi override reverses a line in
+		// a browser too (#2090).
 		rows = append(rows, htmlSession{
-			Date: date.Format("2006-01-02"), Harness: s.Harness, Project: project,
-			Title: stats.Title(s), Messages: len(s.Messages),
+			Date: date.Format("2006-01-02"), Harness: s.Harness,
+			Project: search.SafePath(project),
+			Title:   search.SafeLine(stats.Title(s)), Messages: len(s.Messages),
 		})
 	}
 	truncated := len(rows) > statsHTMLCap

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/redact"
+	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/stats"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -122,6 +123,20 @@ func redactMask(s string) string {
 	return out
 }
 
+// safeLineForPage is redactMask plus the scrub every printed row gets: a page
+// is read by a person too, and a bidi override reverses a line in a browser as
+// surely as in a terminal (#2090). For the one-line fields — a project, a
+// title — where a line break would be a second row rather than a paragraph.
+func safeLineForPage(s string) string { return search.SafeLine(redactMask(s)) }
+
+// safeNameForPage is for the fields a person copies rather than reads — a
+// project is what `--project` is given back — so the spaces inside it are part
+// of it, the way they are in a path (#2044).
+func safeNameForPage(s string) string { return search.SafePath(redactMask(s)) }
+
+// safeTextForPage is the same for a body, where the newlines are meant.
+func safeTextForPage(s string) string { return search.SafeText(redactMask(s)) }
+
 func writeViewHTML(dir, out string) (string, int, error) {
 	abs, err := filepath.Abs(out)
 	if err != nil {
@@ -185,24 +200,27 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	// someone opens and passes on, and the index it is built from may have been
 	// written by an older deja or before a pattern was fixed.
 	for i := range sessions {
-		sessions[i].Title = redactMask(sessions[i].Title)
-		sessions[i].Preview = redactMask(sessions[i].Preview)
-		sessions[i].Project = redactMask(sessions[i].Project)
+		// The id too: it is a filename stem for most harnesses, and a
+		// filename takes a control byte on every Unix filesystem.
+		sessions[i].ID = safeNameForPage(sessions[i].ID)
+		sessions[i].Title = safeLineForPage(sessions[i].Title)
+		sessions[i].Preview = safeTextForPage(sessions[i].Preview)
+		sessions[i].Project = safeNameForPage(sessions[i].Project)
 	}
 	for i := range recalls {
-		recalls[i].Digest = redactMask(recalls[i].Digest)
+		recalls[i].Digest = safeTextForPage(recalls[i].Digest)
 		for j := range recalls[i].Terms {
-			recalls[i].Terms[j] = redactMask(recalls[i].Terms[j])
+			recalls[i].Terms[j] = safeLineForPage(recalls[i].Terms[j])
 		}
 	}
 	for i := range notes {
-		notes[i].Title = redactMask(notes[i].Title)
-		notes[i].Text = redactMask(notes[i].Text)
+		notes[i].Title = safeLineForPage(notes[i].Title)
+		notes[i].Text = safeTextForPage(notes[i].Text)
 		// A note's project and tags are what the user typed, so they are text
 		// like the rest rather than structure deja minted.
-		notes[i].Project = redactMask(notes[i].Project)
+		notes[i].Project = safeNameForPage(notes[i].Project)
 		for j := range notes[i].Tags {
-			notes[i].Tags[j] = redactMask(notes[i].Tags[j])
+			notes[i].Tags[j] = safeNameForPage(notes[i].Tags[j])
 		}
 	}
 	sj, err := json.Marshal(sessions)


### PR DESCRIPTION
Fixes #2090. Sweeping `deja stats` for transcript-derived text printed raw — the follow-up #2059 asked for — found the terminal screen clean and both HTML surfaces not.

`deja stats --html` embedded a project name as it came:

```json
{"project":"</script><img src=x onerror=alert(1)> <ESC>[31m & <b>bold<U+202E>"}
```

The markup is harmless — `json.Marshal` escapes `<`, `>` and `&`, so the script block cannot be closed — but the escape byte and the bidi override go into the page. `deja view` was the same: `redactMask` takes out secrets and nothing took out anything else, so a project, a title, a note or a message body carried them.

U+202E is not decoration in a browser any more than in a terminal: it reverses the rendering of what follows it, which is why deja strips it from every row it prints. The pages now use the same functions — `SafeLine` for the one-line fields, `SafeText` for the bodies, where the newlines are meant.

Two tests: the stats page's JSON, and an end-to-end `deja view` page built from a promoted note carrying the hostile string, since a note is text a person wrote and reaches the page the way a transcript's title does.

A project keeps the treatment a path gets rather than a sentence: it is what `--project` is given back, so the spaces inside it are part of it (#2044). The reviewer's catch was the session id, which is a filename stem for most harnesses and takes a control byte on any Unix filesystem — scrubbed the same way now.
