### PR TITLE
fix(stats): count deja vu injections as impact activity

### DIFF
--- a/cmd/deja/impact_dejavu_only_test.go
+++ b/cmd/deja/impact_dejavu_only_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A machine with only the prompt hook installed never increments `recalls`
+// (recall/context kinds) or `injections` (session starts) — its digests land
+// in `dejavu_moments`. The empty check read those two counters, so the report
+// said nothing was recorded while `deja log`, the stats card and its own JSON
+// all listed the injections (#2303).
+func TestImpactCountsAPromptHookOnlyMachine(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	for i := 0; i < 5; i++ {
+		usage.RecordDigestInto(dir, usage.KindDejaVu, "<deja-recall>\n  - Session: **a** `1`\n", "agent1", 2, 1160,
+			[]string{"panic", "quaxbolt"}, "r0", "r1")
+	}
+
+	var out bytes.Buffer
+	if err := runStatsImpact(&out, dir, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "no recall activity recorded yet") {
+		t.Fatalf("five injections read as nothing recorded:\n%s", got)
+	}
+	if !strings.Contains(got, "déjà vu moments") {
+		t.Errorf("the report does not name what did happen:\n%s", got)
+	}
+	// The closing line divides by what was served — 0 here before the fix,
+	// which reads as "none of 0".
+	if strings.Contains(got, "of 0 ") {
+		t.Errorf("credited-aloud line counts against nothing:\n%s", got)
+	}
+
+	// An untouched machine still says so.
+	hermeticEnv(t)
+	out.Reset()
+	if err := runStatsImpact(&out, index.DefaultDir(), false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "no recall activity recorded yet") {
+		t.Errorf("an empty log lost its explanation:\n%s", out.String())
+	}
+}

--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -24,7 +24,7 @@ func runStatsImpact(w io.Writer, dir string, jsonOut bool) error {
 	// from four ignored ones is the agent naming deja out loud in a later
 	// transcript, and that lives in the index, not in the usage log (#1062).
 	// Only pay for the session scan when there is activity to explain.
-	if r.Recalls > 0 || r.Injections > 0 {
+	if impactHasActivity(r) {
 		if ss, err := index.SearchWithRecovery(dir, search.Options{All: true}, io.Discard); err == nil {
 			// Filtered like `deja stats` filters its own report: this count is
 			// derived from session text, and every other surface that reads
@@ -55,7 +55,7 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 		_, err = fmt.Fprintf(w, "%s,\n  \"credited_aloud\": %d\n}\n", body, credits)
 		return err
 	}
-	if r.Recalls == 0 && r.Injections == 0 {
+	if !impactHasActivity(r) {
 		fmt.Fprintln(w, "deja: no recall activity recorded yet — impact numbers appear once agents start recalling")
 		return nil
 	}
@@ -97,7 +97,7 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 	if r.DejaVuMoments > 0 {
 		fmt.Fprintf(w, "  déjà vu moments    %d prompt%s matched work you had already done\n", r.DejaVuMoments, pluralS(r.DejaVuMoments))
 	}
-	served := r.Recalls + r.Injections
+	served := r.Recalls + r.Injections + r.DejaVuMoments
 	switch {
 	case credits > 0:
 		fmt.Fprintf(w, "  credited aloud     %d of %d said \"deja-vu recalled\" — memory that was used, not just served\n", credits, served)
@@ -108,4 +108,15 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 	fmt.Fprintln(w, "the source transcripts those digests distilled. `deja log` shows every entry.")
 	fmt.Fprintln(w, "for retrieval timing on your own corpus, run `deja bench recall`.")
 	return nil
+}
+
+// impactHasActivity says whether this machine has served anything at all.
+// The two counters this used to read — recalls and session-start injections —
+// are exactly the two a machine running only the prompt hook never increments:
+// a per-prompt déjà vu lands in DejaVuMoments and hook-tool under no counter at
+// all, both carrying their bytes. So the default install read as "nothing
+// recorded" while `deja log`, the stats card and this report's own --json
+// listed the injections (#2303).
+func impactHasActivity(r usage.ImpactReport) bool {
+	return r.Recalls > 0 || r.Injections > 0 || r.DejaVuMoments > 0 || r.ServedBytes > 0
 }


### PR DESCRIPTION
On a machine running only the prompt hook, `stats --impact` said "no recall activity recorded yet" while `deja log`, the stats card and its own `--json` all listed the injections. The gate read `recalls` and `injections` — the two counters that machine never increments, since a per-prompt déjà vu lands in `dejavu_moments` and carries the bytes with it.

Gate now asks whether anything was served at all, and the credited-aloud line counts against the same set instead of dividing by zero.

Fixes #2303.