### PR TITLE
fix: size the dedup map without summing two lengths

### DIFF
--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -166,7 +166,10 @@ func hasLetterOrDigit(s string) bool {
 }
 
 func appendUnique(dst []string, values ...string) []string {
-	seen := make(map[string]bool, len(dst)+len(values))
+	// Sized on dst alone. The sum is the same map either way — it grows on its
+	// own — and adding two lengths is what the allocation-size analyser reads
+	// as an overflow candidate.
+	seen := make(map[string]bool, len(dst))
 	for _, v := range dst {
 		seen[v] = true
 	}


### PR DESCRIPTION
CodeQL flags `make(map[string]bool, len(dst)+len(values))` in `appendUnique` as an allocation-size overflow, twice, high severity. The code is from #1430 and unchanged; it surfaced now because the tokeniser move in #2136 put the file in a package the diff touched.

The hint is only a hint — the map grows either way — so sizing on `dst` alone removes the sum and keeps the allocation. Blocking #2143, which is otherwise green.