### PR TITLE
fix(uninstall): say when a retired guidance block had to stay

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -193,8 +193,12 @@ func retiredGuidancePaths(harness string) []string {
 }
 
 // dropRetiredGuidance removes deja's marked block from a file it no longer
-// writes, leaving every other line in it alone.
-func dropRetiredGuidance(harness string) error {
+// writes, leaving every other line in it alone. It returns what the caller
+// should say about the files it had to leave: a block whose markers do not pair
+// cannot be bounded, and guessing its end is what deleted a file in #1705 — but
+// leaving deja's instructions in front of an agent after an uninstall, without
+// a word, is the other way to get it wrong (#2218).
+func dropRetiredGuidance(harness string, uninstall bool) (note string, err error) {
 	keep := guidancePath(harness)
 	for _, path := range retiredGuidancePaths(harness) {
 		// A relocation variable can point a harness's own directory at the
@@ -208,7 +212,7 @@ func dropRetiredGuidance(harness string) error {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return err
+			return note, err
 		}
 		if start, end := guidanceMarkerLines(string(old)); start < 0 || end < 0 {
 			// A skill file has frontmatter rather than markers. Ours is
@@ -219,30 +223,40 @@ func dropRetiredGuidance(harness string) error {
 				filepath.Base(filepath.Dir(path)) == "deja-history" &&
 				strings.Contains(string(old), "name: deja-history") {
 				if err := os.Remove(path); err != nil {
-					return err
+					return note, err
 				}
 				// Take the directory too, but only if we emptied it.
 				_ = os.Remove(filepath.Dir(path))
+				continue
+			}
+			// A start with no end: deja's text is still in a file the agent
+			// reads, and only the reader can decide where it ends. Said on the
+			// way out, where "leave nothing behind" is the promise; on the way
+			// in the block is deja's own guidance twice over, and "delete this
+			// by hand" is not advice for someone installing.
+			if start >= 0 && uninstall {
+				note = path + ": deja's guidance block has no end marker, so it was left as it is — delete from " +
+					guidanceStart + " to the end of that block by hand"
 			}
 			continue
 		}
 		next, uerr := updateGuidanceBlock(string(old), true)
 		if uerr != nil {
-			return uerr
+			return note, markerErrorFor(path, uerr)
 		}
 		// A file that held nothing but our block was ours to begin with, so
 		// leaving it behind empty would be litter rather than someone's content.
 		if strings.TrimSpace(next) == "" {
 			if err := os.Remove(path); err != nil {
-				return err
+				return note, err
 			}
 			continue
 		}
 		if _, err := writeIfChanged(path, old, []byte(next)); err != nil {
-			return err
+			return note, err
 		}
 	}
-	return nil
+	return note, nil
 }
 
 // sharedSkillStillWanted reports whether a harness other than the one being
@@ -342,7 +356,8 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 	if path == "" {
 		return installResult{}, nil
 	}
-	if err := dropRetiredGuidance(harness); err != nil {
+	retiredNote, err := dropRetiredGuidance(harness, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
 	// Grok Build reads the cross-agent skills directory, so it gets the shared
@@ -362,17 +377,17 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 	if guidanceOwnsWholeFile(harness) {
 		if uninstall {
 			if len(old) == 0 {
-				return installResult{Path: path, Action: "unchanged"}, nil
+				return installResult{Path: path, Action: "unchanged", Note: retiredNote}, nil
 			}
 			// One file serves several harnesses, so removing it because one of
 			// them was uninstalled would take the memory away from the rest.
 			if sharedSkillHarnesses[harness] && sharedSkillStillWanted(harness) {
-				return installResult{Path: path, Action: "kept"}, nil
+				return installResult{Path: path, Action: "kept", Note: retiredNote}, nil
 			}
 			if err := os.Remove(path); err != nil {
 				return installResult{}, err
 			}
-			return installResult{Path: path, Action: "removed"}, nil
+			return installResult{Path: path, Action: "removed", Note: retiredNote}, nil
 		} else {
 			next = []byte(guidanceText(harness))
 			// A skill inside an antigravity plugin directory is ingested only
@@ -428,7 +443,7 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	if a == "kept" {
-		return installResult{Path: path, Action: a}, nil
+		return installResult{Path: path, Action: a, Note: retiredNote}, nil
 	}
 	// grok is three CLIs sharing one directory: the one that still reads
 	// GROK.md is not the one being maintained, and grok-dev reads AGENTS.md
@@ -447,7 +462,7 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 			return installResult{}, werr
 		}
 	}
-	return installResult{Path: path, Action: a}, nil
+	return installResult{Path: path, Action: a, Note: retiredNote}, nil
 }
 
 // markerErrorFor names the file a marker refusal is about. The refusal is the
@@ -625,5 +640,11 @@ func guidanceOutput(harness string, result installResult) string {
 	if result.Path == "" {
 		return fmt.Sprintf("%s: guidance unsupported", harness)
 	}
-	return fmt.Sprintf("%s: guidance %s %s", harness, result.Action, result.Path)
+	line := fmt.Sprintf("%s: guidance %s %s", harness, result.Action, result.Path)
+	// A file deja knows about and could not act on. Printed under the action
+	// rather than in place of it: the action is still what happened (#2218).
+	if result.Note != "" {
+		line += "\n" + strings.Repeat(" ", len(harness)+2) + result.Note
+	}
+	return line
 }

--- a/cmd/deja/guidance_foreign_skill_test.go
+++ b/cmd/deja/guidance_foreign_skill_test.go
@@ -31,7 +31,7 @@ func TestRetiringGuidanceLeavesAForeignSkillAlone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dropRetiredGuidance("gemini"); err != nil {
+	if err := dropRetiredGuidanceForTest("gemini"); err != nil {
 		t.Fatalf("dropRetiredGuidance: %v", err)
 	}
 
@@ -57,7 +57,7 @@ func TestRetiringGuidanceRemovesOurOwnSkill(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dropRetiredGuidance("gemini"); err != nil {
+	if err := dropRetiredGuidanceForTest("gemini"); err != nil {
 		t.Fatalf("dropRetiredGuidance: %v", err)
 	}
 
@@ -87,7 +87,7 @@ func TestRetiringGuidanceKeepsADirectoryThatIsNotEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dropRetiredGuidance("gemini"); err != nil {
+	if err := dropRetiredGuidanceForTest("gemini"); err != nil {
 		t.Fatalf("dropRetiredGuidance: %v", err)
 	}
 
@@ -124,7 +124,7 @@ func TestRetiringGuidanceSparesTheSharedSkill(t *testing.T) {
 		t.Fatalf("wrong fixture: no retired path equals %s\n  %v", shared, retiredGuidancePaths("cursor"))
 	}
 
-	if err := dropRetiredGuidance("cursor"); err != nil {
+	if err := dropRetiredGuidanceForTest("cursor"); err != nil {
 		t.Fatalf("dropRetiredGuidance: %v", err)
 	}
 
@@ -135,4 +135,11 @@ func TestRetiringGuidanceSparesTheSharedSkill(t *testing.T) {
 	if string(got) != body {
 		t.Errorf("the shared skill was rewritten:\n%q", string(got))
 	}
+}
+
+// dropRetiredGuidanceForTest keeps these tests reading as they did before the
+// note was added: they are about what the files look like afterwards.
+func dropRetiredGuidanceForTest(harness string) error {
+	_, err := dropRetiredGuidance(harness, true)
+	return err
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -19,7 +19,13 @@ import (
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
-type installResult struct{ Path, Action string }
+type installResult struct {
+	Path, Action string
+	// Note is what the caller should say besides the action: a file deja knows
+	// about, could not act on, and left as it found it. Empty in every ordinary
+	// case, so a printer can append it blind (#2218).
+	Note string
+}
 
 func runInstall(dir string, args []string, uninstall bool) error {
 	// Every path deja writes hangs off the home directory, and homeDir()
@@ -123,6 +129,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		defer func() { removingTargets = nil }()
 	}
 	defer recordWiring(targets, uninstall)
+	saidNotes := map[string]bool{}
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
 	var done []lineItem
@@ -151,6 +158,14 @@ func runInstall(dir string, args []string, uninstall bool) error {
 			if err != nil {
 				note(t, err)
 				continue
+			}
+			// Two targets can share one guidance harness — `gemini` and
+			// `gemini-auto` do — and a note about a file is about the file,
+			// not about the target that noticed it.
+			if gr.Note != "" && saidNotes[gr.Note] {
+				gr.Note = ""
+			} else if gr.Note != "" {
+				saidNotes[gr.Note] = true
 			}
 			if gr.Path != "" && !banner {
 				fmt.Println(guidanceOutput(t, gr))

--- a/cmd/deja/retired_block_notice_test.go
+++ b/cmd/deja/retired_block_notice_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// deja used to write guidance into the file gemini reads and now writes the
+// shared skill, so the old block is retired on the way past — unless its
+// markers are unbalanced, when it is skipped. Skipping is right: the block
+// cannot be bounded, and cutting to the next end marker is what deleted a file
+// in #1705. Skipping in silence is not, on the one command whose job is to
+// leave nothing behind (#2218).
+func TestUninstallSaysWhenARetiredBlockHasToStay(t *testing.T) {
+	hermeticEnv(t)
+	retired := filepath.Join(sources.GeminiHome(), "GEMINI.md")
+	if err := os.MkdirAll(filepath.Dir(retired), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	whole := "my own gemini notes\n\n" + guidanceStart + "\nold guidance\n" + guidanceEnd + "\n"
+	if err := os.WriteFile(retired, []byte(whole), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: a block deja can bound is taken out without a word.
+	res, err := installGuidance("gemini", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Note != "" {
+		t.Fatalf("a block deja removed was announced: %q", res.Note)
+	}
+	b, err := os.ReadFile(retired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), guidanceStart) {
+		t.Fatalf("the well-formed block was not removed, so this measures nothing:\n%s", b)
+	}
+
+	// The same file with its end marker gone.
+	half := "my own gemini notes\n\n" + guidanceStart + "\nold guidance\n"
+	if err := os.WriteFile(retired, []byte(half), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = installGuidance("gemini", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Note, retired) {
+		t.Errorf("nothing names the file deja had to leave alone: %q", res.Note)
+	}
+	after, err := os.ReadFile(retired)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Left as it was, user's text and all: an unbounded block is not something
+	// to guess the end of.
+	if string(after) != half {
+		t.Errorf("the file deja could not bound was rewritten:\n%s", after)
+	}
+}


### PR DESCRIPTION
Closes #2218.

deja used to write guidance into `~/.gemini/GEMINI.md` and now writes the shared skill, so the old block is retired on the way past. A block whose markers do not pair is skipped instead — rightly, since guessing where it ends is what deleted a file in #1705 — and until now, silently:

    $ deja install gemini && deja uninstall gemini
    $ cat ~/.gemini/GEMINI.md
    my own gemini notes

    <!-- deja guidance:start -->
    Before re-deriving past work, search deja.

The same file with both markers is cleaned properly, so the user who uninstalled deja was the one left with deja's instructions in front of their agent.

The line now travels with the target's guidance result:

    gemini: guidance removed ~/.agents/skills/deja-history/SKILL.md
            ~/.gemini/GEMINI.md: deja's guidance block has no end marker, so it was
            left as it is — delete from <!-- deja guidance:start --> to the end of
            that block by hand

On the way out only: installing, the same block is deja's own guidance twice over, and "delete this by hand" is not advice for someone installing. Said once per file, since `gemini` and `gemini-auto` share a guidance harness and a note is about the file, not about the target that noticed it.
