### PR TITLE
fix(recall): stop Japanese grammar bigrams from triggering auto-recall

### DIFF
--- a/internal/prompt/japanese_terms_test.go
+++ b/internal/prompt/japanese_terms_test.go
@@ -1,0 +1,66 @@
+package prompt
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestTermsJapaneseGrammarBigrams2260(t *testing.T) {
+	tests := []struct {
+		name   string
+		prompt string
+		want   []string
+	}{
+		{
+			name:   "test request",
+			prompt: "すべてのテストを直してください",
+			want:   []string{"テス", "スト"},
+		},
+		{
+			name:   "review request",
+			prompt: "この変更をレビューして、問題があれば教えて",
+			want:   []string{"変更", "レビ", "ビュ", "ュー", "問題"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Terms(tc.prompt)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("Terms(%q) = %v, want %v", tc.prompt, got, tc.want)
+			}
+		})
+	}
+
+	got := Terms("すべての変更を確認")
+	for _, grammar := range []string{"すべ", "べて", "ての"} {
+		if slices.Contains(got, grammar) {
+			t.Errorf("Terms beginning with すべての = %v, contains grammar bigram %q", got, grammar)
+		}
+	}
+	for _, content := range []string{"変更", "確認"} {
+		if !slices.Contains(got, content) {
+			t.Errorf("Terms beginning with すべての = %v, missing content bigram %q", got, content)
+		}
+	}
+}
+
+func TestTermsJapaneseKeepsContent2260(t *testing.T) {
+	prompt := "サーバーのログを確認"
+	want := []string{"サー", "ーバ", "バー", "ログ", "確認"}
+
+	got := Terms(prompt)
+	if !slices.Equal(got, want) {
+		t.Fatalf("Terms(%q) = %v, want %v", prompt, got, want)
+	}
+}
+
+func TestTermsChineseUnaffected2260(t *testing.T) {
+	prompt := "装订计数是什么"
+	want := []string{"装订", "订计", "计数", "数是"}
+
+	got := Terms(prompt)
+	if !slices.Equal(got, want) {
+		t.Fatalf("Terms(%q) = %v, want %v", prompt, got, want)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -60,12 +60,18 @@ func Terms(prompt string) []string {
 	// field, and techTerm rejects every rune above 127 — a Chinese, Japanese
 	// or Korean prompt therefore yields no terms at all and auto-recall can
 	// never fire for it. Fall back to the terms the relevance tier already
-	// ranks on: per-run bigrams with pure-grammar pairs dropped. A bigram is
-	// as specific as the identifiers techTerm looks for, and the caller still
+	// ranks on: per-run bigrams with pure-grammar pairs dropped. That filter
+	// is a Chinese closed class, while Japanese grammar lives in hiragana:
+	// particles and inflection, and even pairs such as "ての" where the
+	// bigram slide crosses the word boundary in "すべて|の". A bigram with
+	// hiragana is therefore grammar or an okurigana fragment rather than a
+	// topic; kanji and katakana runs carry the content this hook can act on.
+	// Issue 2260 is the field failure this distinction fixes. A bigram is as
+	// specific as the identifiers techTerm looks for, and the caller still
 	// demands two of them overlap before claiming a déjà vu.
 	if hasCJKRune(prompt) {
 		for _, t := range relevanceTerms(prompt) {
-			if !hasCJKRune(t) {
+			if !hasCJKRune(t) || hasHiragana(t) {
 				continue
 			}
 			if add(t) {
@@ -130,10 +136,20 @@ func cyrPromptTerm(f string) bool {
 	}
 	return !strings.Contains(f, "-")
 }
+
 func hasCJKRune(s string) bool {
 	for _, r := range s {
 		if unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
 			unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasHiragana(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Hiragana, r) {
 			return true
 		}
 	}


### PR DESCRIPTION
The fix promised on #2260, failing test first.

`prompt.Terms` falls back for CJK prompts to the relevance tier's bigrams, filtered only by `cjkFunctionRunes` — a closed class for three Chinese scripts with no Japanese entries. Japanese grammar lives in hiragana, and the bigram slide also crosses word boundaries (ての spans 「すべて|の」), so a Japanese prompt spent the six-term cap on sentence grammar and auto-recall said "you have been here" about sessions that shared nothing else.

One added condition in the fallback: skip a bigram that contains a hiragana rune. Measured on the probes from the issue:

| prompt | before | after |
|---|---|---|
| すべてのテストを直してください | すべ べて ての のテ テス スト | テス スト |
| この変更をレビューして、問題があれば教えて | この の変 変更 更を をレ レビ | 変更 レビ ビュ ュー 問題 |
| すべての結果を保存する方法は? | すべ べて ての の結 結果 果を | 結果 保存 方法 |

The junk stops earning recalls, and content later in the prompt reaches the cap instead of being crowded out by the opening grammar — the third row's 保存 and 方法 never made the list before.

The trade, stated in the comment as well as the issue: an all-hiragana content word (ひらがな, ちらつき) and okurigana pairs (直し, 教え) no longer trigger on their own. For a hook that fires on every prompt and already demands co-occurring terms before speaking, precision is the right side. Scope is the trigger-extraction path only — index, ranking and the query side are untouched, and Chinese and Korean prompts carry no hiragana, so nothing changes for them; the Chinese fixture pins that. ー U+30FC is a katakana mark rather than hiragana, so loanword bigrams like ュー survive, consistent with the mark handling from #1392.

Tests, written before the fix and measured failing against it reverted: `TestTermsJapaneseGrammarBigrams2260` (the probe goldens, plus the field case — no すべ/べて/ての from a prompt starting 「すべての」), `TestTermsJapaneseKeepsContent2260` (サーバーのログを確認 → サー ーバ バー ログ 確認), `TestTermsChineseUnaffected2260` (装订计数是什么 unchanged; it also passes on the unfixed tree, which is the point). Targeted suites across `cmd/deja`, `internal/query` and `internal/prompt` pass.

Fixes #2260.
