### PR TITLE
fix(log): name the recipient and the terms in the --last header

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -61,11 +62,7 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			enc.SetIndent("", "  ")
 			return enc.Encode(s)
 		}
-		pol := ""
-		if s.Policy != "" {
-			pol = " · policy: " + s.Policy
-		}
-		fmt.Fprintf(w, "# %s · %s · %d session%s · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, pluralS(s.Sessions), humanBytes(int64(s.Bytes)), pol)
+		fmt.Fprintf(w, "# %s · %s · %d session%s · %s%s\n\n", s.Kind, s.Time.Local().Format("2006-01-02 15:04"), s.Sessions, pluralS(s.Sessions), humanBytes(int64(s.Bytes)), snapshotTail(s))
 		fmt.Fprintln(w, s.Digest)
 		// This is the newest digest by its stamp (#2140), so a stamp from
 		// ahead of the clock holds the spot until the clock catches up — and
@@ -137,4 +134,24 @@ func eventsStampedAhead(events []usage.Event, now time.Time) int {
 		}
 	}
 	return n
+}
+
+// snapshotTail is the part of the header that depends on what the record
+// happens to carry. The record knows which agent session received the digest
+// and which terms fired it — both were added to explain an injection after the
+// fact (#1494) — and only --json ever said them, so the surface a person types
+// answered "what was injected" and never to whom or why (#2301). Fields the
+// record does not carry print nothing, the way policy already did.
+func snapshotTail(s usage.Snapshot) string {
+	var b strings.Builder
+	if s.Policy != "" {
+		b.WriteString(" · policy: " + s.Policy)
+	}
+	if s.Into != "" {
+		b.WriteString(" · into: " + s.Into)
+	}
+	if len(s.Terms) > 0 {
+		b.WriteString(" · terms: " + strings.Join(s.Terms, ", "))
+	}
+	return b.String()
 }

--- a/cmd/deja/log_last_into_test.go
+++ b/cmd/deja/log_last_into_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The record knows which agent session received the digest and which terms
+// fired it — the JSON hands both over. The header a person reads printed
+// neither, so `deja log --last` said what was injected and never to whom or
+// why (#2301).
+func TestLogLastNamesTheRecipientAndTheTerms(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordDigestInto(dir, usage.KindDejaVu, "<deja-recall>\n  - Session: **a** `1`\n", "agent3", 2, 4096,
+		[]string{"panic", "quaxbolt", "overflow"}, "r0", "r1")
+
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	head := strings.SplitN(out.String(), "\n", 2)[0]
+	if !strings.Contains(head, "agent3") {
+		t.Errorf("header does not say which session received it: %q", head)
+	}
+	if !strings.Contains(head, "quaxbolt") {
+		t.Errorf("header does not say what fired it: %q", head)
+	}
+
+	// A record without them keeps the short header — no empty labels.
+	hermeticEnv(t)
+	dir = index.DefaultDir()
+	usage.RecordDigestPolicy(dir, usage.KindHook, "<deja-recall>\n  - Session: **b** `2`\n", 1, 4096, "local-only")
+	out.Reset()
+	if err := runLogTo(&out, dir, []string{"--last"}); err != nil {
+		t.Fatal(err)
+	}
+	head = strings.SplitN(out.String(), "\n", 2)[0]
+	if strings.Contains(head, "into:") || strings.Contains(head, "terms:") {
+		t.Errorf("header labels fields the record does not carry: %q", head)
+	}
+	if !strings.Contains(head, "policy: local-only") {
+		t.Errorf("header lost the policy: %q", head)
+	}
+}


### PR DESCRIPTION
`deja log --last` printed kind, time, sessions, bytes and policy. The record also carries `into` — the agent session that got the digest, added in #1494 precisely because the log "said what was injected and never to whom" — and `terms`, kept so a wrong "you have been here" can be explained. Both went only to `--json`.

Header now appends them when the record has them; a record without them is unchanged. JSON untouched.

Fixes #2301.