### PR TITLE
feat(brief): give the first screen a name

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -48,7 +48,10 @@ func briefWithholdingRule(withheld map[string]int, total int) string {
 
 // runBrief is what a bare `deja` on a terminal shows: the memory, alive.
 // Manifest metadata and the usage sidecar only — it must feel instant.
-// Pipes and scripts still get the usage text; `deja help` always works.
+//
+// A bare `deja` into a pipe or a script still gets the usage text, which is the
+// right answer when nobody asked for a screen. `deja brief` asks for it, and
+// then it goes wherever the writer goes (#2108); `deja help` always works.
 func runBrief(dir string, w io.Writer) error {
 	justGreeted := false
 	ov, err := index.Overview(dir)
@@ -73,7 +76,10 @@ func runBrief(dir string, w io.Writer) error {
 			return nil
 		}
 	}
-	color := statColorOK(os.Stdout)
+	// The writer, not os.Stdout: this screen has a name now, so it can be
+	// written somewhere that is not the terminal, and the escapes belong to
+	// wherever it is going (#2108).
+	color := statColorOK(w)
 	bold, dim, reset := "", "", ""
 	if color {
 		bold, dim, reset = logoBold, logoDim, logoReset

--- a/cmd/deja/brief_command_test.go
+++ b/cmd/deja/brief_command_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The first screen printed only when stdout was a terminal, so `deja | less`
+// and `deja > file` got the usage screen and there was no way to ask for it on
+// purpose — the obvious guess was a search for the word (#2108).
+func TestBriefIsACommandAndPrintsIntoAPipe(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the pool was exhausted while the migration held the lock"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// captureRun's stdout is a pipe, which is the case this is about.
+	out, err := captureRun(t, "brief")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"across 1 agent", "recent", "the pool was exhausted"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the first screen does not carry %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "no matches") || strings.Contains(out, "Usage:") {
+		t.Errorf("`deja brief` did not print the first screen:\n%s", out)
+	}
+}

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -52,7 +52,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]-}"
     action="${COMP_WORDS[2]-}"
 
-    local commands="blame bench check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="%HARNESSES%"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -177,6 +177,7 @@ _deja() {
     'index:build or refresh the index'
     'install:wire deja into an agent'
     'last:list recent sessions'
+    'brief:the screen bare deja prints on a terminal'
     'log:show what deja served to agents'
     'mcp:serve the MCP protocol'
     'remember:store a durable note'
@@ -275,7 +276,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -160,6 +160,10 @@ var commands = map[string]command{
 	"check": func(dir string, rest []string) error {
 		return runCheck(dir, rest, os.Stdin, os.Stdout)
 	},
+	// The screen `deja` prints on a terminal, under a name, so it can be paged,
+	// captured into a bug report or read over a pipe — and so the obvious guess
+	// stops being a search for the word (#2108).
+	"brief":           func(dir string, _ []string) error { return runBrief(dir, os.Stdout) },
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
 	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },
@@ -2874,6 +2878,7 @@ Usage:
   deja index [--rebuild]
   deja embed
   deja bench recall|context|prompt [--json] [--seed n]
+  deja brief         (the screen a bare deja prints on a terminal)
   deja log [n] [--last] [--json]
   deja statusline
   deja stats [--json] [--impact] [--redaction] [--card [path]] [--html [path]]


### PR DESCRIPTION
Fixes #2108. The first screen — "N sessions across M agents", `today`, `ahead`, `recent`, the wiring line — had no name. `run` prints it when it gets no arguments *and* stdout is a character device that is not `/dev/null`, so:

```
$ deja | less        the usage screen
$ deja > screen.txt  the usage screen
$ deja brief         deja: no matches in 1 indexed session — try fewer words or --re (query "brief")
```

The TTY rule is right for the no-argument case — a script running bare `deja` wants the usage — but there was no way to ask for the screen on purpose, so it could not be paged, captured into a bug report, or read over a pipe, and the obvious guess answered with a search that found nothing.

`deja brief` is that name now. It costs the word as a bare query, which is the trade this project already takes for every subcommand and documents on `cmdSearch`: "a single word that happens to name a subcommand runs that instead". `deja search brief` still finds it.

Help and the three completions list it, because their coverage tests require every dispatched command to appear — which is how this stayed honest.

Two things from review, both about the screen having a name now: `runBrief`'s comment said pipes get the usage text, which is still true of a bare `deja` and no longer of this; and it decided colour from `os.Stdout` while taking a writer, so the escapes now follow the writer the way `printStats` does.
