### PR TITLE
fix(uninstall): name the file with the unbounded block, and clear its twin

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -390,18 +390,36 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 	} else {
 		// grok writes a twin below; check its markers before touching this
 		// file, or a refusal there leaves this one already rewritten (#1705).
-		if harness == "grok" {
+		//
+		// Only on the way in. Removing is the other direction: the two blocks
+		// are bounded independently, and refusing to take out the one that can
+		// be taken out left a complete deja block in a file nobody had been
+		// told about (#2210).
+		if harness == "grok" && !uninstall {
 			b, rerr := os.ReadFile(filepath.Join(sources.GrokHome(), "AGENTS.md"))
 			if rerr != nil && !os.IsNotExist(rerr) {
 				return installResult{}, rerr
 			}
 			if cerr := checkGuidanceMarkers(string(b)); cerr != nil {
-				return installResult{}, cerr
+				return installResult{}, markerErrorFor(filepath.Join(sources.GrokHome(), "AGENTS.md"), cerr)
 			}
 		}
 		updated, uerr := updateGuidanceBlock(string(old), uninstall)
 		if uerr != nil {
-			return installResult{}, uerr
+			// The twin still has to be dealt with: this file is the one that
+			// cannot be bounded, and the other one's block is nobody's hostage.
+			if harness == "grok" && uninstall {
+				twin, terr := removeGrokTwinBlock()
+				if terr != nil {
+					return installResult{}, terr
+				}
+				// Both unbounded is the case where saying only one path sends
+				// the reader to fix half of it and run into the other half.
+				if twin != "" {
+					return installResult{}, fmt.Errorf("%s: %w (and the same in %s)", path, uerr, twin)
+				}
+			}
+			return installResult{}, markerErrorFor(path, uerr)
 		}
 		next = []byte(updated)
 	}
@@ -423,13 +441,44 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		}
 		updatedAlt, uerr := updateGuidanceBlock(string(oldAlt), uninstall)
 		if uerr != nil {
-			return installResult{}, uerr
+			return installResult{}, markerErrorFor(alt, uerr)
 		}
 		if _, werr := writeIfChanged(alt, oldAlt, []byte(updatedAlt)); werr != nil {
 			return installResult{}, werr
 		}
 	}
 	return installResult{Path: path, Action: a}, nil
+}
+
+// markerErrorFor names the file a marker refusal is about. The refusal is the
+// instruction to finish the job by hand, and it used to leave the reader
+// looking for which of deja's files it meant (#2210).
+func markerErrorFor(path string, err error) error {
+	return fmt.Errorf("%s: %w", path, err)
+}
+
+// removeGrokTwinBlock takes deja's block out of grok's other file when this one
+// cannot be bounded. Written for the uninstall direction only: the two blocks
+// stand on their own, so one broken file is no reason to keep the other.
+//
+// The first return value is the twin's path when it is unbounded too, so the
+// caller can name both files at once — `grok-auto` runs `grok` first and would
+// otherwise fail on the same file twice and never mention this one.
+func removeGrokTwinBlock() (unbounded string, err error) {
+	alt := filepath.Join(sources.GrokHome(), "AGENTS.md")
+	oldAlt, rerr := os.ReadFile(alt)
+	if rerr != nil {
+		if os.IsNotExist(rerr) {
+			return "", nil
+		}
+		return "", rerr
+	}
+	updated, uerr := updateGuidanceBlock(string(oldAlt), true)
+	if uerr != nil {
+		return alt, nil
+	}
+	_, werr := writeIfChanged(alt, oldAlt, []byte(updated))
+	return "", werr
 }
 
 func updateGuidanceBlock(old string, uninstall bool) (string, error) {

--- a/cmd/deja/uninstall_half_marked_test.go
+++ b/cmd/deja/uninstall_half_marked_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A block whose end marker went missing cannot be bounded, so it is refused
+// (#1705). On the way out that refusal has to hand the work back properly: name
+// the file, and take out the blocks that *can* be taken out — grok's guidance
+// lives in two files, and one broken block kept a well-formed one (#2210).
+func TestUninstallNamesTheFileItRefusesAndClearsTheOther(t *testing.T) {
+	hermeticEnv(t)
+	home := sources.GrokHome()
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	grokMD := filepath.Join(home, "GROK.md")
+	agentsMD := filepath.Join(home, "AGENTS.md")
+	if err := os.WriteFile(grokMD, []byte("my own notes about this box\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("grok", false); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: both files carry a block, so the removal below has two
+	// things to do and not one.
+	for _, p := range []string{grokMD, agentsMD} {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(b), guidanceStart) || !strings.Contains(string(b), guidanceEnd) {
+			t.Fatalf("%s does not carry a complete block, so this measures nothing:\n%s", p, b)
+		}
+	}
+
+	// An editor eats one end marker.
+	b, err := os.ReadFile(grokMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := strings.Replace(string(b), guidanceEnd+"\n", "", 1) + "\nsomething the user wrote afterwards\n"
+	if err := os.WriteFile(grokMD, []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = installGuidance("grok", true)
+	if err == nil {
+		t.Fatal("the unbounded block was removed anyway")
+	}
+	// The refusal is the instruction to do it by hand, so it has to say where.
+	if !strings.Contains(err.Error(), grokMD) {
+		t.Errorf("the refusal names no file, so nobody knows what to edit: %v", err)
+	}
+
+	// And the file that was fine is clean: its block is independent, and on the
+	// way out the reader wants as much gone as can go.
+	after, err := os.ReadFile(agentsMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(after), guidanceStart) {
+		t.Errorf("the twin still carries a complete deja block nobody mentioned:\n%s", after)
+	}
+	// The half-marked file is untouched, including the user's own text.
+	still, err := os.ReadFile(grokMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(still), "my own notes about this box") ||
+		!strings.Contains(string(still), "something the user wrote afterwards") {
+		t.Errorf("the refused file lost the user's text:\n%s", still)
+	}
+}
+
+// Both files unbounded: `grok-auto` runs `grok` first and fails on the same
+// file twice, so naming only that one sends the reader to fix half of it and
+// walk into the other half (#2210).
+func TestUninstallNamesBothFilesWhenBothAreUnbounded(t *testing.T) {
+	hermeticEnv(t)
+	home := sources.GrokHome()
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	grokMD := filepath.Join(home, "GROK.md")
+	agentsMD := filepath.Join(home, "AGENTS.md")
+	if err := os.WriteFile(grokMD, []byte("my own notes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGuidance("grok", false); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{grokMD, agentsMD} {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		broken := strings.Replace(string(b), guidanceEnd+"\n", "", 1)
+		if broken == string(b) {
+			t.Fatalf("%s had no end marker to remove, so this measures nothing", p)
+		}
+		if err := os.WriteFile(p, []byte(broken+"\nthe user's own tail\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := installGuidance("grok", true)
+	if err == nil {
+		t.Fatal("two unbounded blocks were removed anyway")
+	}
+	for _, want := range []string{grokMD, agentsMD} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not mention %s: %v", want, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2210.

A guidance block whose end marker went missing cannot be bounded, so it is refused (#1705). Refusing is right; the refusal was the problem.

    $ deja uninstall grok
    deja: uninstall finished what it could; 2 targets refused: grok: deja's
    guidance block has no end marker — put it back, or delete the block entirely

Which file? deja knows and did not say. It is the one message whose whole job is to hand the work back to the person doing it by hand, so it names the path now.

And grok's guidance lives in two files — `~/.grok/GROK.md` and `~/.grok/AGENTS.md`. A broken block in the first left a complete, well-formed block in the second, unremoved and unmentioned. The pre-check that couples them exists so an install cannot half-write one file before refusing the other (#1705); on the way out the blocks are independent and the reader wants as much gone as can go, so the check now applies to the install direction only and the twin is cleared even when this file is refused.

When both are unbounded the refusal names both, since `grok-auto` runs `grok` first and would otherwise report the same file twice and never mention the other.
