### PR TITLE
fix(query): break a word at typographic punctuation

### DIFF
--- a/cmd/deja/search_typographic_test.go
+++ b/cmd/deja/search_typographic_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The end of #2117: a query pasted with typographic punctuation reaches the
+// word the index holds, rather than missing outright or being rescued by the
+// close-spellings fallback — which tells the reader they misspelled something
+// they did not.
+func TestAPastedQueryFindsWhatItAsksFor(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message":   map[string]any{"role": "user", "content": "the retry budget keeps blowing up under load"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the plain query works, so the rest is about the punctuation.
+	if out, _ := captureRun(t, "search", "retry budget"); !strings.Contains(out, "retry budget") {
+		t.Fatalf("the plain query found nothing, so this measures nothing: %q", out)
+	}
+	for _, q := range []string{
+		"“retry budget”",
+		"—retry—",
+		"«retry»",
+		"budget…",
+		"retry’s budget",
+	} {
+		var out string
+		stderr := captureStderr(t, func() { out, _ = captureRun(t, "search", q) })
+		if !strings.Contains(out, "s1") {
+			t.Errorf("%q found nothing: %q %q", q, out, strings.TrimSpace(stderr))
+			continue
+		}
+		if strings.Contains(stderr, "close spellings") {
+			t.Errorf("%q was treated as a misspelling: %q", q, strings.TrimSpace(stderr))
+		}
+	}
+}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -205,12 +205,39 @@ func MatchesParts(text string, terms, phrases []string, variants map[string][]st
 	return len(terms) > 0 || len(phrases) > 0
 }
 
-// Tokens lowercases and dedupes whitespace-separated query tokens.
+// Tokens lowercases and dedupes the words of a query.
+//
+// A word is broken by whitespace or by punctuation and symbols outside ASCII,
+// and then trimmed of the ASCII punctuation this has always trimmed. The middle
+// step is the fix: a query pasted from a chat client or a word processor
+// carries typographic punctuation, and it used to stay glued to the word —
+// `“retry”`, `—retry—` and `budget…` could not match the plain word the index
+// holds, so two of them were rescued by the close-spellings fallback, which
+// tells the reader they misspelled something, and `—retry—` missed outright
+// (#2117).
+//
+// ASCII keeps trimming rather than splitting, and this is deliberately not the
+// index's own rule (letters, digits, `_`, `-`). Two things depend on it: a
+// regex query is words to this function and a pattern to the matcher, so
+// splitting `dad|gift` changes which passage an excerpt centres on
+// (TestRegexSnippetsStillRankByMatchCount), and an apostrophe inside a word is
+// left where the reader typed it.
+//
+// The length cut stays on bytes: "л" and "舵" are one rune and two or three
+// bytes, and a rule that calls them too short to look up is wrong for half the
+// world's alphabets (#828).
 func Tokens(s string) []string {
+	const asciiTrim = "\t\n\r .,;:!?()[]{}<>\"'`"
+	broken := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		if r < 0x80 {
+			return unicode.IsSpace(r)
+		}
+		return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+	})
 	seen := map[string]bool{}
 	var out []string
-	for _, tok := range strings.Fields(strings.ToLower(s)) {
-		tok = strings.Trim(tok, "\t\n\r .,;:!?()[]{}<>\"'`")
+	for _, tok := range broken {
+		tok = strings.Trim(tok, asciiTrim)
 		if len(tok) < 2 || seen[tok] {
 			continue
 		}

--- a/internal/query/typographic_test.go
+++ b/internal/query/typographic_test.go
@@ -1,0 +1,42 @@
+package query
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A query pasted from a chat client, a word processor or an agent's own prose
+// carries typographic punctuation, and the ASCII trim left it glued to the
+// word — so the token matched nothing while the index, which splits on
+// everything that is not a letter, digit, `_` or `-`, held the plain word
+// (#2117).
+func TestTokensTrimTypographicPunctuation(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want []string
+	}{
+		{`retry`, []string{"retry"}},
+		{`"retry"`, []string{"retry"}},
+		{"“retry”", []string{"retry"}},
+		{"«retry»", []string{"retry"}},
+		{"‘retry’", []string{"retry"}},
+		{"—retry—", []string{"retry"}},
+		{"the retry budget…", []string{"the", "retry", "budget"}},
+		// A curly apostrophe is punctuation outside ASCII, so it breaks the
+		// word; "s" is one byte and drops out.
+		{"retry’s budget", []string{"retry", "budget"}},
+		// The ASCII one is trimmed at the ends only, as it always has been —
+		// a regex query depends on ASCII staying where the reader put it.
+		{"retry's budget", []string{"retry's", "budget"}},
+		{"dad|gift", []string{"dad|gift"}},
+		// What the index keeps inside a token stays inside it here.
+		{"retry-budget retry_budget", []string{"retry-budget", "retry_budget"}},
+		// A flag is not a query word — parseSearch takes those before this is
+		// reached — and `-` is part of a token either way.
+		{"--re", []string{"--re"}},
+	} {
+		if got := Tokens(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("Tokens(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2117. `query.Tokens` trimmed an ASCII list, so a query pasted from a chat client, a word processor, or an agent's own prose kept its typographic punctuation glued to the word. Against a store holding "the retry budget keeps blowing up":

```
"retry budget"     hits=1
"“retry budget”"   hits=1 — but through "no exact match, trying close spellings"
"—retry—"          hits=0 — "no matches — try fewer words"
"budget…"          hits=1 — again through close spellings
```

The index does not have this problem: it splits on everything that is not a letter, a digit, `_` or `-`, so it holds the plain word. Only the query side was wrong, which is why the miss is silent — there is nothing wrong with the index to notice, and the reader is told they misspelled something they did not.

A word now also ends at punctuation or a symbol **outside ASCII**. The ASCII behaviour is unchanged on purpose, and that is not caution for its own sake: widening it to the index's own rule broke two tests that are right —

- `TestWhichTierJoinsAWordToItsMarkedForm`: marks are not letters, so the wider rule merged a marked query with the unmarked word, which that tier holds apart deliberately;
- `TestRegexSnippetsStillRankByMatchCount`: `dad|gift` became two words, and the excerpt centred on where those words meet rather than on the passage the pattern actually hit.

The length cut stays on bytes, for the reason #828 gives: "л" and "舵" are one rune and two or three bytes, and a rule that calls them too short to look up is wrong for half the world's alphabets.

Review caught the claim being looser than the code: my first version split on ASCII punctuation anywhere in a word, so `retry's` became `retry` — a change I had said I was not making. ASCII trims at the ends now, as it always did, and only punctuation and symbols outside ASCII break a word. `retry's` and `dad|gift` are pinned in the test beside the typographic cases.
