### PR TITLE
fix: say a directory refuses writes instead of blaming the disk or a rebuild

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -56,6 +56,15 @@ func rebuildWindowError(err error) error {
 		return err
 	}
 	if !rebuildInProgress(index.DefaultDir()) {
+		// Not a rebuild, so the manifest is missing for some other reason —
+		// and on a machine where the cache cannot be created that reached the
+		// reader as `open …/manifest.gob: no such file or directory`, which is
+		// the shape #798 replaced everywhere else (#2267).
+		if d := index.DefaultDir(); !dirExists(d) {
+			if a := nearestExistingDir(filepath.Dir(d)); a != "" && !dirWritable(a) {
+				return fmt.Errorf("cannot create the index directory (%s) — %s is not writable; check its permissions, or point DEJA_INDEX_DIR somewhere writable", filepath.Dir(d), a)
+			}
+		}
 		return err
 	}
 	return fmt.Errorf("the index is being rebuilt right now — run this again in a moment")
@@ -3420,6 +3429,39 @@ func existingNonDirAncestor(p string) string {
 	}
 }
 
+// nearestExistingDir walks up until it finds a directory that is there, so a
+// refusal can name the thing that actually refused rather than the path that
+// could not be created under it.
+func nearestExistingDir(p string) string {
+	for cur := filepath.Clean(p); ; {
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			if dirExists(cur) {
+				return cur
+			}
+			return ""
+		}
+		if dirExists(parent) {
+			return parent
+		}
+		cur = parent
+	}
+}
+
+// dirWritable reports whether this process can create something in dir.
+// Permission bits alone answer for the wrong user on the wrong platform, so it
+// asks the filesystem.
+func dirWritable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".deja-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	_ = f.Close()
+	_ = os.Remove(name)
+	return true
+}
+
 // ensureError turns a failed build into something the reader can act on.
 // A denied write surfaced as `ensure: open /…/index.db.lock: permission
 // denied` — the path of an internal lock file and a syscall error, which says
@@ -3435,6 +3477,13 @@ func ensureError(dir string, err error) error {
 		// paths hit (#893, #906), and the reader is sent to check the
 		// permissions of a directory that no longer exists (#931).
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
+			// Unless something above it is there and simply refuses: a
+			// locked-down ~/.cache cannot be written into either, and reading
+			// that as an ejected volume sent the reader to reconnect a disk
+			// that never left (#2267).
+			if a := nearestExistingDir(parent); a != "" && !dirWritable(a) {
+				return fmt.Errorf("cannot create the index directory (%s) — %s is not writable; check its permissions, or point DEJA_INDEX_DIR somewhere writable", parent, a)
+			}
 			return fmt.Errorf("the index directory is not there (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
 		}
 		// The denial is not always about the index: forget writes the

--- a/cmd/deja/unwritable_cache_test.go
+++ b/cmd/deja/unwritable_cache_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A home whose cache directory refuses writes is a locked-down laptop, not an
+// ejected disk and not a rebuild in flight — and deja told both of those
+// stories, sending the reader to reconnect a disk that is present and to wait
+// for a rebuild that will never finish (#2267).
+func TestAnUnwritableCacheIsNotAnUnmountedDisk(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not deny creation the same way on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes through the permission")
+	}
+	tmp := t.TempDir()
+	cache := filepath.Join(tmp, "cache")
+	if err := os.MkdirAll(cache, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cache, 0o700) })
+	dir := filepath.Join(cache, "deja", "index.db")
+
+	// The premise: the build really is refused here.
+	err := index.Ensure(dir, "", false, nil)
+	if err == nil {
+		t.Fatal("the build succeeded under an unwritable cache")
+	}
+
+	said := ensureError(dir, err).Error()
+	if strings.Contains(said, "unmounted") {
+		t.Errorf("an unwritable directory was reported as an unmounted disk: %s", said)
+	}
+	if !strings.Contains(said, "permission") && !strings.Contains(said, "writable") {
+		t.Errorf("the refusal does not name what is wrong: %s", said)
+	}
+
+	// And nothing is being rebuilt: the lock could not be created, which is not
+	// the same as somebody holding it.
+	if index.RebuildInProgress(dir) {
+		t.Error("an unwritable index directory reads as a rebuild in progress")
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -515,6 +515,14 @@ func RebuildInProgress(dir string) bool {
 		unlock()
 		return false
 	}
+	// A lock that could not be created is not a lock somebody holds: tryLockDir
+	// answers "not acquired, no error" for a directory it may not write into,
+	// so a read-only index still serves readers — and that read as a rebuild in
+	// flight, telling people to wait for something that never finishes (#2267).
+	// A real holder left the file behind.
+	if _, err := os.Stat(dir + ".lock"); err != nil {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
Closes #2267.

With `~/.cache` not writable — a locked-down home, a read-only overlay — deja told two stories, neither true:

    $ deja index
    deja: the index directory is not there (…/.cache/deja) — the disk it lives on may have been unmounted; reconnect it, …
    $ deja search gateway_timeout
    deja: the index is being rebuilt right now — run this again in a moment

After:

    deja: cannot create the index directory (…/.cache/deja) — …/.cache is not writable; check its permissions, or point DEJA_INDEX_DIR somewhere writable

Three parts:

- `ensureError` checks the nearest directory that does exist before reaching for the unmounted-volume story; if that one refuses writes, it says so and names it. An ejected volume keeps its old sentence — the ancestor there is writable, or absent.
- `RebuildInProgress` no longer reads "could not create the lock" as "somebody holds the lock". A real holder leaves the lock file behind; that is what it checks now.
- Without the false rebuild claim, `deja search` fell through to `open …/manifest.gob: no such file or directory`, so the same diagnosis is applied there rather than handing back a syscall.

Writability is probed by creating a temp file rather than reading mode bits, which answer for the wrong user often enough.
