### PR TITLE
perf(usage): decide the log has nothing to drop without parsing it

### DIFF
--- a/internal/usage/rotate_scan_test.go
+++ b/internal/usage/rotate_scan_test.go
@@ -1,0 +1,189 @@
+package usage
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A log over the rotation trigger with nothing old enough to drop is the
+// ordinary state of a busy machine, and every short-lived hook used to read and
+// parse the whole file to find that out — 13 ms on 12 000 events, against 64 µs
+// for the same write once a memo exists. The answer is one bit and the stamps
+// are text (#2220).
+func TestDecidingThereIsNothingToDropDoesNotParseTheLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing")
+	}
+	write := func(dir string, n int, oldest time.Duration) {
+		t.Helper()
+		var b strings.Builder
+		now := time.Now().UTC()
+		step := oldest / time.Duration(n)
+		for i := 0; i < n; i++ {
+			stamp := now.Add(-time.Duration(i) * step).Format(time.RFC3339Nano)
+			fmt.Fprintf(&b, `{"t":%q,"kind":"recall","bytes":900,"sessions":2,"raw":9000,"ids":["s%d"]}`+"\n", stamp, i)
+		}
+		if err := os.WriteFile(Path(dir), []byte(b.String()), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The premise: this log is over the trigger, so rotate does not simply
+	// stat it and leave.
+	dir := t.TempDir()
+	write(dir, 12000, 13*24*time.Hour)
+	fi, err := os.Stat(Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Size() < rotateAt {
+		t.Fatalf("the fixture is %d bytes, under the %d trigger, so this measures nothing", fi.Size(), rotateAt)
+	}
+
+	// Two cold writes of the same size, best of three each: one over a log with
+	// nothing to drop, one over a log that has to be rotated. The second is the
+	// work the first used to do. Comparing them rather than the clock keeps the
+	// measurement about the parse and not about the machine.
+	best := func(age time.Duration) time.Duration {
+		t.Helper()
+		fastest := time.Duration(1<<62 - 1)
+		for round := 0; round < 3; round++ {
+			fresh := t.TempDir()
+			write(fresh, 12000, age)
+			start := time.Now()
+			RecordResultRaw(fresh, KindHook, 600, 1, false, 6000)
+			if took := time.Since(start); took < fastest {
+				fastest = took
+			}
+		}
+		return fastest
+	}
+	nothingOld := best(13 * 24 * time.Hour)
+	mustRotate := best(30 * 24 * time.Hour)
+	warm := time.Duration(1<<62 - 1)
+	for round := 0; round < 3; round++ {
+		start := time.Now()
+		RecordResultRaw(dir, KindHook, 600, 1, false, 6000)
+		if took := time.Since(start); took < warm {
+			warm = took
+		}
+	}
+	t.Logf("cold with nothing to drop %v, cold with a rotation %v, warm %v",
+		nothingOld.Round(time.Microsecond), mustRotate.Round(time.Microsecond), warm.Round(time.Microsecond))
+	// A third of the rotation's cost. Before this the two were the same call
+	// and measured within noise of each other; parsing is what separates them.
+	if nothingOld > mustRotate/3 {
+		t.Errorf("deciding there was nothing to drop cost %v against %v to actually rotate: it is still parsing the whole log",
+			nothingOld, mustRotate)
+	}
+
+	// And the rotation it decides about still happens when it should.
+	old := t.TempDir()
+	write(old, 12000, 30*24*time.Hour)
+	before, err := os.Stat(Path(old))
+	if err != nil {
+		t.Fatal(err)
+	}
+	RecordResultRaw(old, KindHook, 600, 1, false, 6000)
+	after, err := os.Stat(Path(old))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Size() >= before.Size() {
+		t.Errorf("a log holding a month of events was not rotated: %d bytes, was %d", after.Size(), before.Size())
+	}
+	for _, e := range read(Path(old)) {
+		if time.Since(e.Time) > keepWindow+time.Hour {
+			t.Errorf("an event %v old survived the rotation", time.Since(e.Time).Round(time.Hour))
+			break
+		}
+	}
+}
+
+// The scan answers with what the parser would have answered, on the shapes a
+// log actually carries: a fraction that RFC3339Nano trimmed, a stamp with none
+// at all, an event out of order behind a newer one, and lines this scan cannot
+// speak for — a foreign field order, a truncated tail — which have to fall back
+// rather than answer (#2220).
+func TestTheStampScanAgreesWithTheParser(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, c := range []struct {
+		name  string
+		lines []string
+		ok    bool
+		want  time.Time
+	}{
+		{
+			name: "trimmed fractions in one second",
+			lines: []string{
+				`{"t":"` + now.Add(500*time.Millisecond).Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`,
+				`{"t":"` + now.Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`,
+				`{"t":"` + now.Add(50*time.Millisecond).Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`,
+			},
+			ok:   true,
+			want: now,
+		},
+		{
+			name: "an older event behind a newer one",
+			lines: []string{
+				`{"t":"` + now.Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`,
+				`{"t":"` + now.Add(-72*time.Hour).Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`,
+			},
+			ok:   true,
+			want: now.Add(-72 * time.Hour),
+		},
+		{
+			name:  "another field first",
+			lines: []string{`{"kind":"recall","t":"` + now.Format(time.RFC3339Nano) + `","bytes":1}`},
+			ok:    false,
+		},
+		{
+			name:  "a stamp with an offset rather than Z",
+			lines: []string{`{"t":"2026-08-27T10:00:00+02:00","kind":"recall","bytes":1}`},
+			ok:    false,
+		},
+		{
+			name:  "a truncated last line",
+			lines: []string{`{"t":"` + now.Format(time.RFC3339Nano) + `","kind":"recall","bytes":1}`, `{"t":"2026-08`},
+			ok:    false,
+		},
+		{
+			name:  "nothing at all",
+			lines: []string{},
+			ok:    false,
+		},
+	} {
+		dir := t.TempDir()
+		body := ""
+		if len(c.lines) > 0 {
+			body = strings.Join(c.lines, "\n") + "\n"
+		}
+		if err := os.WriteFile(Path(dir), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := oldestStampIn(Path(dir))
+		if ok != c.ok {
+			t.Errorf("%s: ok = %v, want %v", c.name, ok, c.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		// Against the parser, not against a second copy of my arithmetic.
+		var oldest time.Time
+		for _, e := range read(Path(dir)) {
+			if oldest.IsZero() || e.Time.Before(oldest) {
+				oldest = e.Time
+			}
+		}
+		if !got.Truncate(time.Second).Equal(oldest.Truncate(time.Second)) {
+			t.Errorf("%s: scan says %v, the parser says %v", c.name, got, oldest)
+		}
+		if !got.Truncate(time.Second).Equal(c.want.Truncate(time.Second)) {
+			t.Errorf("%s: scan says %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -472,6 +472,15 @@ func rotate(p string) {
 		return
 	}
 	cutoff := time.Now().UTC().Add(-keepWindow)
+	// One bit decides whether this write pays for a rotation: is any event old
+	// enough to drop. Parsing the whole log to learn it cost every short-lived
+	// hook 13 ms on a log of twelve thousand events, and the memo below only
+	// spares the second write in the same process (#2220).
+	oldest, ok := oldestStampIn(p)
+	if ok && !oldest.Before(cutoff) {
+		rememberOldest(p, oldest, fi.Size())
+		return
+	}
 	all := read(p)
 	var keep []Event
 	for _, e := range all {
@@ -508,6 +517,85 @@ func rotate(p string) {
 		}
 	}
 	_ = atomicfile.Write(p, buf.Bytes(), 0o600)
+}
+
+// oldestStampIn reads the log's stamps without decoding its records. Every line
+// this package writes starts with {"t":"<RFC3339>", so the oldest event can be
+// found by comparing text.
+//
+// To the second, deliberately. RFC3339Nano drops trailing zeros from the
+// fraction, so "…:00.5Z" and "…:00Z" differ first at '.' against 'Z' and sort
+// the wrong way round — the fraction is exactly where text order stops being
+// time order. Seconds are all this decides with: the question is whether
+// anything is older than a fortnight.
+//
+// ok is false when a line does not carry a stamp where the writer puts it: a
+// log from another version, a half-written line, anything this cannot speak
+// for. The caller then does what it always did and parses.
+func oldestStampIn(p string) (oldest time.Time, ok bool) {
+	f, err := os.Open(p)
+	if err != nil {
+		return time.Time{}, false
+	}
+	defer func() { _ = f.Close() }()
+	best := ""
+	sc := bufio.NewScanner(f)
+	// The same line ceiling read() uses: a line longer than that is one this
+	// scan cannot speak for either.
+	sc.Buffer(make([]byte, 4096), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		stamp, found := stampPrefix(line)
+		if !found {
+			return time.Time{}, false
+		}
+		if best == "" || stamp[:len(secondsPrecision)] < best[:len(secondsPrecision)] {
+			best = stamp
+		}
+	}
+	if sc.Err() != nil || best == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339Nano, best)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t.UTC(), true
+}
+
+// stampPrefix returns the value of the leading "t" field, which is where this
+// package's writer puts it. Anything else is left to the parser.
+func stampPrefix(line string) (string, bool) {
+	const prefix = `{"t":"`
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	rest := line[len(prefix):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return "", false
+	}
+	stamp := rest[:end]
+	// Only the shape the writer emits: UTC, with the trailing Z, and long
+	// enough to carry whole seconds. An offset like +02:00 sorts by its digits
+	// rather than by when it happened.
+	if len(stamp) < len(secondsPrecision) || !strings.HasSuffix(stamp, "Z") {
+		return "", false
+	}
+	return stamp, true
+}
+
+// secondsPrecision is the prefix of an RFC 3339 stamp up to whole seconds —
+// "2026-08-27T10:00:00" — and its length is how much of one this compares.
+const secondsPrecision = "2006-01-02T15:04:05"
+
+// rememberOldest records what the scan above found, in the same shape the full
+// read records, so the memo means one thing however it was filled.
+func rememberOldest(p string, oldest time.Time, size int64) {
+	nothingToDrop.Store(p, rotationMemo{oldest: oldest, size: size, at: time.Now().UTC()})
 }
 
 // WornSessions counts, per session id, how often agent-initiated recalls


### PR DESCRIPTION
Closes #2220.

Once the usage log passes the 1 MB rotation trigger, the first write in a process read and JSON-parsed the whole file to decide one bit: is any event old enough to drop. A session-start hook writes once and exits, so it paid that every run — the memo from #1972 only spares the second write in the same process.

    12000 events (1.2 MB): cold write 13.411ms, warm    64µs
    40000 events (4.2 MB): cold write 38.243ms, warm 13.774ms

The stamps are text and every line this package writes starts with `{"t":"`, so the oldest event is found by scanning rather than decoding. Same fixture, cold either way:

    deciding there is nothing to drop:  771µs
    actually rotating:               11.443ms

To the second, deliberately: `RFC3339Nano` trims trailing zeros, so `…:00.5Z` and `…:00Z` differ first at `.` against `Z` and sort the wrong way round. The fraction is exactly where text order stops being time order, and whole seconds are all a fortnight-wide cutoff needs.

Anything the scan cannot speak for falls back to the parse and behaves as before: a line whose first field is not `t`, a stamp with an offset instead of `Z`, a truncated tail, an empty file. That list is a test, checked against what the parser answers rather than against a second copy of the arithmetic.
