### PR TITLE
fix(brief): refuse arguments it does not take

### DIFF
--- a/cmd/deja/brief_args_test.go
+++ b/cmd/deja/brief_args_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// brief threw its arguments away at the dispatch table, so `deja brief --json`
+// printed the human screen and exited 0 — the shape #2253 fixed for friction
+// and restore (#2265).
+func TestBriefRefusesArgumentsItDoesNotTake(t *testing.T) {
+	withTempStores(t)
+
+	// The premise: it still prints the screen when asked for nothing.
+	out, err := captureRun(t, "brief")
+	if err != nil || !strings.Contains(out, "deja-vu") {
+		t.Fatalf("bare brief: %q err=%v", out, err)
+	}
+
+	for _, arg := range []string{"--json", "extra"} {
+		out, err := captureRun(t, "brief", arg)
+		if err == nil {
+			t.Errorf("brief %s was accepted and printed %q", arg, out)
+			continue
+		}
+		if !strings.Contains(err.Error(), arg) {
+			t.Errorf("brief %s said %v — the message should name what it could not take", arg, err)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -164,7 +164,16 @@ var commands = map[string]command{
 	// The screen `deja` prints on a terminal, under a name, so it can be paged,
 	// captured into a bug report or read over a pipe — and so the obvious guess
 	// stops being a search for the word (#2108).
-	"brief":           func(dir string, _ []string) error { return runBrief(dir, os.Stdout) },
+	// The arguments were thrown away here, so `deja brief --json` printed the
+	// human screen and exited 0 — the shape #2253 fixed for friction and
+	// restore (#2265). statusline stays as it is on purpose: a harness runs it
+	// on every redraw, and a refusal would land in someone's prompt.
+	"brief": func(dir string, rest []string) error {
+		for _, a := range rest {
+			return fmt.Errorf("brief takes no arguments — got %q", a)
+		}
+		return runBrief(dir, os.Stdout)
+	},
 	"hook-context":    cmdHookContext,
 	"hook-precompact": func(dir string, _ []string) error { runHookPrecompact(dir); return nil },
 	"hook-refresh":    func(dir string, _ []string) error { runHookRefresh(dir); return nil },


### PR DESCRIPTION
Closes #2265.

    $ deja brief --json
    deja-vu dev · 1 session across 1 agent wire …    exit 0
    $ deja brief extra
    deja-vu dev · 1 session across 1 agent wire …    exit 0

The dispatch entry dropped `rest` on the floor. Same shape as #2253, which friction and restore were fixed for; `how`, `view`, `sources` and `files` all refuse.

`deja statusline --nope` ignores its arguments too and is deliberately left alone: a harness runs it on every terminal redraw, and a refusal there would replace the status line with an error in someone's prompt. brief is the one a person or a script runs directly.

Rest of the pass found nothing: the MCP server refuses an unknown method, an unknown tool, a non-string query, an empty query and a malformed line with the right JSON-RPC codes, its recall payload stays capped (~4 KB) whatever `limit` says, and `doctor --json`'s top-level keys match docs/json-output.md.
