### PR TITLE
fix(blame): mark where the path ends in an edit line

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -356,7 +356,15 @@ func blameSnippet(text, role string, target BlameTarget) string {
 		// stopped existing and is prose as far as a snippet goes.
 		path, span, _ := strings.Cut(text, "\n")
 		if pathLineFor(path, target) != "" {
-			return strings.TrimSpace(SafePath(path) + " " + snippet(span, target.Base, nil))
+			// A space put nothing between the two, and this command is written
+			// for paths that contain spaces (the comment above), so the reader
+			// could not tell where the path ended — on the line they paste into
+			// `deja restore` (#2284). An em dash cannot occur in either half by
+			// accident.
+			if cut := snippet(span, target.Base, nil); strings.TrimSpace(cut) != "" {
+				return strings.TrimSpace(SafePath(path)) + " — " + strings.TrimSpace(cut)
+			}
+			return strings.TrimSpace(SafePath(path))
 		}
 	}
 	return snippet(text, target.Base, nil)

--- a/internal/search/blame_edit_separator_test.go
+++ b/internal/search/blame_edit_separator_test.go
@@ -1,0 +1,42 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// An edit record is "path\nspan" and the two were joined with a space, so the
+// line read as one path with rubbish after it — on the command whose output
+// people paste into `deja restore <path>`, and which deliberately handles paths
+// containing spaces (#2284).
+func TestAnEditSnippetMarksWhereThePathEnds(t *testing.T) {
+	target := BlameTarget{Base: "upload.go", FullPath: "/work/app/api/upload.go"}
+	got := blameSnippet("/work/app/api/upload.go\nretryBudget := 3 // three is plenty", "edit", target)
+
+	// The premise: both halves are still there, on one line.
+	if !strings.HasPrefix(got, "/work/app/api/upload.go") || !strings.Contains(got, "retryBudget") {
+		t.Fatalf("the snippet lost one of its halves: %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Fatalf("the snippet broke into two lines: %q", got)
+	}
+	if strings.HasPrefix(got, "/work/app/api/upload.go retryBudget") {
+		t.Errorf("nothing marks where the path ends: %q", got)
+	}
+	if !strings.Contains(got, "/work/app/api/upload.go — ") {
+		t.Errorf("the separator is missing: %q", got)
+	}
+
+	// A path with spaces still arrives whole, which is what #2044 was about.
+	spaces := BlameTarget{Base: "two  spaces.go", FullPath: "/tmp/app/two  spaces.go"}
+	got = blameSnippet("/tmp/app/two  spaces.go\nsize = 20", "edit", spaces)
+	if !strings.HasPrefix(got, "/tmp/app/two  spaces.go — ") {
+		t.Errorf("a path holding two spaces lost them or its separator: %q", got)
+	}
+
+	// An edit with no span left is just the path, with no separator dangling.
+	got = blameSnippet("/work/app/api/upload.go\n", "edit", target)
+	if strings.Contains(got, "—") {
+		t.Errorf("an edit with no span printed a bare separator: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2284.

    before:  /work/app/api/upload.go retryBudget := 3 // three is plenty for the happy path
    after:   /work/app/api/upload.go — retryBudget := 3 // three is plenty for the happy path

An edit record is `path\nspan`, and the two were joined with a space. Nothing said where the path ended — on the command whose lines people paste into `deja restore <path>`, and which is deliberately written to handle paths containing spaces (#2044, the comment right above this code).

An em dash cannot show up in either half by accident, so the line stays one row and the boundary is readable. An edit whose span is empty prints the path alone rather than a dangling separator.

The same path also appears one line above from the `files` record; that duplication is a separate question and left alone.
