### PR TITLE
fix(log): order usage events and digests by stamp, not by arrival

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -67,6 +67,13 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		}
 		fmt.Fprintf(w, "# %s · %s · %d session%s · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, pluralS(s.Sessions), humanBytes(int64(s.Bytes)), pol)
 		fmt.Fprintln(w, s.Digest)
+		// This is the newest digest by its stamp (#2140), so a stamp from
+		// ahead of the clock holds the spot until the clock catches up — and
+		// the digest an agent actually received last is then not the one on
+		// screen. The list above names the same fault in its own words.
+		if index.StampedAhead(s.Time, time.Now()) {
+			fmt.Fprintf(os.Stderr, "deja: this digest is stamped later than this machine's clock, so it leads by its stamp — a digest served since may be older by that stamp and sit below it\n")
+		}
 		return nil
 	}
 	events := usage.Events(dir, n)

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -184,7 +185,7 @@ func rotateSnapshots(p string, incoming int) {
 	// deja could not have written — a side effect worth naming rather than
 	// discovering: the file shrinks by more than the rotation alone would
 	// explain (#1946).
-	snaps := snapshotsFrom(p, snapshotsToKeep) // newest first
+	snaps := snapshotsFrom(p, snapshotsToKeep) // last appended first
 	// Keeping a fixed count says nothing about the size that triggered this. A
 	// read of `deja://session/…` records a whole session here, unbudgeted, and
 	// twenty of those sit above the threshold for good: the file then rotates on
@@ -239,6 +240,12 @@ func snapshotsFrom(p string, n int) []Snapshot {
 			out = append(out, s)
 		}
 	}
+	// Last appended first, and no further: this is what the rotation rewrites
+	// from, and there the order decides which records survive. The sibling
+	// rotation in usage.go keeps an event stamped ahead of the window rather
+	// than dropping it, on the grounds that deleting a recorded event on a
+	// guess about someone's clock cannot be undone — retention reads the file
+	// as written, and only the reader below sorts (#2140).
 	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
 		out[i], out[j] = out[j], out[i]
 	}
@@ -249,8 +256,20 @@ func snapshotsFrom(p string, n int) []Snapshot {
 }
 
 // Snapshots returns up to n recorded digests for an index dir, newest first.
+//
+// By stamp, arrival order breaking ties. Reversing the file and stopping there
+// is only newest-first while the file is append-ordered by time, and it is not
+// always: several agents append to one file, and a clock that moved backwards
+// writes an older stamp after a newer one — the case #2105 and #2122 handle
+// elsewhere. `deja log --last` reads the first of these as the most recent
+// digest, and it was the last one appended (#2140).
 func Snapshots(indexDir string, n int) []Snapshot {
-	return snapshotsFrom(SnapshotPath(indexDir), n)
+	out := snapshotsFrom(SnapshotPath(indexDir), 0)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	if n > 0 && len(out) > n {
+		out = out[:n]
+	}
+	return out
 }
 
 // Events returns up to n usage events, newest first. n <= 0 means all.
@@ -271,9 +290,13 @@ func Events(indexDir string, n int) []Event {
 			out = append(out, e)
 		}
 	}
+	// By stamp, arrival order breaking ties, for the reason Snapshots above
+	// takes it. This list is read, never rewritten: the usage log's own
+	// rotation reads the file separately (#2140).
 	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
 		out[i], out[j] = out[j], out[i]
 	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
 	if n > 0 && len(out) > n {
 		out = out[:n]
 	}

--- a/internal/usage/stamp_order_test.go
+++ b/internal/usage/stamp_order_test.go
@@ -1,0 +1,168 @@
+package usage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Both readers reverse the file and call the result newest first, so an event
+// appended out of stamp order sat wherever it arrived — and the cut took the
+// first N of that, dropping events newer than the ones it kept (#2140).
+func TestEventsAndSnapshotsAreNewestByStamp(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	at := func(h int) time.Time { return now.Add(-time.Duration(h) * time.Hour) }
+
+	var events strings.Builder
+	for _, e := range []struct {
+		kind string
+		age  int
+	}{{"hook", 5}, {"mcp", 1}, {"search", 9}} {
+		line, err := json.Marshal(map[string]any{
+			"t": at(e.age).UTC().Format(time.RFC3339Nano), "kind": e.kind, "bytes": 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		events.Write(line)
+		events.WriteByte('\n')
+	}
+	if err := os.WriteFile(Path(dir), []byte(events.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := Events(dir, 0)
+	if len(got) != 3 {
+		t.Fatalf("read %d events, want 3", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Time.After(got[i-1].Time) {
+			t.Errorf("events are not newest first: %s then %s", got[i-1].Time, got[i].Time)
+		}
+	}
+	// And the cut takes the newest N, not the last N appended.
+	if two := Events(dir, 2); len(two) != 2 || two[0].Kind != "mcp" || two[1].Kind != "hook" {
+		t.Errorf("Events(2) = %v, want the mcp and hook events — the two newest by stamp", kinds(two))
+	}
+
+	var snaps strings.Builder
+	for _, s := range []struct {
+		kind string
+		age  int
+	}{{"hook", 5}, {"mcp", 1}, {"search", 9}} {
+		line, err := json.Marshal(map[string]any{
+			"t": at(s.age).UTC().Format(time.RFC3339Nano), "kind": s.kind, "digest": "d-" + s.kind,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		snaps.Write(line)
+		snaps.WriteByte('\n')
+	}
+	if err := os.WriteFile(SnapshotPath(dir), []byte(snaps.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// `deja log --last` reads snaps[0] as the most recent digest.
+	if one := Snapshots(dir, 1); len(one) != 1 || one[0].Kind != "mcp" {
+		t.Errorf("Snapshots(1) = %v, want the mcp digest — the newest by stamp", one)
+	}
+}
+
+func kinds(es []Event) []string {
+	var out []string
+	for _, e := range es {
+		out = append(out, e.Kind)
+	}
+	return out
+}
+
+// Events written in stamp order keep the order they arrived in when two share
+// a stamp: the later line is the later event.
+func TestEqualStampsKeepArrivalOrder(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+	var b strings.Builder
+	for _, kind := range []string{"first", "second", "third"} {
+		line, err := json.Marshal(map[string]any{"t": stamp, "kind": kind, "bytes": 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(Path(dir), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := kinds(Events(dir, 0))
+	want := []string{"third", "second", "first"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Events = %v, want %v — with one stamp, the last appended is the newest", got, want)
+		}
+	}
+}
+
+// Reading is sorted; keeping is not. The rotation rewrites the file from what
+// it reads, so ordering that by stamp would delete the digest served last
+// whenever the clock was behind when it was written — the one thing the
+// sibling rotation in usage.go refuses to do (#2140).
+func TestRotationKeepsWhatArrivedLastNotWhatIsStampedLatest(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := SnapshotPath(dir)
+	now := time.Now()
+	// Enough records to rotate, all stamped far in the past except the ones at
+	// the end: the last appended carries the oldest stamp of the lot.
+	body := strings.Repeat("x", RecordRoom/2)
+	var b strings.Builder
+	for i := 0; i < snapshotsToKeep*3; i++ {
+		line, err := marshalSnapshot(Snapshot{
+			Time: now.Add(-time.Duration(i) * time.Minute), Kind: "hook",
+			Bytes: len(body), Digest: fmt.Sprintf("d%03d ", i) + body,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	// Served last, by a machine whose clock was a year behind.
+	last, err := marshalSnapshot(Snapshot{
+		Time: now.AddDate(-1, 0, 0), Kind: "mcp", Bytes: len(body), Digest: "served-last " + body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b.Write(last)
+	b.WriteByte('\n')
+	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() < snapshotRotateAt {
+		t.Fatalf("the file is %d bytes and rotation starts at %d, so this measures nothing", fi.Size(), snapshotRotateAt)
+	}
+	rotateSnapshots(p, 1)
+	kept, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(kept), "served-last") {
+		t.Errorf("rotation dropped the digest that arrived last because its stamp was the oldest")
+	}
+}


### PR DESCRIPTION
Fixes #2140. `usage.Events` and `usage.Snapshots` say "newest first" and give arrival order — they reverse the file and stop. With three events appended out of stamp order:

```
2026-08-27 02:57  search    900 B     ← oldest by stamp, appended last
2026-08-27 10:57  mcp       100 B
2026-08-27 06:57  hook      500 B
```

and `deja log 2` kept the first two, so the event it dropped was newer than one it kept. `deja log --last` had the same shape: `snaps[0]` is "the most recent injected digest", and it was the last one appended.

Out-of-order arrival is not exotic — several agents append to one file, and a clock that moved backwards writes an older stamp after a newer one, which is the case #2105, #2107 and #2122 handle everywhere else. `deja log`'s own ahead-line already describes stamp order: "those events sit above everything from then on".

Both readers sort by stamp now, with the file reversal kept ahead of the sort so two records written in the same second still come back last-appended-first.

Review caught what that would have done to retention: `rotateSnapshots` rewrites the file from `snapshotsFrom`, so sorting there would delete the digest served last whenever the clock was behind when it was written — exactly what the sibling rotation in usage.go refuses to do ("deleting a recorded event on a guess about someone's clock is the one thing here that cannot be undone"). Reading is sorted; keeping reads the file as written, and a test pins it.

It also caught that `--last` now leads with a future-stamped digest silently, so that surface says so, as the list already does.
