### PR TITLE
fix(search): name a mistyped command even when the fallback search matched

### DIFF
--- a/cmd/deja/command_hint_with_hits_test.go
+++ b/cmd/deja/command_hint_with_hits_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureBoth runs one command and returns its stdout and stderr separately:
+// this test is about which of the two the hint lands on.
+func captureBoth(t *testing.T, args ...string) (string, string) {
+	t.Helper()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	go func() { b, _ := io.ReadAll(rOut); outCh <- string(b) }()
+	go func() { b, _ := io.ReadAll(rErr); errCh <- string(b) }()
+	_ = run(args)
+	_ = wOut.Close()
+	_ = wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+	return <-outCh, <-errCh
+}
+
+// A wrong guess at a command falls through to search, and the hint that says so
+// used to run only when the search came back empty (#674). A typo whose word is
+// in the history never got there: the reader saw a conversation they did not
+// ask for and nothing about the command they meant (#2197).
+func TestAMistypedCommandIsNamedEvenWhenTheSearchMatches(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	at := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claude, "alpha", "one.jsonl"), "c1", []string{
+		`{"type":"user","sessionId":"c1","timestamp":"` + at +
+			`","message":{"role":"user","content":"we ran deja stats and doctro on the box"}}`,
+	})
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: this word is in the history, so the search does find it and
+	// the hint is not standing in for an empty result.
+	out, said := captureBoth(t, "doctro")
+	if !strings.Contains(out, "doctro on the box") {
+		t.Fatalf("the fallback search found nothing, so this measures nothing:\n%s\n%s", out, said)
+	}
+	if !strings.Contains(said, "did you mean `deja doctor`?") {
+		t.Errorf("a mistyped command that matched something says nothing about the command:\n%s", said)
+	}
+	// On stderr, so a script reading the results is not fed the hint.
+	if strings.Contains(out, "did you mean") {
+		t.Errorf("the hint is on stdout, where the results are:\n%s", out)
+	}
+
+	// A bare search of more than one word is a search, however close its first
+	// word sits to a command name.
+	if _, saidPhrase := captureBoth(t, "doctro", "box"); strings.Contains(saidPhrase, "did you mean") {
+		t.Errorf("a multi-word bare search was read as a guess at a command:\n%s", saidPhrase)
+	}
+	// The explicit form is someone searching for the word, and stays quiet.
+	_, saidExplicit := captureBoth(t, "search", "doctro")
+	if strings.Contains(saidExplicit, "did you mean") {
+		t.Errorf("`deja search doctro` is a search, not a guess at a command:\n%s", saidExplicit)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -229,7 +229,7 @@ func run(args []string) error {
 	if cmd, ok := commands[args[0]]; ok {
 		return cmd(dir, args[1:])
 	}
-	return runSearch(dir, args, sourceInstance)
+	return runBareSearch(dir, args, sourceInstance)
 }
 
 func cmdVersion(_ string, _ []string) error {
@@ -965,7 +965,18 @@ func ensureForCLISearch(dir string, o search.Options, force bool, progress io.Wr
 	return nil
 }
 
+// runBareSearch is `deja <words>` — the form where the first word stood where a
+// command name goes. That is the only form the mistyped-command hint is about:
+// `deja search doctro` is someone searching for the word (#2197).
+func runBareSearch(dir string, args []string, sourceInstance string) error {
+	return searchWithOptions(dir, args, sourceInstance, true)
+}
+
 func runSearch(dir string, args []string, sourceInstance string) error {
+	return searchWithOptions(dir, args, sourceInstance, false)
+}
+
+func searchWithOptions(dir string, args []string, sourceInstance string, bare bool) error {
 	force := false
 	var filtered []string
 	for _, a := range args {
@@ -1132,6 +1143,19 @@ func runSearch(dir string, args []string, sourceInstance string) error {
 	// (#604).
 	o.Width = printableWidth(os.Stdout)
 	search.Print(os.Stdout, hits, o)
+	// A wrong guess at a command name falls through to search, and the hint
+	// that names it ran only on an empty result — so a typo whose word happens
+	// to be in the history got a conversation back and nothing about the
+	// command it meant (#2197). After the results, on stderr, and only for the
+	// bare form: `deja search doctro` is someone searching for the word.
+	//
+	// One word only, which is narrower than the empty-result hint on purpose.
+	// There, a hint costs nothing over a failed search; here it lands on an
+	// answer the reader may well have wanted, and "doctors pool" is a search
+	// however close its first word sits to a command name.
+	if bare && len(hits) > 0 && len(strings.Fields(o.Query)) == 1 {
+		fmt.Fprint(os.Stderr, commandHint(o.Query))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #2197.

`commandHint` only ran from `printNoMatches`, so a mistyped command whose word happens to be in the history never reached it:

    $ deja doctro
    [claude] alpha · 3d ago · c1 — 1 matches
      we ran deja stats and doctro on the box

The same typo against an empty index says the useful thing. The reader who got a conversation back is in the worse spot: it looks like something they asked for.

The hint now also fires with hits, on stderr after the results, and only for the bare form — `deja search doctro` is someone searching for the word. Narrower than the empty-result hint on purpose: one word only, since here it lands on an answer the reader may well have wanted, and "doctors pool" is a search however close its first word sits to a command name.

While measuring: the symptom the original note described — `deja stats --nosuch` answering `no matches for "stats --nosuch"` — is gone. Every named command refuses an unknown flag and exits 1.