### PR TITLE
fix(hook): key the deja vu limit by the session, not by what the payload says

### DIFF
--- a/cmd/deja/dejavu_key_test.go
+++ b/cmd/deja/dejavu_key_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The déjà vu line is rate-limited per session, and the session id comes from
+// the hook payload. `.dejavu` is a line of two fields, so an id carrying
+// whitespace was never matched — the line then fired on every prompt, which is
+// the wallpaper the limit exists to prevent — and an id carrying a newline
+// wrote a line under whatever followed it, spending another session's window
+// (#2170).
+func TestTheDejaVuLimitIsKeptPerSessionWhateverTheIDLooksLike(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := dir + ".dejavu"
+	for _, sid := range []string{"plain-1", "two words", "forge\nvictim", "tab\tsep"} {
+		if err := os.WriteFile(p, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !dejaVuLineDue(dir, sid) {
+			t.Errorf("session %q was refused its first line", sid)
+		}
+		if dejaVuLineDue(dir, sid) {
+			t.Errorf("session %q is not rate-limited: it may say it again at once", sid)
+		}
+		// One entry per session, whatever its id looks like.
+		body, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n := len(strings.Split(strings.TrimRight(string(body), "\n"), "\n")); n != 1 {
+			t.Errorf("session %q wrote %d lines for one notice:\n%q", sid, n, body)
+		}
+		// And no other session's window was spent on it.
+		for _, other := range strings.FieldsFunc(sid, func(r rune) bool {
+			return r == ' ' || r == '\n' || r == '\t'
+		}) {
+			if other == sid {
+				continue
+			}
+			if !dejaVuLineDue(dir, other) {
+				t.Errorf("a session called %q was silenced by a payload calling itself %q", other, sid)
+			}
+		}
+	}
+
+	// The machine-wide fallback for a host that sends no id keeps its own
+	// window: a session may not spend it by naming itself after the key.
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !dejaVuLineDue(dir, "") {
+		t.Fatal("the no-id fallback was refused its first line")
+	}
+	if dejaVuLineDue(dir, "") {
+		t.Error("the no-id fallback is not rate-limited")
+	}
+	if !dejaVuLineDue(dir, "-") {
+		t.Error("a session calling itself \"-\" was silenced by the no-id fallback's window")
+	}
+}

--- a/cmd/deja/dejavu_line_test.go
+++ b/cmd/deja/dejavu_line_test.go
@@ -48,11 +48,24 @@ func TestDejaVuLineReturnsAfterTheWindow(t *testing.T) {
 	}
 	stale := time.Now().Add(-dejaVuLineWindow - time.Minute).Unix()
 	path := dir + ".dejavu"
-	if err := os.WriteFile(path, []byte("agent-0 "+strconv.FormatInt(stale, 10)+"\n"), 0o600); err != nil {
+	// Written under the key the file actually uses: a hand-spelled id is not
+	// one, and the read would then miss it for the wrong reason and let this
+	// pass without the window ever expiring (#2170).
+	line := dejaVuKey("agent-0") + " " + strconv.FormatInt(stale, 10) + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if !dejaVuLineDue(dir, "agent-0") {
 		t.Error("the line never came back after the window passed")
+	}
+	// The premise the assertion above rests on: the same entry inside the
+	// window does withhold it.
+	fresh := dejaVuKey("agent-0") + " " + strconv.FormatInt(time.Now().Unix(), 10) + "\n"
+	if err := os.WriteFile(path, []byte(fresh), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if dejaVuLineDue(dir, "agent-0") {
+		t.Error("an entry inside the window did not withhold the line, so the test above measures nothing")
 	}
 }
 

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -704,25 +704,11 @@ func rememberInjectedIDs(dir, sid string, ids ...string) {
 func dejaVuLineDue(dir, sid string) bool {
 	p := dir + ".dejavu"
 	now := time.Now()
-	if sid == "" {
-		if b, err := os.ReadFile(p); err == nil {
-			for _, line := range strings.Split(string(b), "\n") {
-				fields := strings.Fields(line)
-				if len(fields) != 2 || fields[0] != "-" {
-					continue
-				}
-				if ts, err := strconv.ParseInt(fields[1], 10, 64); err == nil &&
-					now.Sub(time.Unix(ts, 0)) < dejaVuLineWindow {
-					return false
-				}
-			}
-		}
-		return recordDejaVuLine(p, "-", now)
-	}
+	key := dejaVuKey(sid)
 	if b, err := os.ReadFile(p); err == nil {
 		for _, line := range strings.Split(string(b), "\n") {
 			fields := strings.Fields(line)
-			if len(fields) != 2 || fields[0] != sid {
+			if len(fields) != 2 || fields[0] != key {
 				continue
 			}
 			if ts, err := strconv.ParseInt(fields[1], 10, 64); err == nil &&
@@ -731,7 +717,24 @@ func dejaVuLineDue(dir, sid string) bool {
 			}
 		}
 	}
-	return recordDejaVuLine(p, sid, now)
+	return recordDejaVuLine(p, key, now)
+}
+
+// dejaVuKey is how a session is named in `.dejavu`, which is two fields to a
+// line and holds the machine-wide fallback under "-".
+//
+// Mapped, for the reason hookseenKey is: the id comes from the hook payload, a
+// space made the line three fields so nothing ever matched it — the notice then
+// fired on every prompt, which the limit exists to prevent — and a newline
+// wrote a line under whatever followed it, spending another session's window.
+// Prefixed, so an agent calling itself "-" cannot share the fallback's window
+// with a host that sent no id at all. Entries age out inside twenty minutes, so
+// the shape can change without converting anything (#2170).
+func dejaVuKey(sid string) string {
+	if sid == "" {
+		return "-"
+	}
+	return "s" + hookseenKey(sid)
 }
 
 const (


### PR DESCRIPTION
Fixes #2170, the sibling of #2167 one file over. `.dejavu` is `sid <unix>` per line, read with `strings.Fields`, and the id comes from the hook payload:

```
sid="two words"     due=true,true,true    "two words 1787832592|"
sid="forge\nvictim" due=true,true,true    "forge|victim …|victim …|"   victimDue=false
sid="-"             due=true,false,false  "- 1787832592|"
no id:              due=true then false
a session calling itself "-": due=false
```

Three faults, and the middle one is two at once: an id with a space is never matched, so the déjà vu notice fires on every prompt — the wallpaper the limit exists to prevent; an id with a newline writes a line under whatever follows it, spending another session's window while never spending its own; and `-` is the machine-wide fallback's key, so a session naming itself that shares the window meant for a host that sends no id.

The mapping from #2167 answers the first two. The third wants the two kinds of key told apart, so a session is written as `s` plus the mapped id, and the two read branches — which differed only in that key — are one. Entries age out inside twenty minutes, so nothing needs converting.

Review caught that the change made `TestDejaVuLineReturnsAfterTheWindow` pass for the wrong reason: it hand-writes a stale entry, and with the old spelling the read now misses it on the key rather than on the window. It writes the real key and checks the premise — the same entry inside the window does withhold the line — so the expiry is tested again.
