### PR TITLE
fix(view): cap a note's body the way a preview is capped

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -209,7 +209,7 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		// filename takes a control byte on every Unix filesystem.
 		sessions[i].ID = safeNameForPage(sessions[i].ID)
 		sessions[i].Title = safeTitleForPage(sessions[i].Title)
-		sessions[i].Preview = safeTextForPage(sessions[i].Preview)
+		sessions[i].Preview = clipForPage(safeTextForPage(sessions[i].Preview))
 		sessions[i].Project = safeNameForPage(sessions[i].Project)
 	}
 	for i := range recalls {
@@ -220,7 +220,10 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	}
 	for i := range notes {
 		notes[i].Title = safeTitleForPage(notes[i].Title)
-		notes[i].Text = safeTextForPage(notes[i].Text)
+		// Capped like a session's preview, and for the same reason: a promoted
+		// note carries whatever was promoted, and one of a megabyte outweighed
+		// a hundred sessions on the page (#2100).
+		notes[i].Text = clipForPage(safeTextForPage(notes[i].Text))
 		// A note's project and tags are what the user typed, so they are text
 		// like the rest rather than structure deja minted.
 		notes[i].Project = safeNameForPage(notes[i].Project)
@@ -284,15 +287,23 @@ func sessionPreview(msgs []model.Message) string {
 			break
 		}
 	}
-	out := b.String()
-	if len(out) > viewPreviewBytes {
-		cut := viewPreviewBytes
-		for cut > 0 && !utf8.RuneStart(out[cut]) {
-			cut--
-		}
-		out = out[:cut] + "…"
+	// Whole messages, and the trailing cut is left to clipForPage: cutting here
+	// happens before the redaction below, so a secret sliced in half stops
+	// matching the pattern that would have masked it and the half is printed.
+	return b.String()
+}
+
+// clipForPage bounds a cell at the size a preview gets, cutting on a rune
+// boundary and saying that it cut.
+func clipForPage(s string) string {
+	if len(s) <= viewPreviewBytes {
+		return s
 	}
-	return out
+	cut := viewPreviewBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…"
 }
 
 func openInBrowser(path string) {

--- a/cmd/deja/view_note_size_test.go
+++ b/cmd/deja/view_note_size_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The page caps a session's preview so it stays a single fast file. A note's
+// body is the same kind of content in the same page and had no cap, so one
+// promoted note outweighed a hundred sessions (#2100).
+func TestANoteDoesNotOutweighThePage(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	render := func(what string) int64 {
+		t.Helper()
+		if _, err := captureRun(t, "index"); err != nil {
+			t.Fatal(err)
+		}
+		out := filepath.Join(t.TempDir(), "view.html")
+		if _, err := captureRun(t, "view", "--no-open", "--out", out); err != nil {
+			t.Fatal(err)
+		}
+		fi, err := os.Stat(out)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("%s: %d bytes", what, fi.Size())
+		return fi.Size()
+	}
+	small := render("an empty store")
+
+	huge := strings.Repeat("the pool was exhausted. ", 40000) // about a megabyte
+	line, err := json.Marshal(map[string]any{
+		"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
+		"session": "claude:s1", "state": "accepted", "project": "app",
+		"title": "pool sizing", "text": huge,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notes, append(line, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withNote := render("plus one note of a megabyte")
+
+	// The premise: the note reached the page at all.
+	if withNote <= small {
+		t.Fatalf("the note did not reach the page, so this measures nothing")
+	}
+	// A promoted note reaches the page twice — as a note, and as the deja
+	// session it is indexed as, whose preview is capped too — so the page grows
+	// by two capped copies and the rows around them.
+	if grew := withNote - small; grew > 3*viewPreviewBytes {
+		t.Errorf("one note grew the page by %d bytes; the preview cap is %d", grew, viewPreviewBytes)
+	}
+}

--- a/cmd/deja/view_preview_test.go
+++ b/cmd/deja/view_preview_test.go
@@ -15,7 +15,9 @@ func TestSessionPreviewCutsOnARuneBoundary(t *testing.T) {
 	for i := 0; i < 90; i++ {
 		msgs = append(msgs, model.Message{Role: "user", Text: "x" + strings.Repeat("é", 40)})
 	}
-	out := sessionPreview(msgs)
+	// The trailing cut moved to clipForPage, which runs after the redaction —
+	// cutting before it would slice a secret in half and print the half (#2100).
+	out := clipForPage(sessionPreview(msgs))
 	if len(out) <= viewPreviewBytes {
 		t.Fatalf("fixture did not reach the cap: %d bytes", len(out))
 	}

--- a/cmd/deja/view_test.go
+++ b/cmd/deja/view_test.go
@@ -98,7 +98,7 @@ func TestViewGeneratesSelfContainedHTML(t *testing.T) {
 
 func TestViewPreviewCap(t *testing.T) {
 	long := strings.Repeat("word ", viewPreviewBytes)
-	got := sessionPreview([]model.Message{{Role: "user", Text: long}})
+	got := clipForPage(sessionPreview([]model.Message{{Role: "user", Text: long}}))
 	if len(got) > viewPreviewBytes+8 {
 		t.Fatalf("preview exceeds cap: %d", len(got))
 	}


### PR DESCRIPTION
Fixes #2100. The page caps what it puts in a session's cell and says why — "viewPreviewBytes caps each preview so the page stays a single fast file even over a multi-gigabyte store". A note's body is the same kind of content in the same page and had no cap:

```
100 sessions, 13 KB each:            page =   638,706 bytes
the same page plus one 1 MB note:    page = 1,605,078 bytes  (+966,372)
```

One note outweighed a hundred sessions, and nothing stopped it: a promoted note carries whatever was promoted, and `deja promote` takes a decision along with the excerpt that led to it.

It takes the preview's own cap now — 6 KB is about a thousand words, so every note anyone actually writes stays whole — cut on a rune boundary with the ellipsis the preview already uses, and applied after the redaction and the scrub so the cut cannot uncover anything.

The test allows three caps rather than one because a promoted note reaches the page twice: as a note, and as the deja session it is indexed as, whose preview is capped too.

Left on the issue: whether the number of notes wants a bound the way transcripts have one (`viewTranscripts = 200`) — today the page carries every promoted note there is.

Review turned up the order the cut had been in: the preview's own trailing cut ran *before* the redaction, so a secret sliced by it stopped matching the pattern that would have masked it and the half was printed. `sessionPreview` now stops at whole messages and the trailing cut happens with the note's, after the scrub. The two tests that pinned the cut moved with it.

Still unbounded on that page, for the issue rather than for here: a session id, a project, a note's tags and a recall's digest and terms.
