### PR TITLE
fix(goose): take the project from the hook payload, not the process cwd

### DIFF
--- a/cmd/deja/goose_hook_payload_test.go
+++ b/cmd/deja/goose_hook_payload_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The goose hooks are the two doors #2183's guard cannot see, because they live
+// beside the installer rather than in `hook_*.go`. Both threw the payload away
+// and recalled from wherever the process stood, so a host that runs its hooks
+// from a plugin directory rather than the project got an empty file and no
+// reason why. Goose's own payload fields are not documented to include cwd, so
+// this is the door being right about a field it is handed, not a fix that
+// changes goose's behaviour today (#2187).
+func TestTheGooseHooksRecallForTheProjectTheirPayloadNames(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	at := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "beta1", []string{
+		`{"type":"user","sessionId":"beta1","timestamp":"` + at +
+			`","message":{"role":"user","content":"the beta work: the kafka consumer keeps rebalancing"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	base := t.TempDir()
+	beta := filepath.Join(base, "tmp", "beta")
+	elsewhere := filepath.Join(base, "plugin-dir")
+	for _, d := range []string{beta, elsewhere} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	moim := filepath.Join(base, "moim.md")
+	t.Setenv("CLAUDE_PROJECT_DIR", "")
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", moim)
+	recalled := func() string {
+		b, err := os.ReadFile(moim)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+
+	// The premise: standing in the project, the session-start hook recalls it.
+	t.Chdir(beta)
+	withHookStdin(t, hookPayload(t, map[string]string{"session_id": "s", "cwd": beta}))
+	if err := cmdGooseHook("", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recalled(), "rebalancing") {
+		t.Fatalf("the hook recalled nothing from inside the project, so this measures nothing:\n%s", recalled())
+	}
+	if err := os.Remove(moim); err != nil {
+		t.Fatal(err)
+	}
+
+	// The case: the hook runs where the host put it, and the payload is the
+	// only thing that names the project.
+	t.Chdir(elsewhere)
+	withHookStdin(t, hookPayload(t, map[string]string{"session_id": "s", "cwd": beta}))
+	if err := cmdGooseHook("", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recalled(), "rebalancing") {
+		t.Errorf("the session-start hook ignored the project its payload named:\n%s", recalled())
+	}
+
+	// And the prompt half, which re-encodes a payload of its own and used to
+	// drop the project on the way.
+	if err := os.Remove(moim); err != nil {
+		t.Fatal(err)
+	}
+	payload := hookPayload(t, map[string]string{
+		"session_id": "s", "cwd": beta, "message": "why does the kafka consumer keep rebalancing",
+	})
+	if err := refreshGooseForPrompt(index.DefaultDir(), []byte(payload)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(recalled(), "rebalanc") {
+		t.Errorf("the prompt hook ignored the project its payload named:\n%s", recalled())
+	}
+}

--- a/cmd/deja/hook_project_per_payload_test.go
+++ b/cmd/deja/hook_project_per_payload_test.go
@@ -83,7 +83,7 @@ func TestNoHookDoorReadsTheProjectOutOfTheEnvironment(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(files) < 5 {
-		t.Fatalf("found %d hook files, so this measures nothing", len(files))
+		t.Fatalf("found %d files, so this measures nothing", len(files))
 	}
 	allowed := map[string]bool{
 		// hookCWD is the chain itself: payload, then whatever the host

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -266,8 +266,16 @@ func writeGooseHook() error {
 // searched against what the user just typed rather than chosen when the
 // session opened.
 func cmdGooseHook(_ string, _ []string) error {
-	_ = readHookStdin()
-	return refreshGooseHints()
+	// The payload names the project, when the host puts it there. This door
+	// discarded it and recalled from wherever the process stood, so a host that
+	// runs its hooks from a plugin directory rather than the project got the
+	// recall of nowhere (#2187). Decoded rather than unmarshalled, like the
+	// other doors, so trailing bytes cost nothing.
+	var input struct {
+		CWD string `json:"cwd"`
+	}
+	_ = json.NewDecoder(bytes.NewReader(readHookStdin())).Decode(&input)
+	return refreshGooseHintsFor(input.CWD)
 }
 
 // refreshGooseForPrompt writes prompt-scoped recall where goose will read it.
@@ -284,15 +292,26 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 		// Goose calls it message; matcher_context carries the same text.
 		Message string `json:"message"`
 		Prompt  string `json:"prompt"`
+		CWD     string `json:"cwd"`
 	}
-	_ = json.Unmarshal(payload, &input)
+	_ = json.NewDecoder(bytes.NewReader(payload)).Decode(&input)
 	prompt := input.Message
 	if prompt == "" {
 		prompt = input.Prompt
 	}
+	// The project travels with the prompt: this re-encodes a payload of its
+	// own, and dropping the cwd left the recall scoped to wherever the process
+	// stood (#2187). Marshalled rather than quoted by hand, since strconv.Quote
+	// writes \x escapes that are not JSON.
+	inner, err := json.Marshal(struct {
+		Prompt string `json:"prompt"`
+		CWD    string `json:"cwd"`
+	}{prompt, input.CWD})
+	if err != nil {
+		return err
+	}
 	var out strings.Builder
-	if err := runHookPromptMode(dir, strings.NewReader(
-		`{"prompt":`+strconv.Quote(prompt)+`}`), &out, true); err != nil {
+	if err := runHookPromptMode(dir, bytes.NewReader(inner), &out, true); err != nil {
 		return err
 	}
 	// Silence means the history has nothing for this question. Leave the
@@ -305,7 +324,7 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 		return err
 	}
 	old, _ := os.ReadFile(path)
-	_, err := writeIfChanged(path, old, []byte(out.String()))
+	_, err = writeIfChanged(path, old, []byte(out.String()))
 	return err
 }
 
@@ -319,7 +338,14 @@ func gooseRecallPath() string {
 }
 
 func refreshGooseHints() error {
-	digest, sessions, _, _, _ := cachedHookDigest(index.DefaultDir())
+	return refreshGooseHintsFor("")
+}
+
+// refreshGooseHintsFor is refreshGooseHints for a caller that was told which
+// project the call is about; "" leaves the chain to answer, which is what the
+// wrapper and the installer want (#2187).
+func refreshGooseHintsFor(cwd string) error {
+	digest, sessions, _, _, _ := cachedHookDigestFor(index.DefaultDir(), cwd)
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(gooseLead + digest)


### PR DESCRIPTION
Closes #2187.

`cmdGooseHook` read its stdin payload and threw it away, then refreshed the hints from `cachedHookDigest` — i.e. from wherever the process happened to stand. `refreshGooseForPrompt` decoded the payload only for the prompt text and re-encoded a payload without the project. A host that runs its hooks from a plugin directory instead of the project got the recall of nowhere:

    payload names beta, process stands elsewhere: recalled=false
    payload names beta, process stands in it:     recalled=true

Both doors now take `cwd` from the payload and pass it down the usual chain (payload, then `CLAUDE_PROJECT_DIR`, then the process cwd), so an absent field leaves behaviour byte-for-byte as it was.

Worth saying plainly: goose is not documented to send `cwd`, and I have no fixture proving it does. If it does not, this changes nothing for goose itself and only makes the door correct about a field it may be handed. The re-encoded prompt payload is now `json.Marshal`ed rather than assembled with `strconv.Quote`, which is not JSON for control bytes.