### PR TITLE
fix(usage): stamp an injection once for both logs

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -311,8 +311,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text) + env
 			deliverEnv()
-			usage.RecordServedSessions(dir, usage.KindRecall, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotPolicy(dir, usage.KindRecall, text, sessions, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedSnapshot(dir, usage.KindRecall, text, sessions, raw, ids, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "recall_context":
@@ -335,8 +334,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead))
-			usage.RecordServedSessions(dir, usage.KindContext, len(text), sessions, sessions == 0, raw, ids)
-			usage.SnapshotPolicy(dir, usage.KindContext, text, sessions, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedSnapshot(dir, usage.KindContext, text, sessions, raw, ids, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "blame":
@@ -379,8 +377,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			// than either — whole sessions rather than budgeted snippets. Not
 			// recording it left `deja log` understating what the agent was
 			// given (#682).
-			usage.RecordResult(dir, usage.KindBlame, len(text), hits, hits == 0)
-			usage.SnapshotPolicy(dir, usage.KindBlame, text, hits, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedSnapshot(dir, usage.KindBlame, text, hits, 0, nil, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "fix":

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -114,8 +114,7 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	text := frameRecall(b.String())
 	// It also left no trace: a whole session reached the agent and `deja log`
 	// stayed empty — the gap #682 closed for blame.
-	usage.RecordServedSessions(dir, usage.KindResource, len(text), 1, false, rawSize([]model.Session{s}), []string{s.ID})
-	usage.SnapshotPolicy(dir, usage.KindResource, text, 1, policy.Load().Describe(policy.ActivationMCP))
+	usage.RecordServedSnapshot(dir, usage.KindResource, text, 1, rawSize([]model.Session{s}), []string{s.ID}, policy.Load().Describe(policy.ActivationMCP))
 	return map[string]any{"contents": []map[string]any{{
 		"uri":      uri,
 		"mimeType": "text/markdown",

--- a/internal/usage/paired_stamp_test.go
+++ b/internal/usage/paired_stamp_test.go
@@ -35,4 +35,20 @@ func TestAnInjectionCarriesOneStampInBothLogs(t *testing.T) {
 		t.Errorf("RecordDigestInto stamps %s and %s",
 			events[0].Time.Format("15:04:05.000000"), snaps[0].Time.Format("15:04:05.000000"))
 	}
+
+	// And the served-answer pair the MCP surfaces use, which called the two
+	// writers back to back at the call site.
+	dir3 := filepath.Join(t.TempDir(), "index.db")
+	RecordServedSnapshot(dir3, "recall", "served text", 1, 42, []string{"s1"}, "local+imported")
+	events, snaps = Events(dir3, 0), Snapshots(dir3, 0)
+	if len(events) != 1 || len(snaps) != 1 {
+		t.Fatalf("%d events and %d snapshots, want one of each", len(events), len(snaps))
+	}
+	if !events[0].Time.Equal(snaps[0].Time) {
+		t.Errorf("RecordServedSnapshot stamps %s and %s",
+			events[0].Time.Format("15:04:05.000000"), snaps[0].Time.Format("15:04:05.000000"))
+	}
+	if events[0].Bytes != len("served text") || snaps[0].Bytes != len("served text") {
+		t.Errorf("the pair disagrees about size: %d and %d", events[0].Bytes, snaps[0].Bytes)
+	}
 }

--- a/internal/usage/paired_stamp_test.go
+++ b/internal/usage/paired_stamp_test.go
@@ -1,0 +1,38 @@
+package usage
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// One injection writes an event and a digest snapshot. They carried separate
+// time.Now() calls, so the two logs disagreed by microseconds about when the
+// same thing happened and nothing could join them (#2294).
+func TestAnInjectionCarriesOneStampInBothLogs(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+
+	RecordDigestPolicyInto(dir, "dejavu", "the digest text", "agent-1", 1, 63, "local+imported")
+
+	events := Events(dir, 0)
+	snaps := Snapshots(dir, 0)
+	// The premise: exactly one of each was written.
+	if len(events) != 1 || len(snaps) != 1 {
+		t.Fatalf("%d events and %d snapshots, want one of each", len(events), len(snaps))
+	}
+	if !events[0].Time.Equal(snaps[0].Time) {
+		t.Errorf("the same injection is stamped %s in the event log and %s in the snapshot log",
+			events[0].Time.Format("15:04:05.000000"), snaps[0].Time.Format("15:04:05.000000"))
+	}
+
+	// The other pair writer has the same shape.
+	dir2 := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestInto(dir2, "recall", "another digest", "agent-2", 2, 99, []string{"gateway"}, "s1", "s2")
+	events, snaps = Events(dir2, 0), Snapshots(dir2, 0)
+	if len(events) != 1 || len(snaps) != 1 {
+		t.Fatalf("%d events and %d snapshots, want one of each", len(events), len(snaps))
+	}
+	if !events[0].Time.Equal(snaps[0].Time) {
+		t.Errorf("RecordDigestInto stamps %s and %s",
+			events[0].Time.Format("15:04:05.000000"), snaps[0].Time.Format("15:04:05.000000"))
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -132,6 +132,16 @@ func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, r
 	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, at)
 }
 
+// RecordServedSnapshot writes the counting event and the digest snapshot for
+// one served answer, stamped alike. The MCP surfaces used to call the two
+// writers back to back, which took two instants for one act and left `deja
+// log` and `deja log --last` disagreeing about when it happened (#2294).
+func RecordServedSnapshot(indexDir, kind, digest string, sessions int, raw int64, ids []string, policyName string) {
+	at := time.Now().UTC()
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, "", sessions, policyName, nil, at)
+}
+
 // SnapshotOnly stores the digest text without writing a counting event, for
 // callers that already recorded one with extra fields.
 func SnapshotOnly(indexDir, kind, digest string, sessions int) {

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -107,8 +107,12 @@ func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, t
 // RecordDigestInto is RecordDigestTerms knowing which agent session received
 // the injection, so a later reading of the store can ask whether it was used.
 func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int64, terms []string, ids ...string) {
-	RecordServedSessions(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids)
-	snapshotWriteInto(indexDir, kind, digest, into, sessions, "", terms)
+	// One instant for both logs: the event and the digest describe the same
+	// injection, and separate time.Now() calls left them microseconds apart
+	// with nothing else to join them on (#2294).
+	at := time.Now().UTC()
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, "", terms, at)
 }
 
 // RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
@@ -123,8 +127,9 @@ func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, 
 // session-start hook, the commonest injection there is, was recording nothing
 // while holding the id (#1949).
 func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, raw int64, policyName string) {
-	RecordResultRaw(indexDir, kind, len(digest), sessions, sessions == 0, raw)
-	snapshotWriteInto(indexDir, kind, digest, into, sessions, policyName, nil)
+	at := time.Now().UTC()
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, nil, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, at)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for
@@ -190,6 +195,12 @@ func runeBoundaryAt(s string, n int) int {
 }
 
 func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policyName string, terms []string) {
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, terms, time.Now().UTC())
+}
+
+// snapshotWriteIntoAt is snapshotWriteInto with the instant supplied, so a
+// caller writing both logs for one injection can stamp them alike (#2294).
+func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, policyName string, terms []string, at time.Time) {
 	if digest == "" {
 		return
 	}
@@ -197,7 +208,7 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
 	}
-	b, err := marshalSnapshot(Snapshot{Time: time.Now().UTC(), Kind: kind, Sessions: sessions,
+	b, err := marshalSnapshot(Snapshot{Time: at, Kind: kind, Sessions: sessions,
 		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: clipDigest(digest)})
 	if err != nil {
 		return

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -212,6 +212,14 @@ func RecordServedSessions(indexDir, kind string, bytes, sessions int, empty bool
 }
 
 func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
+	recordFullAt(indexDir, kind, bytes, sessions, empty, raw, ids, time.Now().UTC())
+}
+
+// recordFullAt is recordFull with the instant supplied, so an injection that
+// writes an event AND a digest snapshot stamps both with one time. Two
+// time.Now() calls left the two logs disagreeing by microseconds about the same
+// injection, and nothing else joins them (#2294).
+func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string, at time.Time) {
 	p := Path(indexDir)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
@@ -232,7 +240,7 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Event{Time: time.Now().UTC(), Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids})
+	b, err := json.Marshal(Event{Time: at, Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Closes #2294.

One injection wrote two records with two `time.Now()` calls:

    usage.jsonl        {"t":"…604308Z","kind":"dejavu","bytes":578,"sessions":1}
    injections.jsonl   {"t":"…604364Z","kind":"dejavu","sessions":1,"bytes":578}

so `deja log --json` and `deja log --last --json` described the same injection at two different instants, and neither record carries an id to join on.

Both pair writers — `RecordDigestInto` and `RecordDigestPolicyInto` — now take the instant once and hand it to both logs. No field names, types or meanings change; the two logs simply agree.

    after: event t = 2026-08-28T05:36:00.230518Z
           digest t = 2026-08-28T05:36:00.230518Z

The public API is untouched: `recordFull` and `snapshotWriteInto` keep their signatures and delegate to `…At` variants.
