### PR TITLE
fix(usage): count every door that carried a digest in the impact ratio

### DIFF
--- a/cmd/deja/stats_impact_test.go
+++ b/cmd/deja/stats_impact_test.go
@@ -16,6 +16,8 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	usage.RecordServedSessions(dir, usage.KindRecall, 500, 1, false, 25000, []string{"s1"})
 	usage.RecordResultRaw(dir, usage.KindRecall, 0, 0, true, 0) // empty result must not count
 	usage.RecordResultRaw(dir, usage.KindHook, 2000, 3, false, 100000)
+	// A per-prompt injection carries a digest like the rest, so its bytes are
+	// in the ratio (#2204).
 	usage.RecordResult(dir, usage.KindDejaVu, 100, 1, false)
 
 	var out bytes.Buffer
@@ -29,7 +31,7 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 		"1 session start began with project memory",
 		"1 session recalled 2+ times",
 		"1 prompt matched work",
-		"50× less",
+		"49× less",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("impact output missing %q:\n%s", want, got)
@@ -44,7 +46,7 @@ func TestStatsImpactCountsAndArithmetic(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &r); err != nil {
 		t.Fatal(err)
 	}
-	if r.Recalls != 2 || r.Injections != 1 || r.ReusedTwice != 1 || r.DejaVuMoments != 1 || r.ServedBytes != 3500 || r.RawBytes != 175000 {
+	if r.Recalls != 2 || r.Injections != 1 || r.ReusedTwice != 1 || r.DejaVuMoments != 1 || r.ServedBytes != 3600 || r.RawBytes != 175000 {
 		t.Fatalf("json report wrong: %+v", r)
 	}
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -455,10 +455,12 @@ one.
 `recalls` counts agent-initiated recalls that returned matches, `injections`
 session starts that began with project memory. `served_bytes` is what the
 digests actually returned and `raw_bytes` the source transcripts they were
-distilled from, so the ratio is how much reading deja saved. The two go
-together: a session start that carried only the environment block is in neither,
-because that block is a summary of what the machine keeps hitting rather than a
-digest of transcripts. `deja stats` counts its bytes, which is the number for
+distilled from, so the ratio is how much reading deja saved. Both cover every
+door that carried a digest — the session start, the per-prompt recall, the
+tool-time line — while `injections` stays the count of session starts. What is
+in neither is a session start that carried only the environment block, because
+that block is a summary of what the machine keeps hitting rather than a digest
+of transcripts. `deja stats` counts its bytes, which is the number for
 everything deja handed over. `reused_twice` is
 sessions agents recalled two or more times, `dejavu_moments` prompts matched to
 prior work, and `credited_aloud` the recalls an agent said out loud.

--- a/internal/usage/coverage_gaps_test.go
+++ b/internal/usage/coverage_gaps_test.go
@@ -39,10 +39,13 @@ func TestImpactCountsEachKindOnce(t *testing.T) {
 	if got.DejaVuMoments != 1 {
 		t.Fatalf("déjà vu moments = %d", got.DejaVuMoments)
 	}
-	if got.ServedBytes != 200 {
-		t.Fatalf("served bytes = %d, want 100+50+30+20", got.ServedBytes)
+	// Every door that carried a digest, the per-prompt one included: it is
+	// distilled from transcripts like the rest, and leaving it out computed the
+	// ratio from a subset of what deja served (#2204).
+	if got.ServedBytes != 210 {
+		t.Fatalf("served bytes = %d, want 100+50+30+20+10", got.ServedBytes)
 	}
-	if got.RawBytes != 20_000 {
+	if got.RawBytes != 21_000 {
 		t.Fatalf("raw bytes = %d", got.RawBytes)
 	}
 }

--- a/internal/usage/impact_injected_kinds_test.go
+++ b/internal/usage/impact_injected_kinds_test.go
@@ -1,0 +1,44 @@
+package usage
+
+import "testing"
+
+// The impact report is a ratio: what deja served against the transcripts behind
+// it. The per-prompt recall and the tool-time line are digests distilled from
+// real transcripts, and both were dropped whole — bytes and raw — so the ratio
+// was computed from a subset of what deja handed over. The documented exclusion
+// is narrower: the environment block, which is an empty hook event carrying a
+// summary of the machine rather than a digest (#2204).
+func TestImpactCountsEveryInjectionThatCarriedADigest(t *testing.T) {
+	dir := t.TempDir()
+	RecordResultRaw(dir, KindHook, 600, 1, false, 6000)
+	RecordResultRaw(dir, KindDejaVu, 500, 1, false, 5000)
+	RecordResultRaw(dir, KindTool, 400, 1, false, 4000)
+	RecordResultRaw(dir, KindRecall, 300, 1, false, 3000)
+
+	tot := Totals(dir)
+	imp := Impact(dir)
+	// The premise: `deja stats` counts all four, so the two reports are about
+	// the same events and any gap below is this report's own.
+	if tot.Bytes != 1800 || tot.RawBytes != 18000 {
+		t.Fatalf("stats counts %d B over %d raw, so this measures nothing", tot.Bytes, tot.RawBytes)
+	}
+	if imp.ServedBytes != 1800 || imp.RawBytes != 18000 {
+		t.Errorf("impact counts %d B over %d raw; the two reports disagree about what deja served",
+			imp.ServedBytes, imp.RawBytes)
+	}
+
+	// The environment block stays out of both halves, which is what the report
+	// documents: it is a summary of the machine, not a digest of transcripts.
+	quiet := t.TempDir()
+	RecordResultRaw(quiet, KindHook, 700, 0, true, 0)
+	RecordResultRaw(quiet, KindDejaVu, 800, 0, true, 0)
+	if r := Impact(quiet); r.ServedBytes != 0 || r.Injections != 0 {
+		t.Errorf("an injection that carried no session was counted: %d B, %d injections", r.ServedBytes, r.Injections)
+	}
+
+	// And `injections` keeps the meaning the docs give it — session starts that
+	// began with project memory — rather than growing to mean every door.
+	if imp.Injections != 1 {
+		t.Errorf("injections is %d; the documented count is session starts, of which there was one", imp.Injections)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -586,7 +586,7 @@ func Impact(indexDir string) ImpactReport {
 			for _, id := range e.SessionIDs {
 				worn[id]++
 			}
-		case e.Kind == KindHook:
+		case injectedKind(e.Kind):
 			// A session start with no project session to show still injects
 			// the environment block, and that event is logged empty. Counting
 			// it made "N session starts began with project memory" claim
@@ -600,13 +600,26 @@ func Impact(indexDir string) ImpactReport {
 			// measured on three recalls and ten blocks, a tenfold saving reads
 			// as fourfold, understating what deja did. Both stay out.
 			if e.Empty {
+				if e.Kind == KindDejaVu {
+					r.DejaVuMoments++
+				}
 				continue
 			}
-			r.Injections++
+			// Every door that carried a digest, not the session-start one
+			// alone: the per-prompt recall and the tool-time line are distilled
+			// from real transcripts too, and dropping them computed the ratio
+			// this report exists for from half the events — the drift #1907
+			// fixed for blame, running the other way (#2204).
+			if e.Kind == KindDejaVu {
+				r.DejaVuMoments++
+			}
+			// `injections` keeps the meaning the report documents: session
+			// starts that began with project memory.
+			if e.Kind == KindHook {
+				r.Injections++
+			}
 			r.ServedBytes += e.Bytes
 			r.RawBytes += e.RawBytes
-		case e.Kind == KindDejaVu:
-			r.DejaVuMoments++
 		}
 	}
 	for _, n := range worn {


### PR DESCRIPTION
Closes #2204.

`Impact` walked the log with a hook-only branch, a déjà-vu branch that counted the moment and dropped the bytes, and no branch at all for the tool-time line. Four non-empty events — a session start, a per-prompt recall, a tool line and an agent recall:

    Totals : bytes=1800 raw=18000 injections=3 recalls=1     ← deja stats
    Impact : served=900  raw=9000  injections=1 recalls=1     ← deja stats --impact

So the ratio the impact screen exists for was computed from half of what deja handed over. Every non-empty injected kind now contributes its bytes and the transcripts behind them.

What is unchanged: `injections` still counts session starts that began with project memory, which is what the docs define it as; the environment block still stays out of both halves, because it summarises the machine rather than distilling transcripts; an empty déjà-vu event still counts as a moment.

Worth naming: this is a change to a user-facing number — the sample screen in the tests moves from "50× less" to "49× less" — and two tests that pinned the old sums are updated. #1908 aligned `Totals`, `Week` and the two `Today` walks onto `injectedKind` and rewrote these two branches without merging them, so whether Impact was meant to stay narrower is a judgement I made from the report's own definition rather than something the history states. Easy to scope back if the intent was "what the agent asked for, plus session starts".
