### PR TITLE
fix(sources): read a stamp in microseconds or nanoseconds as such

### DIFF
--- a/internal/sources/epoch_units_test.go
+++ b/internal/sources/epoch_units_test.go
@@ -1,0 +1,57 @@
+package sources
+
+import (
+	"encoding/json"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// unixGuess is the front door for every numeric timestamp deja reads, and it
+// knew two units: anything larger than milliseconds was read as milliseconds,
+// so a microsecond store was dated to the year 58136 and a nanosecond one to
+// the year 56 million. A session dated in the future takes the top of every
+// recency surface and keeps it (#2063), so one such store pins them all (#2102).
+func TestAStampIsReadInWhicheverUnitItWasWritten(t *testing.T) {
+	when := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	for _, u := range []struct {
+		name string
+		n    int64
+	}{
+		{"seconds", when.Unix()},
+		{"milliseconds", when.UnixMilli()},
+		{"microseconds", when.UnixMicro()},
+		{"nanoseconds", when.UnixNano()},
+	} {
+		got := parseTimeAny(json.Number(strconv.FormatInt(u.n, 10)))
+		if !got.UTC().Equal(when) {
+			t.Errorf("%s (%d) read as %s, want %s", u.name, u.n, got.UTC().Format(time.RFC3339), when.Format(time.RFC3339))
+		}
+	}
+}
+
+// The bands are judged by magnitude, so the edges are worth pinning: a value
+// deja cannot place is better read as the unit that puts it in a plausible year
+// than as one that puts it past the year 5000.
+func TestTheUnitBandsHoldAtTheirEdges(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		n    int64
+		want time.Time
+	}{
+		{"an old seconds stamp", 915148800, time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{"an old millisecond stamp", 915148800000, time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{"a 2001 millisecond stamp", 1_000_000_000_000, time.Date(2001, 9, 9, 1, 46, 40, 0, time.UTC)},
+		{"zero is no stamp", 0, time.Time{}},
+		{"a negative is no stamp", -1, time.Time{}},
+		// The largest thing an int64 can carry: nanoseconds run out in 2262,
+		// and the call takes it rather than panicking.
+		{"the largest int64", math.MaxInt64, time.Unix(0, math.MaxInt64)},
+	} {
+		got := parseTimeAny(json.Number(strconv.FormatInt(c.n, 10)))
+		if !got.UTC().Equal(c.want.UTC()) {
+			t.Errorf("%s (%d) read as %s, want %s", c.name, c.n, got.UTC().Format(time.RFC3339), c.want.UTC().Format(time.RFC3339))
+		}
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -103,21 +103,45 @@ func parseTimeAny(v any) time.Time {
 // pass. Comparing against both unconditionally is the second of those. The
 // split is unixGuess's own, applied to the row rather than to the watermark.
 func newerThanEpoch(expr string, t time.Time) string {
-	return fmt.Sprintf("(%[1]s > %[2]d or (%[1]s <= %[4]d and %[1]s > %[3]d))",
+	// Milliseconds and seconds are the two units a store writes and then
+	// filters on; a microsecond or nanosecond row is a larger number than any
+	// millisecond watermark, so it passes the first test and comes back. Over-
+	// inclusion is the safe direction here — the reader decides the date.
+	return fmt.Sprintf("(%[1]s > %[2]d or (%[1]s < %[4]d and %[1]s > %[3]d))",
 		expr, t.UnixMilli(), t.Unix(), epochMilliCutoff)
 }
 
-// Above this a stamp is milliseconds, below it seconds.
-const epochMilliCutoff = int64(1e12)
+// The magnitudes that tell one unit from another. A moment in the 2020s is
+// about 1.7e9 seconds, 1.7e12 milliseconds, 1.7e15 microseconds and 1.7e18
+// nanoseconds, so each band holds every real stamp of its unit with three
+// decades of room either side.
+//
+// Reading anything above milliseconds AS milliseconds is what this replaces: a
+// microsecond store came back dated to the year 58136 and a nanosecond one to
+// the year 56 million, and a session dated in the future takes the top of every
+// recency surface and keeps it (#2063, #2102).
+const (
+	epochMilliCutoff = int64(1e11)
+	epochMicroCutoff = int64(1e14)
+	epochNanoCutoff  = int64(1e17)
+)
 
+// unixGuess reads a numeric stamp in whichever unit it was written in. It is
+// the front door for every store that writes a number rather than a date, so a
+// unit it cannot place is a whole harness misdated.
 func unixGuess(n int64) time.Time {
-	if n > epochMilliCutoff {
-		return time.UnixMilli(n)
-	}
-	if n > 0 {
+	switch {
+	case n <= 0:
+		return time.Time{}
+	case n < epochMilliCutoff:
 		return time.Unix(n, 0)
+	case n < epochMicroCutoff:
+		return time.UnixMilli(n)
+	case n < epochNanoCutoff:
+		return time.UnixMicro(n)
+	default:
+		return time.Unix(0, n)
 	}
-	return time.Time{}
 }
 
 // textFromContentKind is textFromContent plus the attribution question: did


### PR DESCRIPTION
Fixes #2102. `unixGuess` is where every numeric timestamp deja reads ends up — twenty-odd harnesses, and #2064, #2086 and #2094 all landed there. It knew two units, so anything larger than milliseconds was read as milliseconds. One instant, written four ways:

```
seconds              1772452800  -> 2026-03-02T12:00:00Z
milliseconds      1772452800000  -> 2026-03-02T12:00:00Z
microseconds   1772452800000000  -> 58136-10-17
nanoseconds 1772452800000000000  -> 56168763-04-19
```

Not a cosmetic misreading: #2063 measured what a future-dated session does — it takes the top of `deja last` and keeps it, and the digest's recent block is built the same way. One store stamped in the wrong unit pins every recency surface deja has, and nothing says why.

Microseconds and nanoseconds are ordinary: `time.time_ns()`, `strftime('%s')*1000000`, Go's own `UnixNano` — deja's peer sync carries nanoseconds internally. The registry gains harnesses regularly and this is the function each one lands in.

Four bands by magnitude, the way the existing two were: `< 1e11` seconds, `< 1e14` milliseconds, `< 1e17` microseconds, else nanoseconds. A moment in the 2020s is 1.7e9, 1.7e12, 1.7e15 and 1.7e18, so each band holds every real stamp of its unit with decades of room either side. The band between 1e11 and 1e12 changes meaning — seconds put it in the year 5138, milliseconds in the 1970s — and only one of those is plausible junk.

`newerThanEpoch` needs nothing: a microsecond or nanosecond row is a larger number than any millisecond watermark, so it passes the first test and comes back. Over-inclusion is the safe direction there — the reader is what decides the date.

The reviewer asked whether the nanosecond branch can panic at the top of the range. It cannot — the argument is an `int64`, so `math.MaxInt64` is the largest thing it can carry and `time.Unix(0, n)` takes it, landing in 2262. Pinned as a case rather than argued.
