### PR TITLE
fix(index): reading something is not fixing it

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -173,7 +173,7 @@ func commandHookLine(dir, cmd string) string {
 	// these are the top of the table (git status --short in 116 sessions), and
 	// a line about them on every action is pure noise. The value is in a build,
 	// a test, a deploy — a command that does something.
-	if inspectionCommand(cmd) {
+	if index.InspectionCommand(cmd) {
 		return ""
 	}
 	use, ok := index.CommandHistory(dir, cmd)
@@ -416,30 +416,6 @@ func fileMetaInScope(meta index.SessionMeta, path string, projects []string) boo
 }
 
 func baseName(p string) string { return index.CrossBase(p) }
-
-// inspectionCommand reports whether the command only looks at state rather than
-// changing it — the class whose reuse-count says nothing worth an injection.
-func inspectionCommand(cmd string) bool {
-	f := strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ ")))
-	if len(f) == 0 {
-		return true
-	}
-	switch f[0] {
-	case "ls", "cat", "pwd", "echo", "which", "whoami", "date", "env", "printenv",
-		"head", "tail", "less", "more", "stat", "file", "find", "tree", "df", "du",
-		"ps", "top", "htop", "id", "uname", "hostname", "clear", "history":
-		return true
-	case "git":
-		if len(f) > 1 {
-			switch f[1] {
-			case "status", "diff", "log", "show", "branch", "remote", "stash",
-				"blame", "reflog", "describe", "rev-parse", "ls-files":
-				return true
-			}
-		}
-	}
-	return false
-}
 
 // truncateToolLine caps the line at max bytes on a rune boundary, so a
 // non-ASCII filename near the limit is not split mid-rune into a U+FFFD.

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -349,6 +349,14 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			if commandFailed(ms[j].Text) || outputFailed(ms, j) {
 				continue
 			}
+			// Reading something is not fixing it. The rule that keeps a pair —
+			// the command names what the error named — is satisfied by
+			// construction when the command greps for the symbol the compiler
+			// complained about, so the table filled with the step an agent
+			// takes between hitting an error and solving it.
+			if investigationCommand(cmd) {
+				continue
+			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
 			break
 		}

--- a/internal/index/inspection.go
+++ b/internal/index/inspection.go
@@ -1,0 +1,149 @@
+package index
+
+import "strings"
+
+// InspectionCommand reports whether the command only looks at state rather than
+// changing it — the class whose reuse-count says nothing worth an injection.
+func InspectionCommand(cmd string) bool {
+	for _, part := range commandParts(cmd) {
+		if !inspectionOne(part) {
+			return false
+		}
+	}
+	return true
+}
+
+// commandParts splits a shell line into the commands it runs. A line that
+// changes something is not an inspection because it also ran `cd` first, and
+// `cd /tmp && git grep x` was reaching the classifier as `cd`.
+func commandParts(cmd string) []string {
+	fields := strings.FieldsFunc(cmd, func(r rune) bool { return r == ';' || r == '\n' })
+	var out []string
+	for _, f := range fields {
+		for _, part := range strings.Split(f, "&&") {
+			for _, part := range strings.Split(part, "||") {
+				if p := strings.TrimSpace(part); p != "" {
+					out = append(out, p)
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		return []string{cmd}
+	}
+	return out
+}
+
+func inspectionOne(cmd string) bool {
+	f := strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ ")))
+	if len(f) == 0 {
+		return true
+	}
+	// `cd` decides nothing on its own; what follows it does, and that is a
+	// separate part.
+	if f[0] == "cd" {
+		return true
+	}
+	if f[0] == "git" {
+		// git's own options come before the subcommand: `git -C dir status`
+		// read as the subcommand `-C` and fell through as a change (#2163).
+		f = append([]string{"git"}, dropGitGlobals(f[1:])...)
+	}
+	switch f[0] {
+	case "ls", "cat", "pwd", "echo", "which", "whoami", "date", "env", "printenv",
+		"head", "tail", "less", "more", "stat", "file", "find", "tree", "df", "du",
+		"ps", "top", "htop", "id", "uname", "hostname", "clear", "history":
+		return true
+	case "git":
+		if len(f) > 1 {
+			switch f[1] {
+			case "status", "diff", "log", "show", "branch", "remote", "stash",
+				"blame", "reflog", "describe", "rev-parse", "ls-files",
+				// The rest of git's read side. `ls-files` was here and
+				// `ls-tree` was not, so half of the same class fell through.
+				"ls-tree", "grep", "cat-file", "show-ref", "for-each-ref",
+				"shortlog", "whatchanged", "rev-list", "merge-base", "config":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasFlag(fields []string, flag string) bool {
+	for _, f := range fields[1:] {
+		if f == flag || strings.HasPrefix(f, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// investigationCommand is the wider question the fix miner asks: could this
+// command have been the remedy at all? Reading and searching cannot be, and
+// neither can running the suite — that is how a fix is checked, not what fixes
+// anything. Kept apart from InspectionCommand deliberately: that one decides
+// whether "you have run this before" is worth saying, and a `go test` an agent
+// runs in every session is worth saying nothing about while still being a
+// perfectly ordinary thing to do.
+//
+// Reading the pairs a real store mined, the commands stored as the remedy for
+// `undefined: X` were overwhelmingly a grep for X — the rule that keeps a pair
+// (the command names what the error named) is satisfied by construction there.
+func investigationCommand(cmd string) bool {
+	for _, part := range commandParts(cmd) {
+		if !investigationOne(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func investigationOne(cmd string) bool {
+	if inspectionOne(cmd) {
+		return true
+	}
+	f := strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ ")))
+	if len(f) == 0 {
+		return true
+	}
+	if f[0] == "git" {
+		f = append([]string{"git"}, dropGitGlobals(f[1:])...)
+	}
+	switch f[0] {
+	case "grep", "rg", "ag", "ack", "awk", "wc", "diff", "jq", "yq", "column",
+		"sort", "uniq", "basename", "dirname", "realpath", "readlink", "gofmt":
+		return true
+	case "sed":
+		// `sed -n '10,20p' f` prints; `sed -i …` edits.
+		return !hasFlag(f, "-i") && !hasFlag(f, "--in-place")
+	case "go":
+		if len(f) > 1 {
+			switch f[1] {
+			case "test", "vet", "list", "doc", "version", "env":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dropGitGlobals removes the options git accepts before its subcommand, so the
+// subcommand is where the classifier looks.
+func dropGitGlobals(rest []string) []string {
+	for len(rest) > 0 {
+		switch {
+		case rest[0] == "-C" || rest[0] == "-c":
+			if len(rest) < 2 {
+				return nil
+			}
+			rest = rest[2:]
+		case strings.HasPrefix(rest[0], "--git-dir=") || strings.HasPrefix(rest[0], "--work-tree="),
+			rest[0] == "--no-pager", rest[0] == "--paginate", rest[0] == "--no-replace-objects":
+			rest = rest[1:]
+		default:
+			return rest
+		}
+	}
+	return nil
+}

--- a/internal/index/inspection_test.go
+++ b/internal/index/inspection_test.go
@@ -1,0 +1,68 @@
+package index
+
+import "testing"
+
+// InspectionCommand decides whether "you have run this before" is worth saying.
+// Two shapes were reaching it as changes: git's own options sit before the
+// subcommand, so `git -C dir status` was read as the subcommand `-C`, and a
+// line that starts with `cd` was read as `cd`.
+func TestInspectionCommandReadsPastGitOptionsAndCd(t *testing.T) {
+	for _, cmd := range []string{
+		"git status --short",
+		"git -C /tmp/wt status --short",
+		"git --no-pager -C /tmp/wt log -1",
+		"git -c user.name=x -C /tmp/wt show HEAD",
+		"cd /tmp && git -C /tmp/wt grep -n foo",
+		"cd /tmp; ls -la",
+	} {
+		if !InspectionCommand(cmd) {
+			t.Errorf("looking at state read as changing it: %q", cmd)
+		}
+	}
+	for _, cmd := range []string{
+		"git checkout -- cmd/deja/mcp.go",
+		"git -C /tmp/wt checkout HEAD -- x.go",
+		"cd /tmp && rm -rf build",
+		"brew install coreutils",
+		"ls -la && rm -rf build",
+	} {
+		if InspectionCommand(cmd) {
+			t.Errorf("changing state read as looking at it: %q", cmd)
+		}
+	}
+}
+
+// The miner asks a wider question than the hook: could this have been the
+// remedy at all? Running the suite is how a fix is checked, and a grep for the
+// symbol the compiler named is what an agent does before fixing it — the rule
+// that keeps a pair is satisfied by construction there.
+func TestInvestigationCommandCoversTheStepsBeforeAFix(t *testing.T) {
+	for _, cmd := range []string{
+		"go test ./internal/index/ -count=1",
+		"go vet ./...",
+		"grep -rn 'undefined' internal/",
+		"sed -n '10,20p' internal/index/ingest.go",
+		"rg -n reduceToTerms",
+		"gofmt -l internal",
+	} {
+		if !investigationCommand(cmd) {
+			t.Errorf("a step taken before the fix read as the fix: %q", cmd)
+		}
+	}
+	for _, cmd := range []string{
+		"sed -i '' 's/a/b/' f.go",
+		"go mod tidy",
+		"brew install gnu-sed",
+		"rm internal/index/zz_probe_test.go",
+	} {
+		if investigationCommand(cmd) {
+			t.Errorf("a change read as investigation: %q", cmd)
+		}
+	}
+	// The hook's question is narrower and must stay that way: an agent runs
+	// `go test` in every session, and that is worth saying nothing about
+	// while still being an ordinary thing to do rather than an inspection.
+	if InspectionCommand("go test ./... -count=1") {
+		t.Error("the miner's rule leaked into the hook's")
+	}
+}


### PR DESCRIPTION
The last of the three things #2163 measured. Reading the confirmed pairs off a real store, the commands stored as the remedy for `undefined: X` were overwhelmingly a grep for X — because the rule that keeps a pair, *the command names something the error named*, is satisfied by construction when the command is an investigation of that error.

deja already classifies this: `inspectionCommand` decides whether "you have run this before" is worth saying. It lived in `cmd/deja` where the miner could not reach it, so it moves to `internal/index` and both surfaces use one list.

**The two questions are kept apart on purpose.** `InspectionCommand` answers the hook's: is the reuse count worth an injection. `investigationCommand` answers the miner's: could this have been the remedy at all — which also rules out `go test` and `go vet`, since running the suite is how a fix is checked rather than what fixes anything. Folding those into the shared list broke the hook's own test, correctly, and that is what split them.

Two gaps in the existing classifier turned up while measuring and are fixed for both surfaces:

- git's options come before the subcommand, so `git -C dir status` was read as the subcommand `-C` and fell through as a change.
- a line was classified by its first word, so `cd /tmp && rm -rf build` was read as `cd`. Each part is classified now, and the line is an inspection only if all of them are.
- `ls-files` was in the git read list and `ls-tree` and `grep` were not, so half the same class fell through.

On a rebuild of the same store, confirmed pairs 70 → 32 and candidates 563 → 452. What is left reads like remedies — `git checkout -- cmd/deja/mcp.go` for a file broken mid-edit, `rm <stale test file>` before rerunning — rather than the step before one.