### PR TITLE
fix(cursor): read a composer whose bubbles moved, not only one whose stamp did

### DIFF
--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -149,6 +149,32 @@ func ParseCursorDB(db string) ([]model.Session, error) {
 	return parseCursorDB(db, time.Time{})
 }
 
+// cursorComposerListMax is how many composers a pass will name one by one. The
+// query goes to sqlite3 as a single argument, so a list long enough stops being
+// a query at all; past this the caller asks for every composer instead, which
+// costs a scan of a metadata table rather than a failed pass.
+const cursorComposerListMax = 400
+
+// cursorComposerKeyList names, as a SQL value list, the composer rows the given
+// bubbles belong to. A bubble key is "bubbleId:<composerId>:<bubbleId>", which
+// is the only place that link is written down, and a composer row is keyed
+// "composerData:<composerId>" — the shape the reader already falls back to when
+// a row carries no composerId of its own. The list is bounded by what this pass
+// read, so it names the changed composers rather than the store's.
+func cursorComposerKeyList(bubbles []map[string]any) string {
+	seen := map[string]bool{}
+	var out []string
+	for _, b := range bubbles {
+		parts := strings.SplitN(str(b["key"]), ":", 3)
+		if len(parts) != 3 || parts[1] == "" || seen[parts[1]] {
+			continue
+		}
+		seen[parts[1]] = true
+		out = append(out, "'"+sqlEscape("composerData:"+parts[1])+"'")
+	}
+	return strings.Join(out, ",")
+}
+
 func parseCursorDB(db string, since time.Time) ([]model.Session, error) {
 	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
 		return nil, nil
@@ -161,6 +187,38 @@ func parseCursorDB(db string, since time.Time) ([]model.Session, error) {
 		composerWhere = " and " + newerThanEpoch("json_extract(value,'$.lastUpdatedAt')", since)
 		bubbleWhere = " and " + newerThanEpoch("json_extract(value,'$.timestamp')", since)
 	}
+	// The bubbles first, because they decide which composers are worth
+	// reading. Cursor writes a composer's lastUpdatedAt when it feels like it
+	// and the turns arrive regardless, so filtering the composers on their own
+	// stamp skipped every turn written after it — and the next pass, carrying a
+	// later watermark, excluded the bubble on its own stamp too, which loses
+	// the turn for good (#2159).
+	bubbles, err := cursorQuery(db, `select key,`+
+		`json_extract(value,'$.type') as type,`+
+		`coalesce(json_extract(value,'$.text'), json_extract(value,'$.rawText')) as text,`+
+		`json_extract(value,'$.timestamp') as ts,`+
+		`json_extract(value,'$.workspaceProjectDir') as wsdir `+
+		`from cursorDiskKV where key >= 'bubbleId:' and key < 'bubbleId;' and value is not null`+bubbleWhere)
+	if err != nil {
+		return nil, err
+	}
+	if composerWhere != "" {
+		switch keys := cursorComposerKeyList(bubbles); {
+		case keys == "":
+			// No bubble moved, so no composer can be pulled in by one.
+		case strings.Count(keys, ",") >= cursorComposerListMax:
+			// Past this many the list is the wrong shape for the job: the
+			// query is one argv element to sqlite3, and a long enough one is
+			// refused outright — which would turn a large pass into an error
+			// where it used to be a read. Every composer row comes back
+			// instead; they are metadata, the bubbles stay filtered, and a
+			// composer with no new turns is dropped below anyway.
+			composerWhere = ""
+		default:
+			composerWhere = " and (" + strings.TrimPrefix(composerWhere, " and ") +
+				" or key in (" + keys + "))"
+		}
+	}
 	composers, err := cursorQuery(db, `select key,`+
 		`json_extract(value,'$.composerId') as cid,`+
 		`json_extract(value,'$.name') as name,`+
@@ -172,15 +230,6 @@ func parseCursorDB(db string, since time.Time) ([]model.Session, error) {
 	}
 	if len(composers) == 0 {
 		return nil, nil
-	}
-	bubbles, err := cursorQuery(db, `select key,`+
-		`json_extract(value,'$.type') as type,`+
-		`coalesce(json_extract(value,'$.text'), json_extract(value,'$.rawText')) as text,`+
-		`json_extract(value,'$.timestamp') as ts,`+
-		`json_extract(value,'$.workspaceProjectDir') as wsdir `+
-		`from cursorDiskKV where key >= 'bubbleId:' and key < 'bubbleId;' and value is not null`+bubbleWhere)
-	if err != nil {
-		return nil, err
 	}
 	byComposer := map[string][]map[string]any{}
 	for _, b := range bubbles {

--- a/internal/sources/cursor_composer_since_test.go
+++ b/internal/sources/cursor_composer_since_test.go
@@ -1,0 +1,76 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// cursor writes a composer's `lastUpdatedAt` when it feels like it, and the
+// bubbles keep arriving regardless. The pass filtered both sides and read no
+// bubble whose composer had not also moved, so a turn written after the
+// composer's own stamp was skipped — and the next pass, carrying a later
+// watermark, excluded the bubble on its own stamp too (#2159).
+func TestACursorTurnSurvivesAComposerThatStoppedAdvancing(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	db := filepath.Join(t.TempDir(), "state.vscdb")
+	schema := `create table cursorDiskKV (key text primary key, value text);
+insert into cursorDiskKV values
+ ('composerData:comp-1', json('{"composerId":"comp-1","name":"Fix the pager","createdAt":1752600000000,"lastUpdatedAt":1752600100000}')),
+ ('bubbleId:comp-1:b1', json('{"type":1,"text":"the first question","timestamp":1752600001000,"workspaceProjectDir":"/Users/me/work/my-app"}')),
+ ('bubbleId:comp-1:b2', json('{"type":2,"text":"the later answer","timestamp":1752600900000}'));`
+	if out, err := exec.Command("sqlite3", db, schema).CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	texts := func(ms int64) []string {
+		t.Helper()
+		ss, err := parseCursorDB(db, time.UnixMilli(ms).UTC())
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out []string
+		for _, s := range ss {
+			for _, m := range s.Messages {
+				out = append(out, m.Text)
+			}
+		}
+		return out
+	}
+	// The premise: a watermark before everything brings both turns.
+	if got := texts(1752600000000); len(got) != 2 {
+		t.Fatalf("a watermark before the store returned %v, want both turns", got)
+	}
+	// The watermark a pass would carry after the first turn: past the
+	// composer's own stamp, before the later bubble.
+	got := texts(1752600200000)
+	if strings.Join(got, " ") != "the later answer" {
+		t.Errorf("returned %v, want the turn written after the composer stopped advancing", got)
+	}
+	// Nothing already indexed comes back with it: the bubbles keep their own
+	// filter, so the session carries exactly the one new turn.
+	ss, err := parseCursorDB(db, time.UnixMilli(1752600200000).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Errorf("the pass returned %d session(s) carrying %d message(s), want one of each", len(ss), messageCount(ss))
+	}
+	// And it is still a filter: past every bubble, the pass is empty.
+	if got := texts(1752601000000); len(got) != 0 {
+		t.Errorf("a watermark past every bubble returned %v, want nothing", got)
+	}
+}
+
+func messageCount(ss []model.Session) int {
+	n := 0
+	for _, s := range ss {
+		n += len(s.Messages)
+	}
+	return n
+}


### PR DESCRIPTION
Fixes #2159. `parseCursorDB` filtered composers and bubbles separately and read no bubble whose composer had not also passed the filter. Cursor writes a composer's `lastUpdatedAt` when it feels like it; the turns arrive regardless. One composer stamped 17:21:40 and a bubble from 17:35:

```
whole store                    sessions=1 [no stamp | first question | later answer]
since 2025-07-15T17:20:00Z     sessions=1 [first question | later answer]
since 2025-07-15T17:23:20Z     sessions=0 []
since 2025-07-15T17:36:40Z     sessions=0 []
```

At 17:23:20 — past the composer's stamp, before the bubble — the pass returns nothing, so the later answer is never indexed; the next pass carries a watermark past 17:35 and the bubble's own clause excludes it. The turn is gone until something rebuilds from scratch, and cursor is one of the three stores that carry a watermark, so this is live.

The bubbles are read first now and the composer clause is widened by the composers they name. The bubbles keep their own filter, so nothing already indexed comes back with the recovered turn, and a composer returning with no new turns is dropped as before.

Review found the shape that widening could break: the query reaches sqlite3 as one argument, so a long enough id list stops being a query at all and the whole pass errors where it used to read. Past 400 composers the list is dropped and every composer row comes back instead — a scan of a metadata table rather than a failed pass. The redundant second list (by `composerId`) is gone too; the row key covers both shapes.

Not fixed, and written into the issue: a bubble with no timestamp survives no incremental pass at all. Including it whenever its composer is read would hand it back every time, and the writer stores what it is handed — #2158 measured that. It needs the writer to know what it already has.
