### PR TITLE
fix(sync): do not claim a redaction that did not happen

### DIFF
--- a/cmd/deja/export_redaction_line_test.go
+++ b/cmd/deja/export_redaction_line_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The one line deja prints about secrets leaving the machine said records were
+// redacted whatever the count was, so an export with nothing masked announced a
+// redaction that never happened (#2255).
+func TestTheExportLineDoesNotClaimARedactionThatDidNotHappen(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+
+	write := func(name, body string) {
+		t.Helper()
+		at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app",`+
+			`"message":{"role":"user","content":%q}}`, name, at, body)
+		if err := os.WriteFile(filepath.Join(claude, name+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Nothing in this session matches a redaction pattern.
+	write("clean", "gateway_timeout on the reconnect_loop")
+	out := filepath.Join(tmp, "out-clean")
+	said := captureStderr(t, func() {
+		if err := runSync(dir, []string{"export", out}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// The premise: something was exported, or the line is not printed at all.
+	if !strings.Contains(said, "0 masked") && !strings.Contains(said, "nothing matched") {
+		t.Logf("stderr was: %s", said)
+	}
+	if strings.Contains(said, "records were redacted") {
+		t.Errorf("nothing was masked and the export said records were redacted:\n%s", said)
+	}
+	if !strings.Contains(said, "review the export") {
+		t.Errorf("the caution is the point of the line and it is gone:\n%s", said)
+	}
+
+	// And with a secret in the store, the sentence is true and stays.
+	write("dirty", "the token is ghp_"+strings.Repeat("a", 36))
+	out2 := filepath.Join(tmp, "out-dirty")
+	said = captureStderr(t, func() {
+		if err := runSync(dir, []string{"export", out2, "--full"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(said, "records were redacted") {
+		t.Errorf("a redacted store no longer says so:\n%s", said)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -169,7 +169,15 @@ func runSync(dir string, args []string) error {
 			if rs, rerr := index.Redactions(dir); rerr == nil {
 				masked = rs.Total
 			}
-			fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
+			// The count decides the sentence: saying records were redacted
+			// when none were is a claim about secrets that is not true, and
+			// this is the one line deja prints about them leaving the machine
+			// (#2255). The caution holds either way and is the point of it.
+			if masked > 0 {
+				fmt.Fprintf(os.Stderr, "deja: records were redacted at index time (%d masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.\n", masked)
+			} else {
+				fmt.Fprintln(os.Stderr, "deja: nothing in these records matched deja's redaction patterns. pattern redaction is a floor — review the export before moving it; rotate anything that leaked.")
+			}
 		}
 		return nil
 	case "import":


### PR DESCRIPTION
Closes #2255.

    $ deja sync export /tmp/out1
    deja: exported 1 record
    deja: records were redacted at index time (0 masked). pattern redaction is a floor — review the export before moving it; rotate anything that leaked.

Nothing was masked. With a count of zero the sentence now says so instead:

    deja: nothing in these records matched deja's redaction patterns. pattern redaction is a floor — review the export before moving it; rotate anything that leaked.

The caution is the point of the line and is unchanged in both branches; only the claim in front of it follows the count. Test covers both a clean store and one holding a token.
