### PR TITLE
fix(fix): say deja is waiting for a second sighting, not that nothing ran

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -76,6 +76,15 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 		// "never seen it", but the test it used rejects `Error: …`, `npm ERR!`
 		// and any line with a quote — the exact output people paste — so it
 		// accused users of not pasting an error when they had.
+		// Held-but-unconfirmed is not the same as never seen, and saying the
+		// second about the first tells someone who fixed this an hour ago that
+		// deja lost it (#2282).
+		if index.FixCandidateSeen(dir, text, func(project string) bool {
+			return pol.Allows(policy.ActivationSearch, project)
+		}) {
+			fmt.Fprintln(stdout, "deja: one session ran something after that error, and nothing has confirmed it worked — deja waits for a second sighting before naming a remedy")
+			return nil
+		}
 		fmt.Fprintln(stdout, "deja: no session on this machine ran a command after that error")
 		return nil
 	}

--- a/cmd/deja/fix_candidate_test.go
+++ b/cmd/deja/fix_candidate_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// deja holds the first sighting of an error-and-remedy as a candidate and waits
+// for a second before naming it, which is right. It said "no session on this
+// machine ran a command after that error" while holding exactly that (#2282).
+func TestFixSaysItIsWaitingRatherThanDenyingTheSighting(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+
+	fail := "undefined: snorblefunc in vendor/blarg/api.go"
+	write := func(id string, hoursAgo int) {
+		t.Helper()
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		rows := []string{
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":"the build is broken"}}`, id, at),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go build ./..."}}]}}`, id, at),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"message":{"role":"user","content":[{"type":"tool_result","content":%q}]}}`, id, at, fail),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go mod vendor && go build ./..."}}]}}`, id, at),
+		}
+		name := filepath.Join(claude, id+".jsonl")
+		if err := os.WriteFile(name, []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write("f1", 5)
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "fix", fail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "no session on this machine ran a command") {
+		t.Errorf("fix denied the sighting it is holding: %q", out)
+	}
+	if !strings.Contains(out, "confirmed") {
+		t.Errorf("fix does not say what it is waiting for: %q", out)
+	}
+
+	// An error nobody has hit still gets the plain answer.
+	out, err = captureRun(t, "fix", "undefined: neverseenfunc in nowhere.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no session on this machine ran a command") {
+		t.Errorf("an unseen error should still say nothing ran after it: %q", out)
+	}
+
+	// And a second sighting names the remedy, as before.
+	write("f2", 4)
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "fix", fail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "go mod vendor") {
+		t.Errorf("a confirmed pair was not named: %q", out)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -410,6 +410,13 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if !index.LooksLikeError(a.Error) {
 				return "That text does not read like an error line - pass the failing output itself.", nil
 			}
+			// Held-but-unconfirmed is not never-seen, and the agent asking is
+			// the one that would otherwise re-derive the remedy (#2282).
+			if index.FixCandidateSeen(dir, a.Error, func(project string) bool {
+				return pol.Allows(policy.ActivationMCP, project)
+			}) {
+				return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", nil
+			}
 			return "No session on this machine ran a command after that error.", nil
 		}
 		var fb strings.Builder

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -462,3 +462,29 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	}
 	return out
 }
+
+// FixCandidateSeen reports whether deja is holding an unconfirmed sighting for
+// this error: something WAS run after it once, which is not yet evidence that
+// it worked. The command that says "nothing ran after that error" asks first,
+// so it does not deny holding what it is holding (#2282).
+func FixCandidateSeen(dir, text string, allow func(project string) bool) bool {
+	sigs := map[uint64]bool{}
+	for _, raw := range strings.Split(text, "\n") {
+		if line, ok := FrictionLine(raw); ok {
+			sigs[frictionHash(line)] = true
+		}
+	}
+	if len(sigs) == 0 {
+		return false
+	}
+	for _, p := range ReadFixes(dir) {
+		if !sigs[p.Sig] || !p.Candidate {
+			continue
+		}
+		if allow != nil && !allow(p.Project) {
+			continue
+		}
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Closes #2282.

One session that hit an error and ran something after it:

    $ deja fix 'undefined: snorblefunc in vendor/blarg/api.go'
    deja: no session on this machine ran a command after that error

A session did. deja recorded the pair and is holding it as a candidate, because one sighting is not evidence the remedy worked (fixpair.go:450). A second sighting produces the answer.

The withholding is right; the sentence was not. Someone who fixed that error an hour ago reads it as deja having lost it.

    deja: one session ran something after that error, and nothing has confirmed it worked — deja waits for a second sighting before naming a remedy

An error nobody has hit still gets the plain line, and a confirmed pair still names the remedy — both covered by the test, which was also run red against the unpatched tree.

`FixCandidateSeen` takes the same project gate as `FixesFor`, so a candidate from a project the trust policy withholds does not change the answer either.
