### PR TITLE
fix(grok): compare stamps in the shapes the reader accepts

### DIFF
--- a/internal/sources/grok_since_shapes_test.go
+++ b/internal/sources/grok_since_shapes_test.go
@@ -1,0 +1,113 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// grokShapeDB writes the same two messages with whichever stamp shape the
+// caller names — grokDBTime reads all of them, so the filter has to as well.
+func grokShapeDB(t *testing.T, early, late string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "grok.db")
+	schema := `
+CREATE TABLE workspaces (id TEXT PRIMARY KEY, canonical_path TEXT);
+CREATE TABLE sessions (id TEXT PRIMARY KEY, workspace_id TEXT, title TEXT, cwd_last TEXT, created_at TEXT);
+CREATE TABLE messages (session_id TEXT, seq INTEGER, role TEXT, message_json TEXT, created_at TEXT);
+INSERT INTO sessions VALUES ('s1','w1','Pool timeouts','/work/api','` + early + `');
+INSERT INTO messages VALUES ('s1',0,'user','{"role":"user","content":"connection pool exhausted again"}','` + early + `');
+INSERT INTO messages VALUES ('s1',1,'assistant','{"role":"assistant","content":[{"type":"text","text":"raise max_conns"}]}','` + late + `');
+`
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = stringsReader(schema)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	return db
+}
+
+// The filter compared strings while the reader parsed three shapes, so a store
+// writing sqlite's own "2026-07-27 15:29:47" had every same-day message read
+// as older than the watermark: a space sorts below the T of an RFC3339 string.
+// Nothing reached the index until the date rolled over (#2150, the shape #2030
+// fixed for goose).
+func TestGrokSinceHandlesEveryStampShapeItReads(t *testing.T) {
+	for _, shape := range []struct {
+		name, early, late string
+	}{
+		{"rfc3339", "2026-07-27T10:00:00.000Z", "2026-07-27T15:29:47.000Z"},
+		{"sqlite", "2026-07-27 10:00:00", "2026-07-27 15:29:47"},
+		// A stamp carrying an offset rather than Z: normalising both sides
+		// converts it, where a text comparison reads the digits as written.
+		{"offset", "2026-07-27T13:00:00+03:00", "2026-07-27T18:29:47+03:00"},
+	} {
+		t.Run(shape.name, func(t *testing.T) {
+			db := grokShapeDB(t, shape.early, shape.late)
+			count := func(cut string) int {
+				at, err := time.Parse(time.RFC3339, cut)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ss, err := ParseGrokDBSince(db, at)
+				if err != nil {
+					t.Fatal(err)
+				}
+				n := 0
+				for _, s := range ss {
+					n += len(s.Messages)
+				}
+				return n
+			}
+			// The premise: both messages are there when nothing is filtered.
+			ss, err := ParseGrokDBSince(db, time.Time{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ss) != 1 || len(ss[0].Messages) != 2 {
+				t.Fatalf("unfiltered read: %d session(s), want one with two messages", len(ss))
+			}
+			if n := count("2026-07-27T09:00:00Z"); n != 2 {
+				t.Errorf("a watermark earlier the same day returned %d messages, want both", n)
+			}
+			if n := count("2026-07-27T12:00:00Z"); n != 1 {
+				t.Errorf("a watermark between the two returned %d messages, want the later one", n)
+			}
+			if n := count("2026-07-27T16:00:00Z"); n != 0 {
+				t.Errorf("a watermark after both returned %d messages, want none", n)
+			}
+			// The boundary: a message stamped at the watermark is already in
+			// the index, and one a fraction of a second later is not.
+			if n := count("2026-07-27T15:29:47Z"); n != 0 {
+				t.Errorf("a watermark exactly at the later message returned %d, want none", n)
+			}
+		})
+	}
+}
+
+// A stamp sqlite cannot read normalises to null. Such a row comes back on
+// every incremental pass rather than disappearing from all of them: an
+// unreadable stamp is a reason to look at a message, not to hide it — the rule
+// zed's reader already follows.
+func TestGrokSinceKeepsAMessageWithAnUnreadableStamp(t *testing.T) {
+	db := grokShapeDB(t, "2026-07-27 10:00:00", "not a timestamp at all")
+	at, err := time.Parse(time.RFC3339, "2026-07-27T16:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGrokDBSince(db, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, s := range ss {
+		n += len(s.Messages)
+	}
+	if n != 1 {
+		t.Errorf("%d message(s) came back, want the one whose stamp cannot be read", n)
+	}
+}

--- a/internal/sources/grokdb.go
+++ b/internal/sources/grokdb.go
@@ -38,7 +38,22 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 	}
 	where := ""
 	if !t.IsZero() {
-		where = " and m.created_at > '" + sqlEscape(t.UTC().Format(time.RFC3339Nano)) + "'"
+		// Both sides normalised, the way the zed reader does it, because the
+		// two are written in different shapes: grokDBTime reads sqlite's own
+		// "2026-07-27 15:29:47" as happily as an RFC3339 string, and compared
+		// as text a space sorts below the T — so on such a store every message
+		// stamped later the same day read as older than the watermark and
+		// nothing reached the index until the date rolled over (#2150, the
+		// shape #2030 fixed for goose).
+		//
+		// strftime rather than datetime: datetime() drops the fraction, and a
+		// message half a second after the watermark would compare equal to it
+		// and be left out. A stamp sqlite cannot read at all normalises to
+		// null, and those rows are kept rather than dropped — an unreadable
+		// stamp is a reason to look at a message, not to hide it.
+		const norm = `strftime('%Y-%m-%dT%H:%M:%f',m.created_at)`
+		w := sqlEscape(t.UTC().Format("2006-01-02T15:04:05.000"))
+		where = " and (" + norm + " is null or " + norm + " > '" + w + "')"
 	}
 	q := `select s.id as id,s.cwd_last as cwd,s.title as title,` +
 		`m.role as role,m.message_json as body,m.created_at as at ` +


### PR DESCRIPTION
Fixes #2150. `grokDBTime` reads three stamp shapes; the since clause compared one of them as text:

```
filter:  m.created_at > '2026-07-27T09:00:00Z'
reader:  RFC3339Nano | RFC3339 | "2006-01-02 15:04:05"
```

A store writing sqlite's own space-separated stamp is read back correctly and filtered wrongly — at position 11 a space sorts below `T`:

```
all                              1 session, 2 messages
since 2026-07-27T09:00:00Z    -> 0 sessions, 0 messages
since 2026-07-27T12:00:00Z    -> 0 sessions, 0 messages
since 2026-07-26T09:00:00Z    -> 1 session,  2 messages
```

Nothing from the day of the work reaches the index until the date rolls over. Goose had this and #2030 fixed it; grok kept the text comparison.

Both sides are normalised now, the way zed's reader does it. `strftime` rather than `datetime`, for two reasons review found in the first version: `datetime()` drops the fraction, so a message later in the same second as the watermark is dropped forever, and `datetime()` of an unparseable stamp is NULL, which would have hidden such rows from every incremental pass instead of showing them. Null normalises are kept, and there is a test for that.

Worth knowing when weighing this: `setStoreLastUpdated` stamps a watermark for opencode, goose and cursor only, so `ParseGrokDBSince` runs with a zero time in production today and this clause is unreachable outside tests. It is a landmine removed before grok joins that list, not a fault a reader is hitting now. Noted on the issue too.

The rest of the sweep the queue item asked for: goose normalises both sides, zed normalises with strftime, hermes filters and reads the same REAL seconds, cursor and opencode go through `newerThanEpoch`. Grok was the one left.
