### PR TITLE
fix(install): name the config a parse refusal is about

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -751,6 +751,14 @@ var removingTargets map[string]bool
 // has been edited since it wrote it.
 var forceGuidance bool
 
+// configParseError names the file a parse refusal is about. The refusal is what
+// a reader is sent to act on — doctor points at `deja install <targets>` when a
+// rewire failed, and the parser's own words alone left them guessing which of
+// the harness configs it had opened (#2214).
+func configParseError(path string, err error) error {
+	return fmt.Errorf("%s: %w", path, err)
+}
+
 // mentionsDeja reports whether a config snapshot carries deja's own wiring.
 // The markers are what every generator writes: the subcommands the hooks call,
 // and the name of the MCP server and extension entries.
@@ -920,7 +928,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {
@@ -953,7 +961,7 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	nextRoot := updateClaudeSessionStartHook(root, exe, uninstall)
 	nextRoot = updateClaudeHook(nextRoot, "PreCompact", exe+" hook-precompact", "manual|auto", uninstall)
@@ -1108,7 +1116,7 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	cmd := exe + " statusline"
 	existing, _ := root["statusLine"].(map[string]any)
@@ -1258,7 +1266,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {
@@ -1294,7 +1302,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	mcp, _ := root["mcp"].(map[string]any)
 	if mcp == nil {
@@ -1327,7 +1335,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	m, _ := root["mcpServers"].(map[string]any)
 	if m == nil {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -27,7 +27,7 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	// SessionStart carries the project digest; PreToolUse (hook-tool) carries
 	// the prior decision for the file or command about to change. Codex uses the
@@ -302,7 +302,7 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	hooks, _ := root["hooks"].(map[string]any)
 	if hooks == nil {

--- a/cmd/deja/install_cursor.go
+++ b/cmd/deja/install_cursor.go
@@ -24,7 +24,7 @@ func installCursorHooks(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	if !uninstall {
 		root["version"] = 1

--- a/cmd/deja/install_grok.go
+++ b/cmd/deja/install_grok.go
@@ -30,7 +30,7 @@ func installGrokUserSettings(exe string, uninstall bool) (installResult, error) 
 	root := map[string]any{}
 	if len(old) > 0 {
 		if err := json.Unmarshal(old, &root); err != nil {
-			return installResult{}, err
+			return installResult{}, configParseError(path, err)
 		}
 	}
 	mcp, _ := root["mcp"].(map[string]any)

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -41,7 +41,7 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return installResult{}, err
+		return installResult{}, configParseError(path, err)
 	}
 	root = updateClaudeHook(root, "SessionStart", exe+" hook-context", "startup|resume", false)
 	root = updateClaudeHook(root, "PreCompact", exe+" hook-precompact", "manual|auto", false)

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -72,7 +72,7 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		}
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return "", err
+		return "", configParseError(path, err)
 	}
 	hooks, _ := root["hooks"].(map[string]any)
 	internal, _ := mapAt(hooks, "internal")

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -73,7 +73,7 @@ func setOpenClawPluginEnabled(on bool) (string, error) {
 		}
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return "", err
+		return "", configParseError(path, err)
 	}
 	plugins, _ := root["plugins"].(map[string]any)
 	entries, _ := mapAt(plugins, "entries")

--- a/cmd/deja/install_parse_error_names_file_test.go
+++ b/cmd/deja/install_parse_error_names_file_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A config deja cannot parse makes the target refuse, and the refusal used to
+// be a bare parser error: "unexpected end of JSON input — fix what it reports
+// and run it again", with the path deja had just read left out. It is the end
+// of the trail doctor sends people down after a failed rewire (#2214).
+func TestInstallNamesTheConfigItCannotParse(t *testing.T) {
+	hermeticEnv(t)
+	claudeJSON := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(claudeJSON), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installTarget("claude", "/some/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	good, err := os.ReadFile(claudeJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: this file parses today, so the refusal below is about the
+	// damage and not about the fixture.
+	if _, err := installTarget("claude", "/some/deja", false); err != nil {
+		t.Fatalf("a config deja just wrote does not parse: %v", err)
+	}
+
+	if err := os.WriteFile(claudeJSON, good[:len(good)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = installTarget("claude", "/some/deja", false)
+	if err == nil {
+		t.Fatal("a truncated config was accepted")
+	}
+	if !strings.Contains(err.Error(), claudeJSON) {
+		t.Errorf("the refusal names no file, so nobody knows what to fix: %v", err)
+	}
+	// The parser's own words stay: they say what is wrong with it.
+	if !strings.Contains(err.Error(), "unexpected end of JSON input") {
+		t.Errorf("the refusal dropped what the parser said: %v", err)
+	}
+
+	// The same for the other writers that read a config of their own.
+	settings := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claudeJSON, good, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(settings, []byte(`{"hooks":`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installTarget("claude-auto", "/some/deja", false); err == nil {
+		t.Error("a truncated settings.json was accepted")
+	} else if !strings.Contains(err.Error(), settings) {
+		t.Errorf("the refusal names no file: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #2214.

A config deja cannot parse makes the target refuse with the parser's words and nothing else:

    deja: install finished what it could; 1 target refused: claude: unexpected
    end of JSON input — fix what it reports and run it again

Which file? The writer read it one line earlier and knows. It matters more than usual because this is where a trail ends: after #2213 a failed rewire keeps the wiring record honest, so `doctor` reports it and hands over `deja install <targets>` — and that command was the dead end.

Thirteen sites across seven files, each `path` the file whose bytes were just read. The parser's own words stay; the path goes in front of them.
