### PR TITLE
fix(install): do not record a rewire that was refused

### DIFF
--- a/cmd/deja/rewire_failure_test.go
+++ b/cmd/deja/rewire_failure_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The refresh a session start runs skips a target it cannot rewrite, which is
+// right — a damaged config is not a thing to overwrite. Stamping the record as
+// though it had been rewritten is not: nothing retries afterwards, and doctor's
+// stale-wiring check reads that record rather than the configs, so it goes
+// quiet too (#2212).
+func TestAFailedRewireIsNotRecordedAsDone(t *testing.T) {
+	hermeticEnv(t)
+	claudeJSON := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(claudeJSON), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installTarget("claude", "/old/path/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	recordWiring([]string{"claude"}, false)
+	before, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the config names the old binary, so a rewire has work to do.
+	if !strings.Contains(string(before), "/old/path/deja") {
+		t.Fatalf("the install did not write the path, so this measures nothing:\n%s", before)
+	}
+
+	st := readWiringState()
+	st.Version, st.Exe = "0.0.1", "/old/path/deja"
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(wiringStatePath(), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Damaged the way an interrupted write leaves it.
+	if err := os.WriteFile(claudeJSON, before[:len(before)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if changed := refreshWiringAfterUpgrade(); len(changed) != 0 {
+		t.Fatalf("a damaged config was reported rewired: %v", changed)
+	}
+	after := readWiringState()
+	if after.Version == version {
+		t.Errorf("the record says version %q, the one now running, though nothing was rewritten", after.Version)
+	}
+	if after.Exe != "/old/path/deja" {
+		t.Errorf("the record names %q; the configs still name /old/path/deja, which is what doctor reads", after.Exe)
+	}
+
+	// The damage is not repeated, and the next start tries again.
+	now, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(now) != len(before)/2 {
+		t.Errorf("the damaged config was rewritten (%d bytes, was %d)", len(now), len(before)/2)
+	}
+	if err := os.WriteFile(claudeJSON, before, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if changed := refreshWiringAfterUpgrade(); len(changed) == 0 {
+		t.Errorf("the start after the file was repaired did not try again")
+	}
+	fixed, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(fixed), "/old/path/deja") {
+		t.Errorf("the repaired config still names the old binary:\n%s", fixed)
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -139,16 +139,26 @@ func refreshWiringAfterUpgrade() []string {
 		return nil
 	}
 	var changed []string
+	failed := false
 	for _, target := range st.Targets {
 		res, err := installTarget(target, exe, false)
 		if err != nil {
 			// A harness the user has since removed is not an error worth
 			// surfacing: the next install run will drop it from the record.
+			failed = true
 			continue
 		}
 		if res.Action != "" && res.Action != "unchanged" {
 			changed = append(changed, target)
 		}
+	}
+	// Only when every target took the new path. Stamping the record after a
+	// refusal claimed a rewire that did not happen: the version then matched,
+	// so no later start tried again, and doctor's stale-wiring check reads the
+	// recorded path — which named the binary that exists while the config on
+	// disk still named the old one, so it said nothing either (#2212).
+	if failed {
+		return changed
 	}
 	recordWiring(st.Targets, false)
 	return changed


### PR DESCRIPTION
Closes #2212.

After an upgrade a session start re-runs the wiring for the recorded targets and skips any it cannot write, which is right — a damaged config is not something to overwrite. It then stamped the record with the new version and binary path anyway:

    changed=[]                  nothing was rewired
    state version="dev"         recorded as if it had been
    config parses now: false    untouched, damage not repeated
    second start retries: []    and never would

So the harness kept a config naming a binary that may no longer exist, permanently, and `doctor` said nothing either: `doctorWiringExe` asks whether the *recorded* exe exists, and the record now named the one that does.

The record is written only when every target took the new path. The next start retries, and until then doctor keeps reporting the wiring as stale, which it is.

Checked the obvious risk — that a harness the user has since removed would now keep the record stale for ever. It does not: `installTarget` on a bare machine returns "created" or an explanatory action for all twenty-one targets and errors for none, so retries are confined to genuinely broken or unwritable files.
