### PR TITLE
fix(doctor): file ingest counts under the store, as the docs say

### DIFF
--- a/internal/index/db_store_counts_test.go
+++ b/internal/index/db_store_counts_test.go
@@ -136,7 +136,9 @@ func TestAGooseSessionThatContinuesIsNotCountedTwice(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return m.IngestHealth["goose-db"].ClippedMessages
+		// By the store, which is the key doctor files these under since #2234
+		// — "goose-db" is the file kind.
+		return m.IngestHealth["goose"].ClippedMessages
 	}
 	if got := clipped(); got != 1 {
 		t.Fatalf("the build clipped %d messages, so this measures nothing", got)

--- a/internal/index/health_keys_test.go
+++ b/internal/index/health_keys_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The run narrates a store and doctor filed the same fact under the file kind —
+// "cline-sdk" where the screen said "cline" — while the documentation calls the
+// key a harness. A reader carrying a number from one to the other had to know a
+// mapping deja never showed them (#2234).
+func TestIngestHealthIsKeyedByTheStoreTheRunNames(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+
+	proj := filepath.Join(claude, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stamp := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	good := fmt.Sprintf(`{"type":"user","sessionId":"s1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"the pool timed out during the migration"}}`, stamp)
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(good+"\nnot json at all\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cline, "1234.messages.json"), []byte(`[{"ts":1,`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	var out strings.Builder
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatal(err)
+	}
+	health := IngestHealth(dir)
+	// The premise: both stores are in there, or the names below prove nothing.
+	if len(health) < 2 {
+		t.Fatalf("only %d store reported anything:\n%s\n%v", len(health), out.String(), health)
+	}
+	for name := range health {
+		if sources.HarnessForKind(name) != name {
+			t.Errorf("doctor files this under %q, which is a file kind; the run says %q",
+				name, sources.HarnessForKind(name))
+		}
+	}
+	// And the store the run named is findable by that name.
+	if _, ok := health["cline"]; !ok {
+		t.Errorf("nothing is filed under the name the run printed: %v", health)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -145,7 +145,11 @@ func mergeIngestDiag(m *Manifest) {
 func healthFromFiles(files map[string]FileIngest) map[string]HarnessIngest {
 	out := map[string]HarnessIngest{}
 	for p, e := range files {
-		h := harnessForPath(p)
+		// The store, not the file kind: the run narrates "cline" and doctor
+		// filed the same fact under "cline-sdk", while the documentation calls
+		// this key a harness. Five stores have kinds by another name, so for
+		// those a script keyed on the documented name found nothing (#2234).
+		h := sources.HarnessForKind(harnessForPath(p))
 		if h == "" {
 			continue
 		}


### PR DESCRIPTION
Closes #2234.

The index run narrates a store; doctor filed the same fact under the file kind:

    deja: cline: nothing indexed — 1 path could not be read
    "ingest_health": {"claude": {...}, "cline-sdk": {...}}

`docs/json-output.md` calls that key a harness, and for five stores it was not — codex has `codex-history`, cursor `cursor-db`, hermes `hermes-pg`, goose `goose-jsonl` and `goose-db`, cline `cline-sdk` and `cline-vscode`. A script keyed on the documented name found nothing for those, and a person carrying a number from the run to the JSON had to know a mapping deja never showed them.

`healthFromFiles` folds through `sources.HarnessForKind` now, the same helper #2231 added for the narration; no kind is another store's name, so nothing lands in the wrong place. `ingest_files` is keyed by path and is untouched.

One test pinned the old key (`IngestHealth["goose-db"]`) and now pins the new one.

No `schema_version` bump: the policy governs field names, types and meanings, and these keys are data. The documented meaning — per harness — is unchanged; what changes is that the data now matches it. A consumer keyed on `cline-sdk` breaks, but that name was never documented, and the example in the same file shows `claude`.
