### PR TITLE
fix(index): name the store whose sessions it could not read

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -681,8 +681,19 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 			// index run that narrates every store it read and stays silent
 			// about the one it skipped makes an empty deja look like an empty
 			// history (#794).
-			if reason := sources.SkipReason(r.name); reason != "" && progress != nil && !SuppressHarnessNarration {
-				fmt.Fprintf(progress, "deja: %s: skipped — %s\n", r.name, reason)
+			//
+			// Two ways to yield nothing, and the second had no line at all: a
+			// store deja could not open has a skip reason, and one whose files
+			// it read and refused has a count instead — computed just above and
+			// then dropped, in the case where nothing else on screen mentions
+			// the store (#2229).
+			if progress != nil && !SuppressHarnessNarration {
+				switch reason := sources.SkipReason(r.name); {
+				case reason != "":
+					fmt.Fprintf(progress, "deja: %s: skipped — %s\n", r.name, reason)
+				case unreadable[r.name] > 0:
+					fmt.Fprintln(progress, nothingReadableNarration(r.name, unreadable[r.name]))
+				}
 			}
 			continue
 		}
@@ -719,6 +730,18 @@ func harnessNarration(name string, ss []model.Session, skipped string, unreadabl
 	return line
 }
 
+// nothingReadableNarration is the line for a store that yielded no session
+// because deja could not read what it found. "0 sessions, 0 messages" is the
+// ordinary line's shape and says the wrong thing here — there were sessions,
+// and none of them survived the read (#2229).
+func nothingReadableNarration(name string, unreadable int) string {
+	label := name
+	if label == "deja" {
+		label = "notes"
+	}
+	return fmt.Sprintf("deja: %s: nothing indexed — %d line%s could not be read", label, unreadable, pluralS(unreadable))
+}
+
 // totalMalformed is malformedByHarness summed: the incremental line names the
 // pass, not a store.
 func totalMalformed() int {
@@ -735,7 +758,10 @@ func totalMalformed() int {
 func malformedByHarness() map[string]int {
 	out := map[string]int{}
 	for p, n := range sources.DiagMalformedCounts() {
-		if h := harnessForPath(p); h != "" {
+		// By the store's own name, not the file kind's: harnessForPath answers
+		// "cline-sdk" where the run narrates "cline", so the count never
+		// reached the line that would have said it (#2229).
+		if h := sources.HarnessForKind(harnessForPath(p)); h != "" {
 			out[h] += n
 		}
 	}

--- a/internal/index/silent_store_test.go
+++ b/internal/index/silent_store_test.go
@@ -1,0 +1,78 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A store deja read and could not use is the one case where nothing else will
+// mention it: the skip line covers a store it could not open, and the count is
+// computed and then thrown away for a store that yielded no session because its
+// file would not parse (#2229). That is #794's shape, one branch over.
+func TestAStoreThatYieldedNothingButRefusedLinesIsNarrated(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+
+	// One healthy store, so the run has a line to print either way and the
+	// silence below is about the other one.
+	proj := filepath.Join(claude, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"s1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"the pool timed out during the migration"}}`, stamp)
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// And one store whose only session will not parse.
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString("[")
+	for i := 0; i < 50; i++ {
+		fmt.Fprintf(&b, `{"ts":%d,"type":"say","say":"text","text":"turn %d about the pool"},`, 1782900000+i, i)
+	}
+	truncated := strings.TrimSuffix(b.String(), ",") // no closing bracket
+	if err := os.WriteFile(filepath.Join(cline, "1234567890.messages.json"), []byte(truncated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	var out strings.Builder
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatal(err)
+	}
+	said := out.String()
+
+	// The premise: deja did notice, and filed it where doctor reads.
+	health := IngestHealth(dir)
+	var counted int
+	for _, e := range health {
+		counted += e.MalformedLines
+	}
+	if counted == 0 {
+		t.Fatalf("nothing was recorded as unreadable, so this measures nothing:\n%s\n%v", said, health)
+	}
+	// The healthy store is narrated, or the run said nothing at all.
+	if !strings.Contains(said, "claude: 1 session") {
+		t.Fatalf("the run did not narrate the store it read:\n%s", said)
+	}
+	// And the one it could not use is named too.
+	if !strings.Contains(said, "cline") {
+		t.Errorf("the run says nothing about the store whose session it refused:\n%s", said)
+	}
+}

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -391,6 +391,24 @@ func IsKnownHarness(name string) bool {
 	return false
 }
 
+// HarnessForKind names the store a fine-grained kind belongs to: "cline-sdk"
+// and "cline-vscode" are both cline. A caller holding a kind and speaking to a
+// person wants this one — the index run narrates per store, and looking a kind
+// up under the harness's own name found nothing (#2229).
+func HarnessForKind(kind string) string {
+	for _, h := range Registry() {
+		if h.Name == kind {
+			return h.Name
+		}
+		for _, k := range h.Kinds {
+			if k.Name == kind {
+				return h.Name
+			}
+		}
+	}
+	return ""
+}
+
 // KindForPath returns the fine-grained kind whose Match accepts p, or "".
 func KindForPath(p string) string {
 	for _, h := range Registry() {


### PR DESCRIPTION
Closes #2229.

An index run narrates every store it read and said nothing about the store whose only session it could not parse — the one case where nothing else on screen mentions it:

    deja: indexing sessions into ~/index.db ...
    deja: claude: 1 session, 1 message

    IngestHealth: map[cline-sdk:{MalformedLines:1}]

Two causes.

The `len(r.ss) == 0` branch printed only when `sources.SkipReason` was set — a missing tool, a directory that would not open. A store deja read and refused has no skip reason, so the count computed two lines above was dropped. It gets a line of its own now rather than the ordinary one, because "0 sessions, 0 messages" says the wrong thing when there were sessions and none survived:

    deja: cline: nothing indexed — 1 line could not be read

The second cause is wider. `malformedByHarness` folded the counts under the file *kind* while the run narrates the *store*, and five harnesses have kinds by another name:

    codex     codex-history, codex
    cursor    cursor-db,     cursor
    hermes    hermes,        hermes-pg
    goose     goose-jsonl,   goose-db
    cline     cline-sdk,     cline-vscode

For goose and cline no kind carries the store's name at all, so their "N lines could not be read" was never printed, sessions or no sessions. For the other three it appeared only for the kind that happens to share the name. `sources.HarnessForKind` folds a kind to its store; no kind is another store's name, so nothing lands in the wrong place.

`IngestHealth` still keys by kind, so `doctor --json` says `cline-sdk` where the run says `cline`. That is a documented JSON key and a separate decision, left alone here.
