### PR TITLE
test(index): pin that a re-offered turn stays one record

### DIFF
--- a/internal/index/reoffered_record_test.go
+++ b/internal/index/reoffered_record_test.go
@@ -1,0 +1,100 @@
+package index
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// goose hands back every turn of a session it touched, so each pass re-offers
+// messages the index already holds — and the incremental writer appends what it
+// is given without asking whether it has seen it. What keeps a re-offered turn
+// from becoming a second record is the whole-store rewrite
+// (`wholeStoresThisPass`/`rereadsWholeSessions`), which is a property of the
+// pass rather than of the writer, and nothing held it: the tests beside this
+// one pin the ingest counts and the survival of earlier turns, neither of which
+// moves when a message is stored twice.
+//
+// A duplicate is not a cosmetic matter here: the same sentence comes back as
+// two hits in one session, and the count beside a search result is what a
+// reader uses to judge whether a session is the one.
+func TestAReofferedTurnDoesNotBecomeASecondRecord(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "goose.db")
+	t.Setenv("DEJA_GOOSE_DB", db)
+
+	const first = "the pgbouncer pool timed out during the migration"
+	seedGooseTurn(t, db, "g1", "user", first, 1767322800)
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	records := func() int {
+		t.Helper()
+		m, err := readManifest(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		if err := eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
+			if strings.Contains(r.Text, "pgbouncer pool timed out") {
+				n++
+			}
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return n
+	}
+	if got := records(); got != 1 {
+		t.Fatalf("the first pass stored the turn %d times, so this measures nothing", got)
+	}
+	// Two more passes, each of which hands the first turn back with the new one.
+	for i, ts := range []int64{1767326400, 1767330000} {
+		seedGooseTurn(t, db, "g1", "assistant", "a short answer", ts)
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+		if got := records(); got != 1 {
+			t.Errorf("after pass %d the store holds the same turn %d times", i+2, got)
+		}
+	}
+	// And the reader sees one of it: a session whose every line is doubled
+	// reads as a conversation that repeated itself.
+	s, ok, err := FindByIdentity(dir, "goose", "g1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("the session is gone from the index")
+	}
+	seen := 0
+	for _, msg := range s.Messages {
+		if strings.Contains(msg.Text, "pgbouncer pool timed out") {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("the session carries the same turn %d times", seen)
+	}
+	res, err := SearchDetailed(dir, search.Options{Query: "pgbouncer pool", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 1 {
+		t.Fatalf("search returned %d sessions, want the one", len(res.Sessions))
+	}
+	if n := len(res.Sessions[0].Messages); n != 1 {
+		t.Errorf("search shows the turn %d times in one session", n)
+	}
+}


### PR DESCRIPTION
No defect. The claim was that the incremental writer appends whatever it is handed with no `newMessages` filter, so a message a source offers twice becomes two records and two hits. That part is true of the writer; it does not happen. Measured on goose, the one source that re-offers turns — it asks for every message of any session it touched:

```
pass1    records=1 sessionMessages=1 counted=1
pass2    records=1 sessionMessages=1 counted=2
pass3    records=1 sessionMessages=1 counted=3
```

What keeps the record single is the pass, not the writer: goose is marked `rereadsWholeSessions`, so its store is rewritten rather than appended to. `Counted` is the pass statistic and climbs correctly.

That distinction is worth a test, because the two live apart: the protection is in `wholeStoresThisPass`, which knows three harnesses, and the writer below it will duplicate anything a fourth store hands back twice — which is what the comment there already warns about ("a watermark added to another database later would have to join fromDatabase and this function in the same change"). With `rereadsWholeSessions` returning false, the same turn is stored two and then three times and search shows it three times in one session; the sibling tests stay green through all of it, because they pin ingest counts and derived-field growth, neither of which moves when a message is stored twice.

Review confirmed the other two message-level stores cannot re-offer: opencode and cursor filter with a strict `>` against the newest stored stamp.
