### PR TITLE
fix(search): say when a flag belongs to another command

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2042,7 +2042,6 @@ func parseSearch(args []string) (search.Options, error) {
 	return o, nil
 }
 
-// searchFlags is every flag the bare search form accepts, for the typo check.
 // flagsOfOtherCommands names the command each flag belongs to, for the tokens
 // that are real deja flags somewhere but not here. Only exact matches: a query
 // may legitimately start with a dash, and `--` still ends option parsing.
@@ -2072,6 +2071,7 @@ var flagsOfOtherCommands = map[string]string{
 	"--seed":        "bench",
 }
 
+// searchFlags is every flag the bare search form accepts, for the typo check.
 var searchFlags = []string{
 	"--json", "--re", "--all", "--no-embed", "--rebuild",
 	"--harness", "--project", "--since", "--role", "--limit", "--session",

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2021,6 +2021,12 @@ func parseSearch(args []string) (search.Options, error) {
 			if near := nearestSearchFlag(a); near != "" {
 				return o, fmt.Errorf("unknown flag %q — did you mean %s?", a, near)
 			}
+			// A flag deja takes elsewhere is not a typo and is nowhere near a
+			// search flag by edit distance, so it went into the query and the
+			// search that would have found everything reported nothing (#2249).
+			if cmd := flagsOfOtherCommands[a]; cmd != "" {
+				return o, fmt.Errorf("%s is a flag of `deja %s`, not of search — put it after `--` to search for the text", a, cmd)
+			}
 			q = append(q, a)
 		}
 	}
@@ -2037,6 +2043,35 @@ func parseSearch(args []string) (search.Options, error) {
 }
 
 // searchFlags is every flag the bare search form accepts, for the typo check.
+// flagsOfOtherCommands names the command each flag belongs to, for the tokens
+// that are real deja flags somewhere but not here. Only exact matches: a query
+// may legitimately start with a dash, and `--` still ends option parsing.
+var flagsOfOtherCommands = map[string]string{
+	"--offset":      "show",
+	"--span":        "restore",
+	"--out":         "restore",
+	"--force":       "restore",
+	"--tag":         "remember",
+	"--deep":        "doctor",
+	"--offline":     "doctor",
+	"--dry-run":     "forget",
+	"--all-matches": "forget",
+	"--list":        "forget",
+	"--unforget":    "forget",
+	"--before":      "forget",
+	"--to":          "handoff",
+	"--exec":        "resume",
+	"--plain":       "hook-prompt",
+	"--no-open":     "view",
+	"--full":        "sync export",
+	"--peer":        "sync export",
+	"--pull":        "sync ssh",
+	"--both":        "sync ssh",
+	"--from":        "last",
+	"--last":        "log",
+	"--seed":        "bench",
+}
+
 var searchFlags = []string{
 	"--json", "--re", "--all", "--no-embed", "--rebuild",
 	"--harness", "--project", "--since", "--role", "--limit", "--session",

--- a/cmd/deja/search_foreign_flag_test.go
+++ b/cmd/deja/search_foreign_flag_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A flag deja takes on another command is not a typo and is not near a search
+// flag by edit distance, so it fell through into the query and a search that
+// would have found everything reported nothing (#2249).
+func TestParseSearchRejectsAFlagFromAnotherCommand(t *testing.T) {
+	for flag, command := range map[string]string{
+		"--offset":  "show",
+		"--deep":    "doctor",
+		"--dry-run": "forget",
+		"--span":    "restore",
+		"--tag":     "remember",
+	} {
+		_, err := parseSearch([]string{"retry", flag, "2"})
+		if err == nil {
+			t.Errorf("%s was taken as part of the query", flag)
+			continue
+		}
+		if !strings.Contains(err.Error(), flag) || !strings.Contains(err.Error(), command) {
+			t.Errorf("%s: %v — the message should name the flag and the command that takes it", flag, err)
+		}
+	}
+
+	// The escape hatch stays open: after `--` the same text is a query.
+	o, err := parseSearch([]string{"--", "retry", "--offset"})
+	if err != nil || o.Query != "retry --offset" {
+		t.Errorf("query = %q err = %v", o.Query, err)
+	}
+	// And a dash that is nobody's flag is still a query word.
+	o, err = parseSearch([]string{"--retry", "budget"})
+	if err != nil || o.Query != "--retry budget" {
+		t.Errorf("query = %q err = %v", o.Query, err)
+	}
+}


### PR DESCRIPTION
Closes #2249.

Three indexed sessions, all containing "retry":

    $ deja search retry --offset 2
    deja: no matches in 3 indexed sessions — try fewer words or --re (query "retry --offset 2")

`--offset`, `--deep`, `--dry-run`, `--span`, `--tag` are real deja flags on other commands. They are not typos and not near any search flag by edit distance, so #755's guard stayed silent and they became query words — the search that would have found everything said the memory was empty.

After:

    deja: --offset is a flag of `deja show`, not of search — put it after `--` to search for the text

Exact matches only, so a query starting with a dash still works, and `--` still ends option parsing.
