### PR TITLE
fix(log): say when the list stopped at the default twenty

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -73,7 +73,7 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		}
 		return nil
 	}
-	events := usage.Events(dir, n)
+	events, total := usage.EventsCounted(dir, n)
 	if jsonOut {
 		// A nil slice encodes as null, and null is not an empty list: len()
 		// raises, iteration raises, `jq '.[]'` errors. Every other
@@ -100,6 +100,13 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			sess = fmt.Sprintf(" · %d session%s", e.Sessions, pluralS(e.Sessions))
 		}
 		fmt.Fprintf(w, "%s  %-14s %s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, mark)
+	}
+	if total > len(events) {
+		// Nobody typed the 20 — it is the default above — and this is the
+		// audit trail, where a list that stops without saying so reads as
+		// everything deja served. The same sentence blame and show print
+		// (#2299, #2296, #2305).
+		fmt.Fprintf(w, "\nshowing %d of %d — `deja log %d` shows the rest\n", len(events), total, total)
 	}
 	fmt.Fprintln(w, "\nuse `deja log --last` to see the exact text of the most recent injected digest")
 	// The log's stamps are deja's own, written at recall time, so one in the

--- a/cmd/deja/log_window_test.go
+++ b/cmd/deja/log_window_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The audit trail stopped at twenty rows and said nothing, so twenty read as
+// everything deja had served — the misread #2296 and #2299 are about, and the
+// twenty is a default nobody typed (#2305).
+func TestLogSaysWhenItStoppedAtTheDefault(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	for i := 0; i < 25; i++ {
+		usage.RecordDigest(dir, usage.KindDejaVu, "<deja-recall>\n  - Session: **a** `1`\n", 2, 1160)
+	}
+
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if rows := strings.Count(got, usage.KindDejaVu); rows != 20 {
+		t.Fatalf("printed %d rows, want the default 20", rows)
+	}
+	if !strings.Contains(got, "20 of 25") {
+		t.Errorf("log stopped at twenty without saying so:\n%s", got)
+	}
+
+	// Asked for all of them, there is nothing to announce.
+	out.Reset()
+	if err := runLogTo(&out, dir, []string{"100"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), " of 25") {
+		t.Errorf("a listing that held nothing back still announced a window:\n%s", out.String())
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -340,9 +340,17 @@ func Snapshots(indexDir string, n int) []Snapshot {
 
 // Events returns up to n usage events, newest first. n <= 0 means all.
 func Events(indexDir string, n int) []Event {
+	events, _ := EventsCounted(indexDir, n)
+	return events
+}
+
+// EventsCounted is Events plus how many events the log holds, so a caller that
+// shows a window can say what it left out. The whole file is read either way —
+// the cut happens at the end — so the count costs nothing (#2305).
+func EventsCounted(indexDir string, n int) ([]Event, int) {
 	f, err := os.Open(Path(indexDir))
 	if err != nil {
-		return nil
+		return nil, 0
 	}
 	defer func() { _ = f.Close() }()
 	var out []Event
@@ -363,10 +371,11 @@ func Events(indexDir string, n int) []Event {
 		out[i], out[j] = out[j], out[i]
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	total := len(out)
 	if n > 0 && len(out) > n {
 		out = out[:n]
 	}
-	return out
+	return out, total
 }
 
 // marshalSnapshot writes one record without encoding/json's HTML escaping. That


### PR DESCRIPTION
`deja log` is the audit trail and it printed twenty rows of twenty-five with nothing after them. The twenty is a default (`n := 20`), not a number the reader chose — the distinction that made blame's ten a bug in #2299 and leaves `deja last 3` alone.

`usage.Events` already read the whole file and cut at the end, so `EventsCounted` hands the total back for free. `--json` unchanged.

Fixes #2305.