### PR TITLE
fix(search): let a plural reach the singular it belongs to

### DIFF
--- a/cmd/deja/search_plural_test.go
+++ b/cmd/deja/search_plural_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A correct plural is not a misspelling. The word-forms rung could not reach
+// the singular of a noun ending in "e", so the fuzzy rung answered and the
+// reader was told they had typed it wrong (#2137).
+func TestAPluralIsAnsweredAsAWordFormNotASpelling(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := claudeRecord(t, map[string]any{
+		"type": "user", "sessionId": "s1", "cwd": "/tmp/app",
+		"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+		"message": map[string]any{"role": "user", "content": "the ingest pipeline stalled and the warm cache " +
+			"was dropped on every release"},
+	})
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	for _, q := range []string{"pipelines", "caches", "releases"} {
+		out, _ := captureRun(t, "search", q)
+		if !strings.Contains(out, "s1") {
+			t.Fatalf("%q finds nothing, so this measures nothing:\n%s", q, out)
+		}
+		errOut, err := captureRunStderr(t, "search", q)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(errOut, "close spellings") {
+			t.Errorf("%q is the plural, not a misspelling:\n%s", q, errOut)
+		}
+		if !strings.Contains(errOut, "word forms") {
+			t.Errorf("%q lost the word-forms line:\n%s", q, errOut)
+		}
+	}
+	// A word that really is mistyped keeps the sentence about spelling.
+	errOut, err := captureRunStderr(t, "search", "pipelien")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(errOut, "close spellings") {
+		t.Errorf("a typo should still be answered as one:\n%s", errOut)
+	}
+}

--- a/internal/index/plural_stem_test.go
+++ b/internal/index/plural_stem_test.go
@@ -1,0 +1,39 @@
+package index
+
+import (
+	"slices"
+	"testing"
+)
+
+// The "es" case of the suffix switch returned before the "s" case could run,
+// so the plural of every noun ending in "e" reached only a stub — "pipelin",
+// never "pipeline" — and the fuzzy rung answered instead, telling the reader
+// their correct plural was a misspelling (#2137).
+func TestAPluralReachesTheSingularOfAnEEndingNoun(t *testing.T) {
+	for _, tc := range []struct{ plural, singular string }{
+		{"pipelines", "pipeline"},
+		{"caches", "cache"},
+		{"releases", "release"},
+		{"queues", "queue"},
+		// The "es" strip is right for these, and stays right.
+		{"boxes", "box"},
+		{"matches", "match"},
+		{"classes", "class"},
+		// #1079's case keeps working: consonant+y goes through "ies".
+		{"retries", "retry"},
+		// The "ies" case had the same shape as the "es" one: a word that is
+		// already "ie" plus "s" needs only the "s" gone.
+		{"movies", "movie"},
+		{"cookies", "cookie"},
+	} {
+		forms := suffixForms(tc.plural)
+		if !slices.Contains(forms, tc.singular) {
+			t.Errorf("suffixForms(%q) has no %q: %q", tc.plural, tc.singular, forms)
+		}
+		// And the catalog decides, so a store that holds the singular finds it.
+		got := stemMatches(tc.plural, map[string]bool{tc.singular: true})
+		if !slices.Contains(got, tc.singular) {
+			t.Errorf("stemMatches(%q) = %q, want it to reach %q", tc.plural, got, tc.singular)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2803,6 +2803,10 @@ func oneSuffixStep(word string) []string {
 		// full of "retries" (#1079).
 		add(strings.TrimSuffix(word, "ies") + "y")
 		add(strings.TrimSuffix(word, "es"))
+		// And the plain "s", for the reason the "es" case below takes it:
+		// "movies" is neither "movy" nor "movi", and nothing further down
+		// strips it again (#2137).
+		add(strings.TrimSuffix(word, "s"))
 	case strings.HasSuffix(word, "ied"):
 		add(strings.TrimSuffix(word, "ied") + "y")
 	case strings.HasSuffix(word, "ed"):
@@ -2814,7 +2818,15 @@ func oneSuffixStep(word string) []string {
 		add(base)
 		add(base + "e")
 	case strings.HasSuffix(word, "es"):
+		// Both strips, because the switch stops here and the plain "s" case
+		// below never runs for these words: "boxes" needs the "es" gone and
+		// "pipelines" needs only the "s", and a plural of every noun ending in
+		// "e" reached the stub "pipelin" and no further. Whichever form the
+		// store does not hold falls out at the catalog, which every lookup
+		// goes through; the relevance keys take the forms unfiltered, and there
+		// the extra one is the real singular (#2137).
 		add(strings.TrimSuffix(word, "es"))
+		add(strings.TrimSuffix(word, "s"))
 	case strings.HasSuffix(word, "s"):
 		add(strings.TrimSuffix(word, "s"))
 	}


### PR DESCRIPTION
Fixes #2137. `deja "pipelines"` finds the store that says "pipeline" and tells the reader they misspelled it:

```
deja: no exact match, trying close spellings: pipelines -> pipeline
```

They did not — that is the plural, and the word-forms rung is for exactly this. It could not get there. `oneSuffixStep` is an exclusive switch, so the `es` case returns before the plain `s` case can run:

```
suffixForms("pipelines")  →  pipelin, pipelins, pipelining, …   no "pipeline"
stemMatches("pipelines", {"pipeline"})  →  []
```

Depth two does not help: "pipelin" ends in a consonant and nothing strips further. What rescued the search was the fuzzy rung, one edit away, which is why this has been invisible — the session comes back, ranked among whatever else is one edit from the query, under a sentence saying the reader typed it wrong. #1079 fixed the same shape for "retries" → "retry".

Both strips belong in that case: "boxes" needs the "es" gone, "pipelines" only the "s". Review found the `ies` case had it too — "movies" reached "movy" and "movi" and never "movie" — so that one takes the plain strip as well. Every lookup goes through the catalog, which drops whichever form the store does not hold; the relevance keys take the forms unfiltered, and there the extra one is the real singular.

After it the plural is answered as what it is:

```
deja: no exact match, trying word forms: pipelines -> pipeline
```

and a real typo still gets the sentence about spelling, which the test pins with "pipelien".
