### PR TITLE
fix(hint): answer the guess that spelled a hyphenated command with a space

### DIFF
--- a/cmd/deja/command_hint_test.go
+++ b/cmd/deja/command_hint_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hint exists for the guess that fell through to search (#674). A guess
+// with an exact answer behind it was sent somewhere else: `hook context` is the
+// hyphen-free spelling of a command that exists, and the hint proposed `deja
+// how`, because the candidate list drops the plumbing and `how` is what
+// survives nearest to `hook` (#2115).
+func TestTheHintNamesTheCommandThatWasGuessedAt(t *testing.T) {
+	for _, c := range []struct {
+		query string
+		want  string
+	}{
+		{"hook context", "deja hook-context"},
+		{"hook prompt --plain", "deja hook-prompt"},
+		// No second word to join, so the stem is all deja has: say the
+		// commands exist rather than pointing at an unrelated one.
+		{"hook", "hook-"},
+		// The word deja's own MCP tool is called, and the docs use it
+		// throughout, so it is a fair guess at the shell form.
+		{"recall pgbouncer", "deja \"pgbouncer\""},
+	} {
+		got := commandHint(c.query)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%q -> %q, want it to name %q", c.query, got, c.want)
+		}
+		if strings.Contains(got, "deja how") {
+			t.Errorf("%q was sent to an unrelated command: %q", c.query, got)
+		}
+	}
+}
+
+// And the hints that already worked keep working.
+func TestTheHintStillAnswersTheGuessesItAlreadyKnew(t *testing.T) {
+	for _, c := range []struct {
+		query, want string
+	}{
+		{"serch pool", "deja search"},
+		{"unpromote", "promote <id> --state rejected"},
+		{"unforget", "forget --unforget"},
+	} {
+		if got := commandHint(c.query); !strings.Contains(got, c.want) {
+			t.Errorf("%q -> %q, want it to name %q", c.query, got, c.want)
+		}
+	}
+	// A word that is a word, not a guess: no hint at all.
+	for _, q := range []string{
+		"pgbouncer pool timeout", "brief", "search pool",
+		// Prose that starts with a stem or with a tool's name is a search, not
+		// a guess at a command.
+		"hook up the pool", "recall the decision we made about the pool",
+	} {
+		if got := commandHint(q); got != "" {
+			t.Errorf("%q got a command hint it did not need: %q", q, got)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1368,7 +1368,33 @@ func commandHint(q string) string {
 	if first == "" || strings.HasPrefix(first, "-") {
 		return ""
 	}
+	// A hint is about a guess at a command, and a guess is short: a command
+	// with an argument or two. "hook up the pool" is a sentence, and a hint
+	// there is noise on top of a search that already failed — the same lesson
+	// #715 learned about short words (#2115).
+	if !looksLikeAnInvocation(q) {
+		return ""
+	}
 	low := strings.ToLower(first)
+	// A guess with an exact answer behind it. `deja hook context` is the
+	// hyphen-free spelling of a command that exists, and the candidate list
+	// below drops every `hook-` name on the grounds that plumbing is not
+	// something anyone means to type — which is right about proposing it and
+	// wrong about hiding it from the reader who typed its own stem (#2115).
+	if hint := hyphenatedCommandHint(q, low); hint != "" {
+		return hint
+	}
+	// The word deja's own MCP tool is called, and the one the documentation
+	// uses throughout, so `deja recall <words>` is a fair guess at the shell
+	// form. Nothing is near it by name, so the hint said nothing at all —
+	// the same shape as the curated answers below (#2115).
+	if low == "recall" {
+		rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(q), first))
+		if rest != "" {
+			return fmt.Sprintf("deja: %q is what the MCP tool is called — from a shell it is `deja %q`, and `deja hook-prompt` is the per-prompt recall\n", first, rest)
+		}
+		return fmt.Sprintf("deja: %q is what the MCP tool is called — from a shell it is `deja <query>`, and `deja hook-prompt` is the per-prompt recall\n", first)
+	}
 	// A one- or two-letter word is a word, not a mistyped command name. Any
 	// prefix counts as "near" — so "a" reached `deja aider` and every sentence
 	// starting with a short word got a hint (#715, my own regression from
@@ -1413,6 +1439,47 @@ func commandHint(q string) string {
 		return "deja: \"unforget\" is not a command — `deja forget --unforget <id>` is, and `deja forget --list` names the ids\n"
 	}
 	return fmt.Sprintf("deja: %q is not a command — did you mean `deja %s`?\n", first, near)
+}
+
+// hyphenatedCommandHint answers the guess that spelled a hyphenated command
+// with a space: the two words joined name a real one, or the first word is the
+// stem of some and there is no second word to join (#2115).
+func hyphenatedCommandHint(q, low string) string {
+	rest := strings.Fields(strings.TrimSpace(q))
+	if len(rest) > 1 {
+		joined := low + "-" + strings.ToLower(rest[1])
+		if _, ok := commands[joined]; ok {
+			return fmt.Sprintf("deja: %q is not a command — did you mean `deja %s`?\n", low+" "+rest[1], joined)
+		}
+	}
+	// Only the stem on its own. With words after it that do not join into a
+	// command, the reader is searching — "hook up the pool" is a sentence, and
+	// a hint about `hook-context` there is noise on top of a failed search.
+	if len(rest) != 1 {
+		return ""
+	}
+	var stems []string
+	for name := range commands {
+		if strings.HasPrefix(name, low+"-") {
+			stems = append(stems, name)
+		}
+	}
+	if len(stems) == 0 {
+		return ""
+	}
+	sort.Strings(stems)
+	if len(stems) > 3 {
+		stems = stems[:3]
+	}
+	return fmt.Sprintf("deja: %q is not a command on its own — `deja %s` and the rest of that family are; `deja help` names them\n",
+		low, strings.Join(stems, "`, `deja "))
+}
+
+// looksLikeAnInvocation separates a guess at a command from prose. A command
+// and an argument or two is short; "recall the decision we made about the pool"
+// is a sentence, and the hint is about the first kind (#2115).
+func looksLikeAnInvocation(q string) bool {
+	return len(strings.Fields(q)) <= 3
 }
 
 // sinceRawArg recovers the text the reader typed after --since. parseSearch


### PR DESCRIPTION
Fixes #2115. `commandHint` answers the guess that fell through to search (#674), and sent the one guess with an exact answer behind it somewhere else:

```
"hook context"     -> deja: "hook" is not a command — did you mean `deja how`?
"recall pgbouncer" -> (nothing)
```

`deja hook context` is the hyphen-free spelling of `hook-context`, a command that exists. The candidate list drops every `hook-` name — "hidden plumbing is not something anyone means to type" — so `how` is what survived nearest to `hook`. Not proposing the plumbing is right; hiding it from the reader who typed its own stem is not.

Two rules, both mechanical: the first two words joined by a hyphen naming a real command, and the first word being the stem of hyphenated commands when there is no second word to join.

`recall` is the third case and a different shape — it is what deja's own MCP tool is called and the word the docs use throughout, so `deja recall <words>` is a fair guess at the shell form, and nothing is near it by name. It joins the curated answers the file already carries for `unpromote`, `demote` and `unforget`.

All of it fires only on a search that found nothing, so nothing that works today changes.

Review caught both branches firing on prose — "hook up the pool" and "recall the decision we made" are searches, not guesses — and following that through showed the older path doing it too: a four-word query starting with a near-miss word already got "did you mean". A hint is about a guess at a command, and a guess is short, so the whole function now stands down past three words. Two of those queries are in the test.
