### PR TITLE
fix(search): reach the words a compound query spells together

### DIFF
--- a/cmd/deja/search_compound_test.go
+++ b/cmd/deja/search_compound_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Indexing splits a compound — `identifierParts` is why `retry backoff` reaches
+// a store that wrote `retry-backoff` — and querying did not, so the same
+// difference the other way round found nothing at all (#2125).
+func TestAHyphenatedQueryReachesTheWordsSpelledApart(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message": map[string]any{"role": "user", "content": "the retry-backoff helper keeps blowing up under load; " +
+			"we raised the pool size"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise and the symmetry: the store's own spellings match, and so
+	// does the compound spelled apart.
+	for _, q := range []string{"retry-backoff", "retry backoff", "blowing up", "pool size"} {
+		if out, _ := captureRun(t, "search", q); !strings.Contains(out, "s1") {
+			t.Fatalf("%q finds nothing, so this measures nothing", q)
+		}
+	}
+	// The direction that had nothing: a hyphen or an underscore where the
+	// transcript had a space.
+	for _, q := range []string{"blowing-up", "pool_size"} {
+		out, _ := captureRun(t, "search", q)
+		if !strings.Contains(out, "s1") {
+			t.Errorf("%q finds nothing, though the session says those words apart:\n%s", q, out)
+		}
+	}
+	// The words have to be together the way the compound says: a session that
+	// holds both words far apart is not what "blowing-up" asked for, and one
+	// that holds neither is not a match at all.
+	for _, q := range []string{"vacuum-freeze", "pool-vacuum"} {
+		if out, _ := captureRun(t, "search", q); strings.Contains(out, "s1") {
+			t.Errorf("%q matched a session that does not say it:\n%s", q, out)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -92,9 +92,23 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 				// token to all indexed tokens containing it (bucket directories only,
 				// no record scan), then intersect.
 				var variants map[string][]string
-				posts, variants, err = intersectSubstringPostingsDetailed(dir, tokens(o.Query))
+				bare, spelledApart := compoundQueryTokens(tokens(o.Query))
+
+				posts, variants, err = intersectSubstringPostingsDetailed(dir, bare)
 				if err != nil {
 					return SearchResult{}, fmt.Errorf("substr postings: %w", err)
+				}
+				// The postings above found the parts; the record check below
+				// counts what the reader typed, and the text does not hold the
+				// compound. Hand it the words spelled apart as this term's
+				// other spelling, which is what the store actually says (#2125).
+				if len(spelledApart) > 0 {
+					if variants == nil {
+						variants = map[string][]string{}
+					}
+					for tok, apart := range spelledApart {
+						variants[tok] = append(variants[tok], apart)
+					}
 				}
 				if len(posts) > 0 {
 					fallbackVariants = variants
@@ -105,7 +119,12 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 					// enough informative words to rank by relevance, prefer
 					// that ranking and keep the substring hits as the tail.
 					if rel, rerr := relevanceSearch(dir, m, o); rerr == nil && len(rel.Sessions) > 0 {
-						closeSS, serr := scanRecords(dir, m, o, postingOffsets(cutPostingsBySession(posts, m, o)))
+						// With the variants too, for the reason the scan below
+						// takes them: a compound spelled apart is not a
+						// substring of what the store wrote, so this
+						// comparison would call the close tier empty and hand
+						// the answer to relevance (#2125).
+						closeSS, serr := scanRecordsWithVariants(dir, m, o, postingOffsets(cutPostingsBySession(posts, m, o)), variants)
 						agree := false
 						if serr == nil {
 							top := rel.Sessions[0].Harness + ":" + rel.Sessions[0].ID
@@ -184,7 +203,12 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 	if len(posts) == 0 {
 		return SearchResult{}, nil
 	}
-	ss, err := scanRecords(dir, m, o, postingOffsets(posts))
+	// With the variants the rung above collected, not without them. A
+	// substring variant needs none — the text holding "opencode" holds "code"
+	// too — but a compound spelled apart is not a substring of anything the
+	// store wrote, so the postings found the session and this check dropped it
+	// again (#2125).
+	ss, err := scanRecordsWithVariants(dir, m, o, postingOffsets(posts), fallbackVariants)
 	if err == nil && len(ss) == 0 {
 		if result, ferr := stemSearch(dir, m, o); ferr != nil {
 			return SearchResult{}, fmt.Errorf("stem postings: %w", ferr)
@@ -2228,6 +2252,44 @@ func intersectPostings(dir string, keys []string) ([]posting, error) {
 func intersectSubstringPostings(dir string, bare []string) ([]posting, error) {
 	posts, _, err := intersectSubstringPostingsDetailed(dir, bare)
 	return posts, err
+}
+
+// compoundQueryTokens spells a compound query token as its parts, and says how
+// the words read spelled apart.
+//
+// The index already splits what it stores — indexKeys adds identifierParts,
+// which is why `retry backoff` reaches a session that wrote `retry-backoff`.
+// The other direction had nothing: a store that says "blowing up" was
+// unreachable from `blowing-up`, because this rung expands a query token to
+// indexed tokens *containing* it ("code" finds "opencode") and no indexed token
+// contains a compound the store never wrote (#2125).
+//
+// The parts replace the compound rather than joining it: the list is
+// intersected, so a token that expands to nothing empties the result. A query
+// naming a compound the store really holds never arrives here — the exact tier
+// answered it — so the replacement costs nothing that works.
+func compoundQueryTokens(toks []string) ([]string, map[string]string) {
+	out := make([]string, 0, len(toks))
+	apart := map[string]string{}
+	for _, tok := range toks {
+		if !strings.ContainsAny(tok, "-_") {
+			out = append(out, tok)
+			continue
+		}
+		var parts []string
+		for _, part := range strings.FieldsFunc(tok, func(r rune) bool { return r == '-' || r == '_' }) {
+			if len(part) >= 2 {
+				parts = append(parts, part)
+			}
+		}
+		if len(parts) < 2 {
+			out = append(out, tok)
+			continue
+		}
+		out = append(out, parts...)
+		apart[tok] = strings.Join(parts, " ")
+	}
+	return out, apart
 }
 
 func intersectSubstringPostingsDetailed(dir string, bare []string) ([]posting, map[string][]string, error) {


### PR DESCRIPTION
Fixes #2125. The index splits a compound when it stores one — `indexKeys` adds `identifierParts`, which is why `retry backoff` reaches a session that wrote `retry-backoff` — and the query side had no matching step:

```
"retry-backoff"  hit    the store's own spelling
"retry backoff"  hit    the parts are indexed too
"blowing up"     hit    the store's own spelling
"blowing-up"     miss   "no matches in 1 indexed session — try fewer words"
```

Not the exact tier, not the close rung, not relevance: a reader who types a hyphen where the transcript had a space gets nothing at all.

Two halves, because the first alone does nothing — which is what I reported on the issue after trying it:

- **postings**: the substring rung is fed the compound's parts. They replace the compound rather than joining it, because that list is intersected and a token expanding to nothing empties the result. A query naming a compound the store really holds never arrives here — the exact tier answered it.
- **verification**: the record check on that path was `scanRecords`, with no variants, so the postings found the session and the check dropped it again — `blowing-up` is not a substring of "blowing up". It takes the rung's variants now, with the compound's spelled-apart form among them.

The substring rung's own variants needed none of this: a text holding "opencode" holds "code" too. A compound is the case where the postings and the check disagree about what the query says.

After it, both directions of the same difference behave alike, and a compound the store never wrote still finds nothing:

```
blowing-up     hits=1
pool_size      hits=1
retry-backoff  hits=1
vacuum-freeze  hits=0
```

Review found the third place the same thing had to be said: the comparison that decides whether to keep the close tier or hand the answer to relevance also scanned without variants, so for a compound it would have judged the close tier empty. It takes them too.
