### PR TITLE
fix(search): accept the notes harness by the name the index run prints

### DIFF
--- a/cmd/deja/harness_notes_alias_test.go
+++ b/cmd/deja/harness_notes_alias_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The index run narrates the notes store as "notes", and filtering by the name
+// it just printed was refused as a typo: `checkHarness` (#1113) rejects the
+// name before retrieval's own alias (#1888) can accept it. Both gates now agree
+// (#2191).
+func TestFilteringByTheNameTheIndexRunPrintsForNotes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	line := `{"ts":"` + now + `","text":"the kafka consumer rebalances when the heartbeat is late"}`
+	if err := os.WriteFile(notes, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	said, err := captureRunStderr(t, "index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: this is the name the run prints, or the filter is being
+	// asked to accept something nobody was shown.
+	if !strings.Contains(said, "notes:") {
+		t.Fatalf("the index run does not call the store notes, so this measures nothing:\n%s", said)
+	}
+	// And the note is searchable under the stored name, so a miss below is the
+	// filter and not an empty index.
+	if out, _ := captureRun(t, "search", "rebalances", "--harness", "deja"); !strings.Contains(out, "heartbeat is late") {
+		t.Fatalf("the note is not searchable under its stored name:\n%s", out)
+	}
+
+	out, err := captureRun(t, "search", "rebalances", "--harness", "notes")
+	if err != nil {
+		t.Fatalf("search --harness notes failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "heartbeat is late") {
+		t.Errorf("search --harness notes does not reach the notes the run just counted:\n%s", out)
+	}
+	stats, err := captureRun(t, "stats", "--harness", "notes")
+	if err != nil {
+		t.Fatalf("stats --harness notes failed: %v\n%s", err, stats)
+	}
+	// The one session in the index is the note, and stats compares the stored
+	// name exactly, so counting it is the whole question.
+	if !strings.Contains(stats, "1 session indexed") {
+		t.Errorf("stats --harness notes does not count the note the run just indexed:\n%s", stats)
+	}
+	// An empty result names the flag the reader passed, not the name deja
+	// stores it under — the same rule the --since echo follows.
+	empty, _ := captureRunStderr(t, "search", "zzzznothing", "--harness", "notes")
+	if strings.Contains(empty, `harness "deja"`) || !strings.Contains(empty, `harness "notes"`) {
+		t.Errorf("the empty result names a filter the reader did not pass:\n%s", empty)
+	}
+	// A real typo is still a typo.
+	if _, err := captureRun(t, "search", "rebalances", "--harness", "notez"); err == nil {
+		t.Errorf("an unknown harness is accepted, so the check no longer tells a typo from a name")
+	}
+}

--- a/cmd/deja/harness_validation_test.go
+++ b/cmd/deja/harness_validation_test.go
@@ -11,16 +11,24 @@ import (
 // sessions — both said "matched nothing under harness X" — so `--harness
 // cluade` read as "you have no claude history" (#1113).
 func TestCheckHarnessRejectsOnlyUnknownNames(t *testing.T) {
-	if err := checkHarness(""); err != nil {
+	empty := ""
+	if err := checkHarness(&empty); err != nil {
 		t.Errorf("an empty harness is the no-filter case, not an error: %v", err)
 	}
 	// Every registry name must pass, installed or not.
 	for _, name := range sources.HarnessNames() {
-		if err := checkHarness(name); err != nil {
+		if err := checkHarness(&name); err != nil {
 			t.Errorf("known harness %q rejected: %v", name, err)
 		}
 	}
-	err := checkHarness("cluade")
+	// The name the index run prints for the notes store, which the check now
+	// rewrites to the one it is stored under (#2191).
+	printed := "notes"
+	if err := checkHarness(&printed); err != nil || printed != "deja" {
+		t.Errorf("notes was not accepted as the printed name for deja: %v, left as %q", err, printed)
+	}
+	typo := "cluade"
+	err := checkHarness(&typo)
 	if err == nil {
 		t.Fatal("a misspelled harness was accepted")
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -800,7 +800,8 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	if err != nil {
 		return err
 	}
-	if err := checkHarness(o.Harness); err != nil {
+	harnessRaw := o.Harness
+	if err := checkHarness(&o.Harness); err != nil {
 		return err
 	}
 	if err := checkRole(o.Role); err != nil {
@@ -836,7 +837,7 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 		// is advice for a state the tool is not in: indexing changes nothing
 		// and doctor reports the stores as found. Name what emptied the result
 		// instead (#637).
-		if where := activeFilters(o, sinceRaw); where != "" {
+		if where := activeFilters(o, sinceRaw, harnessRaw); where != "" {
 			fmt.Fprintf(os.Stderr, "deja: no sessions match %s\n", where)
 			fmt.Fprint(os.Stderr, olderThanWindow(dir, o.Since))
 			return nil
@@ -978,7 +979,8 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	if err != nil {
 		return err
 	}
-	if err := checkHarness(o.Harness); err != nil {
+	harnessRaw := o.Harness
+	if err := checkHarness(&o.Harness); err != nil {
 		return err
 	}
 	if err := checkRole(o.Role); err != nil {
@@ -1100,8 +1102,8 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 		switch note := policyHiddenNote(policy.ActivationSearch, policyHidden); {
 		case note != "":
 			fmt.Fprint(os.Stderr, note)
-		case activeFilters(o, sinceRaw) != "":
-			fmt.Fprintf(os.Stderr, "deja: %q matched nothing under %s\n", o.Query, activeFilters(o, sinceRaw))
+		case activeFilters(o, sinceRaw, harnessRaw) != "":
+			fmt.Fprintf(os.Stderr, "deja: %q matched nothing under %s\n", o.Query, activeFilters(o, sinceRaw, harnessRaw))
 			fmt.Fprint(os.Stderr, emptyRoleNote(dir, o.Role))
 			fmt.Fprint(os.Stderr, olderThanWindow(dir, o.Since))
 		default:
@@ -1545,11 +1547,19 @@ func olderThanWindow(dir string, since time.Duration) string {
 // nothing under harness X" — so `--harness cluade` read as "you have no claude
 // history" instead of "that is not a harness". A known-but-empty harness is
 // still valid; only an unknown name is refused (#1113).
-func checkHarness(name string) error {
-	if name == "" || sources.IsKnownHarness(name) {
+// It also normalises, which is why it takes a pointer: the notes store is
+// stored as "deja" and narrated by the index run as "notes", and retrieval has
+// accepted both since #1888 — but this check ran first and refused the printed
+// name as a typo, so nothing below it ever saw the alias, and `deja stats`
+// compares the stored name exactly (#2191).
+func checkHarness(name *string) error {
+	if *name == "notes" {
+		*name = "deja"
+	}
+	if *name == "" || sources.IsKnownHarness(*name) {
 		return nil
 	}
-	return fmt.Errorf("%q is not a harness deja knows — one of: %s", name, strings.Join(sources.HarnessNames(), ", "))
+	return fmt.Errorf("%q is not a harness deja knows — one of: %s", *name, strings.Join(sources.HarnessNames(), ", "))
 }
 
 // knownRoles is the set `--role` accepts. It lists the documented spellings the
@@ -1601,10 +1611,17 @@ func emptyRoleNote(dir, role string) string {
 // activeFilters names the filters a caller set, so an empty result can say
 // which of them emptied it rather than blaming the index. sinceRaw carries
 // what the reader actually typed: "168h0m0s" is not the flag they passed.
-func activeFilters(o search.Options, sinceRaw string) string {
+func activeFilters(o search.Options, sinceRaw, harnessRaw string) string {
 	var parts []string
 	if o.Harness != "" {
-		parts = append(parts, fmt.Sprintf("harness %q", o.Harness))
+		// Same reason as sinceRaw: `--harness notes` is stored as "deja", and
+		// telling someone their "deja" filter matched nothing names a flag
+		// they did not pass (#2191).
+		name := o.Harness
+		if harnessRaw != "" {
+			name = harnessRaw
+		}
+		parts = append(parts, fmt.Sprintf("harness %q", name))
 	}
 	if o.Project != "" {
 		parts = append(parts, fmt.Sprintf("project %q", o.Project))
@@ -2072,7 +2089,7 @@ func runBlame(dir string, args []string) error {
 	// A typo'd harness must name the mistake, not read as "nobody touched this
 	// file under harness X" — the same reason search and the MCP blame validate
 	// it (#1113). blame has no --role to check.
-	if err := checkHarness(o.Harness); err != nil {
+	if err := checkHarness(&o.Harness); err != nil {
 		return err
 	}
 	target, err := search.ResolveBlamePath(path)

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -610,7 +610,7 @@ func TestPrintNoMatchesReportsTheStoreSize(t *testing.T) {
 }
 
 func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
-	if got := activeFilters(search.Options{}, ""); got != "" {
+	if got := activeFilters(search.Options{}, "", ""); got != "" {
 		t.Fatalf("no filters set, got %q", got)
 	}
 	// Each filter alone, so none of them can be deleted unnoticed.
@@ -623,11 +623,11 @@ func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
 		{search.Options{Role: "command"}, `role "command"`},
 		{search.Options{Since: 24 * time.Hour}, "since 24h0m0s"},
 	} {
-		if got := activeFilters(c.o, ""); got != c.want {
+		if got := activeFilters(c.o, "", ""); got != c.want {
 			t.Errorf("got %q, want %q", got, c.want)
 		}
 	}
-	got := activeFilters(search.Options{Harness: "codex", Project: "api", Role: "command", Since: 24 * time.Hour}, "7d")
+	got := activeFilters(search.Options{Harness: "codex", Project: "api", Role: "command", Since: 24 * time.Hour}, "7d", "")
 	for _, want := range []string{`harness "codex"`, `project "api"`, `role "command"`, "since 7d", " and "} {
 		if !strings.Contains(got, want) {
 			t.Errorf("%q missing from %q", want, got)
@@ -642,7 +642,7 @@ func TestActiveFiltersNamesWhatEmptiedTheResult(t *testing.T) {
 	// from the command line. It stays here because filterRecentSources applies
 	// no time filter for one, and naming it would report a filter that never
 	// ran and suppress the empty-store advice.
-	if got := activeFilters(search.Options{Since: -time.Hour}, "-1h"); got != "" {
+	if got := activeFilters(search.Options{Since: -time.Hour}, "-1h", ""); got != "" {
 		t.Errorf("named a filter that was never applied: %q", got)
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -296,7 +296,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		if err := checkHarness(a.Harness); err != nil {
+		if err := checkHarness(&a.Harness); err != nil {
 			return "", err
 		}
 		if line := buildingNowForAgent(dir); line != "" {
@@ -326,7 +326,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Query) == "" {
 			return "", fmt.Errorf("query required")
 		}
-		if err := checkHarness(a.Harness); err != nil {
+		if err := checkHarness(&a.Harness); err != nil {
 			return "", err
 		}
 		if line := buildingNowForAgent(dir); line != "" {
@@ -354,7 +354,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if strings.TrimSpace(a.Path) == "" {
 			return "", fmt.Errorf("path required")
 		}
-		if err := checkHarness(a.Harness); err != nil {
+		if err := checkHarness(&a.Harness); err != nil {
 			return "", err
 		}
 		var since time.Duration

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -108,7 +108,7 @@ func runStats(dir string, args []string) error {
 	if (jsonOut && card) || (jsonOut && html) || (card && html) {
 		return fmt.Errorf("stats: choose one output")
 	}
-	if err := checkHarness(options.Harness); err != nil {
+	if err := checkHarness(&options.Harness); err != nil {
 		return fmt.Errorf("stats: %w", err)
 	}
 	if err := checkRole(options.Role); err != nil {


### PR DESCRIPTION
Closes #2191.

The index run prints `notes: 1 session`, and `--harness notes` came back with `"notes" is not a harness deja knows`. Retrieval has accepted the alias since #1888 — `checkHarness` (#1113) runs first and rejects it as a typo, so nothing below ever saw it, and `deja stats` compares the stored name exactly and never had the alias at all.

The check normalises `notes` to `deja` and then validates, so every surface that already calls it agrees. A typo is still refused, and `--harness deja` still works.

An empty result keeps the spelling the reader passed (`matched nothing under harness "notes"`), the same rule `--since` already follows.

Which of the two names should go is a separate question.