### PR TITLE
fix(sources): subtract excluded projects from the opencode row

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2488,12 +2488,30 @@ func printSources(dir string) {
 		size = fi.Size()
 	}
 	s, m, _ := sources.OpencodeCounts()
+	// The counts come out of sqlite, which knows nothing about the exclude
+	// list, so with a pattern in force this row kept reporting sessions that
+	// are not indexed, not searchable and not exported while every other row
+	// subtracted them (#2247). Only then is the store loaded: counting by SQL
+	// is why this row is cheap on a large database.
+	opencodeExcluded := 0
+	if len(sources.ExclusionPatterns()) > 0 {
+		raw := sources.LoadOpencode()
+		kept := sources.FilterSessions(raw)
+		opencodeExcluded = len(raw) - len(kept)
+		s, m = sources.CountSessions(kept), 0
+		for _, x := range kept {
+			m += len(x.Messages)
+		}
+	}
 	note = ""
 	if size > 0 && !sources.SQLite3Available() {
 		note = "\t(sqlite3 CLI not found — opencode sessions unavailable)"
 	}
 	if n := len(sources.ExclusionPatterns()); n > 0 {
 		note += fmt.Sprintf("\texcluded-patterns=%d", n)
+	}
+	if opencodeExcluded > 0 {
+		note += fmt.Sprintf("\texcluded-sessions=%d", opencodeExcluded)
 	}
 	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()], note)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2498,10 +2498,17 @@ func printSources(dir string) {
 		raw := sources.LoadOpencode()
 		kept := sources.FilterSessions(raw)
 		opencodeExcluded = len(raw) - len(kept)
-		s, m = sources.CountSessions(kept), 0
-		for _, x := range kept {
-			m += len(x.Messages)
+		// Subtracted from the SQL numbers rather than recounted from what
+		// loaded: the loader drops a session holding no text at all, which the
+		// row has always counted, so recounting would move the numbers for a
+		// reason that has nothing to do with the exclude list.
+		dropped := 0
+		for _, x := range raw {
+			if sources.ExcludedProject(x.Project) {
+				dropped += len(x.Messages)
+			}
 		}
+		s, m = max(0, s-opencodeExcluded), max(0, m-dropped)
 	}
 	note = ""
 	if size > 0 && !sources.SQLite3Available() {

--- a/cmd/deja/sources_excluded_test.go
+++ b/cmd/deja/sources_excluded_test.go
@@ -82,3 +82,60 @@ insert into part values('p2','m2','{"type":"text","text":"hello from secret"}');
 		t.Errorf("the opencode row does not say what it dropped: %s", got)
 	}
 }
+
+// And a pattern that excludes nothing must leave the numbers alone: the row is
+// counted in SQL, while the loader that measures the exclusion drops a session
+// holding no text at all, which SQL counts (#2247).
+func TestAPatternThatMatchesNothingLeavesTheOpencodeRowAlone(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	script := `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/work/keep','2026-01-02T03:00:00Z','2026-01-02T03:00:00Z');
+insert into session values('s2','/work/empty','2026-01-02T03:00:00Z','2026-01-02T03:00:00Z');
+insert into message values('m1','s1',1,'{"role":"user"}');
+insert into part values('p1','m1','{"type":"text","text":"hello from keep"}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v %s", err, out)
+	}
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	row := func() string {
+		out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
+		for _, l := range strings.Split(out, "\n") {
+			if strings.HasPrefix(l, "opencode\t") {
+				return l
+			}
+		}
+		t.Fatalf("no opencode row in:\n%s", out)
+		return ""
+	}
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "")
+	before := row()
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "nothing-matches-this")
+	after := row()
+	for _, want := range []string{"sessions=2", "messages=1"} {
+		if !strings.Contains(before, want) {
+			t.Fatalf("the premise is wrong — without a pattern the row reads %s", before)
+		}
+		if !strings.Contains(after, want) {
+			t.Errorf("a pattern matching nothing changed the row to %s", after)
+		}
+	}
+	if strings.Contains(after, "excluded-sessions=") {
+		t.Errorf("nothing was excluded and the row says it dropped something: %s", after)
+	}
+}

--- a/cmd/deja/sources_excluded_test.go
+++ b/cmd/deja/sources_excluded_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// `deja sources` subtracts excluded sessions from every store's row and says
+// how many it dropped. opencode's row was counted straight out of sqlite, so
+// the one store whose count came from SQL kept reporting sessions that are not
+// indexed, not searchable and not exported (#2247).
+func TestSourcesCountsOpencodeWithoutExcludedProjects(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	script := `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/work/keep','2026-01-02T03:00:00Z','2026-01-02T03:00:00Z');
+insert into session values('s2','/work/secret','2026-01-02T03:00:00Z','2026-01-02T03:00:00Z');
+insert into message values('m1','s1',1,'{"role":"user"}');
+insert into message values('m2','s2',1,'{"role":"user"}');
+insert into part values('p1','m1','{"type":"text","text":"hello from keep"}');
+insert into part values('p2','m2','{"type":"text","text":"hello from secret"}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v %s", err, out)
+	}
+
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	// A claude session in the same excluded project, as the row to compare
+	// against: that store has always subtracted.
+	claude := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claude, "-work-secret")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"c1","timestamp":%q,"cwd":"/work/secret",`+
+		`"message":{"role":"user","content":"hello from secret"}}`, at)
+	if err := os.WriteFile(filepath.Join(proj, "c1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "secret")
+
+	out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
+	row := func(name string) string {
+		for _, l := range strings.Split(out, "\n") {
+			if strings.HasPrefix(l, name+"\t") {
+				return l
+			}
+		}
+		t.Fatalf("no %s row in:\n%s", name, out)
+		return ""
+	}
+
+	// The premise: the store that has always subtracted still does, or there
+	// is nothing to compare against.
+	if got := row("claude"); !strings.Contains(got, "sessions=0") || !strings.Contains(got, "excluded-sessions=1") {
+		t.Fatalf("claude row does not show the exclusion applied: %s", got)
+	}
+	if got := row("opencode"); !strings.Contains(got, "sessions=1 messages=1") {
+		t.Errorf("one of two opencode sessions is excluded, the row says: %s", got)
+	}
+	if got := row("opencode"); !strings.Contains(got, "excluded-sessions=1") {
+		t.Errorf("the opencode row does not say what it dropped: %s", got)
+	}
+}


### PR DESCRIPTION
Closes #2247.

Two opencode sessions with one in an excluded project, and a claude session in the same project:

    claude    …/claude/-work-secret  sessions=0 messages=0 …  excluded-patterns=1  excluded-sessions=1
    opencode  …/opencode.db          sessions=2 messages=2 …  excluded-patterns=1

opencode is printed outside the table that loads and filters, from `select count(*) from session`, so its row counted sessions that are not indexed, not searchable and not exported.

The store is loaded and filtered only when a pattern is actually set — counting by SQL is what keeps this row cheap on a large database — and the row now says what it dropped, like the others.
