### PR TITLE
test: marshal the rest of the fixtures that hold a path

### DIFF
--- a/cmd/deja/hook_cwd_test.go
+++ b/cmd/deja/hook_cwd_test.go
@@ -49,8 +49,13 @@ func TestHooksRecallFromPayloadCWD(t *testing.T) {
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("CLAUDE_PROJECT_DIR", "")
 	at := time.Now().AddDate(0, 0, -2).UTC().Format(time.RFC3339)
-	body := `{"type":"user","sessionId":"a1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"user","content":"the retry budget keeps blowing up under load"}}` + "\n" +
-		`{"type":"assistant","sessionId":"a1","cwd":"` + filepath.ToSlash(root) + `","timestamp":"` + at + `","message":{"role":"assistant","content":[{"type":"text","text":"decision: cap retries at three"}]}}` + "\n"
+	body := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "a1", "cwd": root, "timestamp": at,
+		"message": map[string]any{"role": "user", "content": "the retry budget keeps blowing up under load"},
+	}) + claudeRecord(t, map[string]any{
+		"type": "assistant", "sessionId": "a1", "cwd": root, "timestamp": at,
+		"message": map[string]any{"role": "assistant", "content": []any{map[string]any{"type": "text", "text": "decision: cap retries at three"}}},
+	})
 	if err := os.WriteFile(filepath.Join(root, "a1.jsonl"), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +65,7 @@ func TestHooksRecallFromPayloadCWD(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	payload := `{"prompt":"the retry budget keeps blowing up","cwd":"` + filepath.ToSlash(root) + `"}`
+	payload := hookPayload(t, map[string]string{"prompt": "the retry budget keeps blowing up", "cwd": root})
 	if err := runHookPromptMode(dir, strings.NewReader(payload), &out, false); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/hook_payload_test.go
+++ b/cmd/deja/hook_payload_test.go
@@ -43,3 +43,40 @@ func TestAHookPayloadSurvivesAWindowsPath(t *testing.T) {
 		t.Errorf("the backslashes are not escaped: %s", payload)
 	}
 }
+
+// claudeRecord builds one line of a claude transcript. A record is JSON too, so
+// a path pasted into one has the same hole a payload does — `filepath.ToSlash`
+// covers the backslash a Windows path carries and nothing else (#2096).
+func claudeRecord(t *testing.T, fields map[string]any) string {
+	t.Helper()
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b) + "\n"
+}
+
+// A path can hold a quote on every Unix filesystem, and that is the character
+// ToSlash does nothing about.
+func TestAFixtureSurvivesAPathHoldingAQuote(t *testing.T) {
+	odd := `/tmp/say "hello"/app`
+	payload := hookPayload(t, map[string]string{"source": "startup", "session_id": "ses1", "cwd": odd})
+	var got map[string]string
+	if err := json.Unmarshal([]byte(payload), &got); err != nil {
+		t.Fatalf("the payload is not JSON: %v: %s", err, payload)
+	}
+	if got["cwd"] != odd {
+		t.Errorf("the path did not survive: %q", got["cwd"])
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": odd,
+		"message": map[string]any{"role": "user", "content": "the pool was exhausted"},
+	})
+	var line map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(rec)), &line); err != nil {
+		t.Fatalf("the record is not JSON: %v: %s", err, rec)
+	}
+	if line["cwd"] != odd {
+		t.Errorf("the record's path did not survive: %v", line["cwd"])
+	}
+}

--- a/cmd/deja/hook_worktree_test.go
+++ b/cmd/deja/hook_worktree_test.go
@@ -47,8 +47,10 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 	// The sessions were worked in the main checkout.
 	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
 	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "checkout", "one.jsonl"), "wtterm", []string{
-		`{"type":"user","sessionId":"wtterm","cwd":"` + filepath.ToSlash(repo) + `","timestamp":"` + old +
-			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+		strings.TrimSpace(claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": "wtterm", "cwd": repo, "timestamp": old,
+			"message": map[string]any{"role": "user", "content": "pgbouncer runs in transaction mode and prepared statements are off"},
+		})),
 	})
 	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
 		t.Fatal(err)
@@ -64,7 +66,7 @@ func TestASessionStartedInAWorktreeGetsTheProjectsMemory(t *testing.T) {
 			// A Windows path in a JSON string is a run of invalid escapes, and
 			// the payload would not parse at all — the same reason
 			// hook_cwd_test.go does this.
-			withHookStdin(t, `{"source":"startup","session_id":"ses_wt","cwd":"`+filepath.ToSlash(where.dir)+`"}`)
+			withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "ses_wt", "cwd": where.dir}))
 			out := captureStdout(t, func() {
 				if err := runHookContext(index.DefaultDir(), true); err != nil {
 					t.Error(err)

--- a/internal/sources/antigravity_cli_test.go
+++ b/internal/sources/antigravity_cli_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -139,8 +140,18 @@ func TestParseAntigravityCLISessionGetsAProject(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, transcript := antigravityTree(t)
+	// Marshalled rather than pasted: the path goes inside a JSON string, and a
+	// path can hold a quote as well as a backslash (#2096).
+	viewed, err := json.Marshal(map[string]any{
+		"source": "MODEL", "type": "VIEW_FILE",
+		"content":    "Created At: 2026-08-14T09:00:01Z\nFile Path: file://" + filepath.Join(deep, "pool.go") + "\n\nthe pool is capped at 4",
+		"created_at": "2026-08-14T09:00:01Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	body := `{"source":"USER_EXPLICIT","content":"why is the pool exhausted?","created_at":"2026-08-14T09:00:00Z","type":""}
-{"source":"MODEL","type":"VIEW_FILE","content":"Created At: 2026-08-14T09:00:01Z\nFile Path: file://` + filepath.ToSlash(filepath.Join(deep, "pool.go")) + `\n\nthe pool is capped at 4","created_at":"2026-08-14T09:00:01Z"}
+` + string(viewed) + `
 {"source":"MODEL","type":"PLANNER_RESPONSE","content":"the pool is capped at 4","created_at":"2026-08-14T09:00:02Z"}
 `
 	if err := os.WriteFile(transcript, []byte(body), 0o644); err != nil {


### PR DESCRIPTION
Fixes #2096, the rest of what #2085 started. Five fixtures pasted a path into a JSON string and passed it through `filepath.ToSlash` first:

```
hook_worktree_test.go:50   claude record, cwd
hook_worktree_test.go:67   hook payload, cwd
hook_cwd_test.go:52,53     claude records, cwd
hook_cwd_test.go:63        hook payload, cwd
antigravity_cli_test.go    a file:// path inside "content"
```

`ToSlash` handles the backslash a Windows path carries — the character that made #2085 fail — and nothing else. A path holding a quote is legal on every Unix filesystem and ends the string early, at which point the test measures whatever the parser makes of the wreckage rather than the thing it names.

They marshal now, through the helper #2085 added and a `claudeRecord` beside it for the transcript-shaped ones. Nothing here fails today: the paths come from `t.TempDir()` and a test name cannot hold a quote. The point is not to leave the pattern for the next fixture to copy — #2085's two sites were copied from somewhere.
