### PR TITLE
docs(index): the token counter is a lower bound, not the count

### DIFF
--- a/internal/index/cjkindex_realcorpus492_test.go
+++ b/internal/index/cjkindex_realcorpus492_test.go
@@ -10,9 +10,9 @@
 // The pipeline reproduced here is the one a real build walks before
 // indexKeys() sees a byte (ingest.go:404,448-468):
 //
-//	ParseClaudeFile -> preRedactSessions (NFC + redact + 64 KiB cap)
-//	  -> skip messages that trim to empty -> tokenizedPart(role, text)
-//	  -> indexKeys(text)
+//	ParseClaudeFile -> preRedactSessions (stripSelfRecall -> NFC -> redact
+//	  -> 64 KiB cap) -> skip messages that trim to empty
+//	  -> tokenizedPart(role, text) -> indexKeys(text)
 //
 // Skipping any of those measures a different string than the index does. The
 // cross-file duplicate filter (seenMsgs.dup) is the one step left out; it
@@ -164,9 +164,17 @@ func TestRealCorpusStats492(t *testing.T) {
 		newKeys      int64
 		legacyRaw    int64 // len(cjkfold.Bigrams) — unique unfolded bigrams
 		legacyFolded int64 // distinct folded keys the legacy path yields
-		allTokens    int64 // every indexKeys token, ASCII included: bucket() calls
-		cjkChars     int64
-		totalChars   int64
+		// allTokens sums distinct(indexKeys(text)) per message, which is a lower
+		// bound on the bucket() calls a build makes and not the count itself:
+		// eachIndexKey also hands bucket() the three dateTokens of every
+		// timestamped message (ingest.go:944,1076), and those never reach this
+		// counter. On a 365k-message store that is at most ~1.1M calls, ~2.6%,
+		// and less wherever a year or an ISO date in the text already produced
+		// the same key. Any decomposition checked against this number carries
+		// that much slack by construction.
+		allTokens  int64
+		cjkChars   int64
+		totalChars int64
 	)
 	var sampleAll, sampleCJK []sampleMsg
 	seenMsg, seenCJK := 0, 0


### PR DESCRIPTION
Two comments in `internal/index/cjkindex_realcorpus492_test.go` that @Sora-bluesky's review of #2124 caught after it merged. Neither changes what the file measures.

## The token counter is a lower bound, not the count

`allTokens` sums `distinct(indexKeys(text))` per message and is logged as `bucket() calls`. `eachIndexKey` also hands `bucket()` the three `dateTokens` of every timestamped message (`ingest.go:944,1076`), and those never pass through the counter. On the 365k-message store in #492 that is up to ~1.1M calls it does not see — about 2.6%, and fewer wherever a year or an ISO date in the text already produced the same key and deduped against them.

That matters because the decomposition cross-check in #492 reads this counter as agreeing to 2% on the non-bigram leg. The margin carries this much slack by construction, and a reader should not have to rederive the gap to know it is there. The comment now says so, with the file and line that produce the uncounted calls.

## The pipeline list was one step short

The header names NFC, redact and the 64 KiB cap. `preRedactSessions` also runs `stripSelfRecall`, and runs it first (`ingest.go:2868`). The replay was always right — it calls the real function rather than reimplementing it — so this is the enumeration catching up with the code, now in applied order.

## Checks

- `go vet -tags realcorpus492 ./internal/index/` — clean, exit 0, no output
- `TestFixtureStats492` passes; a plain `go test ./internal/index/` still never compiles the file
- coverage unchanged by construction: `grep -c cjkindex_realcorpus492 coverage.out` is 0
