### PR TITLE
fix(show): say when a session has no messages at all

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -524,6 +524,13 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 // printed and how many there are. Empty when the slice is the whole session,
 // because a reader who asked for everything needs no arithmetic.
 func showWindowNote(offset, returned, total int) string {
+	if total == 0 {
+		// Not the offset's fault, and asked before the full-window case below:
+		// a session deja holds with nothing readable in it answers every
+		// window the same way, and printing a bare header for it is the silent
+		// empty this note exists to end.
+		return "deja: this session has no messages to show"
+	}
 	if offset <= 0 && returned == total {
 		return ""
 	}

--- a/cmd/deja/show_window_test.go
+++ b/cmd/deja/show_window_test.go
@@ -72,6 +72,18 @@ func TestShowSaysWhichSliceItPrinted(t *testing.T) {
 		t.Errorf("an offset past the end printed %q", said)
 	}
 
+	// An empty session is not an offset mistake.
+	if got := showWindowNote(0, 0, 0); !strings.Contains(got, "no messages") {
+		t.Errorf("an empty session reads as an offset error: %q", got)
+	}
+	// The arithmetic at the edges.
+	if got := showWindowNote(15, 5, 20); !strings.Contains(got, "16-20 of 20") {
+		t.Errorf("the last slice reads %q", got)
+	}
+	if got := showWindowNote(0, 20, 20); got != "" {
+		t.Errorf("a full window still printed a note: %q", got)
+	}
+
 	// A whole session says nothing extra.
 	said, err = captureRunStderr(t, "show", "paged", "--harness", "claude")
 	if err != nil {


### PR DESCRIPTION
Follow-up to #2297, which merged while this refinement was still in my working tree — my slip, and the reason it is a second PR rather than a second commit on the first.

Reviewing my own note found the case it described wrongly: a session deja holds with nothing readable in it has `total == 0`, and `--offset 0 --limit 5` on it produced "--offset 0 is past the end — the session has 0 messages", blaming an offset the reader did not get wrong.

    deja: this session has no messages to show

asked before the full-window case, so an empty session says so instead of printing a bare header. Test covers the empty case and the two arithmetic edges (the last slice reads "16-20 of 20"; a full window still prints nothing).
