### PR TITLE
feat(log): say when an event is stamped after this machine's clock

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"time"
 
+	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -96,5 +98,36 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		fmt.Fprintf(w, "%s  %-14s %s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, mark)
 	}
 	fmt.Fprintln(w, "\nuse `deja log --last` to see the exact text of the most recent injected digest")
+	// The log's stamps are deja's own, written at recall time, so one in the
+	// future means the clock moved backwards since — and those events sit above
+	// everything from then on, while the status bar leaves them out of its
+	// counters. Two surfaces reading one file and disagreeing with nothing to
+	// say why is the shape #696 rejected; `deja last` and `doctor` name it
+	// already (#2105, #2107, #2122).
+	if n := eventsStampedAhead(events, time.Now()); n > 0 {
+		fmt.Fprintf(os.Stderr, "deja: %d event%s stamped later than this machine's clock — %s at the top of this list, and the counters leave %s out\n",
+			n, pluralS(n), pluralThatThose(n), pluralThoseOnes(n))
+	}
 	return nil
+}
+
+// pluralThoseOnes is the pronoun for the tail of that sentence, so it never
+// says "leaves it out" about several events or "them" about one.
+func pluralThoseOnes(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
+}
+
+// eventsStampedAhead counts the listed events whose stamp is after now, by the
+// same rule the other surfaces count sessions with.
+func eventsStampedAhead(events []usage.Event, now time.Time) int {
+	n := 0
+	for _, e := range events {
+		if index.StampedAhead(e.Time, now) {
+			n++
+		}
+	}
+	return n
 }

--- a/cmd/deja/log_ahead_test.go
+++ b/cmd/deja/log_ahead_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func writeUsageLog(t *testing.T, lines ...string) string {
+	t.Helper()
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(usage.Path(dir), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The log's stamps are deja's own, written at recall time, so one in the future
+// means the clock moved backwards since — and those events sit above everything
+// afterwards, in the surface someone opens to see what their agents were
+// served. `deja last` and `doctor` name the same state; the log did not (#2122).
+func TestLogSaysWhenAnEventIsStampedAhead(t *testing.T) {
+	future := time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339Nano)
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	// The log shows what was appended last, first, so the event from next year
+	// leads. Its stamp is deja's own: the clock it was written from is not the
+	// clock reading it now.
+	writeUsageLog(t,
+		fmt.Sprintf(`{"t":"%s","kind":"hook","bytes":8181,"sessions":2}`, past),
+		fmt.Sprintf(`{"t":"%s","kind":"hook","bytes":5151,"sessions":1}`, future),
+	)
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "log") })
+	// The premise: the future event really does lead the listing.
+	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
+	if !strings.Contains(first, "5.0 KB") {
+		t.Fatalf("the event stamped ahead is not at the top, so this measures nothing: %q", first)
+	}
+	if !strings.Contains(stderr, "later than this machine's clock") {
+		t.Errorf("the log led with an event that has not happened and said nothing: %q", strings.TrimSpace(stderr))
+	}
+}
+
+// And it says it only when there is one.
+func TestLogIsQuietWhenNothingIsAhead(t *testing.T) {
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	writeUsageLog(t, fmt.Sprintf(`{"t":"%s","kind":"hook","bytes":8181,"sessions":2}`, past))
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "log") })
+	if !strings.Contains(out, "8.0 KB") {
+		t.Fatalf("the log is empty, so this measures nothing: %q", out)
+	}
+	if strings.Contains(stderr, "later than this machine's clock") {
+		t.Errorf("a log with nothing ahead said something was: %q", strings.TrimSpace(stderr))
+	}
+}


### PR DESCRIPTION
Fixes #2122. A usage event stamped later than this machine's clock leads `deja log` and nothing says so, while the status bar leaves the same event out of its counters:

```
$ deja log
2027-08-27 09:01  hook           5.0 KB · 1 session
2026-08-27 08:20  hook           8.0 KB · 2 sessions

$ deja statusline
deja · no agent recalls today · 0 B injected      ← the same event, left out
```

Two surfaces reading one file and disagreeing, with nothing to say why, is the shape #696 rejected for sessions; `deja last` has said it since #2105 and `doctor` since #2107.

The log's stamps are deja's own — written at recall time from the machine's clock — so one in the future means the clock moved backwards since: a container restarted with a bad clock, a laptop resuming, a VM restored. The events written before that move then sit above everything, permanently, in the surface someone opens to see what their agents were served.

It says it now, on stderr like the other advisory lines, and only when there is something to say.

One thing measured on the way, worth knowing: `deja log` lists in append order rather than by stamp. The future event leads because it was appended last, not because it is dated later — so with a clock that moved backwards, the list is in the order things happened while the stamps disagree with it.
