### PR TITLE
fix(stats): the card says the policy is withholding, not that nothing is indexed

### DIFF
--- a/cmd/deja/statscard_term.go
+++ b/cmd/deja/statscard_term.go
@@ -218,6 +218,11 @@ func heroStat(r stats.Report) (string, string) {
 		return formatStatNumber(handed), "recalls handed to your agents"
 	case r.TotalSessions > 0:
 		return formatStatNumber(r.TotalSessions), "sessions of agent history, all searchable"
+	case r.PolicyWithheld > 0:
+		// Indexed and withheld is not empty: `deja index` changes nothing in
+		// that state, and the terminal line and the JSON both already tell the
+		// two apart (#2288).
+		return formatStatNumber(r.PolicyWithheld), "sessions your trust policy keeps to itself"
 	default:
 		return "", "nothing indexed yet — run deja index"
 	}

--- a/cmd/deja/statscard_withheld_test.go
+++ b/cmd/deja/statscard_withheld_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+// The terminal line and the JSON both distinguish "nothing indexed" from "the
+// policy withholds everything indexed". The card told the reader to run `deja
+// index`, which changes nothing in that state (#2288).
+func TestTheCardDoesNotBlameAnEmptyIndexForThePolicy(t *testing.T) {
+	// The premise: with nothing indexed at all, the old sentence is right.
+	_, caption := heroStat(stats.Report{})
+	if !strings.Contains(caption, "deja index") {
+		t.Fatalf("an empty store no longer points at `deja index`: %q", caption)
+	}
+
+	_, caption = heroStat(stats.Report{PolicyWithheld: 3})
+	if strings.Contains(caption, "run deja index") {
+		t.Errorf("the card blames an empty index while the policy holds 3 sessions: %q", caption)
+	}
+	if !strings.Contains(caption, "polic") {
+		t.Errorf("the card does not name what is withholding the sessions: %q", caption)
+	}
+
+	// A store with sessions is unaffected either way.
+	if _, caption := heroStat(stats.Report{TotalSessions: 12}); !strings.Contains(caption, "searchable") {
+		t.Errorf("a normal store lost its line: %q", caption)
+	}
+}


### PR DESCRIPTION
Closes #2288.

One session indexed, a policy that withholds every local session, and the three surfaces of `deja stats` disagreeing:

    terminal:  deja: nothing to report — the trust policy withholds every indexed session from this path
    --json:    {"total_sessions":0,"policy_withheld":1,…}
    --card:    nothing indexed yet — run deja index

Indexing again changes nothing in that state, which is the shape #637 and #834 rejected elsewhere. The card now says what the other two already say:

    3
    sessions your trust policy keeps to itself

An empty store keeps the old sentence, and a store with sessions is untouched — both pinned by the test.
