### PR TITLE
perf(index): stop re-reading a whole transcript to verify an append

### DIFF
--- a/internal/index/freshness_reuse_test.go
+++ b/internal/index/freshness_reuse_test.go
@@ -17,14 +17,14 @@ func TestUnchangedFilesKeepTheirDerivedState(t *testing.T) {
 
 	first := currentFilesWith("", nil)
 	fs, ok := first[path]
-	if !ok || fs.SafeSize == 0 || fs.PrefixHash == 0 {
+	if !ok || fs.SafeSize == 0 || fs.PrefixSample == 0 {
 		t.Fatalf("derived state missing on a first walk: %+v", fs)
 	}
 
 	// Unchanged file: the values must come back identical without being
 	// recomputed, which is what makes the walk a stat pass.
 	second := currentFilesWith("", first)
-	if second[path].SafeSize != fs.SafeSize || second[path].PrefixHash != fs.PrefixHash {
+	if second[path].SafeSize != fs.SafeSize || second[path].PrefixSample != fs.PrefixSample {
 		t.Fatalf("carried state differs: %+v vs %+v", second[path], fs)
 	}
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -126,6 +126,20 @@ type FileState struct {
 	// looks exactly like an append. Without this the rewritten prefix keeps
 	// its old text in the index and the new text is never read.
 	PrefixHash uint64 `json:"prefix_hash,omitempty"`
+	// PrefixSample fingerprints the same span without reading all of it: the
+	// head, the bytes just before SafeSize, and SafeSize itself. The full hash
+	// costs a read of the whole transcript on every search that finds the file
+	// changed, which on a session being written right now is every search —
+	// measured at 1.70s per call against a 250 MB transcript, growing with it.
+	//
+	// It catches what PrefixHash exists to catch. A rewind truncates and
+	// rewrites from the truncation point, so either that point is past
+	// SafeSize and the indexed bytes are genuinely untouched, or it is before
+	// it and the window ending at SafeSize falls inside the rewritten region.
+	//
+	// PrefixHash stays for manifests written before this existed; they verify
+	// the old way once, and the next walk records a sample.
+	PrefixSample uint64 `json:"prefix_sample,omitempty"`
 }
 
 type SessionMeta struct {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -2316,8 +2317,18 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 		// that truncates and regrows past the old length looks exactly like
 		// an append, and appending onto it leaves the rewritten prefix in the
 		// index with its old text. Compare the prefix before trusting it.
-		if of.PrefixHash != 0 && filePrefixHash(p, of.SafeSize) != of.PrefixHash {
-			return false
+		switch {
+		case of.PrefixSample != 0:
+			if filePrefixSample(p, of.SafeSize) != of.PrefixSample {
+				return false
+			}
+		case of.PrefixHash != 0:
+			// A manifest from before the sample existed. Verified the old way
+			// this once; the walk above has already recorded a sample, so the
+			// next call is bounded.
+			if filePrefixHash(p, of.SafeSize) != of.PrefixHash {
+				return false
+			}
 		}
 		switch harnessForPath(p) {
 		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot", "grok":
@@ -2743,9 +2754,10 @@ func currentFilesWith(h string, old map[string]FileState) map[string]FileState {
 				// this is the difference between a stat and 650 ms of reading.
 				if of, ok := old[p]; ok && of.Size == fs.Size && of.MTime == fs.MTime {
 					fs.SafeSize, fs.PrefixHash = of.SafeSize, of.PrefixHash
+					fs.PrefixSample = of.PrefixSample
 				} else {
 					fs.SafeSize = lastCompleteLineOffset(p, fi.Size())
-					fs.PrefixHash = filePrefixHash(p, fs.SafeSize)
+					fs.PrefixSample = filePrefixSample(p, fs.SafeSize)
 				}
 			}
 			if harnessForPath(p) == "grok" {
@@ -2899,9 +2911,51 @@ func preRedactSessions(m *Manifest, ss []model.Session) {
 	wg.Wait()
 }
 
+// prefixSampleWindow is how much is read at each end. Large enough that a
+// rewrite cannot plausibly reproduce it byte for byte, small enough that the
+// cost does not depend on how long the session has been running.
+const prefixSampleWindow = 512 << 10
+
+// filePrefixSample fingerprints the first n bytes by reading at most two
+// windows of them: the head and the bytes ending at n. n is mixed in, so a
+// file that grew and one that was rewritten to the same content at a
+// different length do not collide.
+func filePrefixSample(path string, n int64) uint64 {
+	if n <= 0 {
+		return 0
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	h := fnv.New64a()
+	var b [8]byte
+	binary.LittleEndian.PutUint64(b[:], uint64(n))
+	_, _ = h.Write(b[:])
+	head := min(n, prefixSampleWindow)
+	if _, err := io.Copy(h, io.LimitReader(f, head)); err != nil {
+		return 0
+	}
+	if n > head {
+		start := max(head, n-prefixSampleWindow)
+		if _, err := f.Seek(start, io.SeekStart); err != nil {
+			return 0
+		}
+		if _, err := io.Copy(h, io.LimitReader(f, n-start)); err != nil {
+			return 0
+		}
+	}
+	return h.Sum64()
+}
+
 // filePrefixHash fingerprints the first n bytes of a file. Only used to decide
 // whether an append is safe, so a fast non-cryptographic hash is the right
 // tool: a collision costs one unnecessary full reparse, never a wrong index.
+//
+// Kept for manifests written before filePrefixSample: those store a hash of
+// every byte, and it takes one more read to verify them before the walk
+// records a sample instead.
 func filePrefixHash(path string, n int64) uint64 {
 	if n <= 0 {
 		return 0

--- a/internal/index/prefix_sample_test.go
+++ b/internal/index/prefix_sample_test.go
@@ -1,0 +1,102 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sampleLine(body string) string {
+	return claudeLine("s1", "2026-01-01T00:00:00Z", body+strings.Repeat("x", 200))
+}
+
+// The sample has to catch what the full hash caught: a transcript truncated
+// and rewritten past its old length, which looks exactly like an append. It is
+// caught wherever the rewrite starts — either past SafeSize, where the indexed
+// bytes really are untouched, or before it, where the window ending at
+// SafeSize falls inside the rewritten region.
+func TestPrefixSampleCatchesARewriteAtEveryDepth(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	var b strings.Builder
+	for i := 0; i < 4000; i++ {
+		b.WriteString(sampleLine("original "))
+	}
+	original := b.String()
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	size := int64(len(original))
+	want := filePrefixSample(path, size)
+	if want == 0 {
+		t.Fatal("no sample for a file that exists")
+	}
+
+	for _, depth := range []float64{0, 0.25, 0.5, 0.9, 0.999} {
+		keep := int(float64(len(original)) * depth)
+		var r strings.Builder
+		r.WriteString(original[:keep])
+		for r.Len() < len(original)+5000 {
+			r.WriteString(sampleLine("rewritten "))
+		}
+		if err := os.WriteFile(path, []byte(r.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := filePrefixSample(path, size); got == want {
+			t.Errorf("a rewrite keeping the first %.1f%% passed as an append", depth*100)
+		}
+	}
+
+	// An append still verifies: the bytes up to the old size are the same
+	// bytes, so the sample over them is unchanged.
+	if err := os.WriteFile(path, []byte(original+sampleLine("appended ")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := filePrefixSample(path, size); got != want {
+		t.Errorf("an append was rejected: %d != %d", got, want)
+	}
+}
+
+// The bounded read stated as a property rather than as a duration, which a
+// busy machine would make flaky: two files differing only in the middle share
+// a sample. That is the trade this makes. A rewind rewrites from its
+// truncation point to the end, so it always disturbs the window ending at
+// SafeSize; a rewrite that changes only the middle, keeps both windows and
+// lands on exactly the same length is not something a transcript does.
+func TestPrefixSampleDoesNotReadTheMiddle(t *testing.T) {
+	dir := t.TempDir()
+	big := []byte(strings.Repeat("a", 4<<20))
+	a := filepath.Join(dir, "a.jsonl")
+	if err := os.WriteFile(a, big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	middle := append([]byte(nil), big...)
+	middle[len(middle)/2] = 'b'
+	b := filepath.Join(dir, "b.jsonl")
+	if err := os.WriteFile(b, middle, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if filePrefixSample(a, int64(len(big))) != filePrefixSample(b, int64(len(middle))) {
+		t.Fatalf("the sample covers the middle, so the read is not bounded after all")
+	}
+}
+
+// A file shorter than one window is covered end to end, which is the case
+// every ordinary transcript starts in.
+func TestPrefixSampleCoversASmallFileWhole(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.jsonl")
+	body := []byte(strings.Repeat("a", 4096))
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := filePrefixSample(path, int64(len(body)))
+	body[len(body)/2] = 'b'
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if filePrefixSample(path, int64(len(body))) == want {
+		t.Fatal("a change inside a small file went unnoticed")
+	}
+}


### PR DESCRIPTION
Every search that finds a transcript changed hashes that transcript's entire indexed prefix before trusting the append. For a session being written right now — the one the agent is in — that is every search, and the cost grows with the session.

Measured on a store with one growing transcript, one line appended between reads:

```
transcript   read after one appended line
             before      after
    1 MB      0.04s      0.04s
   25 MB      0.15s      0.07s
  100 MB      0.26s      0.07s
  250 MB      1.70s      0.36s
```

This machine's live store has transcripts of 445 MB, 159 MB and 80 MB open at once, and hashing them costs 0.65s of every read path before any searching happens. It showed up first as `deja_blame` timing out in real agent sessions: 8 of 269 calls, all `MCP error -32001: Request timed out` or aborted.

The guard is still a guard. It reads the head and the window ending at SafeSize, and mixes in SafeSize itself. A rewind truncates and rewrites from the truncation point to the end, so either the truncation is past SafeSize — where the indexed bytes genuinely are untouched — or it is before it, and the window ending at SafeSize is inside the rewritten region. The test rewrites at five depths from the first byte to the last thousandth and each is caught.

What it gives up is stated as a test rather than left implied: a rewrite that changes only the middle, keeps both windows and lands on exactly the same length is invisible. A transcript does not do that.

Manifests written before this keep their full hash and are verified the old way once; the same walk records a sample, so the next call is bounded.