### PR TITLE
fix(json): leave out the time of a message the transcript never stamped

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -164,6 +164,11 @@ when empty:
 `messages` is likewise absent rather than empty on `last`, which never returns
 turns.
 
+Inside a message, `time` is the turn's own stamp and is absent when the
+transcript did not carry one — the zero time reads as a date in the year one
+rather than as the absence of a date, and every surface deja prints shows `-`
+for it instead.
+
 ## `deja last --json`
 
 Recent session metadata uses a versioned envelope and never includes messages:

--- a/internal/model/message_json_test.go
+++ b/internal/model/message_json_test.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The zero time marshals as "0001-01-01T00:00:00Z", which reads as a date
+// rather than as the absence of one — a consumer sorting by it puts the message
+// before everything that ever happened. Every surface deja prints already says
+// "-" for it (#765, #2113).
+func TestAMessageWithNoStampCarriesNoTimeField(t *testing.T) {
+	when := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	stamped, err := json.Marshal(Message{Role: "user", Text: "the pool was exhausted", Time: when})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stamped), `"time":"2026-01-02T03:04:05Z"`) {
+		t.Fatalf("a stamped message lost its time: %s", stamped)
+	}
+
+	bare, err := json.Marshal(Message{Role: "assistant", Text: "raise the pool cap"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(bare), "0001-01-01") {
+		t.Errorf("a message deja could not date is published as the year one: %s", bare)
+	}
+	if strings.Contains(string(bare), `"time"`) {
+		t.Errorf("the time field is present for a message that has none: %s", bare)
+	}
+	// The rest of the message is untouched, and it still round-trips.
+	var back Message
+	if err := json.Unmarshal(bare, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Role != "assistant" || back.Text != "raise the pool cap" || !back.Time.IsZero() {
+		t.Errorf("the message did not survive the round trip: %#v", back)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 )
@@ -9,6 +10,28 @@ type Message struct {
 	Role string    `json:"role"`
 	Text string    `json:"text"`
 	Time time.Time `json:"time"`
+}
+
+// MarshalJSON leaves the time out of a message the transcript never stamped.
+//
+// The zero time marshals as "0001-01-01T00:00:00Z", which reads as a date
+// rather than as the absence of one: a consumer sorting by it puts the message
+// before everything that ever happened, and one bucketing by month gets a
+// bucket in the year one. Every surface deja prints already refuses it — the
+// listing shows "-" because "0001-01-01 reads as corrupted data rather than as
+// a missing field" (#765) — and this is the surface a machine reads (#2113).
+func (m Message) MarshalJSON() ([]byte, error) {
+	// The alias sheds the method, so this does not call itself; the outer Time
+	// shadows the embedded one, which is how a field is dropped without
+	// restating the rest of the shape.
+	type message Message
+	if m.Time.IsZero() {
+		return json.Marshal(struct {
+			message
+			Time *time.Time `json:"time,omitempty"`
+		}{message(m), nil})
+	}
+	return json.Marshal(message(m))
 }
 
 type Session struct {


### PR DESCRIPTION
Fixes #2113. A message the transcript never stamped was published with the year one:

```
$ deja show s1 --json --harness claude
  user      time=2026-08-27T05:24:42+03:00  the pool was exhausted while the migration held the lock
  assistant time=0001-01-01T00:00:00Z       raise the pool cap to 200
```

That is Go's zero time, not a date anyone recorded. A consumer sorting by it puts the message before everything that ever happened, one bucketing by month gets a bucket in the year one, and a person reading the payload sees a date rather than the absence of one.

deja's own surfaces already refuse it: `deja last` prints "-" because "0001-01-01 reads as corrupted data rather than as a missing field" (#765), the first screen leaves such sessions out of its range, and two readers — cursor, and opencode since #2087 — date a stampless message from the conversation it belongs to. The JSON was the one surface publishing the zero as data.

It is omitted now, which says what deja knows: nothing. The alternative — dating the message from the session's start the way the two db readers do — invents a precision the transcript did not have, and that is the wrong answer for a payload a machine reads.

One sentence in `docs/json-output.md` says so, beside the paragraph that already explains when `messages` itself is absent.
