### PR TITLE
fix(index): say which files a store refused, beside the sessions it gave

### DIFF
--- a/internal/index/half_read_store_test.go
+++ b/internal/index/half_read_store_test.go
@@ -1,0 +1,58 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A store can be half-read: some sessions arrive, one file is refused. The line
+// carried the refused *lines* and the missing-tool reason and said nothing
+// about a refused file, so a store that gave up ten sessions and lost three
+// tasks read exactly like a store with nothing wrong (#2236).
+func TestAStoreNarratesTheFilesItRefusedBesideTheSessionsItRead(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stamp := time.Now().Add(-time.Hour).UnixMilli()
+	good := fmt.Sprintf(`{"agent":"lead","messages":[{"ts":%d,"role":"user",`+
+		`"content":"the pool timed out during the migration"}]}`, stamp)
+	if err := os.WriteFile(filepath.Join(cline, "good.messages.json"), []byte(good), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cline, "bad.messages.json"), []byte(`[{"ts":1,`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	var out strings.Builder
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatal(err)
+	}
+	said := out.String()
+
+	// The premise: the store did produce a session, so the line exists and the
+	// silence below is about the other file.
+	if !strings.Contains(said, "cline: 1 session") {
+		t.Fatalf("the readable session did not land, so this measures nothing:\n%s", said)
+	}
+	health := IngestHealth(dir)
+	if health["cline"].FailedFiles != 1 {
+		t.Fatalf("the refused file was not recorded, so this measures nothing: %v", health)
+	}
+	if !strings.Contains(said, "path") {
+		t.Errorf("the line says nothing about the file it could not read:\n%s", said)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -704,7 +704,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 		}
 		ss = append(ss, r.ss...)
 		if progress != nil && !SuppressHarnessNarration {
-			fmt.Fprintln(progress, harnessNarration(r.name, r.ss, sources.SkipReason(r.name), unreadable[r.name]))
+			fmt.Fprintln(progress, harnessNarration(r.name, r.ss, sources.SkipReason(r.name), unreadable[r.name], refused[r.name]))
 		}
 	}
 	return ss
@@ -715,7 +715,7 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 // in SQLite — and the count alone then reads as the whole story while half of
 // it is missing from recall. The skip reason was printed only for a store that
 // yielded nothing at all (#1758, the shape of #794).
-func harnessNarration(name string, ss []model.Session, skipped string, unreadable int) string {
+func harnessNarration(name string, ss []model.Session, skipped string, unreadable, refused int) string {
 	msgs := 0
 	for _, s := range ss {
 		msgs += len(s.Messages)
@@ -728,6 +728,13 @@ func harnessNarration(name string, ss []model.Session, skipped string, unreadabl
 	line := fmt.Sprintf("deja: %s: %d session%s, %d message%s", label, len(ss), pluralS(len(ss)), msgs, pluralS(msgs))
 	if unreadable > 0 {
 		line += fmt.Sprintf(" — %d line%s skipped, deja could not read %s", unreadable, pluralS(unreadable), pluralThem(unreadable))
+	}
+	// A file deja could not read at all is the third fact of this kind, beside
+	// the refused lines and the missing tool. Without it a store that gave up
+	// ten sessions and lost three tasks read like a store with nothing wrong
+	// (#2236).
+	if refused > 0 {
+		line += fmt.Sprintf(" — %d path%s could not be read at all", refused, pluralS(refused))
 	}
 	if skipped != "" {
 		line += " — part of this store could not be read: " + skipped

--- a/internal/index/partial_skip_test.go
+++ b/internal/index/partial_skip_test.go
@@ -12,7 +12,7 @@ import (
 // other does not. The run narrated what it got and said nothing about the rest,
 // while the same run names a store it could not read at all (#1758).
 func TestNarrationNamesAHalfReadStore(t *testing.T) {
-	got := harnessNarration("cursor", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "sqlite3 CLI not found", 0)
+	got := harnessNarration("cursor", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "sqlite3 CLI not found", 0, 0)
 	if !strings.Contains(got, "1 session") {
 		t.Errorf("the line lost its count: %q", got)
 	}
@@ -21,13 +21,13 @@ func TestNarrationNamesAHalfReadStore(t *testing.T) {
 	}
 
 	// Nothing skipped: the line is what it always was.
-	plain := harnessNarration("claude", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0)
+	plain := harnessNarration("claude", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0, 0)
 	if strings.Contains(plain, "—") {
 		t.Errorf("a fully read store gained a caveat: %q", plain)
 	}
 
 	// The notes pseudo-source keeps its label.
-	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0); !strings.HasPrefix(n, "deja: notes:") {
+	if n := harnessNarration("deja", []model.Session{{ID: "a", Messages: []model.Message{{Text: "x"}}}}, "", 0, 0); !strings.HasPrefix(n, "deja: notes:") {
 		t.Errorf("notes narrate as notes: %q", n)
 	}
 }


### PR DESCRIPTION
Closes #2236.

A store that yielded sessions and also had a file refused was narrated as though nothing went wrong:

    deja: cline: 1 session, 1 message
    IngestHealth: map[cline:{FailedFiles:1 LastError:"unexpected end of JSON input"}]

The line already carries the two neighbouring facts — "N lines skipped, deja could not read them", and "part of this store could not be read: <reason>" for a missing tool (#1758). A refused file is the third of the same kind and had no clause, so a store that gave up ten sessions and lost three tasks read exactly like a store with nothing wrong:

    deja: cline: 3 sessions, 3 messages — 2 paths could not be read at all

#2229 gave the zero-session case its own sentence; this is the same silence one branch over, where what the store did produce hides what it lost.
