### PR TITLE
fix(share,ctx): refuse an empty selector

### DIFF
--- a/cmd/deja/empty_selector_test.go
+++ b/cmd/deja/empty_selector_test.go
@@ -74,3 +74,42 @@ func TestAnEmptySelectorIsNotASession(t *testing.T) {
 		t.Errorf("share of a blank selector printed: %q", out.String())
 	}
 }
+
+// And the lookup itself: every id has the empty string as a prefix, so the
+// guard belongs where the class lives rather than only at the callers (#2259).
+func TestFindByPrefixMatchesNothingForABlankPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"sess1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"gateway_timeout on the reconnect_loop"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: a real prefix resolves.
+	if _, ok, err := index.FindByPrefix(dir, "sess1"); err != nil || !ok {
+		t.Fatalf("a real id did not resolve: %v %v", ok, err)
+	}
+	for _, p := range []string{"", " ", "\t"} {
+		if s, ok, err := index.FindByPrefix(dir, p); ok || err != nil {
+			t.Errorf("prefix %q resolved to %q (%v)", p, s.ID, err)
+		}
+	}
+}

--- a/cmd/deja/empty_selector_test.go
+++ b/cmd/deja/empty_selector_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An unset shell variable arrives as an empty argument. Every other selector
+// command refuses one; share printed a shareable digest of whichever session
+// deja reached first, and ctx printed its transcript (#2259).
+func TestAnEmptySelectorIsNotASession(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	for i := 1; i <= 2; i++ {
+		line := fmt.Sprintf(`{"type":"user","sessionId":"sess%d","timestamp":%q,"cwd":"/work/app",`+
+			`"message":{"role":"user","content":"gateway_timeout on the reconnect_loop number %d"}}`, i, at, i)
+		name := fmt.Sprintf("s%d.jsonl", i)
+		if err := os.WriteFile(filepath.Join(claude, name), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	// The premise: both commands work when they are given a real selector.
+	if err := runShare(dir, []string{"sess1"}, &out); err != nil || !strings.Contains(out.String(), "sess1") {
+		t.Fatalf("share of a real id: %v %q", err, out.String())
+	}
+	out.Reset()
+	if err := cmdCtx(dir, []string{"sess1"}); err != nil {
+		t.Fatalf("ctx of a real id: %v", err)
+	}
+
+	out.Reset()
+	err := runShare(dir, []string{""}, &out)
+	if err == nil {
+		t.Errorf("share of an empty selector printed: %q", out.String())
+	} else if !strings.Contains(err.Error(), "id-prefix") {
+		t.Errorf("share of an empty selector said %v", err)
+	}
+
+	if err := cmdCtx(dir, []string{""}); err == nil {
+		t.Error("ctx of an empty selector was answered")
+	} else if !strings.Contains(err.Error(), "id-prefix") {
+		t.Errorf("ctx of an empty selector said %v", err)
+	}
+	// Space is the same nothing.
+	out.Reset()
+	if err := runShare(dir, []string{"  "}, &out); err == nil {
+		t.Errorf("share of a blank selector printed: %q", out.String())
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -672,6 +672,13 @@ func cmdCtx(dir string, rest []string) error {
 		}
 	}
 	q := strings.Join(rest, " ")
+	// Blank is not a query: it matched nothing and the search handed back the
+	// first session in the store, so `deja ctx "$TOPIC"` with the variable
+	// unset printed a transcript nobody asked for (#2259).
+	if strings.TrimSpace(q) == "" {
+		return idPrefixNeeded(dir, "ctx needs a query or an id-prefix",
+			"ctx needs query or id-prefix (see `deja last`)")
+	}
 	if !strings.Contains(q, " ") && len(q) >= 6 {
 		done, err := ctxFromIDPrefix(dir, q)
 		if err != nil || done {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -672,13 +672,6 @@ func cmdCtx(dir string, rest []string) error {
 		}
 	}
 	q := strings.Join(rest, " ")
-	// Blank is not a query: it matched nothing and the search handed back the
-	// first session in the store, so `deja ctx "$TOPIC"` with the variable
-	// unset printed a transcript nobody asked for (#2259).
-	if strings.TrimSpace(q) == "" {
-		return idPrefixNeeded(dir, "ctx needs a query or an id-prefix",
-			"ctx needs query or id-prefix (see `deja last`)")
-	}
 	if !strings.Contains(q, " ") && len(q) >= 6 {
 		done, err := ctxFromIDPrefix(dir, q)
 		if err != nil || done {

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -24,12 +24,6 @@ func runShare(dir string, args []string, w io.Writer) error {
 			return fmt.Errorf("share: unknown flag %q — share writes to stdout (redirect it), and `deja promote <id> --to <path>` is the one that writes a file", a)
 		}
 	}
-	// An empty prefix matches the first session there is, so `deja share
-	// "$ID"` with the variable unset printed a shareable digest of a session
-	// nobody chose (#2259). Every other selector command refuses one.
-	if strings.TrimSpace(args[0]) == "" {
-		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix (see `deja last`)")
-	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -24,6 +24,12 @@ func runShare(dir string, args []string, w io.Writer) error {
 			return fmt.Errorf("share: unknown flag %q — share writes to stdout (redirect it), and `deja promote <id> --to <path>` is the one that writes a file", a)
 		}
 	}
+	// An empty prefix matches the first session there is, so `deja share
+	// "$ID"` with the variable unset printed a shareable digest of a session
+	// nobody chose (#2259). Every other selector command refuses one.
+	if strings.TrimSpace(args[0]) == "" {
+		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix (see `deja last`)")
+	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {

--- a/cmd/deja/share.go
+++ b/cmd/deja/share.go
@@ -24,6 +24,13 @@ func runShare(dir string, args []string, w io.Writer) error {
 			return fmt.Errorf("share: unknown flag %q — share writes to stdout (redirect it), and `deja promote <id> --to <path>` is the one that writes a file", a)
 		}
 	}
+	// An empty prefix used to match the first session there is, so `deja share
+	// "$ID"` with the variable unset printed a shareable digest of a session
+	// nobody chose (#2259). The lookup refuses one now; this says which
+	// argument was missing rather than reporting a session that does not exist.
+	if strings.TrimSpace(args[0]) == "" {
+		return idPrefixNeeded(dir, "share needs an id-prefix", "share needs id-prefix (see `deja last`)")
+	}
 	s, ok, err := findByPrefix(dir, args[0])
 	noteAmbiguousPrefix(dir, args[0], "sharing")
 	if err != nil {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1434,6 +1434,13 @@ func FindByPrefix(dir, p string) (model.Session, bool, error) {
 	if ok {
 		defer unlock()
 	}
+	// Every id has the empty string as a prefix, so a blank selector matched
+	// whichever session came first and the caller handed back a transcript
+	// nobody asked for. The MCP resource reader guards its own (#1728) and the
+	// CLI now guards share and ctx (#2259); doing it here ends the class.
+	if strings.TrimSpace(p) == "" {
+		return model.Session{}, false, nil
+	}
 	m, err := readManifestCached(dir)
 	if err != nil {
 		return model.Session{}, false, err


### PR DESCRIPTION
Closes #2259.

    $ deja share ''
    # deja share: sess1
    - Project: work/app
    …
    deja: 0 secrets masked in this share. pattern redaction is a floor — review before sending.
    (exit 0)

    $ deja ctx ''
    # deja context: claude · work/app · sess1 · updated 2026-08-28
    (exit 0)

An empty prefix matches the first session there is, and an empty query returns the first hit. `search`, `show`, `resume`, `promote`, `blame`, `files`, `how`, `fix`, `restore` and `handoff` all refuse an empty argument; these two handed back a session's content instead.

The shape that matters is `deja share "$ID"` with the variable unset — a shareable digest of a session nobody chose, with the redaction line under it. Both now give the same refusal as the no-argument case, blank strings included.
