### PR TITLE
feat(doctor): name the sessions stamped after this machine's clock

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1171,6 +1171,14 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 	default:
 		fmt.Fprintln(w, "  freshness up to date")
 	}
+	// A stamp the clock cannot account for puts a session at the top of every
+	// surface ordered by date, and leaves it there. The first screen has said
+	// so since #696 and the listing since #2105; this is where a reader looks
+	// when a store reads wrong (#2106).
+	if idx.SessionsAhead > 0 {
+		fmt.Fprintf(w, "  clock    %s stamped later than this machine's clock — `deja last` leads with %s\n",
+			doctorCount(idx.SessionsAhead, "session"), pluralThatThose(idx.SessionsAhead))
+	}
 	// What the last sync did with this machine's own rules: records that were
 	// dropped because they belong to sessions forgotten here are invisible
 	// afterwards, and a peer who keeps sending them drops them every time

--- a/cmd/deja/doctor_ahead_test.go
+++ b/cmd/deja/doctor_ahead_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func seedAheadIndex(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the pool was exhausted while the migration held the lock"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ahead, err := json.Marshal(map[string]any{
+		"ts": time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339Nano), "kind": "promoted",
+		"session": "claude:s9", "state": "accepted", "project": "app",
+		"title": "a note from next year", "text": "pgbouncer runs in transaction mode",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(notes, append(ahead, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// doctor is where someone looks when a store reads wrong, and it named this for
+// a peer's clock since #1855 while saying nothing about a session's (#2106).
+func TestDoctorNamesSessionsStampedAhead(t *testing.T) {
+	seedAheadIndex(t)
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the index really holds the session ahead.
+	if !strings.Contains(out, "freshness") {
+		t.Fatalf("doctor did not report on the index at all: %q", out)
+	}
+	if !strings.Contains(out, "later than this machine's clock") {
+		t.Errorf("doctor says nothing about a session dated next year:\n%s", out)
+	}
+}
+
+// And the machine-readable side, which is what a script reads.
+func TestDoctorJSONCarriesTheAheadCount(t *testing.T) {
+	seedAheadIndex(t)
+	out, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Index struct {
+			SessionsAhead int `json:"sessions_stamped_ahead"`
+		} `json:"index"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("doctor --json: %v: %s", err, out)
+	}
+	if report.Index.SessionsAhead != 1 {
+		t.Errorf("doctor --json counts %d sessions stamped ahead, want 1", report.Index.SessionsAhead)
+	}
+}
+
+// A store with nothing ahead says nothing: the line is a state, not a
+// decoration on every run.
+func TestDoctorIsQuietWhenNothingIsAhead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the pool was exhausted"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "later than this machine's clock") {
+		t.Errorf("doctor reported a session ahead where there is none:\n%s", out)
+	}
+}

--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -43,7 +43,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		"indexed_sessions": true, "indexed_from_elsewhere": true,
 		"denied": true, "skipped": true, "partial": true, "unchecked": true,
 		// doctorComponent
-		"path": true, "stale_stores": true,
+		"path": true, "stale_stores": true, "sessions_stamped_ahead": true,
 		// doctorVersionReport
 		"current": true, "latest": true,
 		// doctorEmbedReport

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -62,6 +62,12 @@ type doctorIndexReport struct {
 	State       string `json:"state"`
 	Path        string `json:"path,omitempty"`
 	StaleStores int    `json:"stale_stores"`
+	// SessionsAhead counts sessions stamped later than this machine's clock.
+	// One of those leads `deja last` and the digest's recent block until the
+	// data is edited, and it arrives from an ordinary place: a hand-written
+	// note's ts (#2063), or a store whose stamps were read in the wrong unit
+	// (#2102). doctor has named the same fact for a peer since #1855.
+	SessionsAhead int `json:"sessions_stamped_ahead"`
 }
 
 type doctorVersionReport struct {
@@ -606,6 +612,9 @@ func inspectDoctorIndex(dir string, storeMods []time.Time) doctorIndexReport {
 		return result
 	}
 	result.State = "ok"
+	if ov, err := index.Overview(dir); err == nil {
+		result.SessionsAhead = ov.Future
+	}
 	builtAt := index.ManifestBuiltAt(dir)
 	for _, mod := range storeMods {
 		if !mod.IsZero() && mod.After(builtAt) {

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -195,7 +195,8 @@
   "index": {
     "state": "missing",
     "path": "<tmp>/index.db",
-    "stale_stores": 0
+    "stale_stores": 0,
+    "sessions_stamped_ahead": 0
   },
   "mcp": [
     {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -311,7 +311,8 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
   "index": {
     "state": "ok",
     "path": "/home/user/.cache/deja/index.db",
-    "stale_stores": 0
+    "stale_stores": 0,
+    "sessions_stamped_ahead": 0
   },
   "mcp": [
     {


### PR DESCRIPTION
Fixes #2106. A session stamped after this machine's clock leads every surface ordered by date and stays there. The first screen has named it since #696, `deja last` since #2105, and `doctor` — where a reader goes when a store reads wrong — said nothing, though it has reported the same fact for a *peer's* clock since #1855 and `index.Overview` already counts sessions ahead.

```
  freshness up to date
  clock    1 session stamped later than this machine's clock — `deja last` leads with that one
```

and in the machine-readable form, `index.sessions_stamped_ahead`, documented with the rest of the doctor contract.

Two routes to it were measured this week and neither is exotic: a hand-written note's `ts` (#2063) and a store whose stamps deja read in the wrong unit, which dated it to the year 58136 (#2102).

Silence when there is nothing ahead, with a test for that too. Clamping stays a decision on #2104: deja cannot tell a skewed clock from a deliberate date, so what it can do is say so where the reader is looking.

Review caught the field carrying `omitempty`, which the struct's own comment forbids for exactly this reason: #1710 records a script raising on every machine whose index was fresh, because the zero the documented example shows was the one value never written. Dropped, and the golden file carries the key.
