### PR TITLE
feat(hooks): give a spawned agent the memory its parent has

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -50,7 +50,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
+        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent",
         "hooks": [
           {
             "type": "command",

--- a/cmd/deja/hook_spawn.go
+++ b/cmd/deja/hook_spawn.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// A spawned agent starts with no memory and no way to be given one.
+//
+// Measured on this machine's store, 289 of 328 sessions that had deja
+// available were Task subagents, and they received a recall in 1% of them and
+// called the tool in none. The reason is structural rather than a bar being
+// too high: the per-prompt hook fires on what a person types, and a subagent's
+// prompt is not typed — it is a tool input written by the parent. So the
+// surface that carries memory never sees the work that most needs it, while
+// the subagent does the reviewing, the hunting and the migrating.
+//
+// PreToolUse can rewrite a tool's input, which is the one place a subagent's
+// prompt can still be reached. Fed through the same recall the per-prompt hook
+// runs — same bar, same dedup, same policy — what comes back is appended to
+// the prompt the subagent is about to receive.
+
+// spawnPromptFields is where each harness keeps the instruction it hands the
+// spawned agent. Claude Code calls it prompt; the others that grew a subagent
+// tool since have kept the name, and the fallbacks cost nothing.
+var spawnPromptFields = []string{"prompt", "instructions", "task"}
+
+// isSpawnTool reports whether this action spawns an agent. Claude Code calls it
+// Task; the name is matched case-insensitively because a harness that wires the
+// hook with its own matcher may spell it differently.
+func isSpawnTool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "task", "agent", "subagent":
+		return true
+	}
+	return false
+}
+
+// runHookSpawn answers a PreToolUse on the tool that spawns an agent. The reply
+// carries the whole tool input back with the prompt extended, because a
+// PreToolUse reply replaces the input rather than merging into it: dropping a
+// field here would silently drop the subagent_type or the model the parent
+// chose.
+func runHookSpawn(dir string, input toolHookInput, raw []byte, stdout io.Writer) error {
+	var payload struct {
+		ToolInput map[string]json.RawMessage `json:"tool_input"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil || len(payload.ToolInput) == 0 {
+		return nil
+	}
+	field, text := spawnPrompt(payload.ToolInput)
+	if field == "" || strings.TrimSpace(text) == "" {
+		return nil
+	}
+	block := spawnRecall(dir, input.SessionID, input.CWD, text)
+	if block == "" {
+		return nil
+	}
+	extended, err := json.Marshal(text + "\n\n" + block)
+	if err != nil {
+		return nil
+	}
+	payload.ToolInput[field] = extended
+
+	var resp struct {
+		HookSpecificOutput struct {
+			HookEventName      string                     `json:"hookEventName"`
+			PermissionDecision string                     `json:"permissionDecision"`
+			UpdatedInput       map[string]json.RawMessage `json:"updatedInput"`
+		} `json:"hookSpecificOutput"`
+	}
+	resp.HookSpecificOutput.HookEventName = "PreToolUse"
+	// allow, not ask: this changes what the agent is told, not what it is
+	// permitted to do, and a prompt for every spawned agent would make the
+	// memory the most annoying thing in the session.
+	resp.HookSpecificOutput.PermissionDecision = "allow"
+	resp.HookSpecificOutput.UpdatedInput = payload.ToolInput
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	fmt.Fprintln(stdout, string(b))
+	return nil
+}
+
+func spawnPrompt(in map[string]json.RawMessage) (string, string) {
+	for _, f := range spawnPromptFields {
+		v, ok := in[f]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil && strings.TrimSpace(s) != "" {
+			return f, s
+		}
+	}
+	return "", ""
+}
+
+// spawnRecall runs the per-prompt hook over the spawned agent's instructions and
+// returns the block it would have injected, or "" for the silence that is the
+// usual answer.
+//
+// The parent's own session id is deliberately not used. Dedup and the cooldown
+// are per session, and sharing the parent's would mean a recall the parent was
+// shown a minute ago is withheld from an agent that has never seen anything —
+// and that a fleet of ten agents spawned together all count as one reader.
+// Keyed on the parent plus the instructions instead, so re-spawning the same
+// agent twice is the repeat that gets suppressed.
+func spawnRecall(dir, sid, cwd, text string) string {
+	payload, err := json.Marshal(struct {
+		Prompt    string `json:"prompt"`
+		SessionID string `json:"session_id"`
+		CWD       string `json:"cwd"`
+	}{
+		Prompt:    text,
+		SessionID: "task:" + sid + ":" + shortHash(text),
+		CWD:       cwd,
+	})
+	if err != nil {
+		return ""
+	}
+	var out bytes.Buffer
+	// plain: the block itself, not a hook envelope. It is going inside another
+	// tool's input, where a JSON reply of its own would be read as text.
+	if err := runHookPromptMode(dir, bytes.NewReader(payload), &out, true); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out.String())
+}

--- a/cmd/deja/hook_spawn_test.go
+++ b/cmd/deja/hook_spawn_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type spawnHookResponse struct {
+	HookSpecificOutput struct {
+		HookEventName      string                     `json:"hookEventName"`
+		PermissionDecision string                     `json:"permissionDecision"`
+		UpdatedInput       map[string]json.RawMessage `json:"updatedInput"`
+	} `json:"hookSpecificOutput"`
+}
+
+// A spawned agent has no session start and sends no user prompt, so the only
+// thing that reaches it is the instructions the parent wrote. Answering the
+// spawn with additionalContext would hand the memory to the parent, which
+// already has it; the reply has to rewrite the input.
+func TestSpawnHookPutsRecallInsideTheSubagentsPrompt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "app", "past.jsonl"), "past", []string{
+		`{"type":"user","sessionId":"past","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the pgbouncer prepared statement error again"}}`,
+		`{"type":"assistant","sessionId":"past","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":"We decided to set default_query_exec_mode=exec for pgbouncer, because prepared statements do not survive transaction pooling."}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// The recall is ranked inside the project the parent is working in, so the
+	// spawn has to be answered from one.
+	cwd := filepath.Join(t.TempDir(), "src", "app")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	payload := `{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":` +
+		`{"prompt":"Investigate the pgbouncer prepared statement failure in the orders service.",` +
+		`"subagent_type":"general-purpose","description":"pgbouncer dig"},"session_id":"parent"}`
+	out := toolHookRun(t, payload)
+	if out == "" {
+		t.Fatal("a spawn whose subject the store answers carried nothing")
+	}
+	var resp spawnHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not the PreToolUse shape: %v (%q)", err, out)
+	}
+	if resp.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Errorf("wrong event name: %q", resp.HookSpecificOutput.HookEventName)
+	}
+	if resp.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("a memory must not turn a spawn into a prompt: %q",
+			resp.HookSpecificOutput.PermissionDecision)
+	}
+	// Every field of the original input has to come back. A PreToolUse reply
+	// replaces the input rather than merging into it, so a dropped field here
+	// silently loses the agent type or the description the parent chose.
+	for _, f := range []string{"prompt", "subagent_type", "description"} {
+		if _, ok := resp.HookSpecificOutput.UpdatedInput[f]; !ok {
+			t.Errorf("updatedInput dropped %q", f)
+		}
+	}
+	var prompt string
+	if err := json.Unmarshal(resp.HookSpecificOutput.UpdatedInput["prompt"], &prompt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(prompt, "Investigate the pgbouncer prepared statement failure") {
+		t.Errorf("the parent's instructions were not kept intact: %q", prompt[:60])
+	}
+	if !strings.Contains(prompt, "default_query_exec_mode") {
+		t.Errorf("the recall did not reach the subagent's prompt: %q", prompt)
+	}
+}
+
+// The tool that spawns an agent is called Task in Claude Code and Agent in
+// hosts that renamed it. Both are the same event and both must be answered,
+// because the wiring matches on the name.
+func TestSpawnHookAnswersBothNames(t *testing.T) {
+	for _, name := range []string{"Task", "Agent", "task", "subagent"} {
+		if !isSpawnTool(name) {
+			t.Errorf("%q is a spawn and was not recognised", name)
+		}
+	}
+	for _, name := range []string{"Bash", "Edit", "Write", "TaskOutput"} {
+		if isSpawnTool(name) {
+			t.Errorf("%q is not a spawn", name)
+		}
+	}
+}
+
+// Silence is the default here as everywhere else: a spawn about work the store
+// knows nothing about is left exactly as the parent wrote it.
+func TestSpawnHookStaysSilentWithNothingToSay(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "app", "past.jsonl"), "past", []string{
+		`{"type":"user","sessionId":"past","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"rename the changelog heading"}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":`+
+		`{"prompt":"Port the kubernetes admission webhook to the new cert rotation scheme."},"session_id":"parent"}`)
+	if got != "" {
+		t.Errorf("spoke about work it has no history of: %q", got)
+	}
+	// A spawn with no prompt at all is not something to answer either.
+	got = toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":{"description":"x"},"session_id":"parent"}`)
+	if got != "" {
+		t.Errorf("answered a spawn with no instructions: %q", got)
+	}
+}

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -72,9 +72,18 @@ type toolHookInput struct {
 }
 
 func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
+	raw := readHookPayload(stdin, hookStdinWait)
 	var input toolHookInput
-	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	_ = json.NewDecoder(bytes.NewReader(raw)).Decode(&input)
 	adoptHookCWD(input.CWD)
+	// Spawning an agent is the one action whose reply has to reach someone
+	// other than the caller, so it answers in its own shape. See hook_spawn.go.
+	if isSpawnTool(input.ToolName) {
+		if !planIndexReady(dir) {
+			return nil
+		}
+		return runHookSpawn(dir, input, raw, stdout)
+	}
 	// Never build or repair from here. This runs inside an action the user is
 	// waiting on, and a miss costs nothing while a rebuild costs seconds.
 	if !planIndexReady(dir) {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -961,7 +961,11 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	// Recall at the moment of the action: before an edit or a command, hook-tool
 	// names the file's or command's prior decision. Scoped to the tools that
 	// change something so it never fires on a Read or a Glob.
-	nextRoot = updateClaudeHook(nextRoot, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit", uninstall)
+	// Task and Agent are the same event under two names: the parent spawning a
+	// subagent. That agent gets no session start and sends no user prompt, so
+	// its instructions are the only place memory can reach it, and hook-tool
+	// answers this one by rewriting them rather than by speaking to the parent.
+	nextRoot = updateClaudeHook(nextRoot, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", uninstall)
 	// The other half of the point of action: the pre-tool line speaks before a
 	// command runs, this one speaks when it failed and the store knows what
 	// followed that error before. Bash only — a failed edit does not carry a

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -47,7 +47,7 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	root = updateClaudeHook(root, "PreCompact", exe+" hook-precompact", "manual|auto", false)
 	root = updateClaudeHook(root, "UserPromptSubmit", exe+" hook-prompt", "", false)
 	// Scoped to the tools that change something, so it never fires on a read.
-	root = updateClaudeHook(root, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit", false)
+	root = updateClaudeHook(root, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", false)
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return installResult{}, err


### PR DESCRIPTION
Most of the agent work on this machine happens inside spawned subagents, and none of it had memory.

Counted on the real store, over sessions where deja was installed and available:

```
                        sessions   got a recall   called the tool
own session                   39            10%               33%
Task/Agent subagent          289             1%                0%
```

The 1% is measurement noise — those files contain the words because the agent was reading deja's own source. The real number is zero, and the reason is structural rather than a bar set too high: the per-prompt hook fires on what a person types, and a subagent's prompt is not typed, it is a tool input the parent wrote. Session start does not fire for it either. So the surface that carries memory never sees the agent doing the reviewing, the hunting and the migrating.

PreToolUse is the one event that can still reach it, because its reply can rewrite the tool's input. `hook-tool` now answers a spawn by running the parent's instructions through the same recall the per-prompt hook uses — same bar, same dedup, same trust policy — and appending what comes back to the prompt the subagent is about to receive.

Fed the 622 real spawns in this store, it carries memory into 14 of 25 sampled, at 800–1600 bytes each.

Three details worth reviewing.

The reply returns the whole tool input, not just the prompt: a PreToolUse reply replaces the input rather than merging into it, so a dropped field would silently lose the subagent_type or the model the parent chose. The test asserts every field survives.

Dedup is keyed on the parent plus the instructions, not on the parent's session id. Sharing the parent's key would withhold from an agent that has never seen anything because the parent saw it a minute ago, and would make ten agents spawned together count as one reader.

`permissionDecision` is `allow`. This changes what the agent is told, not what it may do, and a permission prompt on every spawn would make the memory the most annoying thing in the session.

The matcher gains `Task|Agent` — the same event under two names, depending on the host.
