### PR TITLE
fix(index): stop deja fix's own output counting as a fresh error

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -116,6 +116,11 @@ func trimTimestamp(l string) string {
 	return l
 }
 
+// dejaFixReport matches the header line `deja fix` prints: the error, then the
+// date of the session it came from. Nothing else writes that separator with a
+// bare date behind it.
+var dejaFixReport = regexp.MustCompile(` · \d{4}-\d{2}-\d{2}$`)
+
 var leadingTimestamp = regexp.MustCompile(`^\[?\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\]?\s+`)
 
 // isFriction keeps the error shapes that name something specific. The generic
@@ -164,6 +169,15 @@ func isFriction(l string) bool {
 		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
 			return false
 		}
+	}
+	// `deja fix` prints the error it answers with the date beside it, and the
+	// command underneath. Both come back as tool output in the next session:
+	// the first is read as a fresh sighting of the error it is quoting, so
+	// asking deja about an error taught deja that the error happened again,
+	// and the command it printed became a candidate remedy for it. Found on a
+	// real store as the pair `command not found: python · 2026-05-18`.
+	if dejaFixReport.MatchString(l) || strings.HasPrefix(l, "ran next: ") {
+		return false
 	}
 	// The list was nine phrases about things not being found or permitted, and
 	// it matched 3 of 12 ordinary errors on measurement — missing runtime

--- a/internal/index/self_report_test.go
+++ b/internal/index/self_report_test.go
@@ -1,0 +1,35 @@
+package index
+
+import "testing"
+
+// Asking deja about an error must not teach deja that the error happened
+// again. `deja fix` prints the error with the date beside it and the command
+// underneath; both land in the next session's tool output, where the header
+// read as a fresh sighting and the command below it became a remedy for the
+// error it was quoting. Found on a real store as the pair
+// `command not found: python · 2026-05-18`.
+func TestDejasOwnFixReportIsNotFriction(t *testing.T) {
+	for _, l := range []string{
+		"command not found: python · 2026-05-18",
+		"zsh:1: command not found: timeout · 2026-01-02",
+		"  ran next: brew install coreutils",
+	} {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("deja's own report read as friction: %q", l)
+		}
+	}
+	// The same errors, as a tool actually prints them, still are.
+	for _, l := range []string{
+		"zsh:1: command not found: timeout",
+		"ModuleNotFoundError: No module named 'yaml'",
+	} {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("a real error stopped being friction: %q", l)
+		}
+	}
+	// A date at the end is deja's separator, not a general rule: a line that
+	// happens to end in a date without it keeps its meaning.
+	if _, ok := FrictionLine("fatal: could not read repository state at 2026-05-18"); !ok {
+		t.Error("a line ending in a date lost its meaning")
+	}
+}


### PR DESCRIPTION
Found while reading the confirmed pairs on a real store, where one of them is:

```
command not found: python · 2026-05-18   ->   git -C …/pin-manifests …
```

That error text with a date beside it is not something a shell prints — it is the header `deja fix` itself prints. So the sequence is: an agent asks deja about an error, deja answers, the answer lands in the next session's tool output, the header is read as a fresh sighting of the error it was quoting, and whatever command ran next became a candidate remedy for it.

The guard against deja's own report already exists for the `N sessions  ` shape, for exactly this reason. This adds the two lines `fix` emits.

The test also pins the other direction: the same errors as a tool actually prints them are still friction, and a line that merely ends in a date — `fatal: could not read repository state at 2026-05-18` — keeps its meaning, because the separator is what identifies the report, not the date.

Related to #2163, which has the wider measurement of what the pairs are worth.