### PR TITLE
fix(handoff): refuse a session the exclude list covers

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -81,6 +82,13 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 	}
 	if err := denyPolicyHidden(prefix, s, os.Stderr); err != nil {
 		return err
+	}
+	// The exclude list is a privacy control that only runs at ingest, so an
+	// index built before the pattern still holds the session. share refuses it
+	// for that reason (#1307) and promote followed (#2278); handing the same
+	// session to another agent is the same move with a longer extract (#2280).
+	if sources.ExcludedProject(s.Project) {
+		return fmt.Errorf("%s is in a project your exclude list covers — `deja index --rebuild` drops it from the index, or remove the pattern to hand it off", prefix)
 	}
 	// Source receipt: the user must always see WHAT is being handed off —
 	// wrong-project or stale handoffs should be obvious before they land.

--- a/cmd/deja/handoff_excluded_test.go
+++ b/cmd/deja/handoff_excluded_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// share and promote refuse a session whose project the exclude list covers,
+// because the pattern only runs at ingest. handoff packages that session for
+// another agent and did not check at all (#2280).
+func TestHandoffRefusesAnExcludedProject(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-secretproj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"sec1","timestamp":%q,"cwd":"/work/secretproj",`+
+		`"message":{"role":"user","content":"the payroll export for acme-prod drops rows"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "s.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: without a pattern the handoff packages the session.
+	var out bytes.Buffer
+	if err := runHandoff(dir, []string{"sec1"}, &out); err != nil {
+		t.Fatalf("handoff without an exclude pattern: %v", err)
+	}
+	if !strings.Contains(out.String(), "payroll") {
+		t.Fatalf("the handoff carried no session text: %q", out.String())
+	}
+
+	t.Setenv("DEJA_EXCLUDE_PROJECTS", "secretproj")
+	out.Reset()
+	err := runHandoff(dir, []string{"sec1"}, &out)
+	if err == nil {
+		t.Errorf("handoff of an excluded project succeeded, printing %q", out.String())
+	} else if !strings.Contains(err.Error(), "exclude") {
+		t.Errorf("handoff said %v — it should name the exclude list, as share does", err)
+	}
+	if strings.Contains(out.String(), "payroll") {
+		t.Error("the refusal still printed the session's text")
+	}
+}


### PR DESCRIPTION
Closes #2280. Named while merging #2279 rather than folded into it.

    $ export DEJA_EXCLUDE_PROJECTS=secretproj
    $ deja share sec1                     deja: … your exclude list covers …   exit 1
    $ deja promote sec1 --state accepted  deja: … your exclude list covers …   exit 1
    $ deja handoff sec1
    You are picking up work handed off from a claude session (project work/secretproj, …)
                                                                               exit 0

The digest carried the excluded session's text four times, and `--to codex` did the same. It is a longer extract than share prints, for the one command whose purpose is handing the session to somebody else.

Same guard, same shape as share and promote. `deja resume` stays as it is — it prints `claude --resume sec1` and no session content.
