### PR TITLE
fix(index): weigh the reading bar by store so cline and goose move it

### DIFF
--- a/internal/index/progress.go
+++ b/internal/index/progress.go
@@ -1,6 +1,10 @@
 package index
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
 
 // Progress reports what a build is doing while it does it. The first build on
 // a real corpus takes about ten seconds, and until now those seconds were
@@ -64,10 +68,19 @@ func reportHarness(name string, sessions, messages int) {
 
 // filesPerHarness weights the reading stage: a store with 900 session files
 // should move the bar far more than one with three.
+//
+// By store, because the parse loop advances by the store's name: counting a
+// file under its kind filed cline's files as "cline-sdk" against a bar that
+// only ever asked for "cline", so those files sized the stage and never moved
+// it (#2242).
 func filesPerHarness(files map[string]FileState) map[string]int {
 	out := map[string]int{}
 	for p := range files {
-		out[harnessForPath(p)]++
+		h := harnessForPath(p)
+		if store := sources.HarnessForKind(h); store != "" {
+			h = store
+		}
+		out[h]++
 	}
 	return out
 }

--- a/internal/index/progress_weights_test.go
+++ b/internal/index/progress_weights_test.go
@@ -1,0 +1,90 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// countingProgress records what the reading stage promised and what it
+// delivered.
+type countingProgress struct {
+	mu       sync.Mutex
+	phase    string
+	total    map[string]int
+	advanced map[string]int
+}
+
+func (c *countingProgress) Phase(name string, total int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.phase = name
+	c.total[name] = total
+}
+
+func (c *countingProgress) Advance(units int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.advanced[c.phase] += units
+}
+
+func (c *countingProgress) Harness(string, int, int) {}
+
+// The bar is sized in files and moved in stores. It counted a file under its
+// kind — "cline-sdk" — and advanced by the store the parse loop names, so a
+// corpus of cline sessions filled the total and left the bar where it was
+// (#2242).
+func TestEveryFileCountedInTheBarAlsoMovesIt(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	cline := filepath.Join(tmp, "cline")
+	if err := os.MkdirAll(cline, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOT", cline)
+
+	stamp := time.Now().Add(-time.Hour).UnixMilli()
+	for i := 0; i < 4; i++ {
+		body := fmt.Sprintf(`{"agent":"lead","messages":[{"ts":%d,"role":"user","content":"hello there"}]}`, stamp)
+		name := fmt.Sprintf("s%d.messages.json", i)
+		if err := os.WriteFile(filepath.Join(cline, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	proj := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"s1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"hello there"}}`, at)
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &countingProgress{total: map[string]int{}, advanced: map[string]int{}}
+	SetProgress(p)
+	defer SetProgress(nil)
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	p.mu.Lock()
+	total, advanced := p.total["reading sessions"], p.advanced["reading sessions"]
+	p.mu.Unlock()
+	// The premise: every file on disk is in the total, or the bar being short
+	// proves nothing.
+	if total != 5 {
+		t.Fatalf("the reading stage was sized at %d for five files on disk", total)
+	}
+	if advanced != total {
+		t.Errorf("the reading stage promised %d files and moved the bar by %d", total, advanced)
+	}
+}


### PR DESCRIPTION
Closes #2242.

Four cline sessions and one claude session, with a sink watching the reading stage:

    reading sessions: bar total 5, advanced 1

The stage is sized in files and moved in stores. `filesPerHarness` counted each file under `harnessForPath` — the file kind, `cline-sdk` — while the parse loop advances by the registry entry's name, the store. cline and goose have no kind named after their store, so their files sized the bar and never moved it; codex, cursor and hermes lost their second kind's files the same way.

The weights fold to the store now. The total is unchanged — same files, fewer keys.
