### PR TITLE
fix(search): stop telling an emoji query it is too short

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -1104,7 +1105,7 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 			fmt.Fprint(os.Stderr, emptyRoleNote(dir, o.Role))
 			fmt.Fprint(os.Stderr, olderThanWindow(dir, o.Since))
 		default:
-			printNoMatches(os.Stderr, dir, o.Query)
+			printNoMatches(os.Stderr, dir, o.Query, o.Regex)
 		}
 	}
 	if o.Capped && len(hits) > 0 {
@@ -1281,7 +1282,7 @@ func termCountLine(dir, q string) string {
 // index holds zero sessions concludes the tool is broken rather than that
 // their query missed. It fired on every ordinary miss, so the signature could
 // not be used to recognise the failure it was written for (#637).
-func printNoMatches(w io.Writer, dir, q string) {
+func printNoMatches(w io.Writer, dir, q string, regex bool) {
 	// An empty store is not a query problem: "fewer words" cannot help when
 	// nothing is indexed, and `last`, `blame` and the brief all say what to do
 	// instead. Search is the command a new machine reaches for first (#832).
@@ -1304,7 +1305,17 @@ func printNoMatches(w io.Writer, dir, q string) {
 	// state the rule — the cut is on bytes, so "л" and "舵" are long enough
 	// while "p" is not, and a rule that reads false to half the world's
 	// alphabets is worse than none.
-	if len(query.Tokens(q)) == 0 {
+	// Both sentences below are about the word index, and --re does not use it:
+	// a regex is matched against the text itself, so an emoji it did not find
+	// is a miss like any other rather than something deja cannot look up.
+	if !regex && len(query.Tokens(q)) == 0 {
+		// Length is the wrong reason for a query that holds no word at all: an
+		// emoji is four bytes, and it was dropped for being a symbol. Sending
+		// that reader after a longer word sends them after nothing (#2133).
+		if !hasIndexableRune(q) {
+			fmt.Fprintf(w, "deja: nothing to search for in %q — deja indexes words, and emoji, symbols and punctuation are not words\n", q)
+			return
+		}
 		fmt.Fprintf(w, "deja: nothing to search for in %q — every word in it is too short to look up\n", q)
 		return
 	}
@@ -1480,6 +1491,18 @@ func hyphenatedCommandHint(q, low string) string {
 // is a sentence, and the hint is about the first kind (#2115).
 func looksLikeAnInvocation(q string) bool {
 	return len(strings.Fields(q)) <= 3
+}
+
+// hasIndexableRune says whether a query holds anything the index could have
+// kept. Letters and digits are what the tokenizer keeps; everything else is a
+// separator, which is why an emoji-only query reaches the index as nothing.
+func hasIndexableRune(q string) bool {
+	for _, r := range q {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // sinceRawArg recovers the text the reader typed after --since. parseSearch

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -593,7 +593,7 @@ func TestStemmedOutputIsDeterministic(t *testing.T) {
 func TestPrintNoMatchesReportsTheStoreSize(t *testing.T) {
 	dir := seedBriefIndex(t)
 	var b bytes.Buffer
-	printNoMatches(&b, dir, "jwt refresh token")
+	printNoMatches(&b, dir, "jwt refresh token", false)
 	out := b.String()
 	if strings.Contains(out, "in 0 indexed session") {
 		t.Fatalf("printed the corruption signature for a healthy index: %q", out)
@@ -603,7 +603,7 @@ func TestPrintNoMatchesReportsTheStoreSize(t *testing.T) {
 	}
 	// No index at all: say nothing rather than a wrong number.
 	var b2 bytes.Buffer
-	printNoMatches(&b2, filepath.Join(t.TempDir(), "gone"), "q")
+	printNoMatches(&b2, filepath.Join(t.TempDir(), "gone"), "q", false)
 	if strings.Contains(b2.String(), "indexed session") {
 		t.Fatalf("invented a count with no index: %q", b2.String())
 	}
@@ -1264,7 +1264,7 @@ func TestSessionCountCountsSessionsNotFiles(t *testing.T) {
 		t.Fatalf("SessionCount = %d, want the 2 sessions across 4 scanned files", n)
 	}
 	var b bytes.Buffer
-	printNoMatches(&b, dir, "nothing")
+	printNoMatches(&b, dir, "nothing", false)
 	if !strings.Contains(b.String(), "in 2 indexed sessions") {
 		t.Fatalf("message = %q", b.String())
 	}

--- a/cmd/deja/search_policy_scope_test.go
+++ b/cmd/deja/search_policy_scope_test.go
@@ -37,7 +37,7 @@ func TestNoMatchesCountsWhatSearchMayRead(t *testing.T) {
 
 	// Without a rule the miss is a wording problem and reads like one.
 	var out bytes.Buffer
-	printNoMatches(&out, dir, "ticker window")
+	printNoMatches(&out, dir, "ticker window", false)
 	if !strings.Contains(out.String(), "no matches in 1 indexed session") {
 		t.Errorf("an ordinary miss lost its count:\n%s", out.String())
 	}
@@ -49,7 +49,7 @@ func TestNoMatchesCountsWhatSearchMayRead(t *testing.T) {
 	t.Setenv("DEJA_POLICY_FILE", policyFile)
 
 	out.Reset()
-	printNoMatches(&out, dir, "ticker window")
+	printNoMatches(&out, dir, "ticker window", false)
 	got := out.String()
 	if strings.Contains(got, "try fewer words") {
 		t.Errorf("the reader was sent after their wording:\n%s", got)

--- a/cmd/deja/search_symbol_query_test.go
+++ b/cmd/deja/search_symbol_query_test.go
@@ -15,7 +15,7 @@ import (
 func TestASymbolOnlyQuerySaysWhyItFoundNothing(t *testing.T) {
 	symbolQueryStore(t)
 
-	for _, q := range []string{"🔥", "🔥🔥", "✅", "!!!", "→", "❤️", "👨‍👩‍👧"} {
+	for _, q := range []string{"🔥", "🔥🔥", "✅", "!!!", "→", "\u2764\ufe0f", "\U0001F468\u200d\U0001F469\u200d\U0001F467"} {
 		out, err := captureRunStderr(t, "search", q)
 		if err != nil {
 			t.Fatal(err)
@@ -49,16 +49,16 @@ func TestASymbolOnlyQuerySaysWhyItFoundNothing(t *testing.T) {
 }
 
 // An emoji written with a joiner or a variation selector used to leave that
-// invisible character standing as the whole query, so "❤️" asked for the
+// invisible character standing as the whole query, so a heart asked for its
 // selector and answered with every session that spelled some other emoji the
 // same way (#2133).
 func TestAnEmojiQueryDoesNotMatchADifferentEmoji(t *testing.T) {
 	symbolQueryStore(t)
 
-	out, _ := captureRun(t, "search", "❤️")
+	out, _ := captureRun(t, "search", "\u2764\ufe0f")
 	for _, sid := range []string{"s1", "s2"} {
 		if strings.Contains(out, sid) {
-			t.Errorf("\"❤️\" matched %s, which says a different emoji:\n%s", sid, out)
+			t.Errorf("the heart query matched %s, which says a different emoji:\n%s", sid, out)
 		}
 	}
 	// The words beside the emoji still find both sessions, which is the only
@@ -81,7 +81,7 @@ func symbolQueryStore(t *testing.T) {
 	}
 	for sid, text := range map[string]string{
 		"s1": "the pump bearing failed ⚠️ again",
-		"s2": "the disk is nearly full \U0001F468‍\U0001F469‍\U0001F467 said the family",
+		"s2": "the disk is nearly full \U0001F468\u200d\U0001F469\u200d\U0001F467 said the family",
 	} {
 		rec := claudeRecord(t, map[string]any{
 			"type": "user", "sessionId": sid, "cwd": "/tmp/app",

--- a/cmd/deja/search_symbol_query_test.go
+++ b/cmd/deja/search_symbol_query_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A query with no word in it is not a query with a short word in it. Emoji are
+// four bytes, well over the cut #828 describes, and the tokenizer drops them
+// because they are symbols — telling the reader to try longer words sends them
+// after something that would never have worked (#2133).
+func TestASymbolOnlyQuerySaysWhyItFoundNothing(t *testing.T) {
+	symbolQueryStore(t)
+
+	for _, q := range []string{"🔥", "🔥🔥", "✅", "!!!", "→", "❤️", "👨‍👩‍👧"} {
+		out, err := captureRunStderr(t, "search", q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "nothing to search for") || !strings.Contains(out, "are not words") {
+			t.Errorf("%q: want the sentence about words, got:\n%s", q, out)
+		}
+		if strings.Contains(out, "too short") {
+			t.Errorf("%q is not too short, it holds no word at all:\n%s", q, out)
+		}
+	}
+	// The sentence that is about length keeps the queries it is about.
+	for _, q := range []string{"p", "a b"} {
+		out, err := captureRunStderr(t, "search", q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "too short") {
+			t.Errorf("%q is the short-word case and should still say so:\n%s", q, out)
+		}
+	}
+	// --re does not use the word index at all, so neither sentence is true
+	// there: a regex that found nothing is an ordinary miss.
+	out, err := captureRunStderr(t, "search", "--re", "🔥")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "nothing to search for") {
+		t.Errorf("--re does not go through the word index:\n%s", out)
+	}
+}
+
+// An emoji written with a joiner or a variation selector used to leave that
+// invisible character standing as the whole query, so "❤️" asked for the
+// selector and answered with every session that spelled some other emoji the
+// same way (#2133).
+func TestAnEmojiQueryDoesNotMatchADifferentEmoji(t *testing.T) {
+	symbolQueryStore(t)
+
+	out, _ := captureRun(t, "search", "❤️")
+	for _, sid := range []string{"s1", "s2"} {
+		if strings.Contains(out, sid) {
+			t.Errorf("\"❤️\" matched %s, which says a different emoji:\n%s", sid, out)
+		}
+	}
+	// The words beside the emoji still find both sessions, which is the only
+	// way either of them was ever reachable.
+	for q, want := range map[string]string{"disk": "s2", "bearing": "s1"} {
+		if out, _ := captureRun(t, "search", q); !strings.Contains(out, want) {
+			t.Errorf("%q lost %s, so this measures nothing:\n%s", q, want, out)
+		}
+	}
+}
+
+// Two sessions whose only emoji are spelled with the invisible characters at
+// issue: a variation selector in one, a zero-width joiner in the other.
+func symbolQueryStore(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for sid, text := range map[string]string{
+		"s1": "the pump bearing failed ⚠️ again",
+		"s2": "the disk is nearly full \U0001F468‍\U0001F469‍\U0001F467 said the family",
+	} {
+		rec := claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/tmp/app",
+			"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": text},
+		})
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/short_query_test.go
+++ b/cmd/deja/short_query_test.go
@@ -24,7 +24,7 @@ func TestQueryWithNothingToLookUpSaysSo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, q := range []string{"p", "a b c", "..."} {
+	for _, q := range []string{"p", "a b c"} {
 		out, err := captureRunStderr(t, q)
 		if err != nil {
 			t.Fatal(err)
@@ -37,9 +37,20 @@ func TestQueryWithNothingToLookUpSaysSo(t *testing.T) {
 		}
 	}
 
+	// Punctuation has no word in it at all, so length is not what stopped it:
+	// that query gets the sentence about words rather than the one about
+	// length (#2133).
+	out, err := captureRunStderr(t, "...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "nothing to search for") || strings.Contains(out, "too short to look up") {
+		t.Errorf("\"...\" is not too short, it holds no word:\n%s", out)
+	}
+
 	// A word the store simply does not have keeps the ordinary answer: there
 	// is something to look up, it just is not there.
-	out, err := captureRunStderr(t, "zzzqqq")
+	out, err = captureRunStderr(t, "zzzqqq")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -233,10 +233,10 @@ func Tokens(s string) []string {
 			return unicode.IsSpace(r)
 		}
 		// Joiners and variation selectors go with them. They are invisible, and
-		// leaving one standing made "❤️" a query for its selector: it matched
-		// every session holding any other emoji spelled with one — "⚠️" among
-		// them — and never the heart (#2133). Other combining marks stay:
-		// they are what tells one Arabic or Hebrew word from another.
+		// leaving one standing made a heart a query for its selector: it matched
+		// every session holding any other emoji spelled with one — a warning
+		// sign among them — and never the heart (#2133). Other combining marks
+		// stay: they are what tells one Arabic or Hebrew word from another.
 		return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) ||
 			unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Variation_Selector, r)
 	})

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -232,7 +232,13 @@ func Tokens(s string) []string {
 		if r < 0x80 {
 			return unicode.IsSpace(r)
 		}
-		return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+		// Joiners and variation selectors go with them. They are invisible, and
+		// leaving one standing made "❤️" a query for its selector: it matched
+		// every session holding any other emoji spelled with one — "⚠️" among
+		// them — and never the heart (#2133). Other combining marks stay:
+		// they are what tells one Arabic or Hebrew word from another.
+		return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) ||
+			unicode.Is(unicode.Cf, r) || unicode.Is(unicode.Variation_Selector, r)
 	})
 	seen := map[string]bool{}
 	var out []string


### PR DESCRIPTION
Fixes #2133. `deja "🔥"` answered with a rule that does not apply:

```
deja: nothing to search for in "🔥" — every word in it is too short to look up
```

Nothing about it is short. 🔥 is four bytes, over the two-byte cut from #828; it was dropped for being a symbol. The index agrees — `indexKeys("🔥")` is empty — so the behaviour is right and only the sentence was wrong. A query with no letter and no digit in it now says that, and the length sentence keeps the queries it is about (`deja "p"`). "..." moves with the emoji, which is why the #828 expectation changed.

Review found the shape this misses, and it is worse than the wording. An emoji written with a joiner or a variation selector left that invisible character standing as the whole query:

```
Tokens("❤️")     = ["️"]
Tokens("👨‍👩‍👧") = ["‍"]
```

so `deja "❤️"` never reached the message at all — it ran a substring search for the selector and answered with every session that spelled some *other* emoji the same way:

```
deja "❤️"  →  the pump bearing failed ⚠️ again
```

Joiners and variation selectors are separators now, like the symbols around them. Other combining marks stay where they are: they are what tells one Arabic or Hebrew word from another.

Two smaller things from the same review: `--re` does not use the word index, so neither sentence is true there and it keeps the ordinary miss; and the new sentence names symbols as well as emoji and punctuation, since `→` and `★` land there too.
