### PR TITLE
fix(cursor): read a stamp in the unit it was written in

### DIFF
--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -139,25 +139,27 @@ func ParseCursorDBSince(db string, t time.Time) ([]model.Session, error) {
 	if t.IsZero() {
 		return ParseCursorDB(db)
 	}
-	return parseCursorDB(db, t.UnixMilli())
+	return parseCursorDB(db, t)
 }
 
 // ParseCursorDB reads composer sessions with a narrow projection — dumping
 // whole JSON values through the sqlite3 pipe on a multi-hundred-MB store
 // takes minutes, extracting scalars takes seconds (same lesson as opencode).
 func ParseCursorDB(db string) ([]model.Session, error) {
-	return parseCursorDB(db, 0)
+	return parseCursorDB(db, time.Time{})
 }
 
-func parseCursorDB(db string, sinceMS int64) ([]model.Session, error) {
+func parseCursorDB(db string, since time.Time) ([]model.Session, error) {
 	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
 		return nil, nil
 	}
 	composerWhere := ""
 	bubbleWhere := ""
-	if sinceMS > 0 {
-		composerWhere = fmt.Sprintf(" and json_extract(value,'$.lastUpdatedAt') > %d", sinceMS)
-		bubbleWhere = fmt.Sprintf(" and json_extract(value,'$.timestamp') > %d", sinceMS)
+	// The clause reads the units the reader does, or the two disagree about
+	// what a store holds (#2086).
+	if !since.IsZero() {
+		composerWhere = " and " + newerThanEpoch("json_extract(value,'$.lastUpdatedAt')", since)
+		bubbleWhere = " and " + newerThanEpoch("json_extract(value,'$.timestamp')", since)
 	}
 	composers, err := cursorQuery(db, `select key,`+
 		`json_extract(value,'$.composerId') as cid,`+
@@ -258,9 +260,13 @@ func numberVal(v any) (int64, bool) {
 	return 0, false
 }
 
+// epochMS reads Cursor's stamps, which it writes in milliseconds — through the
+// same guess every other source uses, because a reader that assumes the unit
+// dates a seconds-stamped store to three weeks after the epoch and says nothing
+// about it (#2094).
 func epochMS(v any) time.Time {
-	if n, ok := numberVal(v); ok && n > 0 {
-		return time.UnixMilli(n)
+	if n, ok := numberVal(v); ok {
+		return unixGuess(n)
 	}
 	return time.Time{}
 }

--- a/internal/sources/cursor_units_test.go
+++ b/internal/sources/cursor_units_test.go
@@ -1,0 +1,104 @@
+package sources
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func seedCursorStamped(t *testing.T, db string, stamp int64) {
+	t.Helper()
+	schema := fmt.Sprintf(`create table cursorDiskKV (key text primary key, value text);
+insert into cursorDiskKV values
+ ('composerData:comp-1', json('{"composerId":"comp-1","name":"pool sizing","createdAt":%[1]d,"lastUpdatedAt":%[1]d,"fullConversationHeadersOnly":[{"bubbleId":"b1","type":1}]}')),
+ ('bubbleId:comp-1:b1', json('{"type":1,"text":"the pool was exhausted","timestamp":%[1]d,"workspaceProjectDir":"/tmp/app"}'));`, stamp)
+	if out, err := exec.Command("sqlite3", db, schema).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// Every source reads a numeric stamp through unixGuess, which takes either
+// unit. Cursor had its own millisecond-only reader, so a seconds-stamped store
+// was dated to three weeks after the epoch and sat behind everything deja knows
+// (#2094).
+func TestACursorStoreStampedInSecondsIsNotDatedTo1970(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	when := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	for _, unit := range []struct {
+		name  string
+		stamp int64
+	}{
+		{"milliseconds", when.UnixMilli()},
+		{"seconds", when.Unix()},
+	} {
+		db := filepath.Join(t.TempDir(), "state.vscdb")
+		seedCursorStamped(t, db, unit.stamp)
+		ss, err := ParseCursorDB(db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 1 || len(ss[0].Messages) != 1 {
+			t.Fatalf("%s: the fixture did not come back whole, so this measures nothing: %#v", unit.name, ss)
+		}
+		for what, got := range map[string]time.Time{
+			"started": ss[0].Started, "updated": ss[0].Updated,
+			"the message": ss[0].Messages[0].Time,
+		} {
+			if !got.UTC().Equal(when) {
+				t.Errorf("%s: %s is %s, want %s", unit.name, what, got.UTC().Format(time.RFC3339), when.Format(time.RFC3339))
+			}
+		}
+	}
+}
+
+// And the clause that decides what a changed store hands back reads the same
+// units the reader does, or the two disagree the way opencode's did (#2086).
+func TestTheCursorSinceClauseTakesEitherUnit(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	newer := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	watermark := newer.Add(-time.Hour)
+	for _, unit := range []struct {
+		name  string
+		stamp int64
+	}{
+		{"milliseconds", newer.UnixMilli()},
+		{"seconds", newer.Unix()},
+	} {
+		db := filepath.Join(t.TempDir(), "state.vscdb")
+		seedCursorStamped(t, db, unit.stamp)
+		if whole, err := ParseCursorDBSince(db, time.Time{}); err != nil || len(whole) != 1 {
+			t.Fatalf("%s: the fixture is not readable at all: %d sessions err=%v", unit.name, len(whole), err)
+		}
+		ss, err := ParseCursorDBSince(db, watermark)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ss) != 1 {
+			t.Errorf("%s: a turn newer than the watermark did not come back: %d sessions", unit.name, len(ss))
+		}
+	}
+}
+
+// The other half of that: a millisecond store must still be filtered, or the
+// watermark buys nothing on the store it exists for.
+func TestTheCursorSinceClauseStillFilters(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	older := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	db := filepath.Join(t.TempDir(), "state.vscdb")
+	seedCursorStamped(t, db, older.UnixMilli())
+	ss, err := ParseCursorDBSince(db, older.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Errorf("a turn older than the watermark came back anyway: %d sessions", len(ss))
+	}
+}


### PR DESCRIPTION
Fixes #2094. `unixGuess` exists because deja does not get to pick the unit a store writes, and every source reads its numeric stamps through it — except cursor, which had its own millisecond-only reader. A seconds-stamped store was dated three weeks after the epoch, silently:

```
milliseconds  started=2026-03-02T12:00:00Z  updated=2026-03-02T12:00:00Z  message=2026-03-02T12:00:00Z
seconds       started=1970-01-21T12:20:52Z  updated=1970-01-21T12:20:52Z  message=1970-01-21T12:20:52Z
```

A session dated 1970 is not lost, but it is behind everything: `deja last` never reaches it, the digest's recent block skips it, ranking treats it as the oldest thing deja knows, and its store's watermark (#2071) sits in 1970 with it.

The since clause moves with the reader, to the helper #2064 added for opencode. Leaving it on milliseconds was right while the reader was millisecond-only; with the reader taking both, a clause that takes one is the split #2086 was about. There is a test for each half, including that a millisecond store is still filtered.

Whether a Cursor build ever writes seconds I cannot show from here — the same caveat as #2086. What is certain is that this was the last reader that assumed, and the assumption fails silently where the guess costs one comparison.
