### PR TITLE
fix(hook): keep a dedup entry under the session that owns it

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -459,6 +460,31 @@ func citationLine(s model.Session, terms []string) string {
 		title, s.Harness, date, shortID(s.ID))
 }
 
+// hookseenKey makes an agent session id safe to be one field of a `.hookseen`
+// line. The file is whitespace-separated and the id arrives in the hook
+// payload, which is whatever the host sends. A space cost that session its
+// dedup and handed its entries to whatever id its first word named, and a
+// newline wrote a line of its own — so a payload could mark memory as already
+// shown to any session it liked (#2167).
+//
+// Writing and reading go through this, so a mapped id matches itself, and every
+// id a harness actually sends maps to itself, which is why no existing file
+// needs converting.
+func hookseenKey(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return '_'
+		}
+		return r
+	}, s)
+}
+
+// hookseenField reports whether a value can be one field of a line as it
+// stands. The session id above is mapped because it is only ever compared with
+// itself; a value is not, because it is compared with the index's own ids —
+// so one that cannot be a field is left out of the file instead.
+func hookseenField(s string) bool { return s != "" && hookseenKey(s) == s }
+
 // alreadyInjected returns the session ids this hook already injected into the
 // given agent session, so follow-up prompts do not repeat the same memory.
 func alreadyInjected(dir, sid string) map[string]bool {
@@ -470,11 +496,12 @@ func alreadyInjected(dir, sid string) map[string]bool {
 	if err != nil {
 		return out
 	}
+	key := hookseenKey(sid)
 	for _, line := range strings.Split(string(b), "\n") {
 		// Two fields when the entry is a block fingerprint, three when it is a
 		// session with the time it was shown.
 		parts := strings.Fields(line)
-		if len(parts) >= 2 && parts[0] == sid {
+		if len(parts) >= 2 && parts[0] == key {
 			out[parts[1]] = true
 		}
 	}
@@ -508,11 +535,12 @@ func recentlyInjected(dir, sid string, window int) map[string]bool {
 		return out
 	}
 	lines := strings.Split(string(b), "\n")
+	key := hookseenKey(sid)
 	// Newest first: the window counts injections, and the file is append-only.
 	kept := 0
 	for i := len(lines) - 1; i >= 0 && kept < window; i-- {
 		parts := strings.Fields(lines[i])
-		if len(parts) < 2 || parts[0] != sid {
+		if len(parts) < 2 || parts[0] != key {
 			continue
 		}
 		kept++
@@ -535,12 +563,13 @@ func forgetInjected(dir, sid string) {
 	if err != nil {
 		return
 	}
+	key := hookseenKey(sid)
 	var kept []string
 	for _, line := range strings.Split(string(b), "\n") {
 		if line == "" {
 			continue
 		}
-		if parts := strings.Fields(line); len(parts) >= 2 && parts[0] == sid {
+		if parts := strings.Fields(line); len(parts) >= 2 && parts[0] == key {
 			continue
 		}
 		kept = append(kept, line)
@@ -579,7 +608,14 @@ func rememberInjected(dir, sid string, ss []model.Session) {
 	}
 	stamp := time.Now().UTC().Format(time.RFC3339)
 	for _, s := range ss {
-		fmt.Fprintf(f, "%s %s %s\n", sid, s.ID, stamp)
+		// The value stays byte-exact: it is looked up against the index's own
+		// ids, and a mapped one would match nothing there. One that cannot be
+		// a field is dropped instead — a missing dedup entry costs a second
+		// showing, where a broken line costs the entry written after it.
+		if !hookseenField(s.ID) {
+			continue
+		}
+		fmt.Fprintf(f, "%s %s %s\n", hookseenKey(sid), s.ID, stamp)
 	}
 }
 
@@ -603,7 +639,7 @@ func rotateHookseen(p, sid string) {
 	// every write rotated a megabyte again: the tool hooks write a token per
 	// call, so that is reachable rather than theoretical (#2164).
 	var keep, mine []string
-	prefix := sid + " "
+	prefix := hookseenKey(sid) + " "
 	for i, ln := range lines {
 		if ln == "" {
 			continue
@@ -647,7 +683,10 @@ func rememberInjectedIDs(dir, sid string, ids ...string) {
 		_, _ = f.WriteString("\n")
 	}
 	for _, id := range ids {
-		fmt.Fprintf(f, "%s %s\n", sid, id)
+		if !hookseenField(id) {
+			continue
+		}
+		fmt.Fprintf(f, "%s %s\n", hookseenKey(sid), id)
 	}
 }
 

--- a/cmd/deja/hookseen_field_test.go
+++ b/cmd/deja/hookseen_field_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// `.hookseen` is a line of fields and the agent session id is written into it
+// verbatim, though it arrives in the hook payload — whatever the host sends. A
+// space cost that session its dedup and gave its entries to another id; a
+// newline let a payload write a line under any id it liked (#2167).
+func TestADedupEntryStaysUnderTheSessionThatOwnsIt(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := dir + ".hookseen"
+	for _, sid := range []string{"plain-1", "two words", "forge\nvictim", "tab\tsep"} {
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rememberInjectedIDs(dir, sid, "tok")
+		rememberInjected(dir, sid, []model.Session{{ID: "sess-a"}})
+
+		// Its own dedup works, whatever the host called it.
+		seen := alreadyInjected(dir, sid)
+		if !seen["tok"] || !seen["sess-a"] {
+			t.Errorf("session %q does not remember what it was shown: %v", sid, seen)
+		}
+		// The file stays one line per entry: a newline in the id cannot open a
+		// line of its own.
+		body, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n := len(strings.Split(strings.TrimRight(string(body), "\n"), "\n")); n != 2 {
+			t.Errorf("session %q wrote %d lines for two entries:\n%q", sid, n, body)
+		}
+		// And nothing lands under another id — neither the first word of this
+		// one nor the tail after a newline.
+		for _, other := range strings.FieldsFunc(sid, func(r rune) bool {
+			return r == ' ' || r == '\n' || r == '\t'
+		}) {
+			if other == sid {
+				continue
+			}
+			if got := alreadyInjected(dir, other); len(got) > 0 {
+				t.Errorf("a session called %q sees %v, written by a payload calling itself %q", other, got, sid)
+			}
+		}
+		// Forgetting is by the same key, so a session can still drop its own.
+		forgetInjected(dir, sid)
+		if got := alreadyInjected(dir, sid); len(got) > 0 {
+			t.Errorf("session %q could not forget its entries: %v", sid, got)
+		}
+	}
+}
+
+// The value side is not mapped — it is looked up against the index's own ids,
+// where a mapped one would match nothing. A value that cannot be a field is
+// dropped instead, which costs a second showing rather than the entry written
+// after it (#2167).
+func TestAValueThatCannotBeAFieldIsDroppedNotMangled(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := dir + ".hookseen"
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rememberInjectedIDs(dir, "ses1", "tok one", "tok-two")
+	rememberInjected(dir, "ses1", []model.Session{{ID: "sess a"}, {ID: "sess-b"}})
+	body, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(body), "\n"), "\n") {
+		if n := len(strings.Fields(line)); n != 2 && n != 3 {
+			t.Errorf("a line of %d fields: %q", n, line)
+		}
+	}
+	seen := alreadyInjected(dir, "ses1")
+	for _, want := range []string{"tok-two", "sess-b"} {
+		if !seen[want] {
+			t.Errorf("%q was not recorded", want)
+		}
+	}
+	// The ids that could not be written are simply absent — the index looks
+	// them up by their own spelling, so a mapped stand-in would match nothing.
+	for _, gone := range []string{"tok", "one", "tok_one", "sess", "a", "sess_a"} {
+		if seen[gone] {
+			t.Errorf("%q reads as already shown, though it was never written", gone)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2167. `.hookseen` is a line of whitespace-separated fields — `sid token [stamp]` — and the agent session id, which arrives in the hook payload, went into it verbatim:

```
sid="plain-1"       plain-1 tok | plain-1 sess-a …       self=true
sid="two words"     two words tok | …                    self=false
   a session called "two" sees 1 entry: map[words:true]
sid="forge\nvictim" forge | victim tok | forge | …       self=false
   a session called "victim" sees map[sess-a:true tok:true]
```

Three harms from one cause: a session whose id holds a space has no dedup at all, so the per-prompt hook shows it the same memory turn after turn — the fault #1967 and #2164 exist to prevent, reached from the other side; its entries land under whatever its first word names; and a newline writes a line of its own, so a payload can put an entry under any session id it likes and memory is withheld from that agent by another agent's payload.

The session id is mapped now — whitespace and control runes to `_` — on the way in and on the way out, so a mapped id matches itself and every id a harness actually sends maps to itself, which is why no file needs converting.

Review caught that I had mapped the value side too, where the value is compared against the index's own ids and a mapped one would match nothing. Values stay byte-exact; one that cannot be a field is left out of the file instead, which costs a second showing rather than the entry written after it. There is a test for that half as well.
