### PR TITLE
fix(index): withhold a fix the error outlived, however much later

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -28,9 +28,12 @@ const (
 	// fixLookAhead is how far past the error a command still counts as an
 	// answer to it. Beyond that the session has moved on to something else.
 	fixLookAhead = 10
-	// fixQuietAfter is how many records must pass without the same error for
-	// the command to count as having settled it.
-	fixQuietAfter = 6
+	// The quiet check runs to the end of the session rather than over a window.
+	// Six records was long enough to miss the session hitting the same error
+	// again a little later, which is the transcript saying the command did not
+	// settle it: measured over this machine's transcripts, 104 of the 831 pairs
+	// the miner kept were contradicted that way, and each one is a wrong answer
+	// handed to an agent at the moment it is stuck.
 	// fixCommandMax bounds what is stored per pair; a command longer than this
 	// is a heredoc or a pasted script, not something to hand back.
 	fixCommandMax = 200
@@ -228,9 +231,30 @@ func trimTermEdges(t string) string {
 	return strings.Trim(t, "/.")
 }
 
+// lastFrictionIndex records, for every error the session hit, the last record
+// it appears in. The quiet check asks whether an error came back after the
+// command that was supposed to settle it, and asking that by rescanning the
+// tail once per candidate is quadratic: on this machine's transcripts it took
+// a full rebuild from 15.8s to 57.8s. One pass answers it for every pair.
+func lastFrictionIndex(ms []model.Message) map[uint64]int {
+	last := make(map[uint64]int)
+	for i, m := range ms {
+		if m.Role != roleToolOutput && m.Role != "assistant" {
+			continue
+		}
+		for _, raw := range strings.Split(m.Text, "\n") {
+			if line, ok := FrictionLine(raw); ok {
+				last[frictionHash(line)] = i
+			}
+		}
+	}
+	return last
+}
+
 // fixPairsIn mines one session.
 func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 	var out []FixPair
+	lastSeen := lastFrictionIndex(ms)
 	for i, m := range ms {
 		if m.Role != roleToolOutput && m.Role != "assistant" {
 			continue
@@ -250,7 +274,7 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 				// records on, instead of abandoning the error entirely.
 				continue
 			}
-			if repeatsError(ms, j+1, j+fixQuietAfter, sig) {
+			if lastSeen[sig] > j {
 				break
 			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
@@ -269,21 +293,6 @@ func firstFrictionLine(text string) (string, uint64, bool) {
 		}
 	}
 	return "", 0, false
-}
-
-// repeatsError reports whether the same error shows up again in ms[from:to].
-func repeatsError(ms []model.Message, from, to int, sig uint64) bool {
-	for k := from; k < len(ms) && k <= to; k++ {
-		if ms[k].Role != roleToolOutput && ms[k].Role != "assistant" {
-			continue
-		}
-		for _, raw := range strings.Split(ms[k].Text, "\n") {
-			if line, ok := FrictionLine(raw); ok && frictionHash(line) == sig {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func firstLineOf(s string) string {

--- a/internal/index/fixpair_test.go
+++ b/internal/index/fixpair_test.go
@@ -41,6 +41,52 @@ func TestFixPairsDropACommandTheErrorSurvived(t *testing.T) {
 	}
 }
 
+// The same error a dozen records later says the same thing as the same error
+// immediately after: the command did not settle it. Six records was the whole
+// of the check, so a session that ran a command, worked on something else and
+// hit the error again stored the command as the fix. Measured over this
+// machine's transcripts, 104 of the 831 pairs the miner kept were contradicted
+// that way.
+func TestFixPairsDropACommandTheErrorOutlivedLater(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh:1: command not found: timeout", Time: now},
+		{Role: "command", Text: "brew install coreutils for timeout", Time: now.Add(time.Minute)},
+	}
+	// Far enough that the old six-record window never reached it.
+	for i := 0; i < 12; i++ {
+		ms = append(ms, model.Message{Role: "tool-output", Text: "ok", Time: now.Add(time.Duration(i) * time.Minute)})
+	}
+	ms = append(ms, model.Message{
+		Role: "tool-output", Text: "zsh:1: command not found: timeout",
+		Time: now.Add(time.Hour),
+	})
+	if pairs := fixPairsIn(ms, "claude:s1", "p"); len(pairs) != 0 {
+		t.Errorf("a command the error outlived was stored as a fix: %+v", pairs)
+	}
+}
+
+// And the check stays a check on the same error: another error later in the
+// session says nothing about this one, and withholding on it would empty the
+// table for any session that hit more than one thing.
+func TestFixPairsKeepACommandADifferentErrorFollowed(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh:1: command not found: timeout", Time: now},
+		{Role: "command", Text: "curl --max-time 5 example.internal", Time: now.Add(time.Minute)},
+	}
+	for i := 0; i < 12; i++ {
+		ms = append(ms, model.Message{Role: "tool-output", Text: "ok", Time: now.Add(time.Duration(i) * time.Minute)})
+	}
+	ms = append(ms, model.Message{
+		Role: "tool-output", Text: "zsh:1: command not found: gsed",
+		Time: now.Add(time.Hour),
+	})
+	if pairs := fixPairsIn(ms, "claude:s1", "p"); len(pairs) != 1 {
+		t.Errorf("a different error later withheld the pair: %+v", pairs)
+	}
+}
+
 // Sequence alone is 13% precise on a real store — the next command is usually
 // the session moving on. A pair survives the build only with a second reason:
 // the command names what the error named, or the same remedy recurs.


### PR DESCRIPTION
From the measurements in #2163.

A pair is kept when the error does not come back in the next six records. Over this machine's transcripts the miner keeps 831 pairs and **104 of them are contradicted by their own session** — the same error appears again later, which is the transcript saying the command did not settle it. Each one is a wrong answer handed to an agent at the moment it is stuck, which is the worst moment to be wrong.

The check now runs to the end of the session. On a rebuild of the same store that removes 3 confirmed pairs and 100 candidates.

Doing it the obvious way was 3.7× slower — rescanning the tail once per candidate is quadratic, and a full rebuild went from 15.8s to 57.8s. So the session is walked once for the last record each error appears in, and the check is a lookup. Rebuild is 17.6s → 18.9s.

A second test pins the other half: a *different* error later in the session must not withhold the pair. Without that the check would empty the table for any session that hit more than one thing, and every real session does.