### PR TITLE
fix(test): let the control-byte guard see a file before it is added

### DIFF
--- a/internal/index/source_bytes_test.go
+++ b/internal/index/source_bytes_test.go
@@ -23,29 +23,23 @@ import (
 // that a text file which somehow contains a NUL is skipped with them.
 func TestNoControlBytesInTrackedText(t *testing.T) {
 	root := repoRoot(t)
-	// Tracked files only, from git rather than from the filesystem: a walk
-	// reads a developer's build output, their .venv, and the agent-session
-	// directories the .gitignore expects in this checkout — all of them full of
-	// captured terminal escapes. That failure lands only on the machines with
-	// junk in the tree, never in CI, which is the worst way for a guard to be
-	// wrong.
-	out, err := exec.Command("git", "-C", root, "ls-files", "-z").Output()
+	names, err := filesUnderReview(root)
 	if err != nil {
 		t.Skipf("no git checkout to ask: %v", err)
 	}
 
 	var found []string
-	for _, name := range bytes.Split(out, []byte{0}) {
+	for _, name := range names {
 		if len(name) == 0 {
 			continue
 		}
-		path := filepath.Join(root, string(name))
+		path := filepath.Join(root, name)
 		b, err := os.ReadFile(path)
 		if err != nil {
-			// A tracked file that cannot be read is not this test's finding,
-			// but it is not a pass either.
+			// A file that cannot be read is not this test's finding, but it
+			// is not a pass either.
 			if !os.IsNotExist(err) {
-				t.Errorf("cannot read tracked file %s: %v", name, err)
+				t.Errorf("cannot read %s: %v", name, err)
 			}
 			continue
 		}
@@ -64,9 +58,37 @@ func TestNoControlBytesInTrackedText(t *testing.T) {
 		}
 	}
 	if len(found) > 0 {
-		t.Errorf("control bytes in tracked text, which no editor and no diff will show:\n%s",
+		t.Errorf("control bytes in the files a reviewer would see, which no editor and no diff will show:\n%s",
 			strings.Join(found, "\n"))
 	}
+}
+
+// filesUnderReview is what git would show a reviewer: everything tracked, plus
+// the files that are untracked and not ignored.
+//
+// From git rather than from the filesystem, for the reason the test's comment
+// gives: a walk reads a developer's build output, their .venv and the
+// agent-session directories this checkout's .gitignore expects, all of them
+// full of captured terminal escapes, and that failure lands only on the
+// machines with junk in the tree.
+//
+// `--others --exclude-standard` is the other half of the same list. Without it
+// the guard is silent exactly while a new file is being written and speaks only
+// after `git add`, in CI, on someone else's machine — which is how a literal
+// escape byte reached #2091.
+func filesUnderReview(root string) ([]string, error) {
+	out, err := exec.Command("git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard").Output()
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, name := range bytes.Split(out, []byte{0}) {
+		if len(name) == 0 {
+			continue
+		}
+		names = append(names, string(name))
+	}
+	return names, nil
 }
 
 // repoRoot walks up to the directory holding go.mod.
@@ -85,5 +107,62 @@ func repoRoot(t *testing.T) string {
 			t.Fatal("no go.mod above the working directory")
 		}
 		dir = parent
+	}
+}
+
+// The list is what a reviewer would see, which includes a file that has not
+// been added yet — the guard used to be silent exactly while one was being
+// written (#2098).
+func TestTheFileListHoldsANewFileBeforeItIsAdded(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("no git")
+	}
+	root := t.TempDir()
+	// Without its own config the scratch repo inherits the developer's
+	// core.excludesFile, and what this test asserts about ignoring is then
+	// whatever that file happens to say.
+	git := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+	git("init", "-q")
+	git("config", "user.email", "t@example.com")
+	git("config", "user.name", "t")
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(root, name)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(".gitignore", "junk/\n")
+	write("committed.go", "package p\n")
+	git("add", ".gitignore", "committed.go")
+	git("commit", "-q", "-m", "seed")
+	write("brand_new.go", "package p\n")
+	write("junk/captured.log", "\x1b[31m\n")
+
+	names, err := filesUnderReview(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, n := range names {
+		got[n] = true
+	}
+	if !got["committed.go"] {
+		t.Error("a committed file is missing from the list")
+	}
+	if !got["brand_new.go"] {
+		t.Error("a file that has not been added yet is missing from the list")
+	}
+	if got["junk/captured.log"] {
+		t.Error("an ignored file is in the list, which is what reading the filesystem would do")
 	}
 }


### PR DESCRIPTION
Fixes #2098. The control-byte guard asks git for its file list rather than walking the filesystem, for the reason its comment gives — a walk reads build output, `.venv` and the agent-session directories this checkout's `.gitignore` expects, all full of captured terminal escapes. It asked with plain `git ls-files`, which lists what is already tracked, so a file being written for the first time was invisible to it.

The guard was therefore silent exactly while the mistake was being made, and spoke only after `git add` — in CI, on someone else's machine. That is how a literal escape byte reached #2091, this hunt's own PR: the local run passed and CI failed with the guard plus three staticcheck ST1018s for the same bytes. Reproduced deliberately with an untracked `.go` file holding `0x1b`:

```
--- PASS: TestNoControlBytesInTrackedText (0.07s)
```

`--others --exclude-standard` is the other half of the same list: untracked **and not ignored**, so a new source file joins and nothing from `.venv` or the session directories does. In this checkout the two lists are the same 1511 files, which is what a clean tree should say.

The scratch repo in the new test holds a committed file, a brand-new unadded one and an ignored one, and asserts the list holds the first two and not the third.

The scratch repo runs with `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` pointed at /dev/null, on the reviewer's point: without that it inherits whatever `core.excludesFile` the developer keeps, and what the test asserts about ignoring becomes whatever that file says.
