### PR TITLE
fix(show,resume): name the mistyped harness instead of the id

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -52,6 +52,11 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 			if strings.HasPrefix(args[i], "-") {
 				return fmt.Errorf("handoff: unknown flag %q", args[i])
 			}
+			// The last one used to win, so a stray word replaced the id and
+			// the refusal named it as the session that was missing (#2251).
+			if prefix != "" {
+				return fmt.Errorf("handoff takes one id-prefix — got %q and %q", prefix, args[i])
+			}
 			prefix = args[i]
 		}
 	}

--- a/cmd/deja/id_command_flags_test.go
+++ b/cmd/deja/id_command_flags_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A mistyped harness must not be reported as a missing session: search, last
+// and blame all say which value they did not recognise, while show blamed the
+// id the reader typed correctly and resume looked the harness up as the id
+// (#2251).
+func TestAMistypedHarnessIsNamedByTheCommandsThatTakeAnID(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"sess1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"the retry budget for uploads"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: the session is there under its real harness.
+	if err := cmdShow(dir, []string{"sess1", "--harness", "claude"}, ""); err != nil {
+		t.Fatalf("the session cannot be shown at all: %v", err)
+	}
+
+	err := cmdShow(dir, []string{"sess1", "--harness", "cluade"}, "")
+	if err == nil {
+		t.Fatal("show accepted a harness that does not exist")
+	}
+	if !strings.Contains(err.Error(), "cluade") || !strings.Contains(err.Error(), "not a harness") {
+		t.Errorf("show said %v — it should name the harness it did not recognise", err)
+	}
+
+	var out bytes.Buffer
+	err = runResume(dir, []string{"sess1", "--harness", "cluade"}, &out)
+	if err == nil {
+		t.Fatal("resume accepted a flag it does not take")
+	}
+	if strings.Contains(err.Error(), `matches "cluade"`) {
+		t.Errorf("resume looked the flag value up as the id: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--harness") {
+		t.Errorf("resume said %v — it should name the flag it does not take", err)
+	}
+	// A second bare word is the same mistake without a dash: it used to replace
+	// the id silently.
+	if err := runResume(dir, []string{"sess1", "extra"}, &out); err == nil ||
+		strings.Contains(err.Error(), `matches "extra"`) {
+		t.Errorf("resume with a stray word: %v", err)
+	}
+}

--- a/cmd/deja/id_command_flags_test.go
+++ b/cmd/deja/id_command_flags_test.go
@@ -73,4 +73,15 @@ func TestAMistypedHarnessIsNamedByTheCommandsThatTakeAnID(t *testing.T) {
 		strings.Contains(err.Error(), `matches "extra"`) {
 		t.Errorf("resume with a stray word: %v", err)
 	}
+
+	// handoff had the same shape, found by running the same input at it.
+	if err := runHandoff(dir, []string{"sess1", "extra"}, &out); err == nil ||
+		strings.Contains(err.Error(), `matches "extra"`) {
+		t.Errorf("handoff with a stray word: %v", err)
+	}
+	// And it still hands off the session it was given.
+	out.Reset()
+	if err := runHandoff(dir, []string{"sess1"}, &out); err != nil {
+		t.Errorf("handoff of a real id: %v", err)
+	}
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -437,6 +437,12 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.id == "" {
 		return idPrefixNeeded(dir, "show needs an id-prefix", showNeedsID)
 	}
+	// A harness that does not exist matches nothing, and the refusal then
+	// blamed the id the reader typed correctly (#2251). search, last, blame
+	// and the MCP tools have always named the value they did not recognise.
+	if err := checkHarness(&o.harness); err != nil {
+		return err
+	}
 	var s model.Session
 	var ok bool
 	if o.harness != "" {

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -29,6 +29,15 @@ func runResume(dir string, args []string, stdout io.Writer) error {
 			doExec = true
 			continue
 		}
+		// The last argument used to win, so a flag resume does not take, or a
+		// stray word, silently replaced the id and the refusal named it as the
+		// session that was missing (#2251).
+		if strings.HasPrefix(a, "-") && a != "-" {
+			return fmt.Errorf("resume: unknown flag %q — it takes an id-prefix and --exec", a)
+		}
+		if prefix != "" {
+			return fmt.Errorf("resume takes one id-prefix — got %q and %q", prefix, a)
+		}
 		prefix = a
 	}
 	if prefix == "" {


### PR DESCRIPTION
Closes #2251.

    $ deja show sess1 --harness cluade
    deja: no session matches "sess1"

    $ deja resume sess1 --harness cluade
    deja: no session matches "cluade"

The session exists both times. show never ran `checkHarness`, so an unknown harness matched nothing and the refusal blamed the id; resume took the last argument that was not `--exec` as the id-prefix, so any flag or stray word replaced it.

show now names the harness it does not know, like search, last and blame; resume rejects a flag it does not take and a second id-prefix instead of quietly preferring one.
