### PR TITLE
fix(friction,restore): refuse a flag they do not take

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -28,14 +28,21 @@ import (
 func runFriction(dir string, args []string, stdout io.Writer) error {
 	limit := 10
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--limit" && i+1 < len(args) {
-			i++
-			n, err := strconv.Atoi(args[i])
-			if err != nil || n <= 0 {
-				return fmt.Errorf("friction: --limit wants a positive number, got %q", args[i])
-			}
-			limit = n
+		// Anything else used to be dropped on the floor, so `deja friction
+		// --json` and `--limt 3` answered in prose and exited 0 as though they
+		// had been understood (#2253).
+		if args[i] != "--limit" {
+			return fmt.Errorf("friction: unknown flag %q — it takes --limit n", args[i])
 		}
+		if i+1 >= len(args) {
+			return fmt.Errorf("friction: --limit needs value")
+		}
+		i++
+		n, err := strconv.Atoi(args[i])
+		if err != nil || n <= 0 {
+			return fmt.Errorf("friction: --limit wants a positive number, got %q", args[i])
+		}
+		limit = n
 	}
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -48,21 +48,29 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 		case "--force":
 			force = true
 		case "--span":
-			if i+1 < len(args) {
-				i++
-				n, err := strconv.Atoi(args[i])
-				if err != nil || n <= 0 {
-					return fmt.Errorf("restore: --span wants a positive number, got %q", args[i])
-				}
-				want = n
+			// A missing value used to be ignored, which for -o meant the file
+			// went to stdout while the reader believed it had been written
+			// (#2253).
+			if i+1 >= len(args) {
+				return fmt.Errorf("restore: --span needs value")
 			}
+			i++
+			n, err := strconv.Atoi(args[i])
+			if err != nil || n <= 0 {
+				return fmt.Errorf("restore: --span wants a positive number, got %q", args[i])
+			}
+			want = n
 		case "-o", "--out":
-			if i+1 < len(args) {
-				i++
-				out = args[i]
+			if i+1 >= len(args) {
+				return fmt.Errorf("restore: -o needs value")
 			}
+			i++
+			out = args[i]
 		default:
-			if !strings.HasPrefix(args[i], "-") && path == "" {
+			if strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("restore: unknown flag %q", args[i])
+			}
+			if path == "" {
 				path = args[i]
 			}
 		}

--- a/cmd/deja/silent_flag_test.go
+++ b/cmd/deja/silent_flag_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every command in this family refuses a flag it does not take. friction and
+// restore dropped one on the floor and answered as though nothing was wrong, so
+// a script asking either for --json got prose on stdout and exit 0 (#2253).
+func TestFrictionAndRestoreRefuseAFlagTheyDoNotTake(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+
+	var out bytes.Buffer
+	for _, args := range [][]string{
+		{"--json"},
+		{"--limt", "3"},
+		{"--limit"},
+	} {
+		out.Reset()
+		err := runFriction(dir, args, &out)
+		if err == nil {
+			t.Errorf("friction %v was accepted, and printed %q", args, out.String())
+			continue
+		}
+		if !strings.Contains(err.Error(), args[0]) {
+			t.Errorf("friction %v: %v — the message should name the flag", args, err)
+		}
+	}
+	// What it does take still works.
+	out.Reset()
+	if err := runFriction(dir, []string{"--limit", "3"}, &out); err != nil {
+		t.Errorf("friction --limit 3: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"api/upload.go", "--json"},
+		{"api/upload.go", "-o"},
+		{"api/upload.go", "--span"},
+	} {
+		out.Reset()
+		err := runRestore(dir, args, &out)
+		if err == nil {
+			t.Errorf("restore %v was accepted, and printed %q", args, out.String())
+			continue
+		}
+		if !strings.Contains(err.Error(), args[1]) {
+			t.Errorf("restore %v: %v — the message should name the flag", args, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2253.

`how`, `fix`, `files`, `view` and `sources` all refuse a flag they do not take. These two did not:

    $ deja friction --json           nothing recurring …               exit 0
    $ deja friction --limit          nothing recurring …               exit 0   (value missing, limit stayed 10)
    $ deja restore api/upload.go --json    no replaced spans recorded  exit 0

`deja restore file.go -o` was the sharp one — the value was missing, the flag was skipped, and the recovered file went to stdout while the reader believed it had been written.

Both now name the flag, and a flag whose value is missing is an error rather than a silent default.
