### PR TITLE
fix(uninstall): refuse a target it does not know

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -113,6 +113,14 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	// means every agent keeps shelling out to a binary the user just removed.
 	if uninstall {
 		targets = withAutoTargets(targets)
+		// A name it does not know drops out of that expansion and leaves
+		// nothing to do, so `deja uninstall claude-cod` printed not one word
+		// and exited 0 — while `deja install claude-cod` names the near miss
+		// (#2273). Someone removing deja by a half-remembered name was told it
+		// worked, with the wiring still in place.
+		if len(targets) == 0 {
+			return unknownTargetError(targetArgs[0])
+		}
 	}
 	exe, err := os.Executable()
 	if err != nil {

--- a/cmd/deja/uninstall_unknown_target_test.go
+++ b/cmd/deja/uninstall_unknown_target_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// install refuses a target it does not know and names the near miss; uninstall
+// printed nothing at all and exited 0, so removing deja by a half-remembered
+// name read as done while the wiring stayed (#2273).
+func TestUninstallRefusesATargetItDoesNotKnow(t *testing.T) {
+	withTempStores(t)
+
+	for _, target := range []string{"nosuchagent", "claude-cod"} {
+		out, err := captureRun(t, "uninstall", target)
+		if err == nil {
+			t.Errorf("uninstall %s succeeded, printing %q", target, out)
+			continue
+		}
+		if !strings.Contains(err.Error(), target) {
+			t.Errorf("uninstall %s said %v — it should name what it did not recognise", target, err)
+		}
+	}
+	// The near miss is named, as install does.
+	if _, err := captureRun(t, "uninstall", "claude-cod"); err == nil ||
+		!strings.Contains(err.Error(), "claude-code") {
+		t.Errorf("uninstall claude-cod does not point at claude-code: %v", err)
+	}
+	// A target it does know still uninstalls, whether or not anything is wired.
+	if _, err := captureRun(t, "uninstall", "claude-code", "--no-index"); err != nil {
+		t.Errorf("uninstall claude-code: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #2273.

    $ deja uninstall claude-cod
    (no output)                                                       exit 0
    $ deja install claude-cod
    deja: … unknown target "claude-cod" — did you mean "claude-code"?  exit 1

On an uninstall the target list is expanded to include the `-auto` siblings, and a name deja does not know drops out of that expansion — leaving nothing to do and nothing to say. Someone removing deja by a half-remembered name was told it worked, with the wiring still there.

It now gives the same refusal install does, near miss included. `--all`, `--auto` and a known target are untouched; the no-target case already refused.

The test was checked red against the unpatched file, not just green after.
