### PR TITLE
test(brief): measure the recent block in columns, not runes

### DIFF
--- a/cmd/deja/brief_width_test.go
+++ b/cmd/deja/brief_width_test.go
@@ -10,11 +10,14 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
 
-// visibleWidth is what a terminal actually spends on a line: ANSI stripped,
-// runes not bytes.
-func visibleWidth(line string) int { return visibleLen(line) }
+// visibleWidth is what a terminal actually spends on a line: ANSI stripped and
+// measured the way the renderer measures, in columns. Counting runes agreed
+// with that for every ASCII fixture here and let a CJK line twice the
+// terminal's width past the guards below (#2130).
+func visibleWidth(line string) int { return termwidth.Columns(visibleText(line)) }
 
 // briefStore writes three sessions whose ages decide how wide the date on the
 // `recent` line is — "today" is five columns, "Jun 27 2025" is eleven.
@@ -125,7 +128,7 @@ func TestBriefRecentLinesHonourColumns(t *testing.T) {
 			t.Errorf("COLUMNS=60: line is %d columns: %q", w, l)
 		}
 		// The floor keeps a readable fragment rather than an empty column.
-		if i := strings.LastIndex(l, " · "); i < 0 || visibleLen(l[i+3:]) < 12 {
+		if i := strings.LastIndex(l, " · "); i < 0 || visibleWidth(l[i+3:]) < 12 {
 			t.Errorf("COLUMNS=60 cut the title down to nothing: %q", l)
 		}
 	}
@@ -140,7 +143,7 @@ func TestBriefRecentLinesHonourColumns(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, l := range recentLines(buf.String()) {
-		if i := strings.LastIndex(l, " · "); i < 0 || visibleLen(l[i+3:]) < 12 {
+		if i := strings.LastIndex(l, " · "); i < 0 || visibleWidth(l[i+3:]) < 12 {
 			t.Errorf("COLUMNS=40 cut the title down to nothing: %q", l)
 		}
 	}

--- a/cmd/deja/brief_width_unit_test.go
+++ b/cmd/deja/brief_width_unit_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+// The width guards on the recent block ask this helper how much of the
+// terminal a line took. A CJK character is one rune and two columns, so a
+// helper counting runes would let a line twice the terminal's width past the
+// guards that exist to stop exactly that (#2130).
+func TestVisibleWidthCountsColumnsNotRunes(t *testing.T) {
+	for _, tc := range []struct {
+		line string
+		want int
+	}{
+		{"recent     [claude] tmp/projc · today · a title", 47},
+		{"\x1b[2m[claude]\x1b[0m tmp/projc", 18},
+		{"消费者重平衡", 12},
+		{"recent     [claude] …者重平衡 · today", 37},
+		// The numbers are written out rather than derived: a table that asks
+		// the helper's own body what to expect agrees with it whatever it says.
+	} {
+		if got := visibleWidth(tc.line); got != tc.want {
+			t.Errorf("visibleWidth(%q) = %d, want %d columns", tc.line, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2130. The guards that pin the `recent` block to 60, 80 and 200 columns read a helper that counted runes:

```go
// visibleWidth is what a terminal actually spends on a line: ANSI stripped,
// runes not bytes.
func visibleWidth(line string) int { return visibleLen(line) }
```

A CJK character is one rune and two columns, so those guards would have accepted a line twice as wide as the terminal they exist to pin. Measured on a store with a CJK project and title at `COLUMNS=60`, where the head and the title add to exactly 60 on every line:

```
total=50 head=39 title=21 | recent     [claude] …者重平衡 · today · 为什么 kafka 消费者…
total=53 head=45 title=15 |            [claude] …者重平衡 · Aug 12 2025 · 为什么 kafka …
```

`total` is the helper. Nothing overflows today — the renderer budgets in `termwidth.Columns`, and the CJK tests already call it directly — so this is a blind guard, not a broken screen. The fixtures behind the guards are ASCII, which is why runes and columns have agreed so far.

The helper measures in columns now, and so do the two title-floor checks beside it, whose 12 is a column floor in the renderer. The new unit test writes its expected numbers out rather than deriving them, so it cannot agree with whatever the helper happens to do.
