### PR TITLE
test(index): pin that a full Russian paradigm fits the form cap

### DIFF
--- a/internal/index/stem_cap_test.go
+++ b/internal/index/stem_cap_test.go
@@ -1,0 +1,44 @@
+package index
+
+import (
+	"slices"
+	"testing"
+)
+
+// stemMatches keeps eight forms, in the order they were built: the English
+// suffix forms first, the developer synonyms, then the Cyrillic ones. The
+// fullest thing a store can hold is a Russian paradigm, and that is seven
+// forms — one slot under the cap, with the single-letter endings that carry
+// the lemma last in the order, so the lemma is what a tighter cap would cut.
+// Nothing said so, and for a Russian query those forms are the whole answer.
+func TestAFullRussianParadigmFitsUnderTheFormCap(t *testing.T) {
+	for _, tc := range []struct {
+		term  string
+		lemma string
+		forms []string
+	}{
+		{"настройки", "настройка", []string{
+			"настройка", "настройки", "настройке", "настройку", "настройкой", "настройками", "настройках"}},
+		{"миграции", "миграция", []string{
+			"миграция", "миграции", "миграцию", "миграцией", "миграциях", "миграциями", "миграций"}},
+		{"обработчика", "обработчик", []string{
+			"обработчик", "обработчика", "обработчику", "обработчиком", "обработчике", "обработчики", "обработчиков"}},
+	} {
+		// A catalog like a real one: what a transcript would contain, and none
+		// of the stubs the expander invents — indexKeys stores tokens, never
+		// expansions, so "настройкиed" is in no catalog anywhere.
+		catalog := map[string]bool{}
+		for _, w := range tc.forms {
+			catalog[w] = true
+		}
+		got := stemMatches(tc.term, catalog)
+		if len(got) != len(tc.forms) {
+			t.Errorf("stemMatches(%q) kept %d of %d forms: %q", tc.term, len(got), len(tc.forms), got)
+		}
+		// The lemma above all: it is what the reader would search next, and it
+		// is last in the build order.
+		if !slices.Contains(got, tc.lemma) {
+			t.Errorf("stemMatches(%q) does not reach the lemma %q: %q", tc.term, tc.lemma, got)
+		}
+	}
+}


### PR DESCRIPTION
No defect behind the queue item that asked whether `stemMatches`' eight-form cap can drop the singular. It cannot, for the stores that exist: a word holds five or six forms, and the eight fill up only when the catalog is synthetic and contains the expander's own inventions ("настройкиed"), which `indexKeys` never writes.

The headroom is one, though. The fullest thing a real store can hold is a Russian paradigm:

```
stemMatches("настройки")  kept=7  [настройки настройками настройках настройкой настройка настройку настройке]
stemMatches("миграции")   kept=7
stemMatches("обработчика") kept=7
```

and the single-letter endings that carry the lemma sit last in the build order, so the lemma is what a tighter cap would cut — for a Russian query, the whole answer. This holds that boundary: seven forms kept of seven, lemma among them. It fails at a cap of six.

Review's first read of this test was right and it was rewritten: the earlier version asserted `len(got) > 8`, which `stemMatches` cannot produce, and its English reach checks duplicated plural_stem_test.go and stemfolds_test.go.
