### PR TITLE
fix(blame): say how many sessions the ten-hit cap held back

### DIFF
--- a/cmd/deja/blame_cap_note_test.go
+++ b/cmd/deja/blame_cap_note_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// blame answers "who touched this file" with the ten best and said nothing
+// about the rest, so ten of forty read as the whole answer — the sentence
+// `search` prints two commands away (#2299).
+func TestBlameSaysHowManyItHeldBack(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "-work-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	for i := 0; i < 25; i++ {
+		at := time.Now().Add(-time.Duration(2+i) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":"s%03d","timestamp":%q,"cwd":"/work/app",`+
+			`"message":{"role":"user","content":"touching api/upload.go, take %d"}}`, i, at, i)
+		name := fmt.Sprintf("s%03d.jsonl", i)
+		if err := os.WriteFile(filepath.Join(claude, name), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: the cap really is holding sessions back.
+	out, err := captureRun(t, "blame", "api/upload.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capped := strings.Count(out, "touching api/upload.go")
+	all, err := captureRun(t, "blame", "api/upload.go", "--all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if whole := strings.Count(all, "touching api/upload.go"); whole <= capped {
+		t.Fatalf("--all shows %d and the default %d, so nothing is being held back", whole, capped)
+	}
+
+	said, err := captureRunStderr(t, "blame", "api/upload.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(said, "--all") {
+		t.Errorf("blame held sessions back without saying so: %q", said)
+	}
+	if !strings.Contains(said, "25") {
+		t.Errorf("the note does not say how many there are: %q", said)
+	}
+
+	// With --all there is nothing to announce.
+	said, err = captureRunStderr(t, "blame", "api/upload.go", "--all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(said, "add --all") {
+		t.Errorf("--all still suggests --all: %q", said)
+	}
+}

--- a/cmd/deja/blame_stale_test.go
+++ b/cmd/deja/blame_stale_test.go
@@ -33,7 +33,7 @@ func TestBlameReadsWithoutWaitingForARebuild(t *testing.T) {
 	}
 
 	// The agent-facing path must not be the blocking one.
-	hits, _, _, err := findBlameHitsStale(dir, search.BlameTarget{Stem: "parser.go", Base: "parser.go"}, search.BlameOptions{All: true}, policy.ActivationMCP, nil)
+	hits, _, _, _, err := findBlameHitsStale(dir, search.BlameTarget{Stem: "parser.go", Base: "parser.go"}, search.BlameOptions{All: true}, policy.ActivationMCP, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/blame_touchers_test.go
+++ b/cmd/deja/blame_touchers_test.go
@@ -46,7 +46,7 @@ func TestBlameFindsSessionsThatOnlyTouchedTheFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestBlameTouchersMatchTheWholeName(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestBlameFindsASessionThatBothMentionsAndTouchesTheFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hits, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
+	hits, _, _, err := findBlameHits(dir, target, search.BlameOptions{All: true}, "search", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2224,7 +2224,7 @@ func runBlame(dir string, args []string) error {
 	if err != nil {
 		return err
 	}
-	hits, hidden, err := findBlameHits(dir, target, o, policy.ActivationSearch, os.Stderr)
+	hits, hidden, total, err := findBlameHits(dir, target, o, policy.ActivationSearch, os.Stderr)
 	if err != nil {
 		return fmt.Errorf("blame search: %w", err)
 	}
@@ -2252,12 +2252,19 @@ func runBlame(dir string, args []string) error {
 		return nil
 	}
 	search.PrintBlame(os.Stdout, hits, false)
+	// blame answers "who touched this file". Ten blocks and nothing else reads
+	// as all of them, the misread search already avoids with the same sentence
+	// (#2299). --json keeps its bare array: a machine consumer reading a total
+	// would need a different shape, and that is a break, not a note.
+	if total > len(hits) {
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), total)
+	}
 	return nil
 }
 
-func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, error) {
-	hits, hidden, _, err := blameHits(dir, target, o, activation, progress, false)
-	return hits, hidden, err
+func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, int, error) {
+	hits, hidden, total, _, err := blameHits(dir, target, o, activation, progress, false)
+	return hits, hidden, total, err
 }
 
 // findBlameHitsStale is findBlameHits for a caller that must not wait: it
@@ -2266,31 +2273,35 @@ func findBlameHits(dir string, target search.BlameTarget, o search.BlameOptions,
 // before editing a file, so declining for the length of a refresh means the
 // edit happens without the history (#1784). The CLI keeps the blocking path —
 // someone typed it and is watching the progress (#1306).
-func findBlameHitsStale(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, bool, error) {
+func findBlameHitsStale(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer) ([]search.BlameHit, int, int, bool, error) {
 	return blameHits(dir, target, o, activation, progress, true)
 }
 
-func blameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer, stale bool) ([]search.BlameHit, int, bool, error) {
+func blameHits(dir string, target search.BlameTarget, o search.BlameOptions, activation string, progress io.Writer, stale bool) ([]search.BlameHit, int, int, bool, error) {
 	query := search.Options{Query: target.Stem, Harness: o.Harness, Project: o.Project, Since: o.Since, All: true}
 	refreshing := false
 	if stale {
 		var err error
 		if refreshing, err = index.EnsureForSearchStale(dir, query, progress); err != nil {
-			return nil, 0, false, err
+			return nil, 0, 0, false, err
 		} else if refreshing {
 			requestWarmup(dir)
 		}
 	} else if err := index.EnsureForSearch(dir, query, false, progress); err != nil {
-		return nil, 0, false, err
+		return nil, 0, 0, false, err
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, query, progress)
 	if err != nil {
-		return nil, 0, false, err
+		return nil, 0, 0, false, err
 	}
 	all := search.Blame(withFileTouchers(dir, result.Sessions, target), target, o)
-	hits := policyFilterBlame(activation, all)
+	visible := policyFilterBlame(activation, all)
+	// Cap after the trust filter, not before: cutting first meant a withheld
+	// session ate one of the ten slots, so a reader could get eight hits with
+	// forty sessions still waiting behind --all.
+	hits := search.CapBlame(visible, o)
 	attachBlameLifecycles(hits)
-	return hits, len(all) - len(hits), refreshing, nil
+	return hits, len(all) - len(visible), len(visible), refreshing, nil
 }
 
 // blameToucherCap bounds how many extra sessions a blame reads from the

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -534,7 +534,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	if err != nil {
 		return "", 0, err
 	}
-	hits, _, refreshing, err := findBlameHitsStale(dir, target, o, policy.ActivationMCP, mcpProgress())
+	hits, _, _, refreshing, err := findBlameHitsStale(dir, target, o, policy.ActivationMCP, mcpProgress())
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -104,6 +104,8 @@ func ResolveBlamePath(name string) (BlameTarget, error) {
 	return BlameTarget{FullPath: full, Base: base, Stem: stem}, nil
 }
 
+// Blame ranks every session that carries evidence for the file, in full. The
+// listing cut lives in CapBlame.
 func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 	// One clock reading for the whole ranking. Called per session, the decay
 	// differed by nanoseconds between candidates, so sessions with identical
@@ -183,8 +185,22 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		}
 		return hits[i].Session.ID < hits[j].Session.ID
 	})
-	if !o.All && len(hits) > 10 {
-		hits = hits[:10]
+	return hits
+}
+
+// BlameCap is how many hits the default listing shows. The rest are behind
+// --all, so a caller that cuts the list here owes the reader the count it cut
+// from — blame is an answer to "who touched this file", and ten of forty reads
+// as the whole answer unless something says otherwise (#2299).
+const BlameCap = 10
+
+// CapBlame trims a ranked list to BlameCap unless the reader asked for all of
+// it. Kept apart from Blame so the caller still holds the full length: the cut
+// used to happen inside the ranking, where nothing downstream could tell ten
+// hits from ten of forty.
+func CapBlame(hits []BlameHit, o BlameOptions) []BlameHit {
+	if !o.All && len(hits) > BlameCap {
+		return hits[:BlameCap]
 	}
 	return hits
 }

--- a/internal/search/blame_test.go
+++ b/internal/search/blame_test.go
@@ -45,9 +45,17 @@ func TestBlameFiltersProjectBoostLimitAndJSON(t *testing.T) {
 		ss = append(ss, model.Session{ID: string(rune('a' + i)), Harness: "claude", Project: "/repo", Updated: now, Messages: []model.Message{{Role: "user", Text: "parser.go"}}})
 	}
 	target := BlameTarget{FullPath: "/repo/parser.go", Base: "parser.go", Stem: "parser"}
-	hits := Blame(ss, target, BlameOptions{Harness: "claude", Project: "repo"})
+	o := BlameOptions{Harness: "claude", Project: "repo"}
+	ranked := Blame(ss, target, o)
+	if len(ranked) != 12 {
+		t.Fatalf("ranked=%d, want every session that touched the file", len(ranked))
+	}
+	hits := CapBlame(ranked, o)
 	if len(hits) != 10 {
 		t.Fatalf("default limit=%d", len(hits))
+	}
+	if all := CapBlame(ranked, BlameOptions{All: true}); len(all) != 12 {
+		t.Fatalf("--all limit=%d", len(all))
 	}
 	if got := Blame(ss, target, BlameOptions{Harness: "codex", All: true}); len(got) != 0 {
 		t.Fatalf("harness filter=%#v", got)


### PR DESCRIPTION
blame showed ten of forty and said nothing, so the cut read as the whole answer — the same silence `show` had in #2296. The cap moved out of `search.Blame` into `CapBlame` so the caller still knows the full count, and it now runs after the trust filter (a withheld session used to eat one of the ten slots). stderr gets the sentence `search` already prints.

`--json` keeps its bare array: carrying a total there needs a different shape, which is a break.

Fixes #2299.