### PR TITLE
fix(hook): answer each payload for the project it names

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -45,10 +45,17 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	// Antigravity runs the hook with the working directory set to the folder
 	// holding hooks.json, not the user's project, so scoping recall by cwd
 	// would silently recall nothing. The payload names the real workspace.
-	if len(input.WorkspacePaths) > 0 && input.WorkspacePaths[0] != "" && os.Getenv("CLAUDE_PROJECT_DIR") == "" {
-		_ = os.Setenv("CLAUDE_PROJECT_DIR", input.WorkspacePaths[0])
+	workspace := ""
+	if len(input.WorkspacePaths) > 0 {
+		workspace = input.WorkspacePaths[0]
 	}
-	digest, sessions, raw, _, _ := cachedHookDigest(dir)
+	if workspace != "" && os.Getenv("CLAUDE_PROJECT_DIR") == "" {
+		_ = os.Setenv("CLAUDE_PROJECT_DIR", workspace)
+	}
+	// The payload, not the export it may or may not have set: the export is
+	// written once per process and refuses to change, so a second payload was
+	// answered for the first one's workspace (#2182).
+	digest, sessions, raw, _, _ := cachedHookDigestFor(dir, workspace)
 	if digest == "" {
 		fmt.Fprintln(stdout, "{}")
 		return nil

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -240,7 +240,7 @@ func runHookContext(dir string, plain bool) error {
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
 	// none (#759).
 	adoptHookCWD(input.CWD)
-	digest, sessions, raw, taskMatched, withheld := cachedHookDigest(dir)
+	digest, sessions, raw, taskMatched, withheld := cachedHookDigestFor(dir, input.CWD)
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
 		// checkout — and exactly where knowing what this machine is missing
@@ -572,7 +572,16 @@ func hookCWD(fromPayload string) string {
 }
 
 func cachedHookDigest(dir string) (string, int, int64, []string, int) {
-	cwd := hookCWD("")
+	return cachedHookDigestFor(dir, "")
+}
+
+// cachedHookDigestFor is cachedHookDigest for a caller that was told which
+// project the call is about. The payload is that authority: `adoptHookCWD`
+// exports it and will not overwrite an export already there, so reading it back
+// out of the environment answered a second payload in the same process with the
+// first one's project (#2182).
+func cachedHookDigestFor(dir, fromPayload string) (string, int, int64, []string, int) {
+	cwd := hookCWD(fromPayload)
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
 		return "", 0, 0, nil, 0
 	}
@@ -601,7 +610,7 @@ func cachedHookDigest(dir string) (string, int, int64, []string, int) {
 			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld
 		}
 	}
-	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
+	digest, sessions, raw, taskMatched, withheld := hookDigestResultFor(dir, cwd)
 	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
 	return digest, sessions, raw, taskMatched, withheld
 }
@@ -676,6 +685,14 @@ func hookDigest(dir string) string {
 }
 
 func hookDigestResult(dir string) (string, int, int64, []string, int) {
+	return hookDigestResultFor(dir, "")
+}
+
+// hookDigestResultFor is hookDigestResult for a caller that was told which
+// project the call is about, rather than one reading it back out of the
+// environment: the export is set once per process and refuses to change, so a
+// second payload was answered with the first one's project (#2182).
+func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string, int) {
 	withheld := 0
 	defer func() { _ = recover() }()
 	trace := os.Getenv("DEJA_TRACE") == "1"
@@ -700,7 +717,10 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 		requestWarmup(dir)
 		return "", 0, 0, nil, 0
 	}
-	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
+	cwd := fromPayload
+	if cwd == "" {
+		cwd = os.Getenv("CLAUDE_PROJECT_DIR")
+	}
 	if cwd == "" {
 		var err error
 		cwd, err = os.Getwd()

--- a/cmd/deja/hook_project_per_payload_test.go
+++ b/cmd/deja/hook_project_per_payload_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The payload says which project a hook call is about. `adoptHookCWD` exports
+// it and refuses to overwrite an export that is already there, so a second
+// payload in the same process was answered with the first one's project —
+// framed and injected exactly as a right answer would be (#2182).
+//
+// One process per invocation is the shape today, which is what made this a
+// landmine rather than a fault; five doors call `adoptHookCWD`, and the second
+// of them in any process inherited the first one's project.
+func TestEachHookPayloadIsAnsweredForItsOwnProject(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "alpha", "one.jsonl"), "alpha1", []string{
+		`{"type":"user","sessionId":"alpha1","timestamp":"` + old +
+			`","message":{"role":"user","content":"the alpha work: pgbouncer runs in transaction mode"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "beta1", []string{
+		`{"type":"user","sessionId":"beta1","timestamp":"` + old +
+			`","message":{"role":"user","content":"the beta work: the kafka consumer keeps rebalancing"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	base := t.TempDir()
+	alpha := filepath.Join(base, "tmp", "alpha")
+	beta := filepath.Join(base, "tmp", "beta")
+	for _, d := range []string{alpha, beta} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Neither the working directory nor the environment names a project, so
+	// the payload is the only thing that does.
+	t.Chdir(base)
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+
+	answer := func(cwd string) string {
+		t.Helper()
+		withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "s", "cwd": cwd}))
+		return captureStdout(t, func() { runHookContextPlain(t) })
+	}
+	// The premise: asked about alpha first, it answers about alpha.
+	first := answer(alpha)
+	if !strings.Contains(first, "transaction mode") {
+		t.Fatalf("the first call did not carry alpha's memory, so this measures nothing:\n%s", first)
+	}
+	// The one that mattered: a second session, another project, same process.
+	second := answer(beta)
+	if strings.Contains(second, "transaction mode") {
+		t.Errorf("a session in beta was handed alpha's memory:\n%s", second)
+	}
+	if !strings.Contains(second, "rebalancing") {
+		t.Errorf("a session in beta was not handed beta's memory:\n%s", second)
+	}
+	// And back, so the answer follows the payload rather than latching onto
+	// whichever project came last.
+	third := answer(alpha)
+	if !strings.Contains(third, "transaction mode") || strings.Contains(third, "rebalancing") {
+		t.Errorf("the third call, about alpha again, was not answered about alpha:\n%s", third)
+	}
+}
+
+// The doors are many and the fault was one line each: read the project out of
+// the process environment rather than out of the payload that named it. This
+// keeps that line from coming back anywhere in the hook files — the two places
+// that may touch the export are the helper that reads the chain and the one
+// that sets it, plus antigravity's guard on whether to set it at all.
+func TestNoHookDoorReadsTheProjectOutOfTheEnvironment(t *testing.T) {
+	files, err := filepath.Glob("hook_*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) < 5 {
+		t.Fatalf("found %d hook files, so this measures nothing", len(files))
+	}
+	allowed := map[string]bool{
+		// hookCWD is the chain itself: payload, then export, then where the
+		// process stands. adoptHookCWD writes it. The antigravity door asks
+		// whether the export is already set before writing the workspace it
+		// was handed.
+		"hook_context.go":     true,
+		"hook_antigravity.go": true,
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") || allowed[filepath.Base(f)] {
+			continue
+		}
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(b), `os.Getenv("CLAUDE_PROJECT_DIR")`) {
+			t.Errorf("%s reads the project out of the environment: the payload names it, and the export "+
+				"is written once per process and will not change (#2182)", f)
+		}
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -152,10 +152,10 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		requestWarmup(dir)
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
-	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
-	if cwd == "" {
-		cwd, _ = os.Getwd()
-	}
+	// The payload first, then the export, then where the process stands: the
+	// export is set once per process and will not change, so reading it alone
+	// answered a second payload with the first one's project (#2182).
+	cwd := hookCWD(input.CWD)
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -80,7 +79,7 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	if !planIndexReady(dir) {
 		return nil
 	}
-	line := toolHookLine(dir, input)
+	line := toolHookLine(dir, hookCWD(input.CWD), input)
 	if line == "" {
 		return nil
 	}
@@ -114,15 +113,15 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 // the tool that runs a command, and a file's history only before the file is
 // changed — Read, Glob and NotebookRead carry a file_path too, and a hook wired
 // with a wide matcher would otherwise fire on every one of them.
-func toolHookLine(dir string, input toolHookInput) string {
+func toolHookLine(dir, cwd string, input toolHookInput) string {
 	switch input.ToolName {
 	case "Bash":
 		if cmd := strings.TrimSpace(input.ToolInput.Command); cmd != "" {
-			return commandHookLine(dir, cmd)
+			return commandHookLine(dir, cwd, cmd)
 		}
 	case "Edit", "Write", "MultiEdit", "NotebookEdit":
 		if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
-			return fileHookLine(dir, path)
+			return fileHookLine(dir, cwd, path)
 		}
 	case "apply_patch":
 		// Codex and other OpenAI-style agents make every file edit through a
@@ -131,7 +130,7 @@ func toolHookLine(dir string, input toolHookInput) string {
 		// file-history line fires here too — without this the hook is blind to
 		// every edit those agents make.
 		for _, path := range applyPatchFiles(input.ToolInput.Command) {
-			if line := fileHookLine(dir, path); line != "" {
+			if line := fileHookLine(dir, cwd, path); line != "" {
 				return line
 			}
 		}
@@ -158,7 +157,7 @@ func applyPatchFiles(patch string) []string {
 	return out
 }
 
-func commandHookLine(dir, cmd string) string {
+func commandHookLine(dir, cwd, cmd string) string {
 	// "You have run this before" is worthless for an inspection command the
 	// agent runs constantly — git status, git diff, ls, cat. On a real store
 	// these are the top of the table (git status --short in 116 sessions), and
@@ -206,7 +205,7 @@ func commandHookLine(dir, cmd string) string {
 	// exists changes nothing. A command deserves the same: before `npm run
 	// build`, what matters is that it failed here last time and why, not that
 	// it has been run twice.
-	if d := commandDecisionLine(dir, cmd); d != "" {
+	if d := commandDecisionLine(dir, cwd, cmd); d != "" {
 		return head + " — last time: " + d
 	}
 	return head + "."
@@ -219,14 +218,10 @@ func commandHookLine(dir, cmd string) string {
 // the files a session touched but not the commands it ran, so there is no
 // cheaper lookup, and this hook fires on a build or a deploy rather than on
 // every message — the prompt hook already pays a search per keystroke.
-func commandDecisionLine(dir, cmd string) string {
+func commandDecisionLine(dir, cwd, cmd string) string {
 	terms := prompt.Terms(normalizedCommandText(cmd))
 	if len(terms) == 0 {
 		return ""
-	}
-	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
-	if cwd == "" {
-		cwd, _ = os.Getwd()
 	}
 	ranked, matched, _, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
 	if err != nil {
@@ -267,16 +262,12 @@ func normalizedCommandText(cmd string) string {
 	return strings.Join(out, " ")
 }
 
-func fileHookLine(dir, path string) string {
+func fileHookLine(dir, cwd, path string) string {
 	// FileSessions matches on the file's basename, so without scoping "main.go"
 	// or "README.md" collects every project's file of that name — the line then
 	// claims a history this file does not have and points `deja blame` at a
 	// pile of other repos. Count only sessions in the project being worked in,
 	// unless the stored path is the exact one (which cannot collide).
-	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
-	if cwd == "" {
-		cwd, _ = os.Getwd()
-	}
 	projects := digest.ProjectNameCandidates(cwd)
 	// A hook that fires unasked is the auto activation, so a session the trust
 	// policy withholds must not even be counted here.


### PR DESCRIPTION
Fixes #2182. `adoptHookCWD` exports the payload's cwd as `CLAUDE_PROJECT_DIR` and refuses to overwrite one already there; the doors then read that export rather than the payload. Three calls in one process — alpha, beta, alpha:

```
payload cwd=alpha  env=alpha  alpha=true beta=false
payload cwd=beta   env=alpha  alpha=true beta=false
payload cwd=alpha  env=alpha  alpha=true beta=false
```

The second session asked about beta and was handed alpha's memory, framed and injected exactly as a right answer would be. One process per invocation is the shape today, so this is a landmine rather than a live fault — but the code cannot see it, and #1953 pinned the export in two tests for this very reason and left the behaviour.

The payload is the authority for which project a call is about, so it is passed down: through the cache lookup and into the digest, which was reading the environment a second time on its own.

Review then made the point that mattered: fixing one of five doors is worse than the uniform bug, because the same helper would mean two different things. So the per-prompt door, both tool-hook lines and the antigravity door take the payload's project too, and a source guard keeps `os.Getenv("CLAUDE_PROJECT_DIR")` out of the hook files — the export is still written, for the rest of the process and anything it spawns, and read only by the chain helper that documents the order.

```
payload cwd=beta   env=alpha  alpha=false beta=true
```
