### PR TITLE
fix(search): name the pattern in a regex error instead of the function

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -486,7 +486,8 @@ func TestAdditionalDispatchAndHelperBranches(t *testing.T) {
 	if _, err := parseSearch([]string{"--all", "needle"}); err != nil {
 		t.Fatalf("parse --all: %v", err)
 	}
-	if out, err := captureRun(t, "--re", "("); err == nil || !strings.Contains(err.Error(), "run:") || out != "" {
+	// The refusal names the input rather than the function it came from (#2286).
+	if out, err := captureRun(t, "--re", "("); err == nil || !strings.Contains(err.Error(), "--re pattern") || out != "" {
 		t.Fatalf("bad regex out=%q err=%v", out, err)
 	}
 	badRoot := t.TempDir()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1101,7 +1101,14 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 		// list the cap has already trimmed.
 		detailed, rerr := search.RunDetailed(ss, o)
 		if rerr != nil {
-			return fmt.Errorf("run: %w", rerr)
+			// "run:" is the name of a function, and the reader of this line is
+			// someone who mistyped a pattern (#2286). The only error that
+			// reaches here in practice is the regexp compile, so it says which
+			// input to look at.
+			if o.Regex {
+				return fmt.Errorf("--re pattern: %w", rerr)
+			}
+			return rerr
 		}
 		hits, o.Total, o.Capped = detailed.Hits, detailed.Total, detailed.Capped
 	}

--- a/cmd/deja/regex_error_test.go
+++ b/cmd/deja/regex_error_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A mistyped pattern is read by someone already confused about their regex, and
+// the sentence began with the name of an internal function: "deja: run: error
+// parsing regexp…" (#2286).
+func TestABadRegexIsReportedWithoutAnInternalName(t *testing.T) {
+	withTempStores(t)
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := captureRun(t, "search", "gate(way", "--re")
+	if err == nil {
+		t.Fatal("a broken regex was accepted")
+	}
+	msg := err.Error()
+	// The premise: it is the regex it is complaining about.
+	if !strings.Contains(msg, "parsing regexp") {
+		t.Fatalf("the refusal is about something else: %q", msg)
+	}
+	if strings.Contains(msg, "run:") {
+		t.Errorf("the refusal carries an internal function name: %q", msg)
+	}
+	if !strings.Contains(msg, "--re") && !strings.Contains(msg, "pattern") {
+		t.Errorf("the refusal does not say which input is wrong: %q", msg)
+	}
+
+	// A good pattern still searches.
+	if _, err := captureRun(t, "search", "frobnicator", "--re"); err != nil {
+		t.Errorf("a valid regex was refused: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #2286.

    before:  deja: run: error parsing regexp: missing closing ): `gate(way`
    after:   deja: --re pattern: error parsing regexp: missing closing ): `gate(way`

`run:` was the name of the function the error passed through. Every other refusal in deja names the command or the input — this one put a meaningless word in front of the sentence that explains a typo in a pattern, read by someone already unsure about their regex.

Non-regex errors from the same call are returned unwrapped rather than mislabelled.

`TestAdditionalDispatchAndHelperBranches` asserted on the substring "run:" while checking that a bad regex is refused; it now asserts on the new wording.

Noticed while checking and deliberately not folded in: `--re` is implicitly case-insensitive (`gateway_timeout` matches `GATEWAY_TIMEOUT`; `(?-i)` restores sensitivity) while the help says only "treat the query as a regular expression". That is a documentation question, and yours rather than mine.
