### PR TITLE
fix(forget): refuse an unforget that restored nothing

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2700,8 +2700,7 @@ func runForget(dir string, args []string) error {
 			// this path went straight to Unforget, which lifts the tombstone
 			// and rebuilds. Name what it would restore and stop (#1066).
 			if len(lifting) == 0 {
-				fmt.Fprintf(os.Stdout, "no tombstone matches %q — `deja forget --list` shows what is forgotten\n", unforget)
-				return nil
+				return fmt.Errorf("no tombstone matches %q — `deja forget --list` shows what is forgotten", unforget)
 			}
 			fmt.Fprintf(os.Stdout, "dry run — nothing was changed\nwould restore %d tombstone%s and rebuild the index — %s\n",
 				len(lifting), pluralS(len(lifting)), joinCapped(lifting, 5))
@@ -2715,8 +2714,11 @@ func runForget(dir string, args []string) error {
 			return err
 		}
 		if lifted == 0 {
-			fmt.Fprintf(os.Stdout, "no tombstone matches %q — `deja forget --list` shows what is forgotten\n", unforget)
-			return nil
+			// A restore that restored nothing used to exit 0, so a script
+			// could not tell it from a restore that worked: the typo, the id
+			// that was never forgotten and the session still gone all read as
+			// success (#2263). Every neighbour refuses what it cannot find.
+			return fmt.Errorf("no tombstone matches %q — `deja forget --list` shows what is forgotten", unforget)
 		}
 		// Lifting a tombstone brings a session back only if the transcript is
 		// still on this machine. An imported one lives only in the index, so

--- a/cmd/deja/privacy_test.go
+++ b/cmd/deja/privacy_test.go
@@ -33,8 +33,10 @@ func TestPrivacyCommandFlags(t *testing.T) {
 	if _, err := captureRun(t, "forget", "--before", "2020-01-01"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := captureRun(t, "forget", "--unforget", "missing"); err != nil {
-		t.Fatal(err)
+	// A restore that finds no tombstone refuses, so a script can tell it from
+	// one that worked (#2263).
+	if _, err := captureRun(t, "forget", "--unforget", "missing"); err == nil {
+		t.Fatal("unforget of a missing tombstone succeeded")
 	}
 	out, err := captureRun(t, "forget", "--list")
 	if err != nil || strings.Contains(out, "claude:") {
@@ -164,12 +166,11 @@ func TestUnforgetBringsTheSessionBackWithoutAFullRebuild(t *testing.T) {
 	if err != nil || len(back) != 2 {
 		t.Fatalf("after unforget: %d sessions err=%v — the session did not come back", len(back), err)
 	}
-	miss, err := captureRun(t, "forget", "--unforget", "nothing-like-this")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(miss, "no tombstone matches") {
-		t.Errorf("a prefix matching nothing said %q", miss)
+	_, err = captureRun(t, "forget", "--unforget", "nothing-like-this")
+	if err == nil {
+		t.Error("a prefix matching nothing was reported as a restore")
+	} else if !strings.Contains(err.Error(), "no tombstone matches") {
+		t.Errorf("a prefix matching nothing said %q", err)
 	}
 }
 

--- a/cmd/deja/unforget_exit_test.go
+++ b/cmd/deja/unforget_exit_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A restore that restored nothing exited 0, so `deja forget --unforget "$id" &&
+// echo back` printed "back" for a typo, for an id that was never forgotten, and
+// for a session that is still gone (#2263).
+func TestUnforgetRefusesWhenItRestoredNothing(t *testing.T) {
+	withTempStores(t)
+
+	out, err := captureRun(t, "forget", "--unforget", "nothing-like-this")
+	if err == nil {
+		t.Errorf("a prefix matching no tombstone succeeded, printing %q", out)
+	}
+	if err != nil && !strings.Contains(err.Error(), "no tombstone matches") {
+		t.Errorf("the refusal reads %q — it should still say what it could not find", err)
+	}
+
+	// The dry run reports the same miss and answers the same way.
+	out, err = captureRun(t, "forget", "--unforget", "nothing-like-this", "--dry-run")
+	if err == nil {
+		t.Errorf("a dry run against no tombstone succeeded, printing %q", out)
+	}
+}


### PR DESCRIPTION
Closes #2263.

    $ deja forget --unforget sess1
    restored 1 session and rebuilt the index — claude:sess1     exit 0
    $ deja forget --unforget sess1
    no tombstone matches "sess1" — …                            exit 0
    $ deja forget --unforget nosuchsession
    no tombstone matches "nosuchsession" — …                    exit 0

So `deja forget --unforget "$id" && echo back` printed "back" for a typo, for an id that was never forgotten, and for a session that is still gone. `promote`, `show` and `sync forget` all refuse what they cannot find.

Both arms — the restore and its `--dry-run` — now return the same sentence as an error. Two existing tests pinned the old exit code incidentally while asserting the message; they now assert the refusal and keep the message check.
