### PR TITLE
fix(index): match the carry-forward to the key it filters

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2102,7 +2102,11 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 		if !skipped {
 			continue
 		}
-		h := harnessForPath(path)
+		// The store, matching the key the rules are filed under since #2238:
+		// asking for the file kind here left "cline-sdk" against a "cline" key,
+		// so nothing matched and every incremental pass carried the old counts
+		// on top of the fresh ones (#2240).
+		h := sources.HarnessForKind(harnessForPath(path))
 		if h == "" && path == sources.OpencodeDB() {
 			h = "opencode"
 		}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2114,7 +2114,18 @@ func carryRedactions(m *Manifest, old Manifest, skip map[string]bool) {
 	}
 	for key, count := range old.RedactionRules {
 		parts := strings.SplitN(key, ":", 2)
-		if len(parts) == 2 && !skipHarness[parts[0]] {
+		if len(parts) != 2 {
+			continue
+		}
+		// Folded before the lookup: an index written before #2238 files these
+		// by file kind, and a pass since then drops by store — so a stale
+		// "cline-sdk" count survived its file being re-read and was added to
+		// the fresh "cline" one when the report folded them (#2240).
+		name := parts[0]
+		if store := sources.HarnessForKind(name); store != "" {
+			name = store
+		}
+		if !skipHarness[name] {
 			m.RedactionRules[key] = count
 		}
 	}

--- a/internal/index/redaction_carry_test.go
+++ b/internal/index/redaction_carry_test.go
@@ -1,0 +1,82 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The carry-forward drops the old counts of a file the pass is re-reading, so
+// the fresh read is the whole story. It decided that by file kind while the key
+// became the store in #2239, so for five stores nothing matched and every
+// incremental pass added the file's secrets on top of the ones already counted
+// (#2240).
+func TestAReReadFileDoesNotCountItsRedactionsTwice(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+
+	secret := "ghp_" + strings.Repeat("a", 36)
+	stamp := time.Now().Add(-time.Hour).UnixMilli()
+	path := filepath.Join(cline, "one.messages.json")
+	write := func(turns int) {
+		t.Helper()
+		var b strings.Builder
+		b.WriteString(`{"agent":"lead","messages":[`)
+		for i := 0; i < turns; i++ {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `{"ts":%d,"role":"user","content":"the token is %s"}`, stamp+int64(i), secret)
+		}
+		b.WriteString("]}")
+		if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	counted := func() int {
+		t.Helper()
+		stats, err := Redactions(filepath.Join(tmp, "index.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return stats.Rules["cline"]["github-token"]
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	write(1)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: one secret in the file, one on the counter.
+	if got := counted(); got != 1 {
+		t.Fatalf("the first build counted %d of one secret, so this measures nothing", got)
+	}
+
+	write(2)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := counted(); got != 2 {
+		t.Errorf("two secrets in the file, %d counted after an incremental pass", got)
+	}
+
+	// And again, to catch a carry that only shows on the second repeat.
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := counted(); got != 2 {
+		t.Errorf("a pass with nothing new to read moved the count to %d", got)
+	}
+}

--- a/internal/index/redaction_carry_test.go
+++ b/internal/index/redaction_carry_test.go
@@ -80,3 +80,57 @@ func TestAReReadFileDoesNotCountItsRedactionsTwice(t *testing.T) {
 		t.Errorf("a pass with nothing new to read moved the count to %d", got)
 	}
 }
+
+// And the same file, in an index whose rules were written before the fold: the
+// stale kind key has to go when its file is re-read, or the report folds it
+// into the fresh count and reports both (#2240).
+func TestAStaleKindKeyIsDroppedWhenItsFileIsReRead(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+
+	secret := "ghp_" + strings.Repeat("a", 36)
+	stamp := time.Now().Add(-time.Hour).UnixMilli()
+	path := filepath.Join(cline, "one.messages.json")
+	turn := func(i int) string {
+		return fmt.Sprintf(`{"ts":%d,"role":"user","content":"the token is %s"}`, stamp+int64(i), secret)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := os.WriteFile(path, []byte(`{"agent":"lead","messages":[`+turn(0)+`]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The manifest as a deja from before the fold left it.
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.RedactionRules = map[string]int{"cline-sdk:github-token": 1}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, []byte(`{"agent":"lead","messages":[`+turn(0)+`,`+turn(1)+`]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := Redactions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stats.Rules["cline"]["github-token"]; got != 2 {
+		t.Errorf("two secrets in the file, the report says %d", got)
+	}
+}


### PR DESCRIPTION
Closes #2240 — a regression from #2239, found by carrying that change's own question one step further.

    after the first build:              map[cline:github-token:1]
    after an incremental pass over it:  map[cline:github-token:3]

Two secrets in the file, three on the counter, and one more on every pass after that.

`carryRedactionRules` drops the old counts of a file the pass is re-reading, so the fresh read is the whole story. It decided that by file kind — `harnessForPath` answers `cline-sdk` — while #2239 made the key the store, so for the five stores whose kinds have another name nothing matched and the old counts were carried on top of the new ones. Both sides are the store now.

The test writes one secret, then two, then indexes again with nothing new to read: 1, 2, 2. The third pass is there because a carry that only shows on the second repeat is exactly the shape this was.
