### PR TITLE
fix(search): reach a Russian word glued to a Latin prefix in any case

### DIFF
--- a/cmd/deja/search_glued_token_test.go
+++ b/cmd/deja/search_glued_token_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A word glued to a Latin prefix has no part of its own in the index — nothing
+// splits "k8sнастройки" — so the substring rung is the only road to it, and
+// that rung looked for the query token as typed. The store's own case reached
+// it and no other did, which is the guess deja exists to spare the reader
+// (#2145).
+func TestAGluedWordIsReachableInAnotherCase(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for sid, text := range map[string]string{
+		"s1": "смотрел k8sнастройки кластера",
+		"s2": "чинил v2обработчик вебхука",
+		"s3": "ничего общего: графики и дашборды",
+		// The four-rune floor's case: "тест" sits at the end of "манифест",
+		// and the two words have nothing to do with each other.
+		"s4": "гонял манифест кластера через ci",
+		"s5": "чинил автотест воркера ночью",
+	} {
+		rec := claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/tmp/app",
+			"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": text},
+		})
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the store's own spelling reaches it.
+	for _, tc := range []struct{ query, want string }{
+		{"настройки кластера", "s1"},
+		{"обработчик вебхука", "s2"},
+	} {
+		if out, _ := captureRun(t, "search", tc.query); !strings.Contains(out, tc.want) {
+			t.Fatalf("%q does not reach %s, so this measures nothing:\n%s", tc.query, tc.want, out)
+		}
+	}
+	// The case nobody types a month later.
+	for _, tc := range []struct{ query, want string }{
+		{"настройка кластера", "s1"},
+		{"настройками кластера", "s1"},
+		{"обработчику вебхука", "s2"},
+	} {
+		out, _ := captureRun(t, "search", tc.query)
+		if !strings.Contains(out, tc.want) {
+			t.Errorf("%q does not reach %s, which says the word in another case:\n%s", tc.query, tc.want, out)
+		}
+	}
+	// And the rung has not become a wildcard. A word the store never says
+	// finds nothing in any case, and neither does one whose short form sits
+	// at the end of an unrelated token — "тест" inside "манифест", which is
+	// what the four-rune floor is there to refuse.
+	for _, q := range []string{"миграции кластера", "миграция кластера", "тесты кластера", "тест кластера"} {
+		out, _ := captureRun(t, "search", q)
+		for _, sid := range []string{"s1", "s2", "s3", "s4"} {
+			if strings.Contains(out, sid) {
+				t.Errorf("%q matched %s, which never says it:\n%s", q, sid, out)
+			}
+		}
+	}
+	// What it does admit, and on purpose: a word really inside a longer one.
+	// "автотест" is an autotest, and a reader asking about tests wants it —
+	// the same trade the substring rung makes when "code" reaches "opencode".
+	if out, _ := captureRun(t, "search", "тесты воркера"); !strings.Contains(out, "s5") {
+		t.Errorf("\"тесты воркера\" does not reach the autotest session:\n%s", out)
+	}
+	// The queries that do reach must not drag the unrelated sessions with them.
+	for _, q := range []string{"настройка кластера", "обработчику вебхука"} {
+		out, _ := captureRun(t, "search", q)
+		for _, sid := range []string{"s3", "s4"} {
+			if strings.Contains(out, sid) {
+				t.Errorf("%q reached %s, which shares nothing with it:\n%s", q, sid, out)
+			}
+		}
+	}
+}

--- a/cmd/deja/search_mixed_script_test.go
+++ b/cmd/deja/search_mixed_script_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A token that mixes scripts — `api_настройки`, `webhook-обработчик` — takes
+// the ASCII path through the form rules, because isCyrToken stops at the first
+// Latin rune. Nothing pins what the reader gets: the reach comes from the
+// parts the indexer splits out and from the close tier, not from the Russian
+// endings, and both are a rung away from the token itself.
+func TestAMixedScriptTokenIsStillReachable(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for sid, text := range map[string]string{
+		"s1": "поправил api_настройки воркера",
+		"s2": "чинил webhook-обработчик в проде",
+		"s3": "смотрел k8sнастройки кластера",
+	} {
+		rec := claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/tmp/app",
+			"timestamp": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": text},
+		})
+		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct{ query, want string }{
+		// The store's own spelling.
+		{"api_настройки", "s1"},
+		{"webhook-обработчик", "s2"},
+		{"k8sнастройки", "s3"},
+		// And another case of the Russian half, which is how someone would
+		// actually type it a month later.
+		{"api_настройка", "s1"},
+		{"webhook-обработчику", "s2"},
+		{"k8sнастройка", "s3"},
+		// The Russian half on its own reaches the token it is part of.
+		{"настройками воркера", "s1"},
+	} {
+		out, _ := captureRun(t, "search", tc.query)
+		if !strings.Contains(out, tc.want) {
+			t.Errorf("%q does not reach %s:\n%s", tc.query, tc.want, out)
+		}
+	}
+	// And it is not reaching everything: a Russian word the store does not
+	// hold finds nothing, mixed token or not.
+	if out, _ := captureRun(t, "search", "миграции кластера"); strings.Contains(out, "s1") {
+		t.Errorf("a word no session says matched anyway:\n%s", out)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2469,9 +2469,16 @@ func stemPostings(dir string, terms, phrases []string) ([]posting, map[string][]
 		return nil, nil, err
 	}
 	matchesPer := make([][]string, len(terms))
-	anchored := 0
 	for i, term := range terms {
 		matchesPer[i] = stemMatches(term, catalog)
+	}
+	// Whatever the catalog has no whole word for gets one pass looking for the
+	// word inside a token that glued it to something else. One pass for all of
+	// them: the catalog is ~200k tokens on a real store, which is the walk the
+	// fuzzy tier goes out of its way not to do per term.
+	fillGluedMatches(terms, matchesPer, catalog)
+	anchored := 0
+	for i := range terms {
 		if len(matchesPer[i]) > 0 {
 			anchored++
 		}
@@ -2564,6 +2571,77 @@ func hasStemToken(terms []string) bool {
 		}
 	}
 	return false
+}
+
+// fillGluedMatches finds a term's other forms inside tokens that glued the
+// word to something else: "k8sнастройки" holds "настройки" and is one token,
+// so nothing splits it and stemMatches, which asks the catalog for whole
+// words, comes back empty. The reader then has to type the case the transcript
+// used, in the one place deja normally spares them that (#2145).
+//
+// Only when the whole-word lookup found nothing, only at the ends of the
+// token, only for forms of four runes or more, and only for Cyrillic terms.
+// That last one is the point rather than caution: Russian is where a word has
+// a dozen endings and the reader cannot be expected to guess which one the
+// transcript used, while in Latin the same rule reaches "latest" from "tests"
+// and "preserve" from "press". English compounds have their own road — the
+// indexer splits them into parts — and this one would only add coincidences.
+func fillGluedMatches(terms []string, matchesPer [][]string, catalog map[string]bool) {
+	formsPer := make([][]string, len(terms))
+	want := false
+	for i, term := range terms {
+		if len(matchesPer[i]) > 0 || len([]rune(term)) < 5 || !isCyrToken(term) {
+			continue
+		}
+		for _, f := range append(stemMatchForms(term), term) {
+			// Four runes is the floor: a shorter fragment at the end of a long
+			// token is a coincidence more often than a word.
+			if len([]rune(f)) >= 4 {
+				formsPer[i] = append(formsPer[i], f)
+				want = true
+			}
+		}
+	}
+	if !want {
+		return
+	}
+	found := make([]map[string]bool, len(terms))
+	for tok := range catalog {
+		for i, forms := range formsPer {
+			for _, f := range forms {
+				// The token has to be the word plus something, and the
+				// something is what makes this rung necessary — so the length
+				// is measured against the form, not against the term, which is
+				// the longer of the two when the query is in a case with a long
+				// ending. Runes on both sides: a byte comparison would admit a
+				// token one byte longer, which in Cyrillic is no character at
+				// all.
+				if len([]rune(tok)) <= len([]rune(f)) ||
+					(!strings.HasPrefix(tok, f) && !strings.HasSuffix(tok, f)) {
+					continue
+				}
+				if found[i] == nil {
+					found[i] = map[string]bool{}
+				}
+				found[i][tok] = true
+				break
+			}
+		}
+	}
+	for i, set := range found {
+		if len(set) == 0 {
+			continue
+		}
+		out := make([]string, 0, len(set))
+		for tok := range set {
+			out = append(out, tok)
+		}
+		sort.Strings(out)
+		if len(out) > 8 {
+			out = out[:8]
+		}
+		matchesPer[i] = out
+	}
 }
 
 func stemMatches(term string, catalog map[string]bool) []string {


### PR DESCRIPTION
Fixes #2145. A word glued to a Latin prefix is one token, so `identifierParts` never splits it and the whole-word catalog lookup finds nothing. The only road left was the substring rung, which asks whether the indexed token contains the query token *as typed*:

```
"настройки кластера"   s1     ("настройки" is inside "k8sнастройки")
"настройка кластера"   —      nothing
"обработчику вебхука"  —      nothing
```

So the reader has to guess the case the transcript used, in the one place deja normally spares them that. In Russian that is the ordinary way to type a query.

When the whole-word lookup comes back empty, the stem tier now looks for the term's forms at the ends of a token, and the answer says what it did:

```
"настройка кластера"   s1     word forms: настройка -> k8sнастройки
```

Cyrillic terms only, and that is the point rather than caution — review found the Latin version of this rule reaching "latest" from "tests" and "preserve" from "press", and English compounds already have their own road through the indexer's parts. Four runes is the floor, the token has to be longer than the form, both measured in runes, and one pass over the catalog covers every term rather than one pass each — the walk the fuzzy tier goes out of its way to avoid.

A first attempt widened the substring rung instead. It reached the same sessions and broke three tier tests: queries the stem tier used to answer were pre-empted a rung earlier, so the reader got "close spellings" where "word forms" is the true sentence.

What it admits on purpose: a word really inside a longer one — "тесты" reaches a session about "автотест", the trade the substring rung already makes when "code" reaches "opencode". The test pins that alongside the misses.
