### PR TITLE
fix(hook): rotate the dedup file for token writes too

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -597,17 +597,28 @@ func rotateHookseen(p, sid string) {
 	if len(lines) > tailLines {
 		start = len(lines) - tailLines
 	}
-	var keep []string
+	// The caller's own lines are kept beyond the tail so its dedup survives the
+	// rotation — but only as many as the tail itself. Keeping all of them left
+	// a long session able to fill the file with its own entries, after which
+	// every write rotated a megabyte again: the tool hooks write a token per
+	// call, so that is reachable rather than theoretical (#2164).
+	var keep, mine []string
 	prefix := sid + " "
 	for i, ln := range lines {
 		if ln == "" {
 			continue
 		}
-		if i >= start || strings.HasPrefix(ln, prefix) {
+		switch {
+		case i >= start:
 			keep = append(keep, ln)
+		case strings.HasPrefix(ln, prefix):
+			mine = append(mine, ln)
 		}
 	}
-	_ = atomicfile.Write(p, []byte(strings.Join(keep, "\n")+"\n"), 0o600)
+	if len(mine) > tailLines {
+		mine = mine[len(mine)-tailLines:]
+	}
+	_ = atomicfile.Write(p, []byte(strings.Join(append(mine, keep...), "\n")+"\n"), 0o600)
 }
 
 // rememberInjectedIDs records arbitrary dedupe tokens against a session, so a
@@ -617,14 +628,21 @@ func rememberInjectedIDs(dir, sid string, ids ...string) {
 	if sid == "" {
 		return
 	}
-	f, err := os.OpenFile(dir+".hookseen", os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	p := dir + ".hookseen"
+	// Rotate rather than stop, for the reason rememberInjected does: a full
+	// file used to end the dedup for good, and the hooks that write tokens are
+	// the ones whose whole job is not repeating themselves to the same agent.
+	// Stopping here left that to whenever a session injection happened to
+	// rotate the file, and on a machine whose hooks inject tokens rather than
+	// sessions, nothing ever did (#2164).
+	if fi, err := os.Stat(p); err == nil && fi.Size() > 1<<20 {
+		rotateHookseen(p, sid)
+	}
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	if fi, err := f.Stat(); err == nil && fi.Size() > 1<<20 {
-		return
-	}
 	if atomicfile.EndsMidLine(f) {
 		_, _ = f.WriteString("\n")
 	}

--- a/cmd/deja/hookseen_full_test.go
+++ b/cmd/deja/hookseen_full_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A full `.hookseen` used to stop the dedup dead, and #1967 replaced that with
+// a rotation — "the per-prompt hook then re-injected the same sessions turn
+// after turn". The token writer three functions below kept the old behaviour,
+// so the surfaces whose whole job is not repeating themselves — the per-prompt
+// block, the two tool hooks — lost their dedup once the file filled, until some
+// session injection happened to rotate it (#2164).
+func TestTheTokenDedupSurvivesAFullHookseen(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := dir + ".hookseen"
+	var b strings.Builder
+	for b.Len() < (1<<20)+4096 {
+		b.WriteString("ses-old some-token 2026-01-01T00:00:00Z\n")
+	}
+	if err := os.WriteFile(p, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rememberInjectedIDs(dir, "ses1", "tok-1")
+	if !alreadyInjected(dir, "ses1")["tok-1"] {
+		t.Errorf("a token written while the file was full does not read back as seen")
+	}
+	// The rotation kept this session's line rather than starting the file over.
+	fi, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() > 1<<20 {
+		t.Errorf("the file is still %d bytes, so nothing rotated", fi.Size())
+	}
+
+	// The session writer is unchanged, and the two keep working together: a
+	// session recorded after the rotation is still seen, and so is a second
+	// token.
+	rememberInjected(dir, "ses1", []model.Session{{ID: "sess-a"}})
+	rememberInjectedIDs(dir, "ses1", "tok-2")
+	seen := alreadyInjected(dir, "ses1")
+	for _, want := range []string{"tok-1", "sess-a", "tok-2"} {
+		if !seen[want] {
+			t.Errorf("%q is not remembered after the file filled and rotated", want)
+		}
+	}
+	// And the rotation cannot be talked into keeping a megabyte of one
+	// session's own lines: that was what made every later write rotate again.
+	var mine strings.Builder
+	for mine.Len() < (1<<20)+4096 {
+		mine.WriteString("ses1 token-of-my-own 2026-01-01T00:00:00Z\n")
+	}
+	if err := os.WriteFile(p, []byte(mine.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rememberInjectedIDs(dir, "ses1", "tok-3")
+	fi, err = os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() > 1<<20 {
+		t.Errorf("the file is %d bytes of one session's own lines, so the next write rotates it again", fi.Size())
+	}
+	if !alreadyInjected(dir, "ses1")["tok-3"] {
+		t.Errorf("the token written through that rotation is not remembered")
+	}
+}


### PR DESCRIPTION
Fixes #2164. `.hookseen` has two writers and had two policies for a full file. `rememberInjected` rotates — that is #1967, written because "past 1MB the dedup file used to stop writing entirely, which permanently broke dedup: the per-prompt hook then re-injected the same sessions turn after turn". `rememberInjectedIDs`, three functions below, still returned:

```
start size=1052680
after rememberInjectedIDs  size=1052680  holds=false  seen=false
after rememberInjected     size=159993   holds=true   seen=true
after rememberInjectedIDs  size=160008   holds=true   seen=true
```

A token written while the file is full is not recorded and never reads back as seen. Its callers are the per-prompt block fingerprint and the two tool hooks — the surfaces whose whole job is not repeating themselves to the same agent. Their dedup stays off until something calls the other writer, which is a session injection; on a machine whose hooks inject tokens rather than sessions, nothing ever does.

The rotation was already written, so this calls it.

Review found what that made reachable: `rotateHookseen` kept *all* of the calling session's lines, so a long session could fill the file with its own entries and then rotate a megabyte on every write — rare for session injections, not for a tool hook writing a token per call. The caller's lines are now capped at the same tail budget as everything else, and the test holds that too.
