### PR TITLE
fix(index): a command that failed is not a fix

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -34,6 +34,10 @@ const (
 	// settle it: measured over this machine's transcripts, 104 of the 831 pairs
 	// the miner kept were contradicted that way, and each one is a wrong answer
 	// handed to an agent at the moment it is stuck.
+	// fixOutputWindow is how far past a command its own output can sit. One
+	// record in the ordinary case; two leaves room for a harness that writes
+	// something between them.
+	fixOutputWindow = 2
 	// fixCommandMax bounds what is stored per pair; a command longer than this
 	// is a heredoc or a pasted script, not something to hand back.
 	fixCommandMax = 200
@@ -251,6 +255,64 @@ func lastFrictionIndex(ms []model.Message) map[uint64]int {
 	return last
 }
 
+// genericFailure are the shapes isFriction turns away. It turns them away for
+// identity — `Error: ` names nothing a second session can be matched on — and
+// that is a different question from whether the command failed, which is all
+// this asks.
+var genericFailure = []string{
+	"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL", "panic: ",
+}
+
+// outputReadsAsFailure reports whether what a command printed is a failure:
+// either a friction line, which is specific enough to be one, or one of the
+// shapes friction declines to name.
+func outputReadsAsFailure(text string) bool {
+	if _, _, ok := firstFrictionLine(text); ok {
+		return true
+	}
+	for _, raw := range strings.Split(text, "\n") {
+		l := strings.TrimSpace(raw)
+		for _, g := range genericFailure {
+			if strings.HasPrefix(l, g) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// commandFailed reads the exit status the record carries, for the harnesses
+// that store one (codex and opencode append it; Claude does not).
+func commandFailed(text string) bool {
+	i := strings.LastIndex(text, "→ exit ")
+	if i < 0 {
+		return false
+	}
+	code := strings.TrimSpace(text[i+len("→ exit "):])
+	if j := strings.IndexAny(code, " \n"); j >= 0 {
+		code = code[:j]
+	}
+	n, err := strconv.Atoi(code)
+	return err == nil && n != 0
+}
+
+// outputFailed reports whether what came back from the command is itself an
+// error. The same friction rules the error side uses, so a command that
+// printed a fresh failure is read as one wherever the exit status is not
+// recorded.
+func outputFailed(ms []model.Message, cmd int) bool {
+	for k := cmd + 1; k < len(ms) && k <= cmd+fixOutputWindow; k++ {
+		if ms[k].Role == roleCommand {
+			return false
+		}
+		if ms[k].Role != roleToolOutput {
+			continue
+		}
+		return outputReadsAsFailure(ms[k].Text)
+	}
+	return false
+}
+
 // fixPairsIn mines one session.
 func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 	var out []FixPair
@@ -276,6 +338,16 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			}
 			if lastSeen[sig] > j {
 				break
+			}
+			// A command that failed is not a remedy for anything, and handing
+			// one to an agent at the moment it is stuck is the worst place to
+			// be wrong. Two ways to know: the record says so, where the
+			// harness stored the exit status, and the output right after it
+			// carries an error of its own. Keep scanning the window — a
+			// session that tried something and failed usually tries again,
+			// and the retry is the pair worth having.
+			if commandFailed(ms[j].Text) || outputFailed(ms, j) {
+				continue
 			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
 			break

--- a/internal/index/fixpair_test.go
+++ b/internal/index/fixpair_test.go
@@ -87,6 +87,55 @@ func TestFixPairsKeepACommandADifferentErrorFollowed(t *testing.T) {
 	}
 }
 
+// A command that failed is not a remedy. Reading 116 confirmed pairs off a real
+// store, ten stored a command whose own record said it exited non-zero — and
+// this line is handed to an agent at the moment it is stuck, where being wrong
+// costs most.
+func TestFixPairsDropACommandThatFailedItself(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh:1: command not found: timeout", Time: now},
+		{Role: "command", Text: "python3 -m pytest  → exit 1", Time: now.Add(time.Minute)},
+	}
+	if pairs := fixPairsIn(ms, "claude:s1", "p"); len(pairs) != 0 {
+		t.Errorf("a command that exited non-zero was stored as a fix: %+v", pairs)
+	}
+}
+
+// Where the harness stores no exit status — Claude does not — the output right
+// after the command says the same thing.
+func TestFixPairsDropACommandWhoseOutputFailed(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh:1: command not found: timeout", Time: now},
+		{Role: "command", Text: "brew install coreutils", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "Error: Permission denied @ dir_s_mkdir - /opt/homebrew/lib", Time: now.Add(2 * time.Minute)},
+	}
+	if pairs := fixPairsIn(ms, "claude:s1", "p"); len(pairs) != 0 {
+		t.Errorf("a command whose output failed was stored as a fix: %+v", pairs)
+	}
+}
+
+// And the retry is what the session is for: a failed attempt must not take the
+// error's whole look-ahead window with it.
+func TestFixPairsKeepTheRetryAfterAFailedAttempt(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh:1: command not found: timeout", Time: now},
+		{Role: "command", Text: "brew install coreutils", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "Error: Permission denied @ dir_s_mkdir - /opt/homebrew/lib", Time: now.Add(2 * time.Minute)},
+		{Role: "command", Text: "curl --max-time 5 example.internal", Time: now.Add(3 * time.Minute)},
+		{Role: "tool-output", Text: "200 OK", Time: now.Add(4 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 {
+		t.Fatalf("want the retry stored, got %d pairs: %+v", len(pairs), pairs)
+	}
+	if pairs[0].Command != "curl --max-time 5 example.internal" {
+		t.Errorf("wrong command stored: %q", pairs[0].Command)
+	}
+}
+
 // Sequence alone is 13% precise on a real store — the next command is usually
 // the session moving on. A pair survives the build only with a second reason:
 // the command names what the error named, or the same remedy recurs.


### PR DESCRIPTION
From reading the confirmed pairs on a real store (#2163). Ten of 116 stored a command whose own record says it exited non-zero — `command not found: python` answered by `python3 -m pytest → exit 1`. That line is handed to an agent at the moment it is stuck, which is where being wrong costs most.

Two ways to know a command failed, because only some harnesses record the first:

- the exit status in the record (codex and opencode append it; Claude does not),
- the output right after it reading as a failure.

The second uses the friction rules plus the shapes friction deliberately declines — `Error: `, `FAIL\t`, `--- FAIL`, `Traceback`, `panic: `. Those are turned away for *identity*: `Error: ` names nothing a second session can be matched on. Whether the command failed is a different question, and for that they are exactly the evidence.

A failed attempt no longer takes the error's whole look-ahead window with it either — the scan continues, so the retry that follows is the pair that gets stored. That is the third test.

On a rebuild of the same store: confirmed pairs 84 → 70, candidates 620 → 563, build time unchanged at 18.3s → 18.7s.

What this does **not** fix is the larger thing in #2163: the surviving pairs are still mostly the next debugging step, because "the command names something the error named" is satisfied by construction when the command greps for the symbol the compiler complained about. That needs its own change.