### PR TITLE
fix(sources): stop losing a message inside the watermark's millisecond

### DIFF
--- a/internal/sources/grok_since_shapes_test.go
+++ b/internal/sources/grok_since_shapes_test.go
@@ -80,10 +80,13 @@ func TestGrokSinceHandlesEveryStampShapeItReads(t *testing.T) {
 			if n := count("2026-07-27T16:00:00Z"); n != 0 {
 				t.Errorf("a watermark after both returned %d messages, want none", n)
 			}
-			// The boundary: a message stamped at the watermark is already in
-			// the index, and one a fraction of a second later is not.
-			if n := count("2026-07-27T15:29:47Z"); n != 0 {
-				t.Errorf("a watermark exactly at the later message returned %d, want none", n)
+			// The boundary: a message stamped at the watermark comes back
+			// once more rather than being skipped. The clause compares
+			// through strftime's %f, which is milliseconds, so the watermark
+			// is backed off by one — offering a message twice is the side of
+			// that error worth being on (#2155).
+			if n := count("2026-07-27T15:29:47Z"); n < 1 {
+				t.Errorf("a watermark exactly at the later message returned %d, want it offered once more", n)
 			}
 		})
 	}

--- a/internal/sources/grokdb.go
+++ b/internal/sources/grokdb.go
@@ -52,7 +52,7 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 		// null, and those rows are kept rather than dropped — an unreadable
 		// stamp is a reason to look at a message, not to hide it.
 		const norm = `strftime('%Y-%m-%dT%H:%M:%f',m.created_at)`
-		w := sqlEscape(t.UTC().Format("2006-01-02T15:04:05.000"))
+		w := sqlEscape(millisecondBackoff(t))
 		where = " and (" + norm + " is null or " + norm + " > '" + w + "')"
 	}
 	q := `select s.id as id,s.cwd_last as cwd,s.title as title,` +

--- a/internal/sources/since_millisecond_test.go
+++ b/internal/sources/since_millisecond_test.go
@@ -1,0 +1,65 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The since clauses normalise both sides with strftime's %f, which is
+// milliseconds, while the readers parse RFC3339Nano. A message stamped inside
+// the watermark's own millisecond compared as not-after it and was skipped for
+// good — and the two sides do not even agree on which millisecond a stamp is
+// in, because Go truncates where strftime rounds (#2155).
+func TestAMessageInsideTheWatermarksMillisecondIsNotLost(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "grok.db")
+	schema := `
+CREATE TABLE workspaces (id TEXT PRIMARY KEY, canonical_path TEXT);
+CREATE TABLE sessions (id TEXT PRIMARY KEY, workspace_id TEXT, title TEXT, cwd_last TEXT, created_at TEXT);
+CREATE TABLE messages (session_id TEXT, seq INTEGER, role TEXT, message_json TEXT, created_at TEXT);
+INSERT INTO sessions VALUES ('s1','w1','t','/work/api','2026-07-27T10:00:00.0000000Z');
+INSERT INTO messages VALUES ('s1',0,'user','{"role":"user","content":"first message"}','2026-07-27T10:00:00.8121000Z');
+INSERT INTO messages VALUES ('s1',1,'user','{"role":"user","content":"second message"}','2026-07-27T10:00:00.8129000Z');
+`
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = stringsReader(schema)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	read := func(cut string) []string {
+		at, err := time.Parse(time.RFC3339Nano, cut)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ss, err := ParseGrokDBSince(db, at)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var texts []string
+		for _, s := range ss {
+			for _, m := range s.Messages {
+				texts = append(texts, m.Text)
+			}
+		}
+		return texts
+	}
+	// A watermark before both messages must leave neither behind.
+	if got := read("2026-07-27T10:00:00.8120000Z"); len(got) != 2 {
+		t.Errorf("watermark before both returned %v, want both messages", got)
+	}
+	// One stamped between them keeps at least the later one — the earlier may
+	// come back too, which costs a message being offered twice and is the side
+	// of the error worth being on.
+	if got := read("2026-07-27T10:00:00.8125000Z"); !strings.Contains(strings.Join(got, " "), "second message") {
+		t.Errorf("watermark between the two returned %v, want at least the later message", got)
+	}
+	// And it is still a filter: a watermark a second later returns nothing.
+	if got := read("2026-07-27T10:00:01.0000000Z"); len(got) != 0 {
+		t.Errorf("watermark after both returned %v, want none", got)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -694,3 +694,14 @@ func truncateRunes(s string, n int) string {
 	}
 	return s[:n]
 }
+
+// millisecondBackoff formats a watermark for a clause that compares through
+// strftime's %f. That is milliseconds, and the readers parse nanoseconds, so a
+// message inside the watermark's own millisecond compares as not after it — and
+// the two sides disagree about which millisecond a stamp is in at all, because
+// Go truncates here where strftime rounds. Backing the watermark off by a
+// millisecond puts the error on the side that costs a message being offered
+// twice rather than the side that skips it for good (#2155).
+func millisecondBackoff(t time.Time) string {
+	return t.UTC().Add(-time.Millisecond).Format("2006-01-02T15:04:05.000")
+}

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -189,7 +189,7 @@ func zedSinceWhere(t time.Time) string {
 		return ""
 	}
 	const norm = `strftime('%Y-%m-%dT%H:%M:%f',updated_at)`
-	w := sqlEscape(t.UTC().Format("2006-01-02T15:04:05.000"))
+	w := sqlEscape(millisecondBackoff(t))
 	return " where " + norm + " is null or " + norm + " > '" + w + "'"
 }
 


### PR DESCRIPTION
Fixes #2155. The grok and zed since clauses compare through `strftime('%Y-%m-%dT%H:%M:%f', …)` — milliseconds — while the readers parse RFC3339Nano. Two messages 0.8 ms apart, and four watermarks around them:

```
since 2026-07-27T10:00:00.8120000Z -> [second message]
since 2026-07-27T10:00:00.8121000Z -> [second message]
since 2026-07-27T10:00:00.8125000Z -> [second message]
since 2026-07-27T10:00:00.8129000Z -> [second message]
```

The first message is missing from all four, including the watermark that precedes it. Two errors compound in there: the comparison is coarser than the stamps, and the sides round differently — Go truncates when it formats, strftime rounds — so they disagree about which millisecond a stamp is in. What makes it worth fixing is the direction: such a message is not served late, it is skipped for good.

The watermark is backed off by a millisecond now, in both clauses, through a helper beside `newerThanEpoch` that says why. One millisecond covers it: strftime moves a stamp by at most half a millisecond and the truncation by at most one.

The cost, and review made me state it rather than assume it: over-inclusion is not free. The incremental writer appends every delivered message to the records and the postings with no `newMessages` filter, so a message offered twice becomes two records and two hits (`Counted` stays right). That is the same cost goose's whole-session re-read already pays, and it is the better half of the trade against losing a message for good — but it is a cost, and it went on the queue as its own item.

Also worth knowing: `setStoreLastUpdated` stamps opencode, goose and cursor, so grok and zed are read whole today and neither clause runs outside tests.

The boundary assertion from #2152 said a message stamped exactly at the watermark must not come back. That is no longer the contract, and it now states the true one.
