### PR TITLE
fix(search): score a cross-script CJK hit on the text that matched it

### DIFF
--- a/internal/search/crossscript_score_test.go
+++ b/internal/search/crossscript_score_test.go
@@ -1,0 +1,68 @@
+package search
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Postings are keyed on folded CJK, so a Simplified query legitimately reaches
+// a Traditional record and the match is counted. Scoring then ran on the
+// surface text, where the query's words appear nowhere: term frequency stayed
+// zero and the record scored zero, ranking below every real match (#1605).
+//
+// Stated as the invariant rather than as an ordering, because ordering also
+// depends on length normalisation and would pass for the wrong reason: the
+// same session, same words, same length, must score the same whichever script
+// it is written in.
+func TestScriptDoesNotChangeTheScore(t *testing.T) {
+	now := time.Now()
+	same := func(id, a, b string) model.Session {
+		return model.Session{
+			ID: id, Harness: "claude", Project: "app", Updated: now,
+			Messages: []model.Message{
+				{Role: "user", Text: a},
+				{Role: "assistant", Text: b},
+			},
+		}
+	}
+	sessions := []model.Session{
+		same("simp", "调度器 又坏了，昨天也是", "调度器 的重试设定改过了"),
+		same("trad", "調度器 又壞了，昨天也是", "調度器 的重試設定改過了"),
+	}
+	// Sessions that never say it: with the word in every document its IDF is
+	// zero and this would measure nothing.
+	for i := 0; i < 8; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("f%d", i), Harness: "claude", Project: "app", Updated: now,
+			Messages: []model.Message{{Role: "user", Text: "今天的部署很順利，沒有問題"}},
+		})
+	}
+
+	hits, err := runScored(sessions, Options{Query: "调度器", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Hit{}
+	for _, h := range hits {
+		byID[h.Session.ID] = h
+	}
+	if len(hits) != 2 {
+		t.Fatalf("both scripts should match through the fold, got %d: %v", len(hits), byID)
+	}
+	if byID["trad"].Score <= 0 {
+		t.Fatalf("the cross-script hit scored %v, so it ranks below every real match",
+			byID["trad"].Score)
+	}
+	if d := math.Abs(byID["trad"].Score - byID["simp"].Score); d > 1e-9 {
+		t.Errorf("the same session scores differently by script: trad=%v simp=%v",
+			byID["trad"].Score, byID["simp"].Score)
+	}
+	if byID["trad"].Count != byID["simp"].Count {
+		t.Errorf("counts differ by script: trad=%d simp=%d",
+			byID["trad"].Count, byID["simp"].Count)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -269,15 +269,22 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 					doc.minWindow = w
 				}
 			}
-			doc.length += countDocumentWords(low, qtoks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
+			// Count the document over the same pair the match was found on.
+			// A cross-script hit is counted above through the fold and then
+			// scored here against the surface text, where the query's words
+			// appear nowhere: term frequency stays zero, BM25 scores zero, and
+			// a record that matched twice ranks below one that matched once
+			// (#1605). windowText and windowToks already carry whichever pair
+			// answered, so scoring follows the same rule proximity does.
+			doc.length += countDocumentWords(windowText, windowToks, o.FuzzyVariants, doc.termCount, doc.userCount, m.Role == "user")
 			// The token, not the raw query — the same rule as countIn. This
 			// path is what scores `retry` inside `retry-backoff`, which
 			// countDocumentWords cannot match because it counts whole words
 			// and treats the hyphen as one. Comparing the raw query here left
 			// a punctuated query with a session that matched three times and
 			// scored zero, ranked below one that matched once (#1603).
-			if len(qtoks) == 1 && doc.termCount[0] == 0 && strings.Contains(low, qtoks[0]) {
-				n := strings.Count(low, qtoks[0])
+			if len(windowToks) == 1 && doc.termCount[0] == 0 && strings.Contains(windowText, windowToks[0]) {
+				n := strings.Count(windowText, windowToks[0])
 				doc.termCount[0] += n
 				if m.Role == "user" {
 					doc.userCount[0] += n


### PR DESCRIPTION
Closes #1605.

Reproduced first. Two sessions with identical text, one Traditional and one Simplified, queried in Simplified:

```
before   trad score=0        simp score=3.04
after    trad score=simp score, to 1e-9
```

Postings are keyed on folded CJK, so the query reaches the other script and `countIn` gives it a real count through the fold. Scoring then ran on the unfolded surface text, where the query's words appear nowhere — term frequency zero, BM25 zero. `windowText`/`windowToks` already hold whichever pair actually matched, because proximity had the same problem and was fixed for it; scoring now follows the same rule, and so does the single-token fallback below it.

The test asserts the invariant rather than an ordering. Ordering would have passed for the wrong reason: my first attempt expected the two-message Traditional session to outrank a one-message Simplified one, and it does not — length normalisation is doing legitimate work there. The right statement is that the same session, same words, same length, scores the same whichever script it is written in.

Mutating the fix back fails four assertions. longmemeval is unchanged at 85.3% hit@1 / 0.895 MRR, and `internal/search` is at 94.4% against its floor of 93.