### PR TITLE
fix(usage): clip a digest to what the injections log can read back

### DIFF
--- a/internal/usage/snapshot_line_cap_test.go
+++ b/internal/usage/snapshot_line_cap_test.go
@@ -12,7 +12,7 @@ import (
 // rotation rewrote the file without it. A record deja cannot read is worse than
 // a record it clipped (#2222).
 func TestADigestTooLargeToReadBackIsClippedRatherThanLost(t *testing.T) {
-	for _, size := range []int{8 << 10, 1 << 20, 3 << 20, 5 << 20, 16 << 20} {
+	for _, size := range []int{8 << 10, 100 << 10, snapshotDigestMax, snapshotDigestMax + 1, 5 << 20, 16 << 20} {
 		dir := t.TempDir()
 		digest := strings.Repeat("z", size)
 		RecordDigestTerms(dir, KindResource, digest, 1, 0, nil, "s1")
@@ -28,15 +28,22 @@ func TestADigestTooLargeToReadBackIsClippedRatherThanLost(t *testing.T) {
 		if !strings.HasPrefix(got[0].Digest, strings.Repeat("z", 4096)) {
 			t.Errorf("a %d B digest came back as something else: %.80q", size, got[0].Digest)
 		}
-		if size <= 3<<20 {
-			// Everything that round-tripped before still does, whole.
+		if size <= snapshotDigestMax {
+			// Anything inside the budget is kept whole, and everything deja
+			// actually injects is far inside it.
 			if got[0].Digest != digest {
-				t.Errorf("a %d B digest was clipped to %d, though it fitted before", size, len(got[0].Digest))
+				t.Errorf("a %d B digest was clipped to %d, though it is within the budget", size, len(got[0].Digest))
 			}
 			continue
 		}
-		if len(got[0].Digest) >= size {
-			t.Errorf("a %d B digest was not clipped: %d bytes came back", size, len(got[0].Digest))
+		// The kept head is inside the budget. The record itself is a little
+		// longer than the head, because it says it was clipped.
+		head := got[0].Digest[:strings.LastIndex(got[0].Digest, "\n… (clipped")]
+		if len(head) > snapshotDigestMax {
+			t.Errorf("a %d B digest kept %d bytes, over the %d budget", size, len(head), snapshotDigestMax)
+		}
+		if len(head) >= size {
+			t.Errorf("a %d B digest was not clipped: %d bytes kept", size, len(head))
 		}
 		// And the clipping says so, rather than ending mid-sentence.
 		if !strings.Contains(got[0].Digest, "clipped") {
@@ -63,6 +70,9 @@ func TestClippingSurvivesTheShapesThatCostMost(t *testing.T) {
 		{"invalid bytes, which triple", strings.Repeat(string([]byte{0xff}), 6<<20)},
 		{"multi-byte runes", strings.Repeat("é", 3<<20)},
 		{"one long rune run", strings.Repeat("🙂", 2<<20)},
+		// One byte in front, so the budget falls inside a rune rather than
+		// between two: this is what backs the cut up.
+		{"a rune the cut lands inside", "a" + strings.Repeat("日", 1<<20)},
 	} {
 		dir := t.TempDir()
 		RecordDigestTerms(dir, KindResource, c.digest, 1, 0, nil, "s1")

--- a/internal/usage/snapshot_line_cap_test.go
+++ b/internal/usage/snapshot_line_cap_test.go
@@ -1,0 +1,85 @@
+package usage
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// The reader caps a line at 4 MB and nothing capped the write, so a digest past
+// that was written and then unreadable: `deja log` showed nothing, and the next
+// rotation rewrote the file without it. A record deja cannot read is worse than
+// a record it clipped (#2222).
+func TestADigestTooLargeToReadBackIsClippedRatherThanLost(t *testing.T) {
+	for _, size := range []int{8 << 10, 1 << 20, 3 << 20, 5 << 20, 16 << 20} {
+		dir := t.TempDir()
+		digest := strings.Repeat("z", size)
+		RecordDigestTerms(dir, KindResource, digest, 1, 0, nil, "s1")
+
+		got := snapshotsFrom(SnapshotPath(dir), 0)
+		if len(got) != 1 {
+			fi, _ := os.Stat(SnapshotPath(dir))
+			t.Errorf("a %d B digest wrote %d bytes and read back as %d records", size, fi.Size(), len(got))
+			continue
+		}
+		// What survives is the head of what was served, so the log still says
+		// what the agent was given.
+		if !strings.HasPrefix(got[0].Digest, strings.Repeat("z", 4096)) {
+			t.Errorf("a %d B digest came back as something else: %.80q", size, got[0].Digest)
+		}
+		if size <= 3<<20 {
+			// Everything that round-tripped before still does, whole.
+			if got[0].Digest != digest {
+				t.Errorf("a %d B digest was clipped to %d, though it fitted before", size, len(got[0].Digest))
+			}
+			continue
+		}
+		if len(got[0].Digest) >= size {
+			t.Errorf("a %d B digest was not clipped: %d bytes came back", size, len(got[0].Digest))
+		}
+		// And the clipping says so, rather than ending mid-sentence.
+		if !strings.Contains(got[0].Digest, "clipped") {
+			t.Errorf("a clipped digest does not say it was clipped: %.120q", got[0].Digest[len(got[0].Digest)-120:])
+		}
+		// Bytes is what was served, not what was kept: the log is about the
+		// injection, and clipping is this file's business.
+		if got[0].Bytes != size {
+			t.Errorf("bytes = %d, want the %d that were served", got[0].Bytes, size)
+		}
+	}
+}
+
+// The shapes that make escaping expensive, and the cut itself. A digest of
+// newlines doubles in JSON, invalid bytes triple, and a cut in the middle of a
+// rune is a mojibake tail on the last line someone reads (#2222).
+func TestClippingSurvivesTheShapesThatCostMost(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		digest string
+	}{
+		{"newlines, which double", strings.Repeat("\n", 6<<20)},
+		{"quotes, which double", strings.Repeat(`"`, 6<<20)},
+		{"invalid bytes, which triple", strings.Repeat(string([]byte{0xff}), 6<<20)},
+		{"multi-byte runes", strings.Repeat("é", 3<<20)},
+		{"one long rune run", strings.Repeat("🙂", 2<<20)},
+	} {
+		dir := t.TempDir()
+		RecordDigestTerms(dir, KindResource, c.digest, 1, 0, nil, "s1")
+		got := snapshotsFrom(SnapshotPath(dir), 0)
+		if len(got) != 1 {
+			fi, _ := os.Stat(SnapshotPath(dir))
+			t.Errorf("%s: wrote %d bytes and read back %d records", c.name, fi.Size(), len(got))
+			continue
+		}
+		if !strings.Contains(got[0].Digest, "clipped") {
+			t.Errorf("%s: not clipped, %d bytes came back", c.name, len(got[0].Digest))
+		}
+		// The kept head is still the text that was served, decodable as it was
+		// written rather than ending in half a character.
+		head := strings.TrimSuffix(got[0].Digest, got[0].Digest[strings.LastIndex(got[0].Digest, "\n… (clipped"):])
+		if !utf8.ValidString(head) && utf8.ValidString(c.digest) {
+			t.Errorf("%s: the kept head is not valid UTF-8 though the digest was", c.name)
+		}
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/atomicfile"
 )
@@ -144,6 +146,56 @@ func snapshotWriteTerms(indexDir, kind, digest string, sessions int, policyName 
 	snapshotWriteInto(indexDir, kind, digest, "", sessions, policyName, terms)
 }
 
+// snapshotLineMax is the longest line the reader takes, and therefore the
+// longest one worth writing. A record past it was written and then unreadable:
+// `deja log` showed nothing for an injection that happened, and the next
+// rotation rewrote the file without it (#2222).
+const snapshotLineMax = 4 << 20
+
+// clipDigest cuts a digest down to what this file can read back, saying so
+// where it cut. The head is kept, because that is what an agent was shown
+// first, and `Bytes` still carries the size that was served: the clipping is
+// this file's business, not a claim about the injection.
+//
+// The budget is on the marshalled line, not on the digest, since escaping is
+// what decides the difference — a digest of newlines doubles.
+func clipDigest(digest string) string {
+	const marker = "\n… (clipped: the whole digest was %d bytes)"
+	if len(digest)+len(marker) < snapshotLineMax {
+		return digest
+	}
+	// Halve until the line fits, then keep what fits. Two passes in practice,
+	// and bounded by the loop rather than by an assumption about escaping.
+	keep := snapshotLineMax / 2
+	for keep > 0 {
+		clipped := digest[:runeBoundaryAt(digest, keep)] + fmt.Sprintf(marker, len(digest))
+		if b, err := json.Marshal(clipped); err == nil && len(b)+snapshotEnvelope < snapshotLineMax {
+			return clipped
+		}
+		keep /= 2
+	}
+	return fmt.Sprintf("(clipped: the whole digest was %d bytes)", len(digest))
+}
+
+// runeBoundaryAt is n backed up to where a rune starts, so a cut lands between
+// characters rather than inside one. A half rune is not an error — the encoder
+// writes U+FFFD for it — but it is a mojibake tail on the last line of a digest
+// someone reads.
+func runeBoundaryAt(s string, n int) int {
+	if n >= len(s) {
+		return len(s)
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return n
+}
+
+// snapshotEnvelope is room for the rest of the record around the digest — the
+// stamp, kind, terms, policy and the session it went into. Generous on purpose:
+// being under the reader's ceiling is what matters, not being near it.
+const snapshotEnvelope = 64 << 10
+
 func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policyName string, terms []string) {
 	if digest == "" {
 		return
@@ -153,7 +205,7 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 		return
 	}
 	b, err := marshalSnapshot(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
-		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: digest})
+		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: clipDigest(digest)})
 	if err != nil {
 		return
 	}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -152,29 +152,30 @@ func snapshotWriteTerms(indexDir, kind, digest string, sessions int, policyName 
 // rotation rewrote the file without it (#2222).
 const snapshotLineMax = 4 << 20
 
-// clipDigest cuts a digest down to what this file can read back, saying so
-// where it cut. The head is kept, because that is what an agent was shown
-// first, and `Bytes` still carries the size that was served: the clipping is
-// this file's business, not a claim about the injection.
+// snapshotDigestMax is how much of a digest goes into the log. The budget is
+// the line's, and one byte of text can cost six of JSON — a control byte is
+// written \u00XX — so this is the ceiling that holds however the text escapes,
+// without a trial encode to find out.
 //
-// The budget is on the marshalled line, not on the digest, since escaping is
-// what decides the difference — a digest of newlines doubles.
+// Generous next to what anything actually injects: a session-start digest is
+// 8 KB and the MCP budget is 4 KB. It is `deja://session/…`, which records the
+// whole session it served, that reaches for megabytes.
+const snapshotDigestMax = (snapshotLineMax - snapshotEnvelope) / 6
+
+// snapshotEnvelope is room for the rest of the record around the digest — the
+// stamp, kind, terms, policy and the session it went into.
+const snapshotEnvelope = 64 << 10
+
+// clipDigest cuts a digest down to what this file can read back, saying where
+// it cut. The head is kept, because that is what an agent was shown first, and
+// `Bytes` still carries the size that was served: the clipping is this file's
+// business, not a claim about the injection.
 func clipDigest(digest string) string {
-	const marker = "\n… (clipped: the whole digest was %d bytes)"
-	if len(digest)+len(marker) < snapshotLineMax {
+	if len(digest) <= snapshotDigestMax {
 		return digest
 	}
-	// Halve until the line fits, then keep what fits. Two passes in practice,
-	// and bounded by the loop rather than by an assumption about escaping.
-	keep := snapshotLineMax / 2
-	for keep > 0 {
-		clipped := digest[:runeBoundaryAt(digest, keep)] + fmt.Sprintf(marker, len(digest))
-		if b, err := json.Marshal(clipped); err == nil && len(b)+snapshotEnvelope < snapshotLineMax {
-			return clipped
-		}
-		keep /= 2
-	}
-	return fmt.Sprintf("(clipped: the whole digest was %d bytes)", len(digest))
+	head := digest[:runeBoundaryAt(digest, snapshotDigestMax)]
+	return head + fmt.Sprintf("\n… (clipped: the whole digest was %d bytes)", len(digest))
 }
 
 // runeBoundaryAt is n backed up to where a rune starts, so a cut lands between
@@ -182,19 +183,11 @@ func clipDigest(digest string) string {
 // writes U+FFFD for it — but it is a mojibake tail on the last line of a digest
 // someone reads.
 func runeBoundaryAt(s string, n int) int {
-	if n >= len(s) {
-		return len(s)
-	}
 	for n > 0 && !utf8.RuneStart(s[n]) {
 		n--
 	}
 	return n
 }
-
-// snapshotEnvelope is room for the rest of the record around the digest — the
-// stamp, kind, terms, policy and the session it went into. Generous on purpose:
-// being under the reader's ceiling is what matters, not being near it.
-const snapshotEnvelope = 64 << 10
 
 func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policyName string, terms []string) {
 	if digest == "" {


### PR DESCRIPTION
Closes #2222.

The injections log is read with a scanner capped at 4 MB a line and nothing capped the write:

    digest  3145728 B: file  3145823 B, records back 1
    digest  5242880 B: file  5242975 B, records back 0
    digest  8388608 B: file  8388703 B, records back 0

So past that size deja wrote a record it could never read: `deja log` showed nothing, `deja log --last` answered as if the injection had not happened, and the next rotation rewrote the file without it — having carried the megabytes in the meantime. `deja://session/…` reaches it, recording the whole session it served, unbudgeted.

The digest is now cut to what the file can read back, saying where it was cut, with `Bytes` still the size that was served. Everything that round-tripped before still does, whole: the budget is on the marshalled line rather than on the digest, since escaping is what decides the difference, and the loop shrinks until the encoder's own output fits. Pinned on the shapes that cost most — newlines and quotes, which double; invalid bytes, which triple; and multi-byte runes, where the cut backs up to a rune boundary rather than leaving half a character on the last line someone reads.

Found while measuring this log's rotation, which the queue asked about and which turned out fine: it keeps a fixed count rather than a time window, so there is no "nothing to drop" shortcut to make, and a rotation brings the file back under the threshold, amortising its 2–17 ms over roughly sixty injections.
