### PR TITLE
feat(opencode): carry recall into a spawned agent

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -238,9 +238,32 @@ export const DejaRecall = async ({ $, client }) => {
         // memory is optional: never break the session over it
       }
     },
+    // A spawned agent gets none of the above: the system prompt is built for
+    // the session that spawned it and the per-prompt pass fires on what the
+    // user typed, which a subagent never does. Its instructions are the one
+    // thing that reaches it, so recall goes in there.
+    "tool.execute.before": async (input, output) => {
+      try {
+        if (input?.tool !== "task") return
+        const args = output?.args
+        if (!args?.prompt) return
+        const payload = JSON.stringify({
+          hook_event_name: "PreToolUse",
+          tool_name: "Task",
+          tool_input: { prompt: args.prompt },
+          session_id: input.sessionID || "",
+        })
+        const raw = await $%secho ${JSON.stringify(payload)} | %s%q hook-tool%s.text()
+        if (!raw.trim()) return
+        const next = JSON.parse(raw)?.hookSpecificOutput?.updatedInput?.prompt
+        if (next) args.prompt = next
+      } catch {
+        // memory is optional: never break a spawn over it
+      }
+    },
   }
 }
-`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", exe, "`", "`", "", exe, "`")
+`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", exe, "`", "`", "", exe, "`", "`", "", exe, "`")
 }
 
 // Gemini CLI and Qwen Code both run a command before the agent loop, which is

--- a/cmd/deja/warmup_status_test.go
+++ b/cmd/deja/warmup_status_test.go
@@ -237,6 +237,30 @@ func TestOpencodePluginRecallsPerPrompt(t *testing.T) {
 	}
 }
 
+// opencode spawns agents through its `task` tool — 817 of them on the store
+// this was measured against — and none of the plugin's other hooks reach one:
+// the system prompt is built for the session that spawned it, and the
+// per-prompt pass fires on what a person typed. Its instructions are the only
+// thing that arrives, so recall has to be put there.
+func TestOpencodePluginCarriesRecallIntoASpawnedAgent(t *testing.T) {
+	src := opencodePluginJS("/bin/deja")
+	for _, want := range []string{
+		"tool.execute.before",
+		`input?.tool !== "task"`,
+		"hook-tool",
+		"updatedInput",
+	} {
+		if !strings.Contains(src, want) {
+			t.Fatalf("generated plugin missing %q:\n%s", want, src)
+		}
+	}
+	// The spawn is rewritten, not blocked, and a spawn deja has nothing to say
+	// about keeps the prompt its parent wrote.
+	if !strings.Contains(src, "if (next) args.prompt = next") {
+		t.Fatalf("plugin does not leave a silent recall alone:\n%s", src)
+	}
+}
+
 // Compaction throws away the working transcript. Claude Code gets it indexed
 // first through PreCompact; opencode fires experimental.session.compacting at
 // the same moment and was going unused.


### PR DESCRIPTION
The opencode half of #2143.

opencode spawns agents through its `task` tool — 817 calls on the store I measured — and none of the plugin's existing hooks reach one. The system prompt is transformed for the session that spawned it, and the per-prompt pass fires on what a person typed, which a subagent never does. So a spawned opencode agent starts with nothing, exactly like the Claude Code case.

`tool.execute.before` hands the plugin the tool's arguments and lets it mutate them, which is the same lever `updatedInput` gives on the Claude side. The plugin now shells out to the same `hook-tool` — one implementation, same bar, same dedup — and replaces `args.prompt` only when something came back.

Fed opencode's own 817 spawns, memory reaches 20 of 30 sampled, 600–1900 bytes each.

Note for review: this touches the generated plugin, so `deja install opencode-auto` has to run again for an existing install to pick it up.