### PR TITLE
fix(sources): report a task that will not parse as a path, not a line

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -396,7 +396,9 @@ Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`.
 
 `ingest_files` is where those counts came from, keyed by file path: `malformed`
-lines, `clipped` messages, and `error` when the file itself would not open. It
+lines, `clipped` messages, and `error` when nothing from that path is in the
+index at all — it would not open, or it is one document that would not parse,
+as a cline or roo task is. It
 is sparse — a file with nothing to report is not in it — and absent when no file
 has anything to report. The per-harness numbers above are the sum of the files
 deja can attribute to a harness, so a path it cannot place is here and in no

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -674,6 +674,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 	}
 	wg.Wait()
 	unreadable := malformedByHarness()
+	refused := failedByHarness()
 	var ss []model.Session
 	for _, r := range results {
 		if len(r.ss) == 0 {
@@ -691,8 +692,8 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 				switch reason := sources.SkipReason(r.name); {
 				case reason != "":
 					fmt.Fprintf(progress, "deja: %s: skipped — %s\n", r.name, reason)
-				case unreadable[r.name] > 0:
-					fmt.Fprintln(progress, nothingReadableNarration(r.name, unreadable[r.name]))
+				case unreadable[r.name] > 0 || refused[r.name] > 0:
+					fmt.Fprintln(progress, nothingReadableNarration(r.name, unreadable[r.name], refused[r.name]))
 				}
 			}
 			continue
@@ -734,12 +735,34 @@ func harnessNarration(name string, ss []model.Session, skipped string, unreadabl
 // because deja could not read what it found. "0 sessions, 0 messages" is the
 // ordinary line's shape and says the wrong thing here — there were sessions,
 // and none of them survived the read (#2229).
-func nothingReadableNarration(name string, unreadable int) string {
+func nothingReadableNarration(name string, unreadable, refused int) string {
 	label := name
 	if label == "deja" {
 		label = "notes"
 	}
-	return fmt.Sprintf("deja: %s: nothing indexed — %d line%s could not be read", label, unreadable, pluralS(unreadable))
+	// Lines and whole files are different losses and the sentence says which:
+	// a task deja could not parse is a path, and calling it a line said "1
+	// line" about three thousand turns (#2232).
+	var what []string
+	if unreadable > 0 {
+		what = append(what, fmt.Sprintf("%d line%s", unreadable, pluralS(unreadable)))
+	}
+	if refused > 0 {
+		what = append(what, fmt.Sprintf("%d path%s", refused, pluralS(refused)))
+	}
+	return fmt.Sprintf("deja: %s: nothing indexed — %s could not be read", label, strings.Join(what, " and "))
+}
+
+// failedByHarness is malformedByHarness for the paths that would not open or
+// would not parse at all.
+func failedByHarness() map[string]int {
+	out := map[string]int{}
+	for p := range sources.DiagFailedPaths() {
+		if h := sources.HarnessForKind(harnessForPath(p)); h != "" {
+			out[h]++
+		}
+	}
+	return out
 }
 
 // totalMalformed is malformedByHarness summed: the incremental line names the

--- a/internal/index/silent_store_test.go
+++ b/internal/index/silent_store_test.go
@@ -58,11 +58,13 @@ func TestAStoreThatYieldedNothingButRefusedLinesIsNarrated(t *testing.T) {
 	}
 	said := out.String()
 
-	// The premise: deja did notice, and filed it where doctor reads.
+	// The premise: deja did notice, and filed it where doctor reads. Either
+	// bucket counts — a task that will not parse is a path deja could not read
+	// (#2232), a line inside a JSONL transcript is a line.
 	health := IngestHealth(dir)
 	var counted int
 	for _, e := range health {
-		counted += e.MalformedLines
+		counted += e.MalformedLines + e.FailedFiles
 	}
 	if counted == 0 {
 		t.Fatalf("nothing was recorded as unreadable, so this measures nothing:\n%s\n%v", said, health)

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -166,7 +166,10 @@ func parseClineModernSession(path string) ([]model.Session, error) {
 	}
 	var msgs clineMessages
 	if err := json.Unmarshal(b, &msgs); err != nil {
-		diagMalformedLine(path)
+		// The whole task is one document: nothing from this path is indexed,
+		// which is a path deja could not read rather than a line it skipped.
+		// "1 line could not be read" was said of three thousand turns (#2232).
+		diagFileError(path, err)
 		return nil, nil
 	}
 	// Only the lead agent's transcript is a user-facing session; subagent
@@ -250,7 +253,7 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 		Content json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal(b, &turns); err != nil {
-		diagMalformedLine(path)
+		diagFileError(path, err)
 		return nil, nil
 	}
 	taskDir := filepath.Dir(path)

--- a/internal/sources/diag.go
+++ b/internal/sources/diag.go
@@ -39,6 +39,20 @@ func DiagMalformedCounts() map[string]int {
 	return out
 }
 
+// DiagFailedPaths returns the paths that could not be read so far, without
+// clearing them — the sibling of DiagMalformedCounts, and for the same reason:
+// the index narrates each store as it lands, before the manifest fold drains
+// these counters (#1993).
+func DiagFailedPaths() map[string]string {
+	diagMu.Lock()
+	defer diagMu.Unlock()
+	out := make(map[string]string, len(diagFailed))
+	for p, msg := range diagFailed {
+		out[p] = msg
+	}
+	return out
+}
+
 // DiagSnapshot returns and clears the counters accumulated since the last
 // snapshot: malformed JSONL lines per file, and files whose parse failed
 // outright with the error text.

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -258,7 +258,9 @@ func ParseRooTask(path string) ([]model.Session, error) {
 		Content json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal(b, &turns); err != nil {
-		diagMalformedLine(path)
+		// One document per task, as in cline: a file that will not parse is a
+		// path deja could not read, not a line (#2232).
+		diagFileError(path, err)
 		return nil, nil
 	}
 	taskDir := filepath.Dir(path)

--- a/internal/sources/whole_file_diag_test.go
+++ b/internal/sources/whole_file_diag_test.go
@@ -1,0 +1,76 @@
+package sources
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A cline or roo task is one JSON document: if it will not unmarshal, nothing
+// from that file is indexed. Counting it as one malformed *line* said "1 line
+// could not be read" about three thousand turns, while the bucket that fits —
+// a path deja could not read, with the parser's words beside it — was right
+// there (#2232).
+func TestAWholeTaskThatWillNotParseIsReportedAsAPath(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("[")
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&b, `{"ts":%d,"type":"say","say":"text","text":"turn %d about the pool"},`, 1782900000+i, i)
+	}
+	truncated := strings.TrimSuffix(b.String(), ",") // no closing bracket
+
+	sessions := filepath.Join(dir, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	modern := filepath.Join(sessions, "abc.messages.json")
+	if err := os.WriteFile(modern, []byte(truncated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	task := filepath.Join(dir, "tasks", "123")
+	if err := os.MkdirAll(task, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(task, "api_conversation_history.json")
+	if err := os.WriteFile(legacy, []byte(truncated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rooTask := filepath.Join(dir, "roo", "tasks", "456")
+	if err := os.MkdirAll(rooTask, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	roo := filepath.Join(rooTask, "api_conversation_history.json")
+	if err := os.WriteFile(roo, []byte(truncated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	DiagSnapshot() // start from nothing
+	if _, err := ParseClineFile(modern); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseClineFile(legacy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseRooTask(roo); err != nil {
+		t.Fatal(err)
+	}
+	malformed, failed := DiagSnapshot()
+
+	for _, p := range []string{modern, legacy, roo} {
+		if n := malformed[p]; n != 0 {
+			t.Errorf("%s: counted as %d malformed line(s); it is a whole file", filepath.Base(p), n)
+		}
+		if failed[p] == "" {
+			t.Errorf("%s: not reported as a path deja could not read", filepath.Base(p))
+			continue
+		}
+		// The parser's own words travel with it, so `doctor --json` says what
+		// was wrong rather than only that something was.
+		if !strings.Contains(failed[p], "JSON") && !strings.Contains(failed[p], "json") {
+			t.Errorf("%s: the recorded reason says nothing about the parse: %q", filepath.Base(p), failed[p])
+		}
+	}
+}


### PR DESCRIPTION
Closes #2232.

A cline or roo task is one JSON document, and a file that will not unmarshal was counted as one malformed *line*:

    deja: cline: nothing indexed — 1 line could not be read

about a file holding three thousand turns.

The counters already had the bucket that fits. `diagFileError` records a path deja could not read — it surfaces as `failed_files`, as "N paths could not be read" on the index run, and since #2190 with the path and the parser's own words in `ingest_files`. That is exactly true of a file that opens and will not parse; "one line" is exactly false. `notes.go` keeps `diagMalformedLine`: there a line is one hand-written record.

Moving those three call sites reopened #2229 for this case — the zero-session branch spoke only for refused *lines* — so it speaks for both now, and the sentence says which loss it is:

    deja: cline: nothing indexed — 1 path could not be read

The failing test came first, on all three parsers, and asserts the parser's words travel with the path rather than only that something was recorded.
