### PR TITLE
fix(show): say which slice of the session was printed

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -494,7 +494,15 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	if o.sliced {
 		// Both flags are documented for `show` and only the JSON path honoured
 		// them; the text output printed the whole session (#709).
+		total := len(s.Messages)
 		s.Messages = sliceMessages(s.Messages, o.offset, o.limit)
+		// The JSON has reported the window all along; the terminal printed the
+		// slice and said nothing, so five turns of two hundred read the same as
+		// a session that is five turns long (#2296). search says it in this
+		// shape two commands away.
+		if line := showWindowNote(o.offset, len(s.Messages), total); line != "" {
+			fmt.Fprintln(os.Stderr, line)
+		}
 	} else if n := len(s.Messages); n > showLargeSession {
 		fmt.Fprintf(os.Stderr, "deja: %d messages — `--offset n --limit n` reads a slice\n", n)
 	}
@@ -510,6 +518,22 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 	printSpawnEdges(os.Stderr, dir, s)
 	search.PrintSession(os.Stdout, s)
 	return nil
+}
+
+// showWindowNote is what the terminal says about a slice: which messages it
+// printed and how many there are. Empty when the slice is the whole session,
+// because a reader who asked for everything needs no arithmetic.
+func showWindowNote(offset, returned, total int) string {
+	if offset <= 0 && returned == total {
+		return ""
+	}
+	if returned == 0 {
+		return fmt.Sprintf("deja: --offset %d is past the end — the session has %d message%s", offset, total, pluralS(total))
+	}
+	first := offset + 1
+	last := offset + returned
+	return fmt.Sprintf("deja: showing message%s %d-%d of %d — `--offset %d` reads the next slice",
+		pluralS(returned), first, last, total, last)
 }
 
 // printSpawnEdges names the sessions around this one when an agent spawned it

--- a/cmd/deja/show_window_test.go
+++ b/cmd/deja/show_window_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `show --json` reports the window it returned; the terminal printed the slice
+// and said nothing, so a reader could not tell five turns of two hundred from a
+// session that is five turns long (#2296).
+func TestShowSaysWhichSliceItPrinted(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "project")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+
+	var lines []string
+	for i := 0; i < 20; i++ {
+		at := time.Now().Add(-time.Duration(60-i) * time.Minute).UTC().Format(time.RFC3339)
+		lines = append(lines, fmt.Sprintf(`{"type":"user","sessionId":"paged","timestamp":%q,"cwd":"/work/project",`+
+			`"message":{"role":"user","content":"marker%02d"}}`, at, i))
+	}
+	if err := os.WriteFile(filepath.Join(claude, "long.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: a slice really is a slice.
+	out, err := captureRun(t, "show", "paged", "--harness", "claude", "--limit", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(out, "marker"); n != 5 {
+		t.Fatalf("--limit 5 printed %d markers", n)
+	}
+
+	said, err := captureRunStderr(t, "show", "paged", "--harness", "claude", "--limit", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(said, "5") || !strings.Contains(said, "20") {
+		t.Errorf("the slice line does not say 5 of 20: %q", said)
+	}
+
+	// Past the end is its own answer, not an empty session.
+	said, err = captureRunStderr(t, "show", "paged", "--harness", "claude", "--offset", "100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(said, "past the end") {
+		t.Errorf("an offset past the end printed %q", said)
+	}
+
+	// A whole session says nothing extra.
+	said, err = captureRunStderr(t, "show", "paged", "--harness", "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(said, "of 20") || strings.Contains(said, "past the end") {
+		t.Errorf("a whole session gained a slice line: %q", said)
+	}
+}


### PR DESCRIPTION
Closes #2296.

    $ deja show paged --harness claude --limit 5
    (five turns, and nothing else)

    $ deja show paged --harness claude --json
    "window": {"offset":0,"limit":5,"total":200,"returned":5}

The JSON has reported the window all along. The terminal printed the slice in silence, so five turns of two hundred read the same as a session that is five turns long — and `deja search` says exactly this two commands away ("showing 5 of 20 — add --all to see the rest").

Now:

    deja: showing messages 1-5 of 200 — `--offset 5` reads the next slice
    deja: --offset 500 is past the end — the session has 200 messages

A whole session says nothing extra, and the note goes to stderr, so piping `deja show` into a file is unchanged.

One correction, which is also on the issue: my first report claimed plain `deja show` truncates long sessions. It does not — it prints all 200 turns; I misread my own grep. The defect is only the explicit-window case.
