### PR TITLE
fix(embed): say when the vector sidecar will not parse

### DIFF
--- a/cmd/deja/embed.go
+++ b/cmd/deja/embed.go
@@ -71,11 +71,36 @@ func embedPolicyKeep(dir string) (func(index.Record) bool, func() int, error) {
 		}, nil
 }
 
+// saidSidecarUnreadable keeps the note below to once per broken file: an empty
+// search runs the rerank and then the semantic tier, and one broken file is one
+// fact. Cleared when a read succeeds, so the MCP server — which lives for the
+// whole session — reports a file that breaks, is rebuilt and breaks again.
+var saidSidecarUnreadable bool
+
+// unreadableSidecarNote names a sidecar that is on disk and will not parse.
+// Falling back to the lexical order is right — a recall must not fail over its
+// own bookkeeping — but this was the one cause of "semantic results stopped"
+// that said nothing, while an unreachable endpoint on the same path has always
+// printed a line (#2201). A sidecar that is simply not there is the ordinary
+// case and stays quiet.
+func unreadableSidecarNote(dir string, err error) string {
+	if saidSidecarUnreadable {
+		return ""
+	}
+	if _, statErr := os.Stat(embed.Path(dir)); statErr != nil {
+		return ""
+	}
+	saidSidecarUnreadable = true
+	return fmt.Sprintf("deja: the vector sidecar will not parse (%v) — semantic search is off until `deja embed` writes it again\n", err)
+}
+
 func maybeRerank(dir string, hits []search.Hit, o search.Options, notice *os.File) []search.Hit {
 	sidecar, err := embed.Read(dir)
 	if err != nil {
+		fmt.Fprint(notice, unreadableSidecarNote(dir, err))
 		return hits
 	}
+	saidSidecarUnreadable = false
 	if embed.Stale(dir, sidecar) {
 		return hits
 	}
@@ -98,8 +123,10 @@ func maybeSemantic(dir string, hits []search.Hit, o search.Options, notice *os.F
 	}
 	sidecar, err := embed.Read(dir)
 	if err != nil {
+		fmt.Fprint(notice, unreadableSidecarNote(dir, err))
 		return hits, false
 	}
+	saidSidecarUnreadable = false
 	if embed.Stale(dir, sidecar) {
 		return hits, false
 	}

--- a/cmd/deja/sidecar_unreadable_notice_test.go
+++ b/cmd/deja/sidecar_unreadable_notice_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/embed"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A sidecar that will not parse turns semantic search off. Falling back to the
+// lexical order is right; doing it in silence is not — the same path says so
+// when the endpoint is the missing piece, and doctor is a screen someone opens
+// after noticing (#2201).
+func TestAnUnreadableSidecarIsNamedOnTheSearchPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Cut off after the header, which is what a partial copy leaves.
+	if err := os.WriteFile(embed.Path(dir), []byte("DJVE\x01\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := embed.Read(dir); err == nil {
+		t.Fatal("the fixture parses, so this measures nothing")
+	}
+
+	said := func(run func(notice *os.File)) string {
+		t.Helper()
+		f, err := os.CreateTemp(t.TempDir(), "notice")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = f.Close() }()
+		run(f)
+		b, err := os.ReadFile(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+
+	// The note is once per process, so each case starts from an unspoken one.
+	reset := func() { saidSidecarUnreadable = false }
+	t.Cleanup(reset)
+
+	hits := []search.Hit{{Session: model.Session{Harness: "claude", ID: "a1", Project: "app"}}}
+	reset()
+	rerank := said(func(notice *os.File) {
+		maybeRerank(dir, hits, search.Options{Query: "pool"}, notice)
+	})
+	if !strings.Contains(rerank, "sidecar") || !strings.Contains(rerank, "deja embed") {
+		t.Errorf("a rerank that gave up on an unreadable sidecar says %q", rerank)
+	}
+	reset()
+	semantic := said(func(notice *os.File) {
+		maybeSemantic(dir, nil, search.Options{Query: "pool"}, notice)
+	})
+	if !strings.Contains(semantic, "sidecar") || !strings.Contains(semantic, "deja embed") {
+		t.Errorf("a semantic search that gave up on an unreadable sidecar says %q", semantic)
+	}
+
+	// One search runs the rerank and then the semantic tier when it found
+	// nothing. One broken file is one fact.
+	reset()
+	both := said(func(notice *os.File) {
+		maybeRerank(dir, nil, search.Options{Query: "pool"}, notice)
+		maybeSemantic(dir, nil, search.Options{Query: "pool"}, notice)
+	})
+	if n := strings.Count(both, "will not parse"); n != 1 {
+		t.Errorf("one search said it %d times:\n%s", n, both)
+	}
+
+	// A directory with no sidecar at all is the ordinary case and stays quiet.
+	empty := filepath.Join(t.TempDir(), "index.db")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reset()
+	quiet := said(func(notice *os.File) {
+		maybeRerank(empty, hits, search.Options{Query: "pool"}, notice)
+		maybeSemantic(empty, nil, search.Options{Query: "pool"}, notice)
+	})
+	if quiet != "" {
+		t.Errorf("nothing is embedded here and deja said %q", quiet)
+	}
+}


### PR DESCRIPTION
Closes #2201.

`embed.Read` reports a truncated sidecar properly and `deja doctor` prints it as `sidecar: unreadable`. The search path threw it away:

    embed.Read says:         invalid vector sidecar
    what the reader is told: ""

so a broken sidecar was the one cause of "semantic results stopped" that said nothing, while an unreachable endpoint on the same path has always printed a line. It does not repair itself either — the file stays until `deja embed` runs again, and that command ignores an unreadable one and rebuilds from scratch, so the advice holds.

Falling back to the lexical order is unchanged. A sidecar that is simply absent stays quiet, and the note is said once per broken file — an empty search runs the rerank and then the semantic tier — with the flag cleared on a successful read so the MCP server, which lives for the whole session, reports a file that breaks again after a rebuild.

deja writes the sidecar through `atomicfile.WriteStream`, so it does not tear one itself: a partial copy of the index directory does, which is exactly when nobody knows.
