### PR TITLE
fix(log): record which agent session each injection went to

### DIFF
--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -99,7 +99,11 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 		if e.Sessions > 0 {
 			sess = fmt.Sprintf(" · %d session%s", e.Sessions, pluralS(e.Sessions))
 		}
-		fmt.Fprintf(w, "%s  %-14s %s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, mark)
+		into := ""
+		if e.Into != "" {
+			into = " · into: " + e.Into
+		}
+		fmt.Fprintf(w, "%s  %-14s %s%s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, into, mark)
 	}
 	if total > len(events) {
 		// Nobody typed the 20 — it is the default above — and this is the

--- a/cmd/deja/log_into_row_test.go
+++ b/cmd/deja/log_into_row_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// Three injections to three agent sessions printed three identical rows: the
+// recipient reached the digest log and never the event, so the audit list could
+// not tell them apart and only the newest was readable, through --last (#2307).
+func TestLogRowsNameTheAgentThatGotThem(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	for _, into := range []string{"alpha", "beta", "gamma"} {
+		usage.RecordDigestInto(dir, usage.KindDejaVu, "<deja-recall>\n  - Session: **a** `1`\n", into, 2, 232,
+			[]string{"panic"}, "r0", "r1")
+	}
+
+	var out bytes.Buffer
+	if err := runLogTo(&out, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, into := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(got, into) {
+			t.Errorf("the row for %q does not name it:\n%s", into, got)
+		}
+	}
+
+	// An event recorded without a recipient — an MCP recall, say — prints no
+	// empty label.
+	hermeticEnv(t)
+	dir = index.DefaultDir()
+	usage.RecordServedSnapshot(dir, usage.KindRecall, "<deja-recall>\n  - Session: **b** `2`\n", 1, 100, []string{"b"}, "")
+	out.Reset()
+	if err := runLogTo(&out, dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "into") {
+		t.Errorf("a row labels a recipient it does not have:\n%s", out.String())
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -522,7 +522,9 @@ no sessions is still a recall, and the count of those is what
 `empty_result_rate` is made of. It does not mean nothing was served: a session
 start on a checkout with no sessions of its own injects the environment block,
 which is about the machine rather than the project, so that event is `empty`
-and carries its `bytes`.
+and carries its `bytes`. `into` names the agent session an injection went to,
+as the harness names it, and is absent when the writer did not know one — an
+MCP recall answers a tool call, not a session start.
 
 A line needs both `t` and `kind` to appear here at all: a half-written line, or
 one from something that is not deja, is skipped rather than shown with a missing

--- a/internal/usage/log_json_contract_test.go
+++ b/internal/usage/log_json_contract_test.go
@@ -36,9 +36,12 @@ func assertShape(t *testing.T, name string, got, want map[string]bool) {
 // Snapshot. docs/json-output.md promises both shapes stay stable and only grow
 // additively; these snapshots enforce that.
 func TestLogJSONShapesAreStable(t *testing.T) {
+	// "into" on the event is additive and optional, for the same reason it is
+	// on the snapshot: the list showed several injections as identical rows,
+	// and the recipient was one file over (#2307).
 	assertShape(t, "Event", topLevelJSONKeys(Event{}), map[string]bool{
 		"t": true, "kind": true, "bytes": true, "sessions": true,
-		"empty": true, "raw": true, "ids": true,
+		"empty": true, "raw": true, "ids": true, "into": true,
 	})
 	// "into" is additive and optional: it names the agent session an injection
 	// went to, which the log never recorded. Without it the only measure of

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -111,7 +111,7 @@ func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int
 	// injection, and separate time.Now() calls left them microseconds apart
 	// with nothing else to join them on (#2294).
 	at := time.Now().UTC()
-	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, at)
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at)
 	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, "", terms, at)
 }
 
@@ -128,7 +128,7 @@ func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, 
 // while holding the id (#1949).
 func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, raw int64, policyName string) {
 	at := time.Now().UTC()
-	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, nil, at)
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, nil, into, at)
 	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, at)
 }
 
@@ -138,7 +138,7 @@ func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, r
 // log` and `deja log --last` disagreeing about when it happened (#2294).
 func RecordServedSnapshot(indexDir, kind, digest string, sessions int, raw int64, ids []string, policyName string) {
 	at := time.Now().UTC()
-	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, at)
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, "", at)
 	snapshotWriteIntoAt(indexDir, kind, digest, "", sessions, policyName, nil, at)
 }
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -101,6 +101,12 @@ type Event struct {
 	// SessionIDs lists the sessions served by an agent-initiated recall, so
 	// search can weigh what agents actually re-used.
 	SessionIDs []string `json:"ids,omitempty"`
+	// Into is the agent session that received this injection, as the harness
+	// names it. The digest log has carried it since #1494, and the event did
+	// not, so the audit list showed several injections as identical rows and
+	// only the newest could be named, through --last (#2307). It is the other
+	// direction from SessionIDs: what was served, and to whom.
+	Into string `json:"into,omitempty"`
 }
 
 type Summary struct {
@@ -212,14 +218,14 @@ func RecordServedSessions(indexDir, kind string, bytes, sessions int, empty bool
 }
 
 func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
-	recordFullAt(indexDir, kind, bytes, sessions, empty, raw, ids, time.Now().UTC())
+	recordFullAt(indexDir, kind, bytes, sessions, empty, raw, ids, "", time.Now().UTC())
 }
 
 // recordFullAt is recordFull with the instant supplied, so an injection that
 // writes an event AND a digest snapshot stamps both with one time. Two
 // time.Now() calls left the two logs disagreeing by microseconds about the same
 // injection, and nothing else joins them (#2294).
-func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string, at time.Time) {
+func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string, into string, at time.Time) {
 	p := Path(indexDir)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
@@ -240,7 +246,7 @@ func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw in
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Event{Time: at, Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids})
+	b, err := json.Marshal(Event{Time: at, Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids, Into: into})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Three prompt-hook injections to three agent sessions printed three identical rows in `deja log`. The recipient was recorded — in the paired digest log, which has carried `into` since #1494 — and only the newest could be read back, through `--last`.

`usage.Event` gains `into` (additive, optional; contract test and docs updated), the writers that know the id pass it, and the rows print it. An MCP recall answers a tool call rather than a session start, so its events carry none and print no label.

Fixes #2307.