### PR TITLE
fix(forget): close a torn tombstone line before appending the next key

### DIFF
--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/atomicfile"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -215,9 +216,20 @@ func appendTombstones(keys []string) error {
 		buf.WriteString(key)
 		buf.WriteByte('\n')
 	}
-	f, err := os.OpenFile(tombstonePath(), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	// O_RDWR because the append has to read the last byte: a process killed
+	// between a key and its newline leaves the file ending mid-line, and the
+	// next key appended onto that line loses both. Losing the interrupted key
+	// is the accepted cost of writing without a lock; losing the forget after
+	// it is not (#2195).
+	f, err := os.OpenFile(tombstonePath(), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0o600)
 	if err != nil {
 		return err
+	}
+	if atomicfile.EndsMidLine(f) {
+		if _, err := f.Write([]byte{'\n'}); err != nil {
+			_ = f.Close()
+			return err
+		}
 	}
 	if _, err := f.Write(buf.Bytes()); err != nil {
 		_ = f.Close()

--- a/internal/index/tombstone_torn_append_test.go
+++ b/internal/index/tombstone_torn_append_test.go
@@ -1,0 +1,47 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A process killed between a key and its newline leaves the file ending
+// mid-line. Losing that key is the accepted cost of appending without a lock
+// (#1029) — taking the next forget down with it is not: the new key was glued
+// onto the partial one, so the authoritative copy held neither, and only the
+// mirror beside the index still knew. Take the index away and the forgotten
+// session comes back (#2195).
+func TestATornTombstoneLineDoesNotSwallowTheNextForget(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	path := filepath.Join(privacyDir(), "tombstones")
+	if err := os.MkdirAll(privacyDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("claude:torn-half"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := appendTombstones([]string{"claude:b1"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Read back from this file alone: the mirror is a second copy for the case
+	// where this one is gone, and it must not be what makes this pass.
+	if got := readTombstoneFile(path); !got["claude:b1"] {
+		t.Errorf("the forget after a torn line is not in the file it is written to:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "claude:torn-halfclaude:b1") {
+		t.Errorf("the new key was appended onto the partial line:\n%s", raw)
+	}
+	// The interrupted key is still lost as a key and kept as a line: what it
+	// says is not a session anyone forgot, and rewriting it away is a decision
+	// for the reader, not for the writer that found it.
+	if lines := strings.Count(string(raw), "\n"); lines != 2 {
+		t.Errorf("file holds %d newlines, want 2:\n%s", lines, raw)
+	}
+}


### PR DESCRIPTION
Closes #2195.

A process killed between a tombstone key and its newline leaves the file ending mid-line. Losing that key is the accepted cost of appending without a lock (#1029); the next forget went with it:

    $ printf claude:torn-half > ~/.config/deja/tombstones
    $ deja forget --session b1
    tombstones added: 1
    $ od -c ~/.config/deja/tombstones
    c l a u d e : t o r n - h a l f c l a u d e : b 1 \n

`forget --list` still looked right because the mirror beside the index answered. Remove the index directory — a rebuild elsewhere, a new machine, a changed `DEJA_INDEX_DIR` — and the forgotten session was searchable again, which is the case the mirror exists for, running the other way.

The append now reads its last byte first, like the usage log (#1901), the notes file and promote (#871). Two writers padding at once leave a blank line, which the reader already skips.