### PR TITLE
fix(doctor): name the files the ingest counts came from in --json

### DIFF
--- a/cmd/deja/doctor_ingest_files_test.go
+++ b/cmd/deja/doctor_ingest_files_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// doctor's ingest line ends "see `deja doctor --json`", and the JSON carried
+// the same two numbers the line had just printed: a person told a line was
+// skipped could not learn which file it was in. The manifest has held that per
+// file since #2015 — nothing exposed it (#2189).
+func TestDoctorJSONNamesTheFilesItsCountsCameFrom(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	lines := []string{
+		`{"ts":"` + now + `","text":"the migration held the lock"}`,
+		`not json at all`,
+		`{"ts":"2026-01-03","text":"a date without a time"}`,
+	}
+	if err := os.WriteFile(notes, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, _ := captureRun(t, "doctor", "--json")
+	var report struct {
+		Ingest map[string]struct {
+			MalformedLines int `json:"malformed_lines"`
+		} `json:"ingest_health"`
+		Files map[string]struct {
+			Malformed int    `json:"malformed,omitempty"`
+			Error     string `json:"error,omitempty"`
+			Clipped   int    `json:"clipped,omitempty"`
+		} `json:"ingest_files"`
+	}
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("doctor --json does not parse: %v", err)
+	}
+	// The premise: this run refused lines, so a report naming no file is
+	// hiding something rather than having nothing to say.
+	if report.Ingest["deja"].MalformedLines != 2 {
+		t.Fatalf("the run did not refuse the two lines, so this measures nothing:\n%s", raw)
+	}
+	if len(report.Files) == 0 {
+		t.Fatalf("doctor --json names no file for the lines it says were skipped:\n%s", raw)
+	}
+	got, ok := report.Files[notes]
+	if !ok {
+		named := make([]string, 0, len(report.Files))
+		for p := range report.Files {
+			named = append(named, p)
+		}
+		t.Fatalf("the notes file is not among the files named (%v); a person fixing it is not told it is theirs", named)
+	}
+	if got.Malformed != 2 {
+		t.Errorf("the notes file is reported with %d refused lines, want 2", got.Malformed)
+	}
+	// And here, where every file belongs to a harness deja knows, the per-file
+	// counts add up to the rollup printed above them — or the reader has two
+	// numbers and no way to tell which one is wrong.
+	sum := 0
+	for _, f := range report.Files {
+		sum += f.Malformed
+	}
+	total := 0
+	for _, h := range report.Ingest {
+		total += h.MalformedLines
+	}
+	if sum != total {
+		t.Errorf("the files account for %d refused lines and the rollup says %d", sum, total)
+	}
+}

--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -37,7 +37,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// doctorReport
 		"schema_version": true, "stores": true, "index": true, "mcp": true,
 		"sqlite3": true, "version": true, "embed": true, "policy": true,
-		"ingest_health": true, "deep": true,
+		"ingest_health": true, "ingest_files": true, "deep": true,
 		// doctorStore
 		"name": true, "state": true, "paths": true, "files": true,
 		"indexed_sessions": true, "indexed_from_elsewhere": true,
@@ -57,6 +57,8 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		"stamped_ahead": true,
 		// index.HarnessIngest
 		"malformed_lines": true, "clipped_messages": true,
+		// index.FileIngest
+		"malformed": true, "clipped": true,
 		"failed_files": true, "last_error": true,
 		// index.DeepReport / index.DeepFinding
 		"files_checked": true, "sessions_indexed": true, "sampled_files": true,

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -86,8 +86,12 @@ type doctorReport struct {
 	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
 	Policy        doctorPolicyReport             `json:"policy"`
 	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
-	Sync          doctorSyncReport               `json:"sync"`
-	Deep          *index.DeepReport              `json:"deep,omitempty"`
+	// IngestFiles is where those counts came from. Without it the pointer at
+	// the end of doctor's ingest line led back to the numbers it had just
+	// printed, and the file to fix was never named (#2189).
+	IngestFiles map[string]index.FileIngest `json:"ingest_files,omitempty"`
+	Sync        doctorSyncReport            `json:"sync"`
+	Deep        *index.DeepReport           `json:"deep,omitempty"`
 }
 
 // doctorSyncReport is the Sync section in the machine form. The text report has
@@ -249,6 +253,7 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	}
 	report.Index = inspectDoctorIndex(dir, storeMods)
 	report.Ingest = index.IngestHealth(dir)
+	report.IngestFiles = index.IngestFilesReport(dir)
 	report.MCP = collectDoctorMCP()
 	report.SQLite3.State = "missing"
 	if sources.SQLite3Available() {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -351,6 +351,9 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
   "ingest_health": {
     "claude": {"malformed_lines": 0, "failed_files": 0}
   },
+  "ingest_files": {
+    "/Users/you/.claude/projects/app/one.jsonl": {"malformed": 2}
+  },
   "sync": {
     "state": "ok",
     "peers": [
@@ -391,6 +394,13 @@ Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 `auto`, each with the rule in force and how many sessions it withheld;
 `ignored` and `inert` list policy lines that matched no harness or no import.
 Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`.
+
+`ingest_files` is where those counts came from, keyed by file path: `malformed`
+lines, `clipped` messages, and `error` when the file itself would not open. It
+is sparse — a file with nothing to report is not in it — and absent when no file
+has anything to report. The per-harness numbers above are the sum of the files
+deja can attribute to a harness, so a path it cannot place is here and in no
+harness's total. Line numbers are not recorded: the parsers count refused lines, not where they were.
 
 `sync.state` is `ok` or `unreadable`; `unreadable` adds an `error` saying why the peers file could not be parsed, and its `peers` list is empty because deja could read nothing from it — a sync is never stopped by a malformed config, so the report is the only place that failure shows. `sync.peers` is every machine this one knows, and it is always present — an
 empty list means no machines are configured, which a script can tell apart from

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -60,6 +60,21 @@ func IngestHealth(dir string) map[string]HarnessIngest {
 	return m.IngestHealth
 }
 
+// IngestFilesReport returns the same story per file: which path each refused
+// line, clipped message or unreadable store came from. The rollup says a line
+// was skipped and doctor points at `--json` for more, which used to hold the
+// rollup again (#2189). Sparse — only files with something to report.
+func IngestFilesReport(dir string) map[string]FileIngest {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	return m.IngestFiles
+}
+
 // mergeIngestDiag folds the sources side-channel counters into the manifest.
 // The counts live per file, because that is what they are about: a pass that
 // re-reads one transcript must not erase what a different one reported, and a


### PR DESCRIPTION
Closes #2189.

`deja doctor` ends its ingest line with "see `deja doctor --json`", and the JSON carried only `ingest_health` — the same per-harness rollup the text line had just printed. So a person told a line was skipped could not find out which file it was in, and the store that hurts most is the notes file, which they wrote by hand.

The counts have been per path in the manifest since #2015. They are now exposed as `ingest_files`, keyed by file, sparse as it is there, and documented. Additive, so no `schema_version` bump.

Line numbers stay out: the parsers count refused lines, they do not record where they were.