### PR TITLE
feat(recall): say when the question itself was asked before

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -338,7 +338,19 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		if nudge != "" {
 			tail += "\n" + nudge
 		}
-		body = promptHookLead + rejectedWarning + digest + tail
+		lead := promptHookLead
+		// A repeat of the question itself is a different claim than a session
+		// about the subject, and a stronger one: the agent does not have to
+		// decide whether the history is relevant, only whether the answer
+		// still holds. Measured over this machine's own sessions, 6.5% of
+		// substantial questions are asked again in a later session, and the
+		// exact-match counter in `deja stats` sees a fifth of them.
+		if again := search.AskedBefore(ss[0], terms); again != "" {
+			lead = "This was asked here before" + askedBeforeWhen(ss[0]) +
+				" — \"" + again + "\". What that session settled is below; " +
+				"say so if it still holds, and say so if it does not.\n"
+		}
+		body = lead + rejectedWarning + digest + tail
 	} else {
 		body = weakRecallPointer(ss, terms) + rejectedWarning
 		if nudge != "" {
@@ -382,6 +394,16 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	fmt.Fprintln(stdout, string(b))
 	return nil
+}
+
+// askedBeforeWhen dates the earlier question, so the reader can weigh a decision
+// from yesterday against one from March. Empty when the session carries no
+// date rather than printing a zero one.
+func askedBeforeWhen(s model.Session) string {
+	if s.Updated.IsZero() {
+		return ""
+	}
+	return " (" + s.Updated.Local().Format("2006-01-02") + ")"
 }
 
 // promptTermsWorthAsking is the gate before the index is touched. Two terms

--- a/internal/search/asked_before.go
+++ b/internal/search/asked_before.go
@@ -1,0 +1,91 @@
+package search
+
+import (
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/prompt"
+)
+
+// A question asked twice is the case this tool exists for, and deja could not
+// see most of them. `stats.RepeatQuestions` counts a repeat only when the
+// words match exactly, so the same thing asked in other words is two different
+// questions to it: measured over this machine's own sessions, 5 by that rule
+// and 23 by meaning — 6.5% of every substantial question a person asked.
+//
+// It is also a different claim than the one the block makes today. "Prior
+// sessions matching this request" is about a subject; "you asked this before,
+// and here is what came of it" is about the question, and an agent can act on
+// the second without deciding whether the first is relevant.
+
+// askedAgainOverlap is how much of the shorter question's terms the two have
+// to share. Three quarters keeps "why is the scheduler retrying" with "what
+// made the scheduler retry" and separates both from "how does the scheduler
+// pick a shard", which shares one word out of three.
+const askedAgainOverlap = 0.75
+
+// askedAgainMinTerms is below what a repeat means nothing: two words overlap
+// by chance often enough that a claim resting on them reads as noise.
+const askedAgainMinTerms = 3
+
+// AskedBefore returns the question this session already asked that the current
+// one repeats, or "" when it asked nothing of the sort. Terms rather than
+// words: the same question in other words is the case worth catching, and it
+// is the only one the exact-match counter misses.
+func AskedBefore(s model.Session, terms []string) string {
+	if len(terms) < askedAgainMinTerms {
+		return ""
+	}
+	want := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		want[t] = true
+	}
+	best, bestShared := "", 0
+	for _, m := range s.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		past := prompt.Terms(m.Text)
+		if len(past) < askedAgainMinTerms {
+			continue
+		}
+		shared := 0
+		for _, t := range past {
+			if want[t] {
+				shared++
+			}
+		}
+		small := len(past)
+		if len(terms) < small {
+			small = len(terms)
+		}
+		if float64(shared)/float64(small) < askedAgainOverlap {
+			continue
+		}
+		if shared > bestShared {
+			best, bestShared = strings.TrimSpace(firstSentence(m.Text)), shared
+		}
+	}
+	return best
+}
+
+// firstSentence keeps the question and drops whatever the person appended to
+// it — a pasted log, a second thought. The block quotes this back, so it has
+// to read as the question that was asked.
+func firstSentence(text string) string {
+	text = strings.TrimSpace(text)
+	if i := strings.IndexAny(text, "\n"); i > 0 {
+		text = text[:i]
+	}
+	const max = 120
+	if len(text) <= max {
+		return text
+	}
+	cut := max
+	for cut > 0 && !isRuneStart(text[cut]) {
+		cut--
+	}
+	return strings.TrimSpace(text[:cut]) + "…"
+}
+
+func isRuneStart(b byte) bool { return b&0xC0 != 0x80 }

--- a/internal/search/asked_before_test.go
+++ b/internal/search/asked_before_test.go
@@ -1,0 +1,63 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func askedSession(texts ...string) model.Session {
+	s := model.Session{ID: "s1", Harness: "claude", Project: "app"}
+	for _, t := range texts {
+		s.Messages = append(s.Messages, model.Message{Role: "user", Text: t})
+	}
+	return s
+}
+
+// The same question in other words is the case the exact-match counter cannot
+// see, and the one a person most needs answered from memory.
+func TestAskedBeforeMatchesTheQuestionNotTheWording(t *testing.T) {
+	s := askedSession("why does the scheduler keep retrying the pgbouncer connection")
+	got := AskedBefore(s, []string{"scheduler", "retrying", "pgbouncer"})
+	if got == "" {
+		t.Fatal("a repeat in other words was not recognised")
+	}
+	if got != "why does the scheduler keep retrying the pgbouncer connection" {
+		t.Errorf("quoted the wrong line: %q", got)
+	}
+}
+
+// A shared word or two is coincidence. The bar is three quarters of the shorter
+// question, so a different question about the same component does not claim to
+// be a repeat.
+func TestAskedBeforeDoesNotClaimADifferentQuestion(t *testing.T) {
+	s := askedSession("how does the scheduler pick a shard for a new tenant")
+	if got := AskedBefore(s, []string{"scheduler", "retrying", "pgbouncer"}); got != "" {
+		t.Errorf("a different question about the same component was called a repeat: %q", got)
+	}
+	// Two terms overlap by chance often enough that the claim reads as noise.
+	if got := AskedBefore(askedSession("restart the pgbouncer pool"), []string{"restart", "pgbouncer"}); got != "" {
+		t.Errorf("two words were enough to claim a repeat: %q", got)
+	}
+}
+
+// The block quotes this back, so it has to read as the question rather than as
+// the question plus whatever was pasted under it.
+func TestAskedBeforeQuotesTheQuestionAlone(t *testing.T) {
+	s := askedSession("why does the scheduler keep retrying pgbouncer\n\npanic: runtime error\n\tat main.go:14\n\tat run.go:88")
+	got := AskedBefore(s, []string{"scheduler", "retrying", "pgbouncer"})
+	if got != "why does the scheduler keep retrying pgbouncer" {
+		t.Errorf("the pasted trace came with it: %q", got)
+	}
+}
+
+// Only what a person said. The agent restating the question back is not the
+// question being asked twice.
+func TestAskedBeforeIgnoresTheAgentsOwnWords(t *testing.T) {
+	s := model.Session{ID: "s1", Messages: []model.Message{
+		{Role: "assistant", Text: "so the scheduler keeps retrying the pgbouncer connection because"},
+	}}
+	if got := AskedBefore(s, []string{"scheduler", "retrying", "pgbouncer"}); got != "" {
+		t.Errorf("the agent's own restatement counted as a repeat: %q", got)
+	}
+}


### PR DESCRIPTION
The block says "deja found prior sessions matching this request" — a claim about a subject, which leaves the agent to decide whether the history is relevant. When the *question* is the one that repeats, deja can make a stronger claim, and it turns out to have been unable to see most of them.

`stats.RepeatQuestions` and `FindAskedTwice` both match a repeat by exact wording — same words, punctuation folded. Measured over this machine's own sessions:

```
repeats by exact wording (what stats reports)     5
repeats by meaning, terms overlapping 3/4 of      23
questions a person asked with 3+ terms          356
```

So a fifth of them were visible, and 6.5% of every substantial question is asked again in a later session. That is the case this tool exists for and the block was answering it in the same voice as everything else.

When the leading session already asked the same thing, the block now opens with it and dates it — `This was asked here before (2026-08-09) — "…"` — and asks the agent to say whether what that session settled still holds.

Fed 150 real prompts from the store, 93 draw a block and 4 of those open with the repeat line.

The bar is deliberately high: three quarters of the shorter question's terms, and never on fewer than three. Two words overlap by chance often enough that the claim reads as noise, and a wrong "you asked this before" is worse than the generic lead. Tests pin both directions — a repeat in other words is caught, a different question about the same component is not — plus that the quote is the question and not the trace pasted under it, and that the agent restating the question back does not count.

No movement on the benches: `bench prompt` unchanged arm for arm, longmemeval 85.3% hit@1 / 0.895 MRR.