### PR TITLE
fix(doctor): report the same ingest error on every run

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -393,7 +393,10 @@ Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 `unreadable` (which adds an `error`); `activations` keys are `search`, `mcp` and
 `auto`, each with the rule in force and how many sessions it withheld;
 `ignored` and `inert` list policy lines that matched no harness or no import.
-Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`.
+Per-harness `ingest_health` may also carry `clipped_messages` and `last_error`,
+which quotes one of that store's failures — the first failing path in order,
+so the same index reports the same error every run. `ingest_files` below has
+every one of them.
 
 `ingest_files` is where those counts came from, keyed by file path: `malformed`
 lines, `clipped` messages, and `error` when nothing from that path is in the

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -142,9 +142,20 @@ func mergeIngestDiag(m *Manifest) {
 }
 
 // healthFromFiles sums the per-file counts per harness.
+//
+// Paths in order, because LastError is one of them: taking whichever the map
+// handed over last gave the same index a different error on every run, so a
+// script diffing `doctor --json` saw a change where nothing changed (#2245).
+// The first failing path is the one quoted; ingest_files holds them all.
 func healthFromFiles(files map[string]FileIngest) map[string]HarnessIngest {
 	out := map[string]HarnessIngest{}
-	for p, e := range files {
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		e := files[p]
 		// The store, not the file kind: the run narrates "cline" and doctor
 		// filed the same fact under "cline-sdk", while the documentation calls
 		// this key a harness. Five stores have kinds by another name, so for
@@ -158,7 +169,9 @@ func healthFromFiles(files map[string]FileIngest) map[string]HarnessIngest {
 		cur.ClippedMessages += e.Clipped
 		if e.Error != "" {
 			cur.FailedFiles++
-			cur.LastError = e.Error
+			if cur.LastError == "" {
+				cur.LastError = e.Error
+			}
 		}
 		out[h] = cur
 	}

--- a/internal/index/last_error_stable_test.go
+++ b/internal/index/last_error_stable_test.go
@@ -1,0 +1,40 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The same index has to answer the same way twice. last_error was whichever
+// failing file Go's map iteration reached last, so `doctor --json` reported a
+// different error each run and a script diffing the report saw a change where
+// nothing changed (#2245).
+func TestTheReportedErrorIsTheSameOnEveryRun(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	proj := filepath.Join(root, "projects", "-work-a")
+	files := map[string]FileIngest{
+		filepath.Join(proj, "aaa.jsonl"): {Error: "open aaa.jsonl: permission denied"},
+		filepath.Join(proj, "bbb.jsonl"): {Error: "unexpected end of JSON input"},
+		filepath.Join(proj, "ccc.jsonl"): {Error: "open ccc.jsonl: is a directory"},
+	}
+
+	first := healthFromFiles(files)["claude"]
+	// The premise: three failures folded into one store, or one answer proves
+	// nothing.
+	if first.FailedFiles != 3 {
+		t.Fatalf("%d failed files counted, want 3", first.FailedFiles)
+	}
+	for i := 0; i < 200; i++ {
+		if got := healthFromFiles(files)["claude"].LastError; got != first.LastError {
+			t.Fatalf("run %d reported %q where the first run reported %q", i+2, got, first.LastError)
+		}
+	}
+	// And it is the one the field claims: the first failing path, so two
+	// machines reading the same index quote the same file.
+	if want := "open aaa.jsonl: permission denied"; first.LastError != want {
+		t.Errorf("reported %q, want the first failing path's error %q", first.LastError, want)
+	}
+}


### PR DESCRIPTION
Closes #2245.

Three failing transcripts in one store, `healthFromFiles` called 200 times on the same input:

    158/200  "open ccc.jsonl: is a directory"
     23/200  "open aaa.jsonl: permission denied"
     19/200  "unexpected end of JSON input"

`last_error` was whichever file Go's map iteration reached last, so `doctor --json` answered differently each run and a script diffing the report saw a change where nothing changed. #2234 widened the pool by folding kinds into one store.

The paths are walked in order now and the first failing one is quoted. No new field and no meaning lost — `ingest_files` has carried every path with its own error since #2190, and the docs now say which failure this one is.
