### PR TITLE
fix(search): score a cross-script match instead of zeroing it

### DIFF
--- a/internal/search/cjk_score_test.go
+++ b/internal/search/cjk_score_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Postings are keyed on folded CJK, so a query in one script reaches a record
+// in the other — and the scorer counted on the unfolded pair, so BM25 saw a
+// term frequency of zero for a match the postings had already found. The
+// cross-script session counted twice and scored nothing, ranking below one that
+// matched once (#1605).
+func TestACrossScriptMatchScoresLikeAnyOther(t *testing.T) {
+	now := time.Now()
+	traditional := model.Session{
+		Harness: "claude", Project: "app", ID: "trad", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "調度器為什麼會重複執行任務"},
+			{Role: "user", Text: "調度器又壞了"},
+		},
+	}
+	simplified := model.Session{
+		Harness: "claude", Project: "app", ID: "simp", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "调度器为什么会重复执行任务"},
+			{Role: "user", Text: "我们把重试次数限制为三次"},
+		},
+	}
+	// Both directions: whichever side has to be folded is the one that used to
+	// score zero.
+	for _, q := range []string{"调度器", "調度器"} {
+		hits, err := runScored([]model.Session{traditional, simplified}, Options{Query: q, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(hits) != 2 {
+			t.Fatalf("%s: %d hits, want both sessions — this measures nothing otherwise", q, len(hits))
+		}
+		for _, h := range hits {
+			if h.Score == 0 {
+				t.Errorf("%s: %s counted %d and scored zero", q, h.Session.ID, h.Count)
+			}
+		}
+		// The session that matched twice leads, whichever script the query is
+		// written in.
+		if hits[0].Session.ID != "trad" {
+			t.Errorf("%s: %s leads with count=%d over trad with two matches",
+				q, hits[0].Session.ID, hits[0].Count)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -231,6 +231,9 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			// folding — measuring the unfolded pair there finds nothing and reports a
 			// genuine match as words that never meet.
 			windowText, windowToks := low, qtoks
+			// The pair the scorer counts on, folded below when that is where
+			// the match came from.
+			scoreLow, scoreToks := low, qtoks
 			if re != nil {
 				c = countRegex(re, m.Text)
 			} else {
@@ -246,6 +249,17 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 						phrasesFolded, o.FuzzyVariants)
 					if c > 0 {
 						windowText, windowToks = foldedLow, qtoksFolded
+						// And the pair the scorer counts on. Leaving it
+						// unfolded gave BM25 a term frequency of zero for a
+						// match the postings had already found, so a
+						// cross-script hit counted twice and scored nothing —
+						// ranked below a record that matched once (#1605).
+						// Only when the two token lists line up: termCount is
+						// indexed by position, and a fold that merged or split
+						// a token would count against the wrong term.
+						if len(qtoksFolded) == len(qtoks) {
+							scoreLow, scoreToks = foldedLow, qtoksFolded
+						}
 					}
 				}
 			}
@@ -264,15 +278,15 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 					doc.minWindow = w
 				}
 			}
-			doc.length += countDocumentWords(low, qtoks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
+			doc.length += countDocumentWords(scoreLow, scoreToks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
 			// The token, not the raw query — the same rule as countIn. This
 			// path is what scores `retry` inside `retry-backoff`, which
 			// countDocumentWords cannot match because it counts whole words
 			// and treats the hyphen as one. Comparing the raw query here left
 			// a punctuated query with a session that matched three times and
 			// scored zero, ranked below one that matched once (#1603).
-			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qtoks[0]) {
-				n := strings.Count(low, qtoks[0])
+			if len(scoreToks) == 1 && doc.termCount[0] == 0 && strings.Contains(scoreLow, scoreToks[0]) {
+				n := strings.Count(scoreLow, scoreToks[0])
 				doc.termCount[0] += n
 				if m.Role == "user" {
 					doc.userCount[0] += n


### PR DESCRIPTION
Fixes #1605. Postings are keyed on Traditional-folded CJK, so a query in one script legitimately reaches a record in the other. `runScored` folds for matching and scored on the unfolded pair, so BM25 saw a term frequency of zero for a match the postings had already found:

```
调度器  cjkB  count=1 score=0.975951
调度器  cjkA  count=2 score=0.000000   ← the better match, ranked last
調度器  cjkA  count=2 score=0.836897
調度器  cjkB  count=1 score=0.000000
```

The zero is always on whichever side had to be folded, so the bug is symmetric and invisible from either script alone.

The loop already keeps a `windowText`/`windowToks` pair for proximity, switched to the folded text where the match came from folding, with a comment saying why: "measuring the unfolded pair there finds nothing and reports a genuine match as words that never meet". The scorer needed the same thing, and now has it — `countDocumentWords` and the single-token fallback count on a `scoreLow`/`scoreToks` pair that follows the match.

Guarded by `len(qtoksFolded) == len(qtoks)`: `termCount` is indexed by position, so a fold that merged or split a token would count against the wrong term.

After it, both directions score the same and the session that matched twice leads:

```
调度器  trad  count=2 score=0.251021
调度器  simp  count=1 score=0.224495
調度器  trad  count=2 score=0.251021
調度器  simp  count=1 score=0.224495
```

One thing the issue assumed that is not true: the remaining gap in my first measurement was BM25 length normalisation, not the fold — a two-message session with two hits can sit below a one-message session with one. With comparable documents the order is what the issue expects, and that is what the test uses.

Review asked for two things to be established rather than argued, and both are measurable:

```
"調度器為什麼會重複執行任務"   runes 13->13  toks 1->1  documentWords 13->13
"scheduler調度器 mixed 文字"  runes 21->21  toks 3->3  documentWords 7->7
"調度器 又壞了"                runes  7->7   toks 2->2  documentWords 6->6
"the pool was exhausted"      runes 22->22  toks 4->4  documentWords 4->4
```

The fold is a codepoint mapping, so it changes neither the word count a document contributes to `doc.length` — mixing folded and unfolded messages cannot distort it — nor the number of tokens a query has, which is what the guard is about. The guard stays as the cheap statement of that invariant rather than as a live branch.
