### PR TITLE
fix(brief): budget the recent block's project once, not per line

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -202,6 +202,28 @@ func runBrief(dir string, w io.Writer) error {
 	}
 	if err == nil && len(recent) > 0 {
 		label := "recent    "
+		// The project is budgeted once for the whole block, against the widest
+		// line in it — usually the widest date, and a longer harness name where
+		// the block mixes harnesses. The line with no project in it is what
+		// gets measured, so the two separators and the date are all counted
+		// exactly once, and both separators are counted because the project is
+		// measured as if it were there — that is the line it has to fit. The
+		// continuation label below is the same width as this one, so measuring
+		// with the first line's label measures them all.
+		// Budgeting per line spelled one project three ways: a date carrying
+		// its year is five columns wider, so the tail was cut further on those
+		// lines and vanished from the widest one, and the block #1073 put
+		// together read as three different projects (#2128). A block of
+		// different projects pays for it — a short one on a narrow-date line is
+		// cut to a budget some other line set — which is the price of the block
+		// reading as a block.
+		blockRest := 0
+		for _, s := range recent {
+			bare := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, "", search.RelativeDate(s.Updated))
+			if r := barColumns(bare); r > blockRest {
+				blockRest = r
+			}
+		}
 		for _, s := range recent {
 			title := s.Title
 			if title == "" {
@@ -219,13 +241,9 @@ func runBrief(dir string, w io.Writer) error {
 			// the prefix alone reached 58, the budget fell to its floor and the
 			// line ran to 71 — a wrapped row rather than a ragged end (#1592).
 			// Shorten the path first, then budget the title against what is
-			// left.
-			// Measure the line with no project in it, so the two separators and
-			// the date are all counted exactly once.
-			// Both separators are counted: the project is measured as if it
-			// were there, because that is the line it has to fit.
-			bare := fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, "", search.RelativeDate(s.Updated))
-			project := fitBriefProject(s.Project, barColumns(bare))
+			// left. The title is still budgeted per line: that is what keeps
+			// the lines the same length when the dates are not.
+			project := fitBriefProject(s.Project, blockRest)
 			head := fmt.Sprintf("%s [%s] %s · ", label, s.Harness, search.RelativeDate(s.Updated))
 			if project != "" {
 				head = fmt.Sprintf("%s [%s] %s · %s · ", label, s.Harness, project, search.RelativeDate(s.Updated))

--- a/cmd/deja/brief_block_project_test.go
+++ b/cmd/deja/brief_block_project_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
+)
+
+// One block, one project: the lines differ only by their date, and a date
+// carrying its year used to cut the project further on the lines that had one
+// — or take it away entirely — because each line budgeted on its own (#2128).
+func TestBriefRecentBlockShowsOneProjectSpelling(t *testing.T) {
+	dir := briefWideProjectAgesStore(t)
+	t.Setenv("COLUMNS", "60")
+
+	var buf bytes.Buffer
+	if err := runBrief(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+	lines := recentLines(buf.String())
+	if len(lines) < 3 {
+		t.Fatalf("want three recent lines, got %d:\n%s", len(lines), buf.String())
+	}
+	var spellings, dates []string
+	for _, l := range lines {
+		project, date := briefLineFields(t, visibleText(l))
+		spellings = append(spellings, project)
+		dates = append(dates, date)
+	}
+	// The premise: the dates are not all the same width, so a per-line budget
+	// has something to differ about. Without this the test passes on any day
+	// the fixture's ages happen to render alike.
+	if termwidth.Columns(dates[0]) == termwidth.Columns(dates[len(dates)-1]) {
+		t.Fatalf("every date is the same width %q, so this measures nothing:\n%s", dates, buf.String())
+	}
+	for _, s := range spellings[1:] {
+		if s != spellings[0] {
+			t.Errorf("one project, %d spellings in one block: %q\n%s", len(spellings), spellings, buf.String())
+			break
+		}
+	}
+	// The block still fits, and shortening did not take the project with it —
+	// the budget that binds here leaves room for a tail (#1592).
+	for _, l := range lines {
+		if w := termwidth.Columns(visibleText(l)); w > 60 {
+			t.Errorf("%d columns: %q", w, visibleText(l))
+		}
+	}
+	if spellings[0] == "" {
+		t.Errorf("every line dropped the project, so this measures nothing:\n%s", buf.String())
+	}
+}
+
+// briefLineFields returns what a recent line prints for the project and the
+// date. The project is empty on a line that dropped it, and the date is the
+// field the title follows.
+func briefLineFields(t *testing.T, text string) (project, date string) {
+	t.Helper()
+	i := strings.Index(text, "] ")
+	if i < 0 {
+		t.Fatalf("no harness on a recent line: %q", text)
+	}
+	// Harness, project and date are separated by " · ", and the title follows
+	// the date. Two fields before the title mean a project is there. The title
+	// may hold a separator of its own, so only the first two are split off.
+	parts := strings.SplitN(text[i+2:], " · ", 3)
+	switch len(parts) {
+	case 0, 1:
+		t.Fatalf("no date on a recent line: %q", text)
+		return "", ""
+	case 2:
+		return "", parts[0]
+	default:
+		return parts[0], parts[1]
+	}
+}
+
+// A wide project and three ages that render three ways whatever day it is: a
+// session from today, and two old enough to carry a year.
+func briefWideProjectAgesStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "-work-数据平台-消费者重平衡")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	const question = "为什么 kafka 消费者在预发环境不断重新平衡，日志里全是 rebalance 超时"
+	day := 24 * time.Hour
+	for i, age := range []time.Duration{2 * time.Hour, 400 * day, 380 * day} {
+		sid := string(rune('a'+i)) + "1b2c3d4"
+		body, err := json.Marshal(map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/work/数据平台/消费者重平衡",
+			"timestamp": time.Now().Add(-age).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": question},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), append(body, '\n'), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}


### PR DESCRIPTION
Fixes #2128. One project, one block, three spellings at 60 columns:

```
51 |recent     [claude] …/消费者重平衡 · Aug 15 · 为什么 kafka …|
53 |           [claude] …者重平衡 · Aug 12 2025 · 为什么 kafka …|
53 |           [claude] …者重平衡 · Jul 23 2025 · 为什么 kafka …|
```

Each line budgeted the project against its own date. A date carrying its year is five columns wider, so the tail was cut further there, and one column further still the project fell under its floor and left that line alone:

```
"today"        rest=36 -> "…衡-service"
"Jul 28"       rest=37 -> "…-service"
"Dec 22 2025"  rest=42 -> ""
```

Dropping it is deliberate (#1592) — an eight-column path tail is unreadable, so the title keeps its floor instead. Deciding it per line is not: #1073 put these three lines in one block so they read as one, and a reader who sees a project on two lines and none on the third reads the third as a different project.

So the block measures itself first — the widest line with no project in it — and every project is budgeted against that. The title stays per line, which is what keeps the lengths equal when the dates are not. A block of different projects pays a little for it: a short project on a narrow-date line is cut to a budget some other line set.

`TestBriefRecentLinesDoNotVaryWithTheDateWidth` missed this at 80 columns with a short ASCII project, where the budget never binds. The new test uses a wide CJK project and asserts up front that the dates are not all one width, so it cannot pass vacuously on a day when the fixture's ages render alike.
