### PR TITLE
test: take the best of three in the two ratio-of-durations tests

### DIFF
--- a/cmd/deja/store_files_cost_test.go
+++ b/cmd/deja/store_files_cost_test.go
@@ -33,16 +33,26 @@ func TestTheEmptyScreenDoesNotParseEveryStore(t *testing.T) {
 		seedClaude(t, claude, "app", string(rune('a'+i)), "the pgbouncer pool kept timing out "+string(long), "we retried")
 	}
 
-	start := time.Now()
-	checks := doctorStoreChecks()
-	enumerate := time.Since(start)
-
-	start = time.Now()
-	answer := noAgentHistoryFound()
-	asked := time.Since(start)
-
-	if answer {
-		t.Fatal("the fixture has history, so this measures nothing")
+	// Best of three on each side. Both are well under a millisecond, and a
+	// runner busy with the rest of the suite stretches such a sample by more
+	// than the bar below allows — the same flake #2193 caught in the usage
+	// package. The minimum is the run that was not interrupted.
+	enumerate, asked := time.Duration(1<<62-1), time.Duration(1<<62-1)
+	var checks []doctorStoreCheck
+	for round := 0; round < 3; round++ {
+		start := time.Now()
+		checks = doctorStoreChecks()
+		if took := time.Since(start); took < enumerate {
+			enumerate = took
+		}
+		start = time.Now()
+		answer := noAgentHistoryFound()
+		if took := time.Since(start); took < asked {
+			asked = took
+		}
+		if answer {
+			t.Fatal("the fixture has history, so this measures nothing")
+		}
 	}
 	// Four times the enumeration, plus a millisecond or two of slack for a
 	// loaded runner: far above the spread between runs, far below the cost of

--- a/internal/usage/rotate_growth_test.go
+++ b/internal/usage/rotate_growth_test.go
@@ -12,30 +12,50 @@ import (
 // next, so a process that records more than once pays it once.
 //
 // A ratio rather than a duration, so it means the same thing on a slow runner.
+//
+// Best of three on each side, because one loop is about six milliseconds and a
+// runner busy with the rest of the suite stretches that by twenty: measured,
+// one sample of each swung between 0.09 and 2.25 while the machine was loaded,
+// and this test has failed once that way and passed alone. The minimum of
+// several runs is the sample that was not interrupted.
 func TestAWriteDoesNotPayForTheWholeLog(t *testing.T) {
 	if testing.Short() {
 		t.Skip("timing")
 	}
-	fresh := t.TempDir()
-	start := time.Now()
-	for i := 0; i < 200; i++ {
-		RecordResultRaw(fresh, KindRecall, 900, 2, false, 9000)
+	best := func(prepare func(dir string)) time.Duration {
+		fastest := time.Duration(1<<62 - 1)
+		for round := 0; round < 3; round++ {
+			dir := t.TempDir()
+			prepare(dir)
+			start := time.Now()
+			for i := 0; i < 200; i++ {
+				RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+			}
+			if took := time.Since(start); took < fastest {
+				fastest = took
+			}
+		}
+		return fastest
 	}
-	base := time.Since(start)
+	base := best(func(string) {})
+	full := best(func(dir string) {
+		for i := 0; i < 12000; i++ {
+			RecordResultRaw(dir, KindRecall, 900, 2, false, 9000)
+		}
+	})
 
-	big := t.TempDir()
-	for i := 0; i < 12000; i++ {
-		RecordResultRaw(big, KindRecall, 900, 2, false, 9000)
+	// Both sides have to be worth measuring, or the ratio below is one piece
+	// of noise divided by another.
+	// Low enough that a machine several times faster than this one still
+	// clears it — two hundred writes take about 6 ms here — and high enough
+	// that a sample of pure noise does not become a ratio.
+	if base < 200*time.Microsecond {
+		t.Fatalf("two hundred writes to a fresh log took %v, which is too cheap to compare against", base)
 	}
-	start = time.Now()
-	for i := 0; i < 200; i++ {
-		RecordResultRaw(big, KindRecall, 900, 2, false, 9000)
-	}
-	full := time.Since(start)
-
 	// Ten times is far below the 135× this same test measures on the branch
 	// before the fix, and far above the noise between two runs of one loop.
 	if full > base*10 {
 		t.Errorf("writing to a full log took %v against %v on a fresh one", full, base)
 	}
+	t.Logf("fresh %v, full %v", base, full)
 }


### PR DESCRIPTION
Closes #2193.

`TestAWriteDoesNotPayForTheWholeLog` failed once inside a full `go test ./...` and passed alone. It times two loops of 200 writes — about 6 ms each — one sample per side, and compares them with a 10x bar. Beside a full suite run the same two loops measured ratios of 0.09, 1.70, 0.41, 2.25, 2.14, with the fresh-log side stretching from 6 ms to 270 ms.

Both sides now take the best of three, which is the run that was not interrupted, plus a floor refusing to compare when the fresh loop is under 200 us. Under the same load the ratio stays at 2.2 and below.

The bar still catches the regression it exists for — with the memo from #1972 disabled it reports `full log took 1.333s against 6.6ms on a fresh one`.

`cmd/deja.TestTheEmptyScreenDoesNotParseEveryStore` has the same shape (both sides under a millisecond, one sample each) and got the same treatment. `internal/index.TestHasRecordOfRoleStopsEarly` already did both. The grok linearity test is left alone: its samples are seconds under `-race`, so repeating it triples the most expensive test in that package.