### PR TITLE
fix(forget): refuse a selector given twice

### DIFF
--- a/cmd/deja/forget_repeated_selector_test.go
+++ b/cmd/deja/forget_repeated_selector_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A repeated selector used to take the last one and drop the first without a
+// word, so a command meant to delete two sessions deleted one and exited 0 —
+// leaving behind a session the reader believes is gone (#2271).
+func TestForgetRefusesARepeatedSelector(t *testing.T) {
+	withTempStores(t)
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"forget", "--session", "a1b2", "--session", "c3d4", "--dry-run"},
+		{"forget", "--project", "alpha", "--project", "beta", "--dry-run"},
+		{"forget", "--before", "30d", "--before", "10d", "--dry-run"},
+	} {
+		out, err := captureRun(t, args...)
+		if err == nil {
+			t.Errorf("%v was accepted, printing %q", args[1:], out)
+			continue
+		}
+		if !strings.Contains(err.Error(), "twice") {
+			t.Errorf("%v said %v — the message should say the flag was given twice", args[1:], err)
+		}
+	}
+
+	// One of each still works, including the combination that narrows.
+	if _, err := captureRun(t, "forget", "--session", "a1b2", "--dry-run"); err != nil {
+		t.Errorf("a single --session: %v", err)
+	}
+	if _, err := captureRun(t, "forget", "--project", "alpha", "--before", "30d", "--dry-run"); err != nil {
+		t.Errorf("--project with --before: %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2612,6 +2612,7 @@ func runForget(dir string, args []string) error {
 	list := false
 	allMatches := false
 	unforget, unforgetGiven := "", false
+	given := map[string]bool{}
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--list":
@@ -2621,6 +2622,14 @@ func runForget(dir string, args []string) error {
 		case "--all-matches":
 			allMatches = true
 		case "--session", "--project", "--before", "--unforget":
+			// Given twice, the last one used to win in silence: `deja forget
+			// --session a --session b` deleted b, reported one session and
+			// left a behind, which the reader believes is gone (#2271).
+			// stats already refuses this shape for its own flags.
+			if given[args[i]] {
+				return fmt.Errorf("forget: %s specified twice", args[i])
+			}
+			given[args[i]] = true
 			if i+1 >= len(args) {
 				return fmt.Errorf("forget: %s needs a value", args[i])
 			}


### PR DESCRIPTION
Closes #2271.

    before: sess1 other1

    $ deja forget --session sess1 --session other1
    sessions dropped: 1  messages dropped: 1  tombstones added: 1
    exit 0

    after:  sess1

The last selector won and the first was dropped without a word, so a command meant to delete two sessions deleted one and the reader has no reason to look. Same for a repeated `--project` or `--before`.

Now:

    deja: forget: --session specified twice

which is the refusal `stats` already gives for its own repeated flags. One of each still works, including `--project` with `--before`.

Elsewhere in deja a repeated filter merely narrows a search; on this command it decides what is deleted, which is why this one is worth refusing rather than documenting.
