### PR TITLE
feat(index): read a failing test as friction, by its name

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -56,6 +56,7 @@ func FrictionLine(l string) (string, bool) {
 func normalizeFriction(l string) string {
 	l = strings.TrimSpace(l)
 	l = strings.TrimSpace(trimLogPrefix(l))
+	l = trimTestDuration(l)
 	// The prefix is `<where>:<line>: `, where <where> is a shell name or an
 	// `(eval)`/`(anon)` marker. Only strip it when the middle field is a
 	// number — `Error: cannot find x: y` must keep its shape.
@@ -136,6 +137,15 @@ func isFriction(l string) bool {
 	// environment block or `deja fix` (#1319).
 	if n := utf8.RuneCountInString(l); n < frictionLineMin || n > frictionLineMax {
 		return false
+	}
+	// A named test failure is the most specific thing a build prints: the test
+	// name is stable across runs and across machines, which is more than most
+	// error strings manage. It was rejected with the bare summary lines, and on
+	// this machine's store that is 2,318 of the 6,744 error lines an agent
+	// actually hit — the single most common failure it sees, and the one it
+	// most often solved before.
+	if namedTestFailure(l) {
+		return true
 	}
 	for _, generic := range []string{
 		"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL",
@@ -399,4 +409,37 @@ func frictionTexts(dir string, m Manifest, metas []SessionMeta, want map[uint64]
 			return
 		}
 	}
+}
+
+// goTestFailure matches the line `go test` prints for a failing test, with the
+// subtest path Go writes for table cases. The name is the identity; anything
+// after it is this run's.
+var goTestFailure = regexp.MustCompile(`^--- (?:FAIL|SKIP): (\S+)`)
+
+// testDuration is the per-run time Go appends to that line. Two runs of the
+// same failing test differ only there, and left in, each run is its own piece
+// of friction and none of them ever reaches a second session.
+var testDuration = regexp.MustCompile(`\s+\(\d+(?:\.\d+)?s\)$`)
+
+func trimTestDuration(l string) string {
+	if !strings.HasPrefix(l, "--- ") {
+		return l
+	}
+	return strings.TrimSpace(testDuration.ReplaceAllString(l, ""))
+}
+
+// namedTestFailure reports whether the line is a test failure carrying a test
+// name, as opposed to the bare `FAIL` and `--- FAIL` summaries that name
+// nothing and are rejected with the other generic shapes.
+func namedTestFailure(l string) bool {
+	m := goTestFailure.FindStringSubmatch(l)
+	if m == nil {
+		return false
+	}
+	// Source that quotes the shape is not a failure — the same reason the
+	// quote and comment guards below exist.
+	if strings.ContainsAny(l, "\"$") {
+		return false
+	}
+	return len(m[1]) > 3
 }

--- a/internal/index/inspection.go
+++ b/internal/index/inspection.go
@@ -39,6 +39,10 @@ func inspectionOne(cmd string) bool {
 	if len(f) == 0 {
 		return true
 	}
+	f = dropShellKeywords(f)
+	if len(f) == 0 {
+		return true
+	}
 	// `cd` decides nothing on its own; what follows it does, and that is a
 	// separate part.
 	if f[0] == "cd" {
@@ -52,12 +56,22 @@ func inspectionOne(cmd string) bool {
 	switch f[0] {
 	case "ls", "cat", "pwd", "echo", "which", "whoami", "date", "env", "printenv",
 		"head", "tail", "less", "more", "stat", "file", "find", "tree", "df", "du",
-		"ps", "top", "htop", "id", "uname", "hostname", "clear", "history":
+		"ps", "top", "htop", "id", "uname", "hostname", "clear", "history",
+		// Waiting is not doing: a poll loop around a read is still a read,
+		// and `sleep` left one part of it unclassified, which made the whole
+		// line count as a change.
+		"sleep", "wait", "true", "false", "printf":
 		return true
 	case "git":
 		if len(f) > 1 {
 			switch f[1] {
-			case "status", "diff", "log", "show", "branch", "remote", "stash",
+			case "stash", "worktree", "tag", "remote":
+				// Read or write depending on the argument: `git stash list`
+				// looks, `git stash push` changes; `git worktree list` looks,
+				// `git worktree add` changes. Listed unconditionally before,
+				// which read every one of them as a look.
+				return len(f) > 2 && gitReadArg(f[2])
+			case "status", "diff", "log", "show", "branch",
 				"blame", "reflog", "describe", "rev-parse", "ls-files",
 				// The rest of git's read side. `ls-files` was here and
 				// `ls-tree` was not, so half of the same class fell through.
@@ -103,7 +117,7 @@ func investigationOne(cmd string) bool {
 	if inspectionOne(cmd) {
 		return true
 	}
-	f := strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ ")))
+	f := dropShellKeywords(strings.Fields(strings.ToLower(strings.TrimPrefix(strings.TrimSpace(cmd), "$ "))))
 	if len(f) == 0 {
 		return true
 	}
@@ -114,6 +128,16 @@ func investigationOne(cmd string) bool {
 	case "grep", "rg", "ag", "ack", "awk", "wc", "diff", "jq", "yq", "column",
 		"sort", "uniq", "basename", "dirname", "realpath", "readlink", "gofmt":
 		return true
+	case "gh":
+		// Going to look at CI after a failure is the same move as grepping
+		// for the symbol: it is where an agent goes next, not what it did
+		// about it.
+		if len(f) > 2 {
+			switch f[2] {
+			case "checks", "view", "list", "status", "diff":
+				return true
+			}
+		}
 	case "sed":
 		// `sed -n '10,20p' f` prints; `sed -i …` edits.
 		return !hasFlag(f, "-i") && !hasFlag(f, "--in-place")
@@ -146,4 +170,30 @@ func dropGitGlobals(rest []string) []string {
 		}
 	}
 	return nil
+}
+
+// dropShellKeywords removes the words a shell puts in front of the command
+// itself. `until gh pr checks …; do sleep 20; done` was classified as the
+// command `until`.
+func dropShellKeywords(f []string) []string {
+	for len(f) > 0 {
+		switch f[0] {
+		case "until", "while", "if", "then", "else", "elif", "do", "done", "fi", "time", "!":
+			f = f[1:]
+		default:
+			return f
+		}
+	}
+	return nil
+}
+
+// gitReadArg is the argument that makes an argument-dependent git subcommand a
+// read: `list` and `show` for stash and worktree, the list flags for tag and
+// remote.
+func gitReadArg(a string) bool {
+	switch a {
+	case "list", "show", "-l", "--list", "-v", "--verbose":
+		return true
+	}
+	return false
 }

--- a/internal/index/test_failure_test.go
+++ b/internal/index/test_failure_test.go
@@ -1,0 +1,69 @@
+package index
+
+import "testing"
+
+// A failing test is the most common thing an agent hits in a Go repo — 2,318
+// of the 6,744 error lines on the store this was measured against — and it was
+// rejected by name, listed with the shapes that identify nothing. The test name
+// identifies plenty: it is stable across runs and across machines, which is
+// more than most error strings manage.
+func TestANamedTestFailureIsFriction(t *testing.T) {
+	line, ok := FrictionLine("--- FAIL: TestGrokSinceHandlesEveryStampShape (0.09s)")
+	if !ok {
+		t.Fatal("a failing test is not read as friction")
+	}
+	// The duration is this run's, not the failure's. Left in, every run is its
+	// own piece of friction and none of them ever reaches a second session.
+	if line != "--- FAIL: TestGrokSinceHandlesEveryStampShape" {
+		t.Errorf("the run's duration stayed in the line: %q", line)
+	}
+	other, _ := FrictionLine("    --- FAIL: TestGrokSinceHandlesEveryStampShape (12.40s)")
+	if other != line {
+		t.Errorf("two runs of the same failing test do not compare equal: %q vs %q", other, line)
+	}
+}
+
+// The summary lines name nothing, which is why they were rejected in the first
+// place, and they stay rejected.
+func TestTheBareFailSummariesAreStillNotFriction(t *testing.T) {
+	for _, l := range []string{
+		"FAIL",
+		"FAIL\tgithub.com/vshulcz/deja-vu/internal/index\t20.4s",
+		"--- FAIL",
+		`t.Fatalf("--- FAIL: %s", name)`,
+	} {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a line that identifies nothing was read as friction: %q", l)
+		}
+	}
+}
+
+// The classifier decides whether a command could have been the remedy, and
+// several git subcommands are a read or a write depending on the argument.
+func TestGitSubcommandsThatDependOnTheirArgument(t *testing.T) {
+	for _, cmd := range []string{
+		"git stash list | head -3",
+		"git worktree list",
+		"git tag -l",
+		"git remote -v",
+	} {
+		if !InspectionCommand(cmd) {
+			t.Errorf("a read was classified as a change: %q", cmd)
+		}
+	}
+	// Going to look at CI is the miner's question, not the hook's: it is where
+	// an agent goes after a failure, not what it did about it.
+	if !investigationCommand("until gh pr checks 2059; do sleep 20; done") {
+		t.Error("a poll loop around a read was classified as a remedy")
+	}
+	for _, cmd := range []string{
+		"git stash push -u -m wip",
+		"git worktree add /tmp/wt main",
+		"git tag v1.2.3",
+		"git remote add origin git@github.com:x/y",
+	} {
+		if InspectionCommand(cmd) {
+			t.Errorf("a change was classified as a read: %q", cmd)
+		}
+	}
+}


### PR DESCRIPTION
I measured this idea in #2163 and threw it away, because the pairs it produced were junk: 419 test-failure pairs, 335 of them just re-running the suite. That was before #2166, #2172 and #2174, which withhold a pair when the error comes back later, when the command failed, and when the command was an investigation rather than a change. Under those rules the junk filters itself, so I measured it again.

```
                                    before   after
confirmed pairs                         32     149
  of those, failing tests                0     119
the failure hook speaks, of 250 real failures    2      10
```

`--- FAIL: TestName (0.09s)` was rejected by name, listed with `FAIL\t` and bare `--- FAIL` as a shape that identifies nothing. The name identifies plenty — it is stable across runs and machines, more than most error strings manage. The per-run duration is normalised away, or two runs of the same failing test never compare equal and neither ever reaches a second session.

Three gaps in the command classifier turned up while reading what the new pairs stored, and they are fixed here because without them the pairs read as noise:

- `git stash`, `worktree`, `tag` and `remote` were listed as reads unconditionally, so `git stash push` and `git worktree add` counted as looking at state.
- a poll loop was classified by its first word: `until gh pr checks 2059; do sleep 20; done` was the command `until`.
- `gh pr checks` / `view` / `list` are where an agent goes to look after a failure, not what it did about it.

The 10-of-250 is still a small number in absolute terms. It is the surface going from silent to speaking, on the moment where being useful matters most.