### PR TITLE
fix(doctor): read a command out of every way these formats quote one

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -946,15 +946,24 @@ func dejaCommandIn(path string) string {
 		return ""
 	}
 	for _, m := range commandValue.FindAllStringSubmatch(string(b), -1) {
-		value := strings.TrimSpace(m[2])
-		// A quoted value carries escapes; an unquoted one is what it says. TOML
-		// and JSONC both double the backslashes in a Windows path, and reading
-		// the raw text of one produced a path that exists nowhere — doctor then
-		// reported a working install as broken (#2216).
-		if m[1] == `"` {
-			value = quotedPathUnescape.Replace(value)
+		// One group per quoting, so a quote inside a value cannot end it: a
+		// path under C:\Users\O'Brien is a path, not a delimiter.
+		//
+		// Only the double-quoted form carries escapes. TOML's literal string
+		// and YAML's single-quoted scalar keep their backslashes, which is how
+		// a Windows path is normally written there, and reading an escaped one
+		// raw named a path that exists nowhere — doctor then called a working
+		// install broken (#2216).
+		var value string
+		switch {
+		case m[1] != "":
+			value = quotedPathUnescape.Replace(m[1])
+		case m[2] != "":
+			value = m[2]
+		default:
+			value = m[3]
 		}
-		if commandIsDeja(value) {
+		if value = strings.TrimSpace(value); commandIsDeja(value) {
 			return value
 		}
 	}
@@ -971,7 +980,7 @@ var quotedPathUnescape = strings.NewReplacer(`\\`, `\`, `\"`, `"`)
 // `=`, YAML uses `:` and quotes nothing. A JSONC file that will not parse as
 // JSON — zed's settings, which carry comments — reaches this too, so the whole
 // text is scanned rather than a line at a time.
-var commandValue = regexp.MustCompile(`"?(?:command|cmd)"?\s*[:=]\s*("?)([^",\n}]+)`)
+var commandValue = regexp.MustCompile(`"?(?:command|cmd)"?\s*[:=]\s*(?:"([^"\n]*)"|'([^'\n]*)'|([^",\n}]+))`)
 
 // mcpEntryDejaCommand is mcpEntryRunsDeja's answer to "which one": the same
 // walk, returning the command or argument that named deja.

--- a/cmd/deja/doctor_dead_command_test.go
+++ b/cmd/deja/doctor_dead_command_test.go
@@ -90,6 +90,12 @@ func TestTheMissingBinaryCheckReadsEveryConfigShapeAndNothingElse(t *testing.T) 
 		// belong to the format, and reading them raw named a path that exists
 		// nowhere — doctor then called a working install broken.
 		{"a quoted path in toml", "[mcp_servers.deja]\ncommand = \"" + realJSON + "\"\n", ""},
+		// TOML's literal string, where a backslash is a backslash and nothing
+		// is escaped — which is how a Windows path is written there.
+		{"a literal path in toml", "[mcp_servers.deja]\ncommand = '" + real + "'\n", ""},
+		{"a literal path that is gone", "[mcp_servers.deja]\ncommand = '" + gone + "'\n", gone},
+		// YAML's double-quoted scalar escapes like JSON does.
+		{"a quoted path in yaml", "extensions:\n  deja:\n    cmd: \"" + goneJSON + "\"\n", gone},
 		{"no deja entry", `{"mcpServers":{"other":{"command":"/usr/bin/other"}}}`, ""},
 		{"a directory named deja", `{"mcpServers":{"deja":{"command":"deja","cwd":"` + goneJSON + `"}}}`, ""},
 		{"an unrelated path in toml", "[tool]\ndata_dir = \"" + goneJSON + "\"\n", ""},


### PR DESCRIPTION
A follow-on to the escaping fix in #2227.

The check that asks whether a wired config names a binary that is there reads the command with a regexp for the formats that do not parse as JSON. It understood two of the three ways those formats quote a value:

    toml double-quoted   ok
    toml literal         invisible — the quote ended up inside the value, so the
                         basename read "deja.exe'" and the check said nothing
    yaml plain           ok

TOML's literal string is exactly how a Windows path is written there — nothing is escaped, so no backslashes are doubled — and it was the one form the check could not see.

Each quoting form has its own group now, and only the double-quoted one is unescaped. That also fixes a case the first attempt would have broken: adding `'` to the value's character class made `C:\Users\O'Brien\bin\deja.exe` stop at `C:\Users\O`. Measured across the forms, before and after:

    toml double-quoted                   ok
    toml literal                         ok
    yaml plain                           ok
    yaml single-quoted                   ok
    jsonc double-quoted                  ok
    an apostrophe in the path, quoted    ok
    an apostrophe in the path, plain     ok
    unix plain                           ok

Three table cases added; without the product change the literal-path one fails with `got "" want …/gone/deja`.
