### PR TITLE
fix(promote): refuse a session the exclude list covers

### DIFF
--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -84,6 +84,15 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	if err := denyPolicyHidden(prefix, s, os.Stderr); err != nil {
 		return err
 	}
+	// The exclude list is a privacy control that only runs at ingest, so an
+	// index built before the pattern still holds the session — share refuses
+	// it for that reason (#1307). promote copied the session's opening line
+	// into deja's own store and reported that the note now outranks the
+	// transcript in recall, while every reading surface filters that note out
+	// again for the same project (#2278).
+	if sources.ExcludedProject(s.Project) {
+		return fmt.Errorf("%s is in a project your exclude list covers — a note promoted from it is filtered out of recall too; `deja index --rebuild` drops the session, or remove the pattern to promote it", prefix)
+	}
 	src := s.Harness + ":" + s.ID
 	if s.Harness == "deja" {
 		// A correction on a promoted note is what `promote` tells you to write,

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -90,7 +90,11 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	// into deja's own store and reported that the note now outranks the
 	// transcript in recall, while every reading surface filters that note out
 	// again for the same project (#2278).
-	if sources.ExcludedProject(s.Project) {
+	// Correcting a note that already exists is exempt: it copies nothing new
+	// out of the excluded project, and taking a mark back on work you have
+	// since excluded is exactly the cleanup someone would want. The note stays
+	// invisible either way, and `deja forget --session deja-note-…` removes it.
+	if s.Harness != "deja" && sources.ExcludedProject(s.Project) {
 		return fmt.Errorf("%s is in a project your exclude list covers — a note promoted from it is filtered out of recall too; `deja index --rebuild` drops the session, or remove the pattern to promote it", prefix)
 	}
 	src := s.Harness + ":" + s.ID

--- a/cmd/deja/promote_excluded_test.go
+++ b/cmd/deja/promote_excluded_test.go
@@ -60,4 +60,11 @@ func TestPromoteRefusesAnExcludedProject(t *testing.T) {
 	if len(after) != len(before) {
 		t.Error("the refusal still wrote a note")
 	}
+
+	// Correcting the note written before the pattern existed is still allowed:
+	// it copies nothing new out of the excluded project, and taking a mark back
+	// on work you have since excluded is the cleanup someone would want.
+	if _, err := captureRun(t, "promote", "deja-note-claude-sec1", "--state", "rejected"); err != nil {
+		t.Errorf("correcting an existing note: %v", err)
+	}
 }

--- a/cmd/deja/promote_excluded_test.go
+++ b/cmd/deja/promote_excluded_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// share refuses a session whose project the exclude list covers, because the
+// pattern only runs at ingest and the index may still hold it. promote wrote
+// the note anyway and told the reader it now outranks the transcript in recall
+// — while every reading surface filters that note out again (#2278).
+func TestPromoteRefusesAnExcludedProject(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-secretproj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"sec1","timestamp":%q,"cwd":"/work/secretproj",`+
+		`"message":{"role":"user","content":"the payroll export for acme-prod drops rows"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "s.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: without a pattern the promotion works.
+	if _, err := captureRun(t, "promote", "sec1", "--state", "accepted"); err != nil {
+		t.Fatalf("promote without an exclude pattern: %v", err)
+	}
+
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "secretproj")
+	before, _ := os.ReadFile(notes)
+	out, err := captureRun(t, "promote", "sec1", "--state", "rejected")
+	if err == nil {
+		t.Errorf("promote of an excluded project succeeded, printing %q", out)
+	} else if !strings.Contains(err.Error(), "exclude") {
+		t.Errorf("promote said %v — it should name the exclude list, as share does", err)
+	}
+	after, _ := os.ReadFile(notes)
+	if len(after) != len(before) {
+		t.Error("the refusal still wrote a note")
+	}
+}


### PR DESCRIPTION
Closes #2278.

    $ export DEJA_EXCLUDE_PROJECTS=secretproj
    $ deja share sec1
    deja: sec1 is in a project your exclude list covers …                 exit 1
    $ deja promote sec1 --state accepted
    promoted claude:sec1 as accepted: the payroll export for acme-prod drops rows
    the note now outranks the raw transcript in recall                    exit 0

The note is written and then nothing can read it: it inherits the excluded project, so every reading surface filters it out again. `deja index && deja search payroll --harness deja --all` returns nothing.

share grew this guard for the same reason (#1307) — the pattern only runs at ingest, so an index built before it still holds the session. promote now refuses in the same shape, and says why the note would not have helped:

    deja: sec1 is in a project your exclude list covers — a note promoted from it is filtered out of recall too; `deja index --rebuild` drops the session, or remove the pattern to promote it

The exclusion itself was holding: I checked that the note reached neither search nor `deja sync export`. What was wrong was the report — and that promote copies the session's opening line into deja's own store on the way.
