### PR TITLE
test(bench492): keep the rig that measured the real store

### DIFF
--- a/internal/index/cjkindex_realcorpus492_test.go
+++ b/internal/index/cjkindex_realcorpus492_test.go
@@ -1,0 +1,438 @@
+//go:build realcorpus492
+
+// Real-corpus instrumentation for upstream issue #492.
+//
+// Opt-in via the realcorpus492 build tag so a normal `go test ./...` never
+// touches a live store. Everything here is read-only: it parses transcripts
+// and runs the two key emitters against them. It writes exactly one file, the
+// sampled message cache, and only to the path given on the command line.
+//
+// The pipeline reproduced here is the one a real build walks before
+// indexKeys() sees a byte (ingest.go:404,448-468):
+//
+//	ParseClaudeFile -> preRedactSessions (NFC + redact + 64 KiB cap)
+//	  -> skip messages that trim to empty -> tokenizedPart(role, text)
+//	  -> indexKeys(text)
+//
+// Skipping any of those measures a different string than the index does. The
+// cross-file duplicate filter (seenMsgs.dup) is the one step left out; it
+// removes messages, it does not rewrite them.
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/cjkfold"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+type sampleMsg struct {
+	Role string `json:"role"`
+	Text string `json:"text"`
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(t testing.TB, key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		t.Fatalf("%s=%q: %v", key, v, err)
+	}
+	return n
+}
+
+// jsonlFiles lists every transcript under root, sorted, so two runs walk the
+// corpus in the same order.
+func jsonlFiles(t testing.TB, root string) []string {
+	var out []string
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && strings.HasSuffix(p, ".jsonl") {
+			out = append(out, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// eachIndexedText replays the ingestion pipeline and hands fn the exact string
+// indexKeys() would receive for every message the index would store.
+func eachIndexedText(t testing.TB, root string, fn func(role, text string)) (files, sessions, messages int) {
+	for _, p := range jsonlFiles(t, root) {
+		ss, err := sources.ParseClaudeFile(p)
+		if err != nil {
+			continue
+		}
+		files++
+		preRedactSessions(nil, ss)
+		for si := range ss {
+			sessions++
+			for _, msg := range ss[si].Messages {
+				if strings.TrimSpace(msg.Text) == "" {
+					continue
+				}
+				messages++
+				fn(msg.Role, tokenizedPart(msg.Role, msg.Text))
+			}
+		}
+	}
+	return files, sessions, messages
+}
+
+// cjkRunOps counts the emitFolded calls cjkIndexKeys makes before its seen-map
+// check: one per adjacent pair inside a CJK run, one for a lone CJK rune. It is
+// also the number of seen-map operations the legacy path performs, so it is the
+// denominator repetition rate is measured against.
+func cjkRunOps(s string) int {
+	ops := 0
+	runLen := 0
+	for _, r := range s {
+		if !cjkfold.IsCJK(r) {
+			if runLen == 1 {
+				ops++
+			}
+			runLen = 0
+			continue
+		}
+		if runLen == 0 {
+			runLen = 1
+			continue
+		}
+		ops++
+		runLen = 2
+	}
+	if runLen == 1 {
+		ops++
+	}
+	return ops
+}
+
+func countCJKIndexKeys(s string) int {
+	n := 0
+	cjkIndexKeys(s, func(string) { n++ })
+	return n
+}
+
+func distinct(keys []string) int {
+	set := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		set[k] = struct{}{}
+	}
+	return len(set)
+}
+
+// TestRealCorpusStats492 answers the repetition-rate question the thread could
+// not reason its way to, and caches a deterministic message sample for the
+// benchmarks below.
+//
+//	DEJA492_CLAUDE_ROOT=/path/to/claude-root \
+//	DEJA492_SAMPLE_OUT=/path/sample.json \
+//	go test -tags realcorpus492 -run TestRealCorpusStats492 -v -timeout 60m ./internal/index/
+func TestRealCorpusStats492(t *testing.T) {
+	root := os.Getenv("DEJA492_CLAUDE_ROOT")
+	if root == "" {
+		t.Skip("DEJA492_CLAUDE_ROOT unset")
+	}
+	sampleOut := os.Getenv("DEJA492_SAMPLE_OUT")
+	sampleEvery := envInt(t, "DEJA492_SAMPLE_EVERY", 200)
+	sampleCap := envInt(t, "DEJA492_SAMPLE_CAP", 4000)
+
+	var (
+		cjkMsgs      int
+		runOps       int64
+		newKeys      int64
+		legacyRaw    int64 // len(cjkfold.Bigrams) — unique unfolded bigrams
+		legacyFolded int64 // distinct folded keys the legacy path yields
+		allTokens    int64 // every indexKeys token, ASCII included: bucket() calls
+		cjkChars     int64
+		totalChars   int64
+	)
+	var sampleAll, sampleCJK []sampleMsg
+	seenMsg, seenCJK := 0, 0
+	cjkEvery := envInt(t, "DEJA492_SAMPLE_EVERY_CJK", 100)
+
+	files, sessions, messages := eachIndexedText(t, root, func(role, text string) {
+		totalChars += int64(len([]rune(text)))
+		allTokens += int64(distinct(indexKeys(text)))
+
+		ops := cjkRunOps(text)
+		if ops > 0 {
+			cjkMsgs++
+			runOps += int64(ops)
+			newKeys += int64(countCJKIndexKeys(text))
+			bg := cjkfold.Bigrams(text)
+			legacyRaw += int64(len(bg))
+			legacyFolded += int64(distinct(legacyCJKKeys(text)))
+			cjkChars += int64(cjkfold.CountCJK(text))
+		}
+
+		// Two independent strides so neither sample is front-loaded: the
+		// CJK one counts only CJK-bearing messages, which are a minority.
+		seenMsg++
+		if seenMsg%sampleEvery == 0 && len(sampleAll) < sampleCap {
+			sampleAll = append(sampleAll, sampleMsg{Role: role, Text: text})
+		}
+		if ops > 0 {
+			seenCJK++
+			if seenCJK%cjkEvery == 0 && len(sampleCJK) < sampleCap {
+				sampleCJK = append(sampleCJK, sampleMsg{Role: role, Text: text})
+			}
+		}
+	})
+
+	f := func(a, b int64) float64 {
+		if b == 0 {
+			return 0
+		}
+		return float64(a) / float64(b)
+	}
+	t.Logf("corpus            files=%d sessions=%d indexed_messages=%d", files, sessions, messages)
+	t.Logf("cjk               messages_with_cjk=%d (%.1f%%) cjk_runes=%d of %d runes (%.1f%%)",
+		cjkMsgs, 100*f(int64(cjkMsgs), int64(messages)), cjkChars, totalChars, 100*f(cjkChars, totalChars))
+	t.Logf("emitter ops       run_ops=%d  new_unique_keys=%d  legacy_unique_bigrams=%d  legacy_distinct_folded=%d",
+		runOps, newKeys, legacyRaw, legacyFolded)
+	t.Logf("REPETITION RATE   run_ops/new_unique_keys      = %.3f", f(runOps, newKeys))
+	t.Logf("REPETITION RATE   run_ops/legacy_unique_bigram = %.3f", f(runOps, legacyRaw))
+	t.Logf("fold collapse     legacy_unfolded -> distinct_folded = %.4f", f(legacyFolded, legacyRaw))
+	t.Logf("per message       run_ops=%.1f new_keys=%.1f (CJK messages only)", f(runOps, int64(cjkMsgs)), f(newKeys, int64(cjkMsgs)))
+	t.Logf("bucket() calls    distinct_index_keys_total=%d  per_message=%.1f", allTokens, f(allTokens, int64(messages)))
+
+	if sampleOut != "" {
+		blob := map[string][]sampleMsg{"all": sampleAll, "cjk": sampleCJK}
+		b, err := json.Marshal(blob)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(sampleOut, b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("sample written    %s  all=%d cjk=%d", sampleOut, len(sampleAll), len(sampleCJK))
+	}
+}
+
+// TestFixtureStats492 prints the same repetition figures for the fixtures the
+// PR benchmarked, so the real-corpus rate has something to be compared against.
+func TestFixtureStats492(t *testing.T) {
+	cases := []struct{ name, text string }{
+		{"PR benchJAText", benchJAText},
+	}
+	if gen := os.Getenv("DEJA492_GEN_ROOT"); gen != "" {
+		var ops, keys int64
+		var n int
+		eachIndexedText(t, gen, func(_, text string) {
+			o := cjkRunOps(text)
+			if o == 0 {
+				return
+			}
+			n++
+			ops += int64(o)
+			keys += int64(countCJKIndexKeys(text))
+		})
+		if n > 0 {
+			t.Logf("%-18s messages=%d run_ops/unique_keys=%.3f per_msg_ops=%.1f",
+				"gen_corpus.py ja", n, float64(ops)/float64(keys), float64(ops)/float64(n))
+		}
+	}
+	for _, c := range cases {
+		ops := cjkRunOps(c.text)
+		keys := countCJKIndexKeys(c.text)
+		bg := len(cjkfold.Bigrams(c.text))
+		t.Logf("%-18s run_ops=%d unique_keys=%d unfolded=%d  repetition=%.3f",
+			c.name, ops, keys, bg, float64(ops)/float64(keys))
+	}
+}
+
+var (
+	loadedAll  []string
+	loadedCJK  []string
+	loadedToks []string
+	sinkInt    int
+	sinkStr    string
+)
+
+func loadSample(b *testing.B) {
+	if loadedAll != nil {
+		return
+	}
+	path := os.Getenv("DEJA492_SAMPLE_FILE")
+	if path == "" {
+		b.Skip("DEJA492_SAMPLE_FILE unset — run TestRealCorpusStats492 with DEJA492_SAMPLE_OUT first")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var blob map[string][]sampleMsg
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		b.Fatal(err)
+	}
+	for _, m := range blob["all"] {
+		loadedAll = append(loadedAll, m.Text)
+	}
+	for _, m := range blob["cjk"] {
+		loadedCJK = append(loadedCJK, m.Text)
+	}
+	if len(loadedAll) == 0 || len(loadedCJK) == 0 {
+		b.Fatalf("empty sample: all=%d cjk=%d", len(loadedAll), len(loadedCJK))
+	}
+	// The bucket() token stream is what eachIndexKey hands it: every distinct
+	// index key of a message, ASCII identifiers included, in emission order.
+	for _, s := range loadedCJK {
+		seen := map[string]bool{}
+		for _, tok := range indexKeys(s) {
+			if seen[tok] {
+				continue
+			}
+			seen[tok] = true
+			loadedToks = append(loadedToks, tok)
+		}
+		if len(loadedToks) > 200000 {
+			break
+		}
+	}
+}
+
+// ns/op and allocs/op below are per message, the same unit the PR quoted.
+func BenchmarkCJKKeysLegacyRealCJK(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkInt += len(legacyCJKKeys(loadedCJK[i%len(loadedCJK)]))
+	}
+}
+
+func BenchmarkCJKKeysNewRealCJK(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := 0
+		cjkIndexKeys(loadedCJK[i%len(loadedCJK)], func(string) { n++ })
+		sinkInt += n
+	}
+}
+
+func BenchmarkCJKKeysLegacyRealAll(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkInt += len(legacyCJKKeys(loadedAll[i%len(loadedAll)]))
+	}
+}
+
+func BenchmarkCJKKeysNewRealAll(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n := 0
+		cjkIndexKeys(loadedAll[i%len(loadedAll)], func(string) { n++ })
+		sinkInt += n
+	}
+}
+
+// ns/op below is per bucket() call, over the real ASCII/CJK token mix.
+func BenchmarkBucketLegacyReal(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkStr = legacyBucket(loadedToks[i%len(loadedToks)])
+	}
+}
+
+func BenchmarkBucketNewReal(b *testing.B) {
+	loadSample(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sinkStr = bucket(loadedToks[i%len(loadedToks)])
+	}
+}
+
+// TestRealCorpusEquivalence492 is the acceptance leg: on real text the two
+// emitters must agree on the key set, not merely on speed.
+func TestRealCorpusEquivalence492(t *testing.T) {
+	path := os.Getenv("DEJA492_SAMPLE_FILE")
+	if path == "" {
+		t.Skip("DEJA492_SAMPLE_FILE unset")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var blob map[string][]sampleMsg
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, m := range append(append([]sampleMsg{}, blob["all"]...), blob["cjk"]...) {
+		got := collectCJKIndexKeys492(m.Text)
+		want := legacyCJKKeys(m.Text)
+		assertSameKeySet492(t, envOr("DEJA492_LABEL", "real message"), got, want)
+		checked++
+	}
+	t.Logf("key sets identical on %d real messages", checked)
+}
+
+// TestSampleRepresentativeness492 checks the one assumption that lets a
+// per-message benchmark rate be multiplied by a corpus-wide message count: the
+// sampled messages must carry the same bigram load as the population they were
+// drawn from. It uses the real cjkfold.IsCJK, not a re-derived predicate.
+func TestSampleRepresentativeness492(t *testing.T) {
+	path := os.Getenv("DEJA492_SAMPLE_FILE")
+	if path == "" {
+		t.Skip("DEJA492_SAMPLE_FILE unset")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var blob map[string][]sampleMsg
+	if err := json.Unmarshal(raw, &blob); err != nil {
+		t.Fatal(err)
+	}
+	for _, which := range []string{"cjk", "all"} {
+		var ops, keys, bucketCalls int64
+		n := 0
+		for _, m := range blob[which] {
+			o := cjkRunOps(m.Text)
+			if which == "cjk" && o == 0 {
+				continue
+			}
+			n++
+			ops += int64(o)
+			keys += int64(countCJKIndexKeys(m.Text))
+			bucketCalls += int64(distinct(indexKeys(m.Text)))
+		}
+		if n == 0 {
+			continue
+		}
+		t.Logf("sample[%s] n=%d  mean_run_ops=%.1f  mean_cjk_keys=%.1f  mean_bucket_calls=%.1f  repetition=%.3f",
+			which, n, float64(ops)/float64(n), float64(keys)/float64(n),
+			float64(bucketCalls)/float64(n), float64(ops)/float64(keys))
+	}
+}

--- a/tools/bench492/README.md
+++ b/tools/bench492/README.md
@@ -33,4 +33,16 @@ Two lessons from using it, so the next measurement does not relearn them:
 - To measure against a real store instead of the generated one, point
   `--out-root` at a directory whose `store-<arm>/claude-root` is a copy of
   (or junction to) the real transcripts. Keep `DEJA_INDEX_DIR` isolation —
-  the runner never writes into a live index either way.
+  the runner never writes into a live index either way. Take that copy
+  before the first build: a live store grows while the run is going, and
+  then the cells are timing different bytes.
+
+The read-only counterpart is `internal/index/cjkindex_realcorpus492_test.go`,
+behind the `realcorpus492` build tag so a normal `go test ./...` never sees
+it. It replays what a real build walks before `indexKeys` sees a byte
+(`ParseClaudeFile` -> `preRedactSessions` -> skip-if-empty -> `tokenizedPart`)
+and reports the one thing no generator can be reasoned into: the bigram
+repetition rate, which is what both dedupe halves are paid for. Measured so
+far — `benchJAText`, the fixture the microbenchmarks use, 4.000; this
+generator, 1.640; a real 365k-message Chinese store, 1.376 (#492). The
+per-message speedups move with it, so quote them against a rate.

--- a/tools/bench492/README.md
+++ b/tools/bench492/README.md
@@ -9,8 +9,14 @@ so a real store on the machine is neither read nor touched.
 python gen_corpus.py --out /tmp/bench --sessions 5000 --projects 50
 go build -o deja-a ./cmd/deja        # baseline commit
 go build -o deja-b ./cmd/deja        # comparison commit (or a stubbed build)
-python run_bench.py --out-root /tmp/bench --head-bin ./deja-a --stub-bin ./deja-b --rounds 7
+python run_bench.py --out-root /tmp/bench --bin base=./deja-a --bin opt=./deja-b --rounds 7
 ```
+
+`--bin LABEL=PATH` is repeatable, so more than two builds can share one
+interleaved window. That is the only way to compare more than two: separate
+runs are not comparable, for the reason in the first lesson below. The first
+`--bin` is the baseline the summary subtracts from, and `--head-bin` /
+`--stub-bin` still work as shorthand for `head=` / `stub=`.
 
 `results.csv` holds one row per (round, arm, binary); `results-summary.txt`
 reports min/median per cell. Interleaving keeps a machine-wide slowdown from

--- a/tools/bench492/run_bench.py
+++ b/tools/bench492/run_bench.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Runner for the #492 CJK bigram build-cost re-measurement.
 
-Matrix: arm {ja, en} x binary {head, stub}, interleaved one round at a time
-(h-ja, s-ja, h-en, s-en, repeat) so a machine-wide slowdown mid-run does not
-land entirely on one cell. Each cell measurement:
+Matrix: arm {ja, en} x every binary passed with --bin, interleaved one round
+at a time (bin1-ja, bin2-ja, ..., bin1-en, ..., repeat) so a machine-wide
+slowdown mid-run does not land entirely on one cell. Each cell measurement:
 
   1. delete the index dir for that (arm, bin) cell
   2. run `<bin> index --rebuild` with the cell's env (isolated store,
@@ -13,7 +13,8 @@ land entirely on one cell. Each cell measurement:
      size in bytes
 
 Output: results.csv (round,arm,bin,seconds,index_bytes) and
-results-summary.txt (min/median per arm x bin cell).
+results-summary.txt (min/median per arm x bin cell, then the cost the first
+binary carries and each later one does not).
 
 This script only measures; it does not build binaries or generate the corpus (gen_corpus.py does that).
 """
@@ -58,6 +59,39 @@ def cell_env(fakehome: str, index_dir: str, claude_root: str) -> dict:
     return env
 
 
+def parse_bins(specs, head_bin: str, stub_bin: str):
+    """Resolve --bin LABEL=PATH (repeatable) into an ordered [(label, path)].
+
+    --head-bin/--stub-bin are kept as shorthand for the two-binary case this
+    script started with, so callers written against it keep working. Order is
+    the order given: the first binary is the one the summary subtracts from.
+    """
+    pairs = list(specs)
+    if head_bin:
+        pairs.insert(0, f"head={head_bin}")
+    if stub_bin:
+        pairs.append(f"stub={stub_bin}")
+    if not pairs:
+        raise SystemExit("run_bench: pass at least one --bin LABEL=PATH (or --head-bin/--stub-bin)")
+
+    out = []
+    seen = set()
+    for spec in pairs:
+        label, sep, path = spec.partition("=")
+        if not sep or not label or not path:
+            raise SystemExit(f"run_bench: --bin wants LABEL=PATH, got {spec!r}")
+        if any(c in label for c in "/\\ ." + os.sep):
+            raise SystemExit(f"run_bench: label {label!r} must be a bare word — it names index dirs and log files")
+        if label in seen:
+            raise SystemExit(f"run_bench: duplicate --bin label {label!r}")
+        seen.add(label)
+        path = os.path.abspath(path)
+        if not os.path.isfile(path):
+            raise SystemExit(f"run_bench: binary not found: {path}")
+        out.append((label, path))
+    return out
+
+
 def run_cell(binary: str, arm: str, bin_label: str, out_root: str, fakehome: str, log_dir: str, round_no: int):
     index_dir = os.path.join(out_root, f"idx-{arm}-{bin_label}")
     claude_root = os.path.join(out_root, f"store-{arm}", "claude-root")
@@ -96,26 +130,26 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--rounds", type=int, default=7)
     ap.add_argument("--out-root", default=HERE)
-    ap.add_argument("--head-bin", required=True, help="baseline deja binary")
-    ap.add_argument("--stub-bin", required=True, help="comparison deja binary (stubbed or optimized)")
+    ap.add_argument(
+        "--bin",
+        action="append",
+        default=[],
+        metavar="LABEL=PATH",
+        help="a deja binary to measure, repeatable; the first one is the baseline",
+    )
+    ap.add_argument("--head-bin", help="shorthand for --bin head=PATH")
+    ap.add_argument("--stub-bin", help="shorthand for --bin stub=PATH")
     ap.add_argument("--arms", default="ja,en")
     args = ap.parse_args()
 
     out_root = os.path.abspath(args.out_root)
-    head_bin = os.path.abspath(args.head_bin)
-    stub_bin = os.path.abspath(args.stub_bin)
     arms = args.arms.split(",")
-
-    for b in (head_bin, stub_bin):
-        if not os.path.isfile(b):
-            raise SystemExit(f"run_bench: binary not found: {b}")
+    binaries = parse_bins(args.bin, args.head_bin, args.stub_bin)
 
     fakehome = os.path.join(out_root, "fakehome")
     os.makedirs(fakehome, exist_ok=True)
     log_dir = os.path.join(out_root, "logs")
     os.makedirs(log_dir, exist_ok=True)
-
-    binaries = [("head", head_bin), ("stub", stub_bin)]
 
     rows = []  # (round, arm, bin, seconds, index_bytes)
     csv_path = os.path.join(out_root, "results.csv")
@@ -150,20 +184,22 @@ def main():
                     f"time min={min(secs):.3f}s median={statistics.median(secs):.3f}s max={max(secs):.3f}s  "
                     f"size min={min(sizes)} median={statistics.median(sizes):.0f} max={max(sizes)}\n"
                 )
-        sf.write("\nbigram cost (head - stub), by median:\n")
-        for arm in arms:
-            h = groups.get((arm, "head"))
-            s = groups.get((arm, "stub"))
-            if not h or not s:
-                continue
-            h_t = statistics.median(v[0] for v in h)
-            s_t = statistics.median(v[0] for v in s)
-            h_sz = statistics.median(v[1] for v in h)
-            s_sz = statistics.median(v[1] for v in s)
-            sf.write(
-                f"  {arm:2s}: time {h_t:.3f}s - {s_t:.3f}s = {h_t - s_t:+.3f}s   "
-                f"size {h_sz:.0f} - {s_sz:.0f} = {h_sz - s_sz:+.0f} bytes\n"
-            )
+        base_label = binaries[0][0]
+        for other_label, _ in binaries[1:]:
+            sf.write(f"\ncost carried by {base_label} and not by {other_label}, by median:\n")
+            for arm in arms:
+                b = groups.get((arm, base_label))
+                o = groups.get((arm, other_label))
+                if not b or not o:
+                    continue
+                b_t = statistics.median(v[0] for v in b)
+                o_t = statistics.median(v[0] for v in o)
+                b_sz = statistics.median(v[1] for v in b)
+                o_sz = statistics.median(v[1] for v in o)
+                sf.write(
+                    f"  {arm:2s}: time {b_t:.3f}s - {o_t:.3f}s = {b_t - o_t:+.3f}s   "
+                    f"size {b_sz:.0f} - {o_sz:.0f} = {b_sz - o_sz:+.0f} bytes\n"
+                )
 
     print(f"wrote {csv_path}")
     print(f"wrote {summary_path}")


### PR DESCRIPTION
Upstreaming the two files the real-store run in #492 used, as asked there.

## `--bin LABEL=PATH`, repeatable

`tools/bench492/run_bench.py` fixed the matrix at two binaries. The real-store measurement needed five in one window — legacy, legacy with bigrams stubbed, new, new with bigrams stubbed, and one built `-trimpath` as a layout probe — and separate runs are not comparable on a loaded machine: the same v0.15.5 on the same corpus measured 38 s and 52.5 s six hours apart. Anything being compared has to share the window, so the window has to hold more than two.

The first `--bin` is the baseline the summary subtracts from, which generalises the old head-minus-stub line without changing what it computes. `--head-bin` / `--stub-bin` stay as shorthand for `head=` / `stub=`, so the invocation in the README still runs and prints the same numbers with the same sign. A label names index directories and log files, so it is rejected unless it is a bare word, and repeats are rejected rather than silently overwriting a cell.

## A real-store replay

`internal/index/cjkindex_realcorpus492_test.go`, behind the `realcorpus492` build tag.

The per-message figures in #1220 come from `benchJAText`, which is `strings.Repeat(sentence, 4)`: every bigram in it occurs exactly four times. That is the ceiling of the repetition range rather than a sample of it — and repetition is exactly what the two dedupe halves are paid for.

| corpus | bigram repetition rate |
|---|---|
| `benchJAText` | 4.000 |
| `gen_corpus.py` ja, 5,000 sessions | 1.640 |
| a real 365,642-message Chinese store | 1.376 |

At 1.376 the same code keeps 2.44× rather than 4.86× on allocations and −30.4% rather than −45.4% on time. Whole builds still recover about a third of the bigram cost, which is the part of the estimate that survives. No generator can be reasoned into a repetition rate, so this measures one on whatever store the machine already has.

It replays what a real build walks before `indexKeys` sees a byte — `ParseClaudeFile` → `preRedactSessions` (NFC, redact, 64 KiB cap) → skip-if-empty → `tokenizedPart` — because skipping any of those measures a different string than the index does. The cross-file duplicate filter is the one step left out; it removes messages rather than rewriting them.

## Coverage is unchanged

The file is a `_test.go` behind a build tag, so it contributes no statements to the profile: `grep -c cjkindex_realcorpus492 coverage.out` is 0.

`internal/index` measures 90.3–90.4% either way. Six runs interleaved, three with the file and three without, produce both numbers in both states:

| round | with | without |
|---|---|---|
| 1 | 90.3% | 90.4% |
| 2 | 90.3% | 90.3% |
| 3 | 90.3% | 90.3% |

So the 0.1 pp is the package's own jitter, not this file. (Worth knowing separately: the floor is 90 and the package sits 0.3–0.4 pp above it while moving 0.1 pp on its own.)

## Checks

- `gofmt -s` clean; `go vet ./internal/index/` and `go vet -tags realcorpus492 ./internal/index/` both clean.
- `go test -race -count=1 ./internal/index/` passes.
- With the tag on and no corpus pointed at, the three tests that need one `SKIP` and the fixture test passes. A normal `go test ./...` never sees the file at all.
- `--bin` exercised end to end: three labels × two arms × two rounds, separate index dirs and logs per label, plus the `--head-bin`/`--stub-bin` path, plus four rejection cases (no `--bin`, malformed spec, label containing a separator, duplicate label).

Everything in the new file is read-only except one sampled-message cache, written only to a path given on the command line.

Refs #492.
