### PR TITLE
fix(completion): complete --json and --from for deja last

### DIFF
--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -113,7 +113,7 @@ _deja_completion() {
             elif [[ "$prev" == "--role" ]]; then
                 COMPREPLY=( $(compgen -W "%ROLES%" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--harness --project --since --role" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--json --from --harness --project --since --role" -- "$cur") )
             fi
             ;;
         remember)
@@ -247,7 +247,7 @@ _deja() {
       _arguments '--no-guidance[skip guidance files]' "1:target:($install_targets)"
       ;;
     last)
-      _arguments '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
+      _arguments '--json[print JSON]' '--from=[which machine]:origin:(machine local)' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '1:count:'
       ;;
     remember)
       _arguments '--project=[note project]:project:' '*--tag=[tag the note, repeatable]:tag:' '1:text:'
@@ -330,6 +330,8 @@ complete -c deja -n '__fish_seen_subcommand_from show' -l json
 complete -c deja -n '__fish_seen_subcommand_from show' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from show' -l offset -r
 complete -c deja -n '__fish_seen_subcommand_from show' -l limit -r
+complete -c deja -n '__fish_seen_subcommand_from last' -l json
+complete -c deja -n '__fish_seen_subcommand_from last' -l from -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from last' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from last' -l since -r
@@ -414,7 +416,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
             'last' {
                 if ($previous -eq '--harness') { $harnesses }
                 elseif ($previous -eq '--role') { @('user', 'assistant', 'tool') }
-                else { @('--harness', '--project', '--since', '--role') }
+                else { @('--json', '--from', '--harness', '--project', '--since', '--role') }
             }
             'remember' { @('--project', '--tag') }
             'resume' { @('--exec') }


### PR DESCRIPTION
@vaibhav8a's commit from #2026, carried here because that branch is behind main and conflicts in `completion.go`, and I cannot rebase a fork branch I have no push access to. The commit is his, unchanged apart from the conflict resolution and the one review point.

Two things I did on top rather than sending him back for them:

The fish block now sits alongside the `show` completions #2021 added, which is what conflicted.

The zsh description for `--from` said "start from a session" and completed a session id. It takes `machine|local`, so it now says which machine and offers those two values.

Closes #1925, and closes #2026 with credit to him.