### PR TITLE
test: stop the suite from calling api.github.com

### DIFF
--- a/cmd/deja/no_network_in_tests_test.go
+++ b/cmd/deja/no_network_in_tests_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// offlineLookupCalls counts the times a test took the stubbed version lookup
+// TestMain installs. It is the evidence that the doctor path did not reach
+// api.github.com, which the suite did eleven times per run (#2206).
+var offlineLookupCalls atomic.Int64
+
+// offlineLookup is what TestMain puts in doctorLookup's place: the answer a
+// machine with no answer gives, which is the state doctor already handles.
+func offlineLookup() (string, bool) {
+	offlineLookupCalls.Add(1)
+	return "", false
+}
+
+// Removing the stub from TestMain puts the network back under every test that
+// runs doctor, and this is what notices: the counter stays where it was.
+func TestDoctorDoesNotReachTheNetwork(t *testing.T) {
+	hermeticEnv(t)
+	before := offlineLookupCalls.Load()
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: this really ran the report, so a lookup that did not happen
+	// is a lookup that went somewhere else.
+	if !strings.Contains(out, "Harness stores:") {
+		t.Fatalf("doctor printed something else entirely:\n%s", out)
+	}
+	if got := offlineLookupCalls.Load(); got == before {
+		t.Errorf("doctor asked for the latest version without going through the stub, so it asked GitHub")
+	}
+}

--- a/cmd/deja/testmain_test.go
+++ b/cmd/deja/testmain_test.go
@@ -43,6 +43,13 @@ func TestMain(m *testing.M) {
 		"DEJA_GROK_ROOT":        filepath.Join(root, "grok"),
 		"DEJA_QWEN_ROOT":        filepath.Join(root, "qwen"),
 	}
+	// The version lookup is the one thing in this package that talks to the
+	// internet, and only one test ever replaced it — so a full run asked
+	// api.github.com eleven times, left HTTP/2 connections whose cleanup
+	// goroutines outlived their tests, and raced the zone tests' writes to
+	// time.Local under -race (#2206). A test that wants the real path can put
+	// it back for itself.
+	doctorLookup = offlineLookup
 	for key, value := range stores {
 		if err := os.Setenv(key, value); err != nil {
 			panic(err)


### PR DESCRIPTION
Closes #2206.

`doctorLookup` says it is "overridable in tests so they never touch the network". One test overrode it; the fourteen that run `doctor` through the dispatcher did not, so a full run asked api.github.com eleven times — counted by instrumenting the default lookup.

    before: 11 requests per `go test ./cmd/deja/`
    after:  0

Beyond being slow and offline-fragile, each request left an HTTP/2 connection whose cleanup goroutine calls `time.Now()` after its test returned, and that raced the `time.Local` writes in the zone tests — the red CI run on #2205.

`TestMain` installs a lookup that answers the way a machine with no answer does, which is a state doctor already handles, so no assertion changes. Not `DEJA_OFFLINE=1`: that prints "check skipped (offline)" and would rewrite what every doctor test reads. A test that wants the real path still replaces the var for itself, as `doctor_test.go` does.

The guard is a counter on the stub: remove the line from `TestMain` and the doctor run stops going through it, which is exactly the thing that would put the network back.

`go test ./cmd/deja/ -race` is green.
