### PR TITLE
fix(sync): count records in singular on the ssh push too

### DIFF
--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -190,7 +190,7 @@ func syncSSHPush(dir, host string, full bool) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stdout, "deja: exported %d records\n", n)
+	fmt.Fprint(os.Stdout, sshExportedLine(n))
 	if n == 0 {
 		fmt.Fprintln(os.Stdout, "deja: nothing new to push")
 		return errNothingToSend
@@ -320,4 +320,11 @@ func sshCapture(host, cmd string) (string, error) {
 
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// sshExportedLine is the push's count, in the same words the local export
+// uses: this path had its own format string and said "exported 1 records" on
+// the first sync anyone runs against a new machine (#2290).
+func sshExportedLine(n int) string {
+	return fmt.Sprintf("deja: exported %d record%s\n", n, pluralS(n))
 }

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -290,7 +290,7 @@ func syncSSHPull(dir, host string, full bool) error {
 		return fmt.Errorf("%w — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, host)
 	}
 	learnPeerMachine(dir, host, before)
-	fmt.Fprintf(os.Stdout, "deja: imported %d records\n", n)
+	fmt.Fprint(os.Stdout, sshCountLine("imported", n))
 	return nil
 }
 
@@ -322,9 +322,12 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
-// sshExportedLine is the push's count, in the same words the local export
-// uses: this path had its own format string and said "exported 1 records" on
-// the first sync anyone runs against a new machine (#2290).
-func sshExportedLine(n int) string {
-	return fmt.Sprintf("deja: exported %d record%s\n", n, pluralS(n))
+// sshCountLine is a push or pull count, in the same words the local paths
+// use: this file had its own format strings and said "exported 1 records" on
+// the first sync anyone runs against a new machine, and the same for the
+// pull (#2290).
+func sshCountLine(verb string, n int) string {
+	return fmt.Sprintf("deja: %s %d record%s\n", verb, n, pluralS(n))
 }
+
+func sshExportedLine(n int) string { return sshCountLine("exported", n) }

--- a/cmd/deja/sync_ssh_plural_test.go
+++ b/cmd/deja/sync_ssh_plural_test.go
@@ -24,4 +24,12 @@ func TestTheSSHExportLineCountsInSingularToo(t *testing.T) {
 			t.Errorf("one record is still plural: %q", got)
 		}
 	}
+
+	// The pull line had the same shape and says it the same way now.
+	if got := sshCountLine("imported", 1); got != "deja: imported 1 record\n" {
+		t.Errorf("the pull line reads %q", got)
+	}
+	if got := sshCountLine("imported", 2); got != "deja: imported 2 records\n" {
+		t.Errorf("the pull line reads %q", got)
+	}
 }

--- a/cmd/deja/sync_ssh_plural_test.go
+++ b/cmd/deja/sync_ssh_plural_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line the first sync against a new machine prints said "exported 1
+// records", while the local path one file away counts properly (#2290).
+func TestTheSSHExportLineCountsInSingularToo(t *testing.T) {
+	for _, c := range []struct {
+		n    int
+		want string
+	}{
+		{1, "exported 1 record\n"},
+		{0, "exported 0 records\n"},
+		{4, "exported 4 records\n"},
+	} {
+		got := sshExportedLine(c.n)
+		if got != "deja: "+c.want {
+			t.Errorf("%d: %q, want %q", c.n, got, "deja: "+c.want)
+		}
+		if c.n == 1 && strings.Contains(got, "1 records") {
+			t.Errorf("one record is still plural: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2290.

    $ deja sync ssh <host>
    deja: exported 1 records

The local path counts properly for the same act — `deja sync export` prints "exported 1 record" — and the two lines are one file apart. It is the line printed on the first sync anyone runs against a new machine.

The count now goes through a small helper so both spellings cannot drift again.

The rest of that surface was checked and is fine: `doctor` reports an unreachable peer as "never exchanged — last attempt failed: …", `deja sync` with only that peer says so and does not pretend, and a batch whose records carry no session id is reported as left out rather than dropped in silence.
