### PR TITLE
fix(view): carry the newest notes rather than all of them

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -31,6 +32,10 @@ const (
 	viewTranscripts  = 200
 	viewPreviewBytes = 6 << 10
 	viewRecalls      = 100
+	// The same bound for notes, for the same reason: a store with a thousand
+	// promoted notes made the page 7.6 MB, which is not the single fast file
+	// the transcript cap exists to keep (#2111).
+	viewNotes = 200
 )
 
 type viewSession struct {
@@ -71,6 +76,10 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// NoteCount is how many notes the page carries and TotalNotes how many
+	// there are, so the page can say when those differ (#2111).
+	NoteCount  int
+	TotalNotes int
 }
 
 func runView(dir string, args []string) error {
@@ -194,8 +203,18 @@ func writeViewHTML(dir, out string) (string, int, error) {
 			Terms: sn.Terms, Digest: sn.Digest,
 		})
 	}
-	notes := make([]viewNote, 0, 16)
-	for _, n := range sources.LoadPromotedNotes() {
+	loaded := sources.LoadPromotedNotes()
+	// By date, newest first: LoadPromotedNotes returns them in the order they
+	// were first written to the file, so cutting that keeps an arbitrary set
+	// rather than the newest — and the page's own order was the file's.
+	sort.SliceStable(loaded, func(i, j int) bool { return loaded[i].At.After(loaded[j].At) })
+	page.TotalNotes = len(loaded)
+	if len(loaded) > viewNotes {
+		loaded = loaded[:viewNotes]
+	}
+	page.NoteCount = len(loaded)
+	notes := make([]viewNote, 0, len(loaded))
+	for _, n := range loaded {
 		notes = append(notes, viewNote{
 			Project: n.Project, State: n.State, Title: n.Title, Text: n.Text,
 			Tags: n.Tags, At: n.At.Format("2006-01-02"),

--- a/cmd/deja/view_notes_cap_test.go
+++ b/cmd/deja/view_notes_cap_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The page bounds its transcripts and each cell's text, and carried every note
+// there is — a thousand of them made it 7.6 MB, which is not the single fast
+// file the cap on transcripts exists to keep (#2111).
+func TestThePageCarriesTheNewestNotesAndSaysSo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+
+	body := strings.Repeat("the connection pool was exhausted while the migration held the lock. ", 90)
+	var b strings.Builder
+	const total = 1000
+	for i := 0; i < total; i++ {
+		// Oldest first in the file, so file order and date order disagree —
+		// which is what makes the sort part of the fix rather than a detail.
+		line, err := json.Marshal(map[string]any{
+			"ts":   time.Now().Add(-time.Duration(total-i) * time.Hour).UTC().Format(time.RFC3339Nano),
+			"kind": "promoted", "session": fmt.Sprintf("claude:s%04d", i),
+			"state": "accepted", "project": "app",
+			"title": fmt.Sprintf("decision %04d", i),
+			"text":  fmt.Sprintf("body-marker-%04d ", i) + body,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(notes, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, err := captureRun(t, "view", "--no-open", "--out", out); err != nil {
+		t.Fatal(err)
+	}
+	page, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the notes reached the page.
+	if !strings.Contains(string(page), "body-marker-0999") {
+		t.Fatalf("the newest note's body is not on the page, so this measures nothing")
+	}
+	if n := len(page); n > 3<<20 {
+		t.Errorf("the page is %d bytes for %d notes", n, total)
+	}
+	// The oldest note's row still appears among the sessions — a note is
+	// indexed as one, and those stay browsable by metadata — but its body is
+	// what the page carries for a note, and that is what the bound is about.
+	if strings.Contains(string(page), "body-marker-0000") {
+		t.Errorf("the page carries the body of the oldest of %d notes, so nothing was bounded", total)
+	}
+	if !strings.Contains(string(page), "most recent notes") {
+		t.Errorf("the page does not say that it carries a subset of the notes")
+	}
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -68,7 +68,7 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
 <p class="note">every injection an agent received, verbatim — the audit trail behind <b>deja log</b>.</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
-<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.</p></div>
+<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}</p></div>
 </div>
 <script>
 const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};


### PR DESCRIPTION
Fixes #2111. The page bounds its transcripts — 200 previews, "the rest stay browsable by metadata" — and since #2101 each cell's text. The number of notes had no bound:

```
1000 notes of ~6 KB: page = 7,601,006 bytes
```

7.6 MB in the one local file the page is meant to be, parsed by the browser before anything renders. A thousand notes is not a strange number for a tool whose pitch is promoting decisions.

They take the transcripts' bound now, and the notes tab says what it did — "The 200 most recent notes of 1000 are on this page" — in the idiom the sessions tab already uses.

The sort is part of the fix rather than a detail: `LoadPromotedNotes` returns notes in the order they were first written to the file, so cutting that would have kept an arbitrary set, and the page's own order was the file's. Newest first, then the cut.

The test seeds a thousand notes oldest-first so file order and date order disagree, and asserts on the newest note's body being present and the oldest's absent — the oldest note's *row* stays, because a note is indexed as a session and those stay browsable by metadata, which is the same promise the transcript cap makes.
