### PR TITLE
fix(recall): match the worn count for a session id the log had to coerce

### DIFF
--- a/internal/model/logged_id_test.go
+++ b/internal/model/logged_id_test.go
@@ -1,0 +1,36 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// LoggedID claims to be what encoding/json does to a string, so it is pinned
+// against the encoder itself rather than against hand-written expectations: a
+// lone 0xff, a truncated multi-byte sequence, a surrogate half, and a
+// replacement character that was already there (#2199).
+func TestLoggedIDIsWhatTheEncoderWrites(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"deja-2026-08-27-app",
+		"a<b&c",
+		string([]byte{0xff}),
+		string([]byte{0xff, 0xfe}),
+		"head" + string([]byte{0xe2, 0x82}) + "tail",
+		"� was already here",
+		string([]byte{0xed, 0xa0, 0x80}),
+		string([]byte{0xf0, 0x9f}),
+	} {
+		raw, err := json.Marshal([]string{in})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var back []string
+		if err := json.Unmarshal(raw, &back); err != nil {
+			t.Fatal(err)
+		}
+		if got := LoggedID(in); got != back[0] {
+			t.Errorf("LoggedID(%q) = %q, the log holds %q", in, got, back[0])
+		}
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type Message struct {
@@ -117,4 +118,33 @@ func (s *Session) Touch(t time.Time) {
 	if s.Updated.IsZero() || t.After(s.Updated) {
 		s.Updated = t
 	}
+}
+
+// LoggedID is a session id as a JSON log holds it. encoding/json replaces every
+// byte that is not valid UTF-8 with U+FFFD, so an id carrying one — a project
+// directory named with a stray byte, which ext4 allows — comes back from the
+// usage log as a different string and matched no session in the index (#2199).
+// Anything comparing an id against one that has been through JSON has to
+// compare the same form.
+//
+// Byte for byte what the encoder does, rather than strings.ToValidUTF8, which
+// collapses a run of bad bytes into one replacement where the encoder writes
+// one per byte.
+func LoggedID(id string) string {
+	if utf8.ValidString(id) {
+		return id
+	}
+	var b strings.Builder
+	b.Grow(len(id))
+	for i := 0; i < len(id); {
+		r, size := utf8.DecodeRuneInString(id[i:])
+		if r == utf8.RuneError && size == 1 {
+			b.WriteRune(utf8.RuneError)
+			i++
+			continue
+		}
+		b.WriteString(id[i : i+size])
+		i += size
+	}
+	return b.String()
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -553,7 +553,10 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 		}
 		score *= proximityBoost(doc.minWindow, queryTokenCount)
 		score *= titleBoost(doc.titleHits, queryTokenCount)
-		if n := worn[doc.hit.Session.ID]; n > 0 {
+		// By the id as a log holds it: the counts come from .usage.jsonl, and
+		// a byte that is not valid UTF-8 is U+FFFD there and itself here, so
+		// the two never met (#2199).
+		if n := worn[model.LoggedID(doc.hit.Session.ID)]; n > 0 {
 			doc.hit.Reused = n
 			score *= wornBoost(n)
 		}

--- a/internal/search/worn_id_bytes_test.go
+++ b/internal/search/worn_id_bytes_test.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The worn count is read from a log written with encoding/json, which replaces
+// every byte that is not valid UTF-8 with U+FFFD. The id in the index keeps its
+// bytes, so a session whose id holds such a byte was never recognised as one
+// deja had already served (#2199).
+func TestAWornCountReachesASessionWhoseIDIsNotValidUTF8(t *testing.T) {
+	id := "deja-2026-08-27-app-" + string([]byte{0xff, 0xfe})
+	// The key the log holds, produced the way the log produces it, rather than
+	// asserted by hand.
+	raw, err := json.Marshal([]string{id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back []string
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+	logged := back[0]
+	if logged == id {
+		t.Fatalf("the id survived the round trip unchanged, so this measures nothing: %q", logged)
+	}
+
+	cold := rankSession("cold", "", "jwt refresh rotation fix applied")
+	worn := rankSession(id, "", "jwt refresh rotation fix applied")
+	hits, err := Run([]model.Session{cold, worn}, Options{
+		Query: "jwt refresh rotation", All: true, RecallWorn: map[string]int{logged: 4},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Hit
+	for _, h := range hits {
+		if h.Session.ID == id {
+			got = h
+		}
+	}
+	if got.Session.ID != id {
+		t.Fatalf("the session is not in the results at all: %+v", hits)
+	}
+	if got.Reused != 4 {
+		t.Errorf("a session deja served four times is reported reused %d times", got.Reused)
+	}
+	if hits[0].Session.ID != id {
+		t.Errorf("the worn session did not win the tie: %v", []string{hits[0].Session.ID, hits[1].Session.ID})
+	}
+}


### PR DESCRIPTION
Closes #2199.

`.usage.jsonl` is written with `encoding/json`, which replaces every byte that is not valid UTF-8 with U+FFFD. `WornSessions` returns the ids as the log holds them; `internal/search` looked them up with the index's raw id, so a session whose id carries such a byte never got its worn boost and always reported `Reused: 0` — deja kept ranking it as if it had never been served.

`model.LoggedID` is that coercion, byte for byte what the encoder does — not `strings.ToValidUTF8`, which collapses a run of bad bytes into one replacement where the encoder writes one per byte. It is pinned against `json.Marshal`/`Unmarshal` itself over a lone 0xff, a truncated multi-byte sequence, a surrogate half, and a replacement character that was already in the string.

Cost: the lookup sits in the per-document scoring loop, so `BenchmarkBM25Scoring1000Candidates`, best of three either way — 114.7 µs before, 113.3 µs after.

`<` and `&` were never the problem: they are escaped and round-trip. The log is bounded by `rotateAt`/`keepWindow`/`EventRoom`.
