### PR TITLE
fix(doctor): report a damaged index in --json too

### DIFF
--- a/cmd/deja/doctor_json_damaged_test.go
+++ b/cmd/deja/doctor_json_damaged_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The human doctor names a damaged index (#735) and the JSON called the same
+// store "ok", so a script watching it for index health was told the store was
+// fine while it could not answer a query (#2292).
+func TestDoctorJSONReportsADamagedIndex(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"s1","timestamp":%q,"cwd":"/work/app",`+
+		`"message":{"role":"user","content":"gateway_timeout"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	state := func() string {
+		t.Helper()
+		out, err := captureRun(t, "doctor", "--json", "--offline")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var report struct {
+			Index struct {
+				State string `json:"state"`
+			} `json:"index"`
+		}
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatalf("doctor --json is not JSON: %v", err)
+		}
+		return report.Index.State
+	}
+
+	// The premise: a healthy index reports ok.
+	if got := state(); got != "ok" {
+		t.Fatalf("a fresh index reports %q", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The premise for the second half: deja itself considers this damaged.
+	if !index.Damaged(dir) {
+		t.Fatal("the store is not damaged, so this measures nothing")
+	}
+	if got := state(); got == "ok" {
+		t.Error("the JSON calls a damaged index ok")
+	} else if !strings.Contains(got, "damaged") {
+		t.Errorf("the JSON reports %q, which does not say the index is damaged", got)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -626,6 +626,14 @@ func inspectDoctorIndex(dir string, storeMods []time.Time) doctorIndexReport {
 			result.StaleStores++
 		}
 	}
+	// Damage outranks staleness: a store that cannot answer is not merely
+	// behind. The human report has named this since #735 while the JSON called
+	// the same store "ok", so a script watching it for index health was told
+	// everything was fine (#2292).
+	if index.Damaged(dir) {
+		result.State = "damaged"
+		return result
+	}
 	if result.StaleStores > 0 {
 		result.State = "stale"
 		// "run `deja index`" is the advice attached to `stale`, and it cannot

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -218,10 +218,12 @@ func TestDoctorIndexStates(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"manifest.gob", "sessions.gob"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("fixture"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+	// A real index, not two files named like one: a manifest that will not
+	// decode is damage by deja's own definition (#735), and since #2292 the
+	// report says so — which is the right answer for a fixture like that and
+	// the wrong one for the staleness arithmetic this test is about.
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
 	}
 	manifestTime := time.Now().Add(-time.Minute)
 	if err := os.Chtimes(filepath.Join(dir, "manifest.gob"), manifestTime, manifestTime); err != nil {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -381,7 +381,10 @@ when it is `unreadable` — the sidecar is on disk and deja cannot parse it —
 with an `error` saying why. A sidecar fault is reported whether or not an
 endpoint is configured, so `embed` is present in that case even with no
 endpoint. `index.path` points at the index
-directory; `index.db` is that directory's name, not a file. Store `state`
+directory; `index.db` is that directory's name, not a file. `index.state` is
+`missing`, `ok`, `stale`, `stale-readonly` (stale where the index cannot be
+written, so `deja index` cannot fix it) or `damaged` (records or postings are
+gone; the next search rebuilds it). Store `state`
 values are `ok`, `missing`, `unreadable`, `parsed-zero`, `denied` (which adds a
 `denied` field naming the unreadable path), `needs-sqlite3` and `needs-zstd`
 (both of which add a `skipped` field saying which CLI is missing); an existing


### PR DESCRIPTION
Closes #2292.

An index whose `records.bin` was replaced with seven bytes while the manifest still says 58:

    doctor:        integrity damaged — records or postings are missing; the next search rebuilds the index
    doctor --json: "index": {"state":"ok", …}

The human line exists because of #735 — "built, up to date" about a store that could not return a result — and the JSON never got it, so a script watching index health was told the store was fine.

`index.state` is now `damaged` in that case, ahead of `stale`: a store that cannot answer is not merely behind. The states are documented now too; `stale-readonly` from #1004 was undocumented as well and is named in the same sentence.

Two notes on the test change: `TestDoctorIndexStates` built its fixture by writing two files called `manifest.gob` and `sessions.gob` containing the word "fixture". That is a damaged index by deja's own definition, so it now reports `damaged` and the staleness arithmetic the test is about could not be reached — it builds a real index instead.
