### PR TITLE
fix(view): clip a note title on the page and in the blame payload

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -684,12 +684,14 @@ func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []by
 	}
 	for _, h := range hits {
 		out = append(out, blameHitJSON{
+			// A note's title carries no bound into the index (#2092), and this
+			// payload is read by an agent whose context it spends.
 			Session: blameSessionJSON{
 				ID: h.Session.ID, Harness: h.Session.Harness, Project: h.Session.Project,
-				Path: h.Session.Path, Title: h.Session.Title,
+				Path: h.Session.Path, Title: search.SafeNoteTitle(h.Session.Title),
 				Started: h.Session.Started, Updated: h.Session.Updated, Touched: h.Session.Touched,
 			},
-			Title: h.Session.Title, Count: h.Count, Score: h.Score,
+			Title: search.SafeNoteTitle(h.Session.Title), Count: h.Count, Score: h.Score,
 			Tier: h.Tier, Snippets: h.Snippets,
 		})
 	}

--- a/cmd/deja/note_title_bounds_test.go
+++ b/cmd/deja/note_title_bounds_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A note title carries no bound into the index on purpose — the state suffix is
+// what every one-line surface reads it for — so each reader clips it for its own
+// layout instead. Nothing held that in place, and the comment on the exemption
+// gave the wrong reason for why it was safe (#2092).
+func TestEverySurfaceThatPrintsANoteTitleBoundsIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	// The marker sits deep inside the title, so a surface that prints it has
+	// not clipped — which is the property, rather than a line-length guess.
+	long := "pgbouncer pool " + strings.Repeat("verylongword ", 400) + "deepmarker [accepted]"
+	line, err := json.Marshal(map[string]any{
+		"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
+		"session": "claude:s1", "state": "accepted", "project": "app",
+		"title": long,
+		"text":  "the pool was exhausted while the migration held the lock",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notes, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the title really is unbounded in the index, which is what
+	// makes the readers' clips the thing under test.
+	stored, ok, err := index.FindByIdentity(os.Getenv("DEJA_INDEX_DIR"), "deja", "deja-note-claude-s1")
+	if err != nil || !ok {
+		t.Fatalf("the note is not indexed: ok=%v err=%v", ok, err)
+	}
+	if !strings.Contains(stored.Title, "deepmarker") {
+		t.Fatalf("the stored title is already bounded, so this measures nothing: %d runes", len([]rune(stored.Title)))
+	}
+
+	// Each surface clips for its own layout, so the bound here is generous: it
+	// is the difference between a row and a page of one.
+	const roomForARow = 400
+	for _, args := range [][]string{{"last"}, {"stats"}, {"search", "migration"}, {"show", "deja-note-claude-s1"}, {"view", "--no-open", "--out", filepath.Join(t.TempDir(), "v.html")}} {
+		out, err := captureRun(t, args...)
+		if err != nil {
+			t.Fatalf("%v: %v", args, err)
+		}
+		if args[0] == "view" {
+			b, err := os.ReadFile(args[3])
+			if err != nil {
+				t.Fatal(err)
+			}
+			out = string(b)
+		}
+		if strings.Contains(out, "deepmarker") {
+			t.Errorf("%v printed the whole note title, marker and all", args)
+		}
+		for _, l := range strings.Split(out, "\n") {
+			if n := len([]rune(l)); n > roomForARow && args[0] != "view" {
+				t.Errorf("%v printed a %d-rune line from a note title", args, n)
+			}
+		}
+	}
+}

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -129,6 +129,11 @@ func redactMask(s string) string {
 // title — where a line break would be a second row rather than a paragraph.
 func safeLineForPage(s string) string { return search.SafeLine(redactMask(s)) }
 
+// safeTitleForPage bounds as well as scrubs. A note's title carries no bound
+// into the index on purpose — the state suffix is what a one-line surface reads
+// it for — so the readers clip it, and this page is one of them (#2092).
+func safeTitleForPage(s string) string { return search.SafeNoteTitle(redactMask(s)) }
+
 // safeNameForPage is for the fields a person copies rather than reads — a
 // project is what `--project` is given back — so the spaces inside it are part
 // of it, the way they are in a path (#2044).
@@ -203,7 +208,7 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		// The id too: it is a filename stem for most harnesses, and a
 		// filename takes a control byte on every Unix filesystem.
 		sessions[i].ID = safeNameForPage(sessions[i].ID)
-		sessions[i].Title = safeLineForPage(sessions[i].Title)
+		sessions[i].Title = safeTitleForPage(sessions[i].Title)
 		sessions[i].Preview = safeTextForPage(sessions[i].Preview)
 		sessions[i].Project = safeNameForPage(sessions[i].Project)
 	}
@@ -214,7 +219,7 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		}
 	}
 	for i := range notes {
-		notes[i].Title = safeLineForPage(notes[i].Title)
+		notes[i].Title = safeTitleForPage(notes[i].Title)
 		notes[i].Text = safeTextForPage(notes[i].Text)
 		// A note's project and tags are what the user typed, so they are text
 		// like the rest rather than structure deja minted.

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1909,8 +1909,14 @@ func titleWorthy(t string) bool {
 // — and the state is what every one-line surface reads it for, so cutting the
 // tail would drop exactly the part that matters and, worse, make a state
 // change invisible to the comparison that decides whether to rewrite the row
-// (#R11). Note titles are deja's own text, so the injection this bound exists
-// to stop cannot arrive through them.
+// (#R11).
+//
+// What makes the exemption safe is not that the text is deja's own — the notes
+// file is edited by hand, so a note title is whatever someone typed (#2063) —
+// but that every reader clips it for its own layout: `last`, `stats`, the view
+// page and the MCP payloads through SafeNoteTitle, hook-context through
+// trimBriefTitle. TestEverySurfaceThatPrintsANoteTitleBoundsIt holds that, and
+// a new surface has to join it (#2092).
 func boundSourceTitle(harness, title string) string {
 	if harness == "deja" {
 		return title


### PR DESCRIPTION
Fixes #2092. No behaviour change: `boundSourceTitle` exempts notes for a reason that is not true, and the reason is what the next person acts on.

> Note titles are deja's own text, so the injection this bound exists to stop cannot arrive through them.

`DEJA_NOTES_FILE` is a JSONL file people are told to edit by hand — #2063 enumerated what a line of it can hold — so a note title is whatever someone typed, at whatever length. What actually makes the exemption safe is that every reader clips it for its own layout. Measured with a 5 KB title:

```
deja last            308   (SafeNoteTitle: 300 plus the state tail)
deja stats           300
mcp recall           124
mcp recall_context   124
hook-context          44   (trimBriefTitle)
deja search / show    print the note's text, not its title
```

Four independent clips, each for its own row — the right shape for a bound that is about a layout rather than about the data. Nothing was holding it, and review found the two surfaces that had already been written without one: the `deja view` page put the whole 5 KB into a table cell, and the MCP blame payload put it into an agent's context. Both clip now, and the test that found them stays.

The other half is on the issue and it is yours: whether the store should bound the title on the way in, keeping the state suffix, so a new surface starts bounded.
