### PR TITLE
fix(hook): recall the only session a new store holds

### DIFF
--- a/cmd/deja/hook_one_session_test.go
+++ b/cmd/deja/hook_one_session_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The second session someone ever has is the first time deja can say "you have
+// been here", and it said nothing: in a one-session store every idf collapses
+// to zero, so the term the session had to have SPOKEN was picked by the prompt's
+// word order and came out "seeing" (#2257).
+func TestAStoreOfOneSessionStillRecallsIt(t *testing.T) {
+	inject := func(t *testing.T, fillers int) string {
+		t.Helper()
+		tmp := t.TempDir()
+		home := filepath.Join(tmp, "home")
+		if err := os.MkdirAll(home, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("HOME", home)
+		t.Setenv("USERPROFILE", home)
+		claude := filepath.Join(tmp, "claude")
+		if err := os.MkdirAll(filepath.Join(claude, "beta"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(claude, "alpha"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("DEJA_CLAUDE_ROOT", claude)
+		t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+		t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+		t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+		at := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":"hookfix","timestamp":%q,`+
+			`"message":{"role":"user","content":"gateway_timeout on the reconnect_loop keeps dropping heartbeats"}}`, at)
+		if err := os.WriteFile(filepath.Join(claude, "beta", "hookfix.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < fillers; i++ {
+			l := fmt.Sprintf(`{"type":"user","sessionId":"filler%d","timestamp":%q,`+
+				`"message":{"role":"user","content":"unrelated work about deployments and dashboards"}}`, i, at)
+			if err := os.WriteFile(filepath.Join(claude, "alpha", fmt.Sprintf("f%d.jsonl", i)), []byte(l+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		dir := filepath.Join(tmp, "index.db")
+		if err := index.Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+		cwd := filepath.Join(tmp, "proj", "beta")
+		if err := os.MkdirAll(cwd, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Chdir(cwd)
+		var out bytes.Buffer
+		in := strings.NewReader(`{"prompt":"seeing gateway_timeout in the reconnect_loop again"}`)
+		if err := runHookPrompt(dir, in, &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	// The premise: with a second session in the store this prompt recalls.
+	if got := inject(t, 1); !strings.Contains(got, "gateway_timeout") {
+		t.Fatalf("two sessions and no recall, so this measures nothing: %q", got)
+	}
+	if got := inject(t, 0); !strings.Contains(got, "gateway_timeout") {
+		t.Errorf("the only session in the store was not recalled: %q", got)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -407,6 +407,13 @@ func byIdentifying(terms []string, idf map[string]float64) []string {
 		// dropped for not saying it (#2257). The rest of the ranking already
 		// treats a tiny corpus as a special case; this is that case for the
 		// lead term: prefer the word that reads like a term of art.
+		// Shape before length, or "dashboards" would out-rank "s3": a word
+		// carrying an underscore, a dot, a slash or a digit names something
+		// whatever its length, and length is only the tiebreak among words
+		// that look alike.
+		if a, b := symbolShaped(out[i]), symbolShaped(out[j]); a != b {
+			return a
+		}
 		if a, b := identifying(out[i]), identifying(out[j]); a != b {
 			return a
 		}
@@ -420,6 +427,17 @@ func byIdentifying(terms []string, idf map[string]float64) []string {
 // admits any ordinary word of three letters, so the length below settles the
 // ties it leaves: "gateway_timeout" over "seeing".
 func identifying(term string) bool { return search.HasIdentifierTerm([]string{term}) }
+
+// symbolShaped reports whether a term is punctuated or numbered the way a
+// symbol, a path or a version is — "gateway_timeout", "pkg/index", "v11", "s3".
+func symbolShaped(term string) bool {
+	for _, r := range term {
+		if r == '_' || r == '.' || r == '/' || r == '-' || (r >= '0' && r <= '9') {
+			return true
+		}
+	}
+	return false
+}
 
 // citationLine pre-writes the narration so the agent copies structure instead
 // of having to follow an instruction — models do the former far more reliably.

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -395,9 +396,30 @@ func byIdentifying(terms []string, idf map[string]float64) []string {
 		return terms
 	}
 	out := append([]string(nil), terms...)
-	sort.SliceStable(out, func(i, j int) bool { return idf[out[i]] > idf[out[j]] })
+	sort.SliceStable(out, func(i, j int) bool {
+		if idf[out[i]] != idf[out[j]] {
+			return idf[out[i]] > idf[out[j]]
+		}
+		// A store of one or two sessions collapses every ratio to zero, so the
+		// terms all tied and the word the session had to have spoken was
+		// whichever the reader typed first — "seeing", in a question about
+		// gateway_timeout. The only session such a store holds was then
+		// dropped for not saying it (#2257). The rest of the ranking already
+		// treats a tiny corpus as a special case; this is that case for the
+		// lead term: prefer the word that reads like a term of art.
+		if a, b := identifying(out[i]), identifying(out[j]); a != b {
+			return a
+		}
+		return utf8.RuneCountInString(out[i]) > utf8.RuneCountInString(out[j])
+	})
 	return out
 }
+
+// identifying reports whether one term reads like a term of art — the same
+// test the recall bar applies to a whole question, asked of a single word. It
+// admits any ordinary word of three letters, so the length below settles the
+// ties it leaves: "gateway_timeout" over "seeing".
+func identifying(term string) bool { return search.HasIdentifierTerm([]string{term}) }
 
 // citationLine pre-writes the narration so the agent copies structure instead
 // of having to follow an instruction — models do the former far more reliably.


### PR DESCRIPTION
Closes #2257.

    session: "gateway_timeout on the reconnect_loop keeps dropping heartbeats"
    prompt:  "seeing gateway_timeout in the reconnect_loop again"

    one session in the store:  nothing
    two sessions in the store: the recall is injected

The ranking was never the problem — both corpora rank the session with the same two matched terms. `byIdentifying` sorts the prompt's terms by idf to pick the word the session must actually have spoken, and in a one-session store every ratio is zero, so the stable sort left the reader's word order and the lead term became "seeing".

Ties now break toward the word that reads like a term of art, and then toward the longer one, which is what separates `gateway_timeout` from `seeing`. `deja bench recall` still reports recall@5 = 1.0 on the 500-session corpus.

Worth naming: this is the first recall someone can ever get — the second session they have — and it was the one case that never fired.
