### PR TITLE
feat(last): say when the listing leads with work that has not happened

### DIFF
--- a/cmd/deja/last_ahead_test.go
+++ b/cmd/deja/last_ahead_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The listing whose job is "most recent" led with a session that has not
+// happened yet and said nothing, while the first screen says it — which is the
+// arrangement #696 rejected there (#2104).
+func TestLastSaysWhenASessionIsStampedAhead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the pool was exhausted while the migration held the lock"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ahead, err := json.Marshal(map[string]any{
+		"ts": time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339Nano), "kind": "promoted",
+		"session": "claude:s9", "state": "accepted", "project": "app",
+		"title": "a note from next year", "text": "pgbouncer runs in transaction mode",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notes, append(ahead, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "last") })
+	// The premise: the future session really does lead the listing.
+	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
+	if !strings.Contains(first, "next year") {
+		t.Fatalf("the session stamped ahead is not at the top, so this measures nothing: %q", first)
+	}
+	if !strings.Contains(stderr, "later than this machine's clock") {
+		t.Errorf("the listing led with work that has not happened and said nothing: %q", strings.TrimSpace(stderr))
+	}
+}
+
+// And it says it only when there is one: the line is about a state, not a
+// decoration on every listing.
+func TestLastIsQuietWhenNothingIsAhead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the pool was exhausted"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "last") })
+	if !strings.Contains(out, "pool was exhausted") {
+		t.Fatalf("the listing is empty, so this measures nothing: %q", out)
+	}
+	if strings.Contains(stderr, "later than this machine's clock") {
+		t.Errorf("a listing with nothing ahead said something was: %q", strings.TrimSpace(stderr))
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -892,7 +892,36 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		}
 		fmt.Println()
 	}
+	// The listing is ordered by a date, so one that has not happened leads it
+	// and nothing else on the screen says why. The first screen carries the
+	// same sentence beside the same list, because leaving it unexplained makes
+	// the counters and the list disagree for no visible reason (#696, #2104).
+	if n := stampedAheadCount(ss, time.Now()); n > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d session%s stamped later than this machine's clock — %s at the top of this list\n",
+			n, pluralS(n), pluralThatThose(n))
+	}
 	return nil
+}
+
+// stampedAheadCount counts the listed sessions whose stamp is after now, by the
+// same rule the first screen counts them with.
+func stampedAheadCount(ss []model.Session, now time.Time) int {
+	n := 0
+	for _, s := range ss {
+		if index.StampedAhead(s.Updated, now) {
+			n++
+		}
+	}
+	return n
+}
+
+// pluralThatThose keeps the sentence above readable for one session and for
+// several, the way pluralThem does for the ingest lines.
+func pluralThatThose(n int) string {
+	if n == 1 {
+		return "that one is"
+	}
+	return "those are"
 }
 
 // cmdSearch is the explicit form. Bare `deja <words>` also searches, but a


### PR DESCRIPTION
Fixes #2104. `deja last` orders by date, so a session stamped after this machine's clock leads it — and the listing said nothing:

```
$ deja last
[deja · app · 2027-08-27 · deja-note-claude-s9] a note from next year [accepted]
[claude · app · 2026-08-27 · s1] the pool was exhausted while the migration held the lock
```

The first screen shows the same two sessions in the same order and explains them:

```
today      1 session
ahead      1 session stamped later than this machine's clock
recent     [deja] app · Aug 27 2027 · a note from next year [accepted]
           [claude] projects · today · the pool was exhausted while the migrati…
```

That sentence exists because #696 found the counters and the list disagreeing with nothing to say why. `deja last` is the surface whose whole job is "most recent", and it had the list without the sentence.

It says it now, on stderr like the other advisory lines there, and only when there is something to say. Two routes to a future stamp were measured this week and neither is exotic: a hand-written note's `ts` (#2063) and a store whose stamps deja read in the wrong unit, which dated it to the year 58136 (#2102).

Clamping the stamp is the other answer and it is on the issue: deja cannot tell a skewed clock from a deliberate date, so that one is a decision rather than a fix.
