### PR TITLE
fix(doctor): say when a wired config names a binary that is not there

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -887,10 +888,100 @@ func doctorMCP(w io.Writer) {
 			status = "plugin"
 		}
 		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)
+		// "Wired" says the server is declared, not that it can start. A config
+		// naming a binary that is gone — a restored backup, a hand edit, a
+		// machine where deja moved and one file was fixed by hand — read as
+		// healthy while no memory arrived (#2216).
+		if status == "wired" {
+			if missing := dejaCommandMissing(c.path); missing != "" {
+				fmt.Fprintf(w, "  %-12s %s\n", "",
+					"points at "+missing+", which is not there — `deja install "+c.name+"` rewrites it for this binary")
+			}
+		}
 		if note := doctorWiringNote(c.name); note != "" && status == "wired" {
 			fmt.Fprintf(w, "  %-12s %s\n", "", note)
 		}
 	}
+}
+
+// dejaCommandMissing returns the deja binary a config names when that file is
+// not there, and "" when the config names one that is, names none, or names it
+// by bare name for the PATH to resolve. deja writes these commands itself, so
+// reading them back is the difference between "declared" and "can start".
+func dejaCommandMissing(path string) string {
+	cmd := dejaCommandIn(path)
+	// A bare name is the PATH's business, and this check would answer for a
+	// lookup it does not do. A relative path or a `~` is worse than that: it
+	// resolves against wherever the reader is standing, or against nothing,
+	// so a stat here would report a working setup broken.
+	if cmd == "" || !filepath.IsAbs(cmd) {
+		return ""
+	}
+	if _, err := os.Stat(cmd); err == nil {
+		return ""
+	}
+	return cmd
+}
+
+// dejaCommandIn finds the command a config runs deja with. JSON configs are
+// parsed the way the wiring check parses them; the rest are read a line at a
+// time, because a `command` key with a path whose name is deja means the same
+// thing in TOML, YAML and JSONC, and adding a parser per format to answer one
+// question is not worth the surface.
+func dejaCommandIn(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	var root map[string]any
+	if json.Unmarshal(b, &root) == nil {
+		for _, key := range []string{"mcpServers", "mcp", "servers"} {
+			m, _ := root[key].(map[string]any)
+			for _, v := range m {
+				if cmd := mcpEntryDejaCommand(v); cmd != "" {
+					return cmd
+				}
+			}
+		}
+		return ""
+	}
+	for _, m := range commandValue.FindAllStringSubmatch(string(b), -1) {
+		if value := strings.TrimSpace(m[1]); commandIsDeja(value) {
+			return value
+		}
+	}
+	return ""
+}
+
+// commandValue matches a `command` or `cmd` key and the value after it, in the
+// three shapes these configs come in: JSON and JSONC quote the key, TOML uses
+// `=`, YAML uses `:` and quotes nothing. A JSONC file that will not parse as
+// JSON — zed's settings, which carry comments — reaches this too, so the whole
+// text is scanned rather than a line at a time.
+var commandValue = regexp.MustCompile(`"?(?:command|cmd)"?\s*[:=]\s*"?([^",\n}]+)`)
+
+// mcpEntryDejaCommand is mcpEntryRunsDeja's answer to "which one": the same
+// walk, returning the command or argument that named deja.
+func mcpEntryDejaCommand(v any) string {
+	m, _ := v.(map[string]any)
+	if m == nil {
+		return ""
+	}
+	if t, ok := m["transport"].(map[string]any); ok {
+		if cmd := mcpEntryDejaCommand(t); cmd != "" {
+			return cmd
+		}
+	}
+	if cmd, _ := m["command"].(string); commandIsDeja(cmd) {
+		return strings.TrimSpace(cmd)
+	}
+	args, _ := m["args"].([]any)
+	for _, a := range args {
+		if s, ok := a.(string); ok && commandIsDeja(s) {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
 }
 
 // doctorWiringNote adds what "wired" cannot promise for a given harness. Three

--- a/cmd/deja/doctor_dead_command_test.go
+++ b/cmd/deja/doctor_dead_command_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A config can name a deja binary that is not there — a restored backup, a hand
+// edit, a machine where deja moved and one file was fixed by hand. The harness
+// then starts a server that cannot run, no memory arrives, and doctor reported
+// the wiring as healthy: its only check asks whether the exe in deja's own
+// record exists, and that one still did (#2216).
+func TestDoctorNamesAConfigPointingAtAMissingBinary(t *testing.T) {
+	hermeticEnv(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installTarget("claude", exe, false); err != nil {
+		t.Fatal(err)
+	}
+	recordWiring([]string{"claude"}, false)
+
+	// The premise: nothing to report while the binary is where the config says.
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "not there") {
+		t.Fatalf("a healthy wiring was reported broken:\n%s", out)
+	}
+
+	p := sources.ClaudeJSONPath()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(strings.ReplaceAll(string(b), exe, "/gone/deja")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err = captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "/gone/deja") {
+		t.Errorf("doctor does not name the binary the config points at:\n%s", out)
+	}
+	if !strings.Contains(out, p) {
+		t.Errorf("doctor does not name the config that points there:\n%s", out)
+	}
+}
+
+// Where the check must stay quiet, and where it must speak. A bare command is
+// the PATH's business; a directory that happens to be named deja is not a
+// binary; and the three config shapes deja writes — JSON, TOML, YAML — plus the
+// JSONC that will not parse as JSON all have to be read (#2216).
+func TestTheMissingBinaryCheckReadsEveryConfigShapeAndNothingElse(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "deja")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"a bare name is the PATH's", `{"mcpServers":{"deja":{"command":"deja","args":["mcp"]}}}`, ""},
+		{"a binary that is there", `{"mcpServers":{"deja":{"command":"` + real + `","args":["mcp"]}}}`, ""},
+		{"no deja entry", `{"mcpServers":{"other":{"command":"/usr/bin/other"}}}`, ""},
+		{"a directory named deja", `{"mcpServers":{"deja":{"command":"deja","cwd":"/gone/deja"}}}`, ""},
+		{"an unrelated path in toml", "[tool]\ndata_dir = \"/gone/deja\"\n", ""},
+		// Both resolve against something this check does not know: the reader's
+		// working directory, and a shell that is not running.
+		{"a relative path", `{"mcpServers":{"deja":{"command":"./deja"}}}`, ""},
+		{"an unexpanded tilde", `{"mcpServers":{"deja":{"command":"~/bin/deja"}}}`, ""},
+		{"json", `{"mcpServers":{"deja":{"command":"/gone/deja"}}}`, "/gone/deja"},
+		{"toml", "[mcp_servers.deja]\ncommand = \"/gone/deja\"\n", "/gone/deja"},
+		{"yaml", "extensions:\n  deja:\n    cmd: /gone/deja\n", "/gone/deja"},
+		{"jsonc with comments", "{\n // deja\n \"mcpServers\":{\"deja\":{\"command\":\"/gone/deja\"}}\n}", "/gone/deja"},
+	} {
+		p := filepath.Join(t.TempDir(), "config")
+		if err := os.WriteFile(p, []byte(c.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := dejaCommandMissing(p); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2216.

A config can name a deja binary that is not there — a restored backup, a hand edit, a machine where deja moved and one file was fixed by hand — and every screen called it healthy:

    everything as installed              doctor says nothing about the wiring
    config names a binary that is gone   doctor says nothing about the wiring

`MCP wiring:` says "wired", which it is, to a file that does not exist; `doctorWiringExe` asks about the exe in deja's own record, which still does. The refresh does not repair it either — it runs when the version or the recorded path changed, and neither did.

A wired row now carries the missing binary and what to run:

    claude       wired          guidance written     ~/.claude.json
                 points at /gone/deja, which is not there — `deja install claude` rewrites it for this binary

deja writes those commands itself, so it reads them back: the JSON configs through the same walk the wiring check uses, the rest through one regexp, since a `command` key with a path named deja means the same thing in TOML, YAML and the JSONC that will not parse as JSON.

Kept deliberately quiet, and pinned: a bare `deja` is the PATH's business; a relative path or a `~` resolves against the reader's working directory or against a shell that is not running, so neither is stat'd; a directory that happens to be named deja is not a command; and a config with no deja entry says nothing.
