### PR TITLE
perf(statusline): read the usage log once per render

### DIFF
--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -73,7 +73,11 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprint(stdout, withFileMemory(dir, in, line))
 		return nil
 	}
-	recalls, bytes, injected := usage.TodayDemand(dir)
+	// One read for the whole line: it renders on every prompt, and two passes
+	// over the log can also straddle a write and print numbers that were never
+	// true together (#2224).
+	n := usage.StatusCounters(dir)
+	recalls, bytes, injected := n.Recalls, n.Bytes, n.Injected
 	if recalls == 0 {
 		// Injections are not recalls, but they are the whole day for someone
 		// who lives on auto-recall: saying "0 B injected" while memory has
@@ -83,7 +87,7 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 			fmt.Fprint(stdout, withFileMemory(dir, in, fmt.Sprintf("deja · no agent recalls today · %s injected", humanBytes(int64(injected)))))
 			return nil
 		}
-		if wr, wb, _, _ := usage.Week(dir); wr > 0 {
+		if wr, wb := n.WeekRecalls, n.WeekBytes; wr > 0 {
 			// The line below this one already branches at one; this one said
 			// "1 agent recalls" all day, on the surface the reader looks at
 			// most (#1600).
@@ -99,7 +103,7 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		noun = "recall"
 	}
 	line := fmt.Sprintf("deja · %d %s · %s ctx today · %s injected", recalls, noun, humanBytes(int64(bytes)), humanBytes(int64(injected)))
-	if raw := usage.TodayRaw(dir); bytes > 0 && raw/int64(bytes) >= 2 {
+	if raw := n.RawToday; bytes > 0 && raw/int64(bytes) >= 2 {
 		line += fmt.Sprintf(" · ~%d× less than replaying", raw/int64(bytes))
 	}
 	fmt.Fprint(stdout, withFileMemory(dir, in, line))

--- a/cmd/deja/statusline_one_read_test.go
+++ b/cmd/deja/statusline_one_read_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The line renders on every prompt, and it read the whole usage log twice to do
+// it — 16 ms on a 1.2 MB log, and two passes that can straddle a write and
+// print two numbers that were never true together. The invariant is about the
+// source: the status line asks the log once (#2224).
+func TestTheStatusLineReadsTheUsageLogOnce(t *testing.T) {
+	src, err := os.ReadFile("statusline.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, gone := range []string{"usage.TodayDemand(", "usage.Week(", "usage.TodayRaw("} {
+		if strings.Contains(string(src), gone) {
+			t.Errorf("statusline.go still calls %s — each is a pass over the log, and the line takes two", gone)
+		}
+	}
+	if !strings.Contains(string(src), "usage.StatusCounters(") {
+		t.Error("statusline.go no longer reads the counters through the single pass")
+	}
+}

--- a/internal/usage/status_counters_test.go
+++ b/internal/usage/status_counters_test.go
@@ -1,0 +1,51 @@
+package usage
+
+import (
+	"testing"
+	"time"
+)
+
+// One pass for the line that renders on every prompt. The numbers have to be
+// the ones the separate readers gave, or this is a different status line
+// (#2224).
+func TestStatusCountersAgreeWithTheReadersTheyReplace(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	appendEventForTest(t, dir, Event{Time: now.Add(-2 * time.Hour), Kind: KindRecall, Bytes: 900, Sessions: 2, RawBytes: 9000})
+	appendEventForTest(t, dir, Event{Time: now.Add(-3 * time.Hour), Kind: KindContext, Bytes: 400, Sessions: 1, RawBytes: 4000})
+	appendEventForTest(t, dir, Event{Time: now.Add(-1 * time.Hour), Kind: KindHook, Bytes: 600, Sessions: 1, RawBytes: 6000})
+	// An empty recall serves nothing and must not count, an empty injection
+	// carried the environment block and its bytes still do (#1962).
+	appendEventForTest(t, dir, Event{Time: now.Add(-30 * time.Minute), Kind: KindRecall, Empty: true})
+	appendEventForTest(t, dir, Event{Time: now.Add(-40 * time.Minute), Kind: KindHook, Bytes: 300, Empty: true})
+	// Earlier in the week but not today.
+	appendEventForTest(t, dir, Event{Time: now.Add(-72 * time.Hour), Kind: KindRecall, Bytes: 100, Sessions: 1, RawBytes: 1000})
+	// Older than the week.
+	appendEventForTest(t, dir, Event{Time: now.Add(-20 * 24 * time.Hour), Kind: KindRecall, Bytes: 5000, Sessions: 1, RawBytes: 50000})
+
+	got := StatusCounters(dir)
+	recalls, bytes, injected := TodayDemand(dir)
+	if got.Recalls != recalls || got.Bytes != bytes || got.Injected != injected {
+		t.Errorf("today: one pass says %d/%d/%d, TodayDemand says %d/%d/%d",
+			got.Recalls, got.Bytes, got.Injected, recalls, bytes, injected)
+	}
+	wr, wb, _, _ := Week(dir)
+	if got.WeekRecalls != wr || got.WeekBytes != wb {
+		t.Errorf("week: one pass says %d/%d, Week says %d/%d", got.WeekRecalls, got.WeekBytes, wr, wb)
+	}
+	if raw := TodayRaw(dir); got.RawToday != raw {
+		t.Errorf("raw: one pass says %d, TodayRaw says %d", got.RawToday, raw)
+	}
+	// The premise: these numbers are not all zero, or agreeing means nothing.
+	if got.Recalls == 0 || got.Bytes == 0 || got.Injected == 0 || got.WeekRecalls == 0 || got.RawToday == 0 {
+		t.Fatalf("the fixture produced %+v, so agreement measures nothing", got)
+	}
+}
+
+// An empty log answers zeros rather than reading anything into them.
+func TestStatusCountersOnAnEmptyLog(t *testing.T) {
+	got := StatusCounters(t.TempDir())
+	if got != (StatusNumbers{}) {
+		t.Errorf("an empty log reports %+v", got)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -275,6 +275,62 @@ func TodayWithInjections(indexDir string) (recalls, bytes, injected int) {
 	return recalls, bytes, injected
 }
 
+// StatusNumbers is everything the status line can print, from one read.
+type StatusNumbers struct {
+	// Today, demand side: what an agent asked for and got, and what deja
+	// injected unprompted, on the same terms TodayDemand uses.
+	Recalls  int
+	Bytes    int
+	Injected int
+	// This week, for the line the quiet days print.
+	WeekRecalls int
+	WeekBytes   int
+	// Today's source transcripts behind what was served, for the "less than
+	// replaying" clause.
+	RawToday int64
+}
+
+// StatusCounters is TodayDemand, Week and TodayRaw in one pass.
+//
+// The line renders on every prompt and took two of these reads — 8 ms each on a
+// busy fortnight's log — for numbers one read produces. TodayDemand's own doc
+// gives the other half of the reason: two passes can straddle a write and
+// report numbers that were never true together, and the line prints today's
+// beside the week's (#2224).
+func StatusCounters(indexDir string) StatusNumbers {
+	var out StatusNumbers
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	cut := WeekCut(now)
+	for _, e := range read(Path(indexDir)) {
+		if ahead(e.Time, now) {
+			continue
+		}
+		// TodayRaw counts what was served today whether or not it found
+		// anything, which is the one place the empty rule differs.
+		if !e.Time.Before(midnight) && (servedKind(e.Kind) || injectedKind(e.Kind)) {
+			out.RawToday += e.RawBytes
+		}
+		if e.FoundNothing() {
+			continue
+		}
+		if !e.Time.Before(midnight) {
+			switch {
+			case servedKind(e.Kind):
+				out.Recalls++
+				out.Bytes += e.Bytes
+			case injectedKind(e.Kind):
+				out.Injected += e.Bytes
+			}
+		}
+		if !e.Time.Before(cut) && servedKind(e.Kind) {
+			out.WeekRecalls++
+			out.WeekBytes += e.Bytes
+		}
+	}
+	return out
+}
+
 // TodayDemand returns today's non-empty, agent-requested memory events, the
 // bytes they served, and separately the bytes deja injected unprompted.
 // Automatic injections and empty results stay out of the recall count so


### PR DESCRIPTION
Closes #2224.

The status line renders on every prompt and read the usage log twice — `TodayDemand` always, then `TodayRaw` when there were recalls today or `Week` when there were none. Each is a full parse:

    2000 events (  202 KB): TodayDemand  2.820ms, Week 2.502ms, TodayRaw 1.934ms
   12000 events (  1.2 MB): TodayDemand  8.176ms, Week 7.655ms, TodayRaw 7.129ms
   40000 events (  4.1 MB): TodayDemand 24.852ms, Week 24.144ms, TodayRaw 23.814ms

One pass now, and the two it replaces measured beside it: 26.5 ms against 49.7 ms at 40 000 events.

The other half of the reason is in `TodayDemand`'s own doc, which already made this argument for the numbers inside it — "two passes over the log can also straddle a write and report two numbers that were never true together" — while the line went on printing today's counters beside the week's from two reads.

The numbers are pinned against the three readers they replace rather than against a second copy of the arithmetic, including the case where they differ: `TodayRaw` counts what was served today whether or not it found anything, and the other two drop an empty result.
