### PR TITLE
fix(stats): count and name tool-time injections in the impact report

### DIFF
--- a/cmd/deja/impact_tool_door_test.go
+++ b/cmd/deja/impact_tool_door_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A machine served only through the PreToolUse hook: no counter named that
+// door, and the bytes line wanted a raw size the tool event never records, so
+// the report opened and printed two zeros about 945 bytes of served lines
+// (#2309).
+func TestImpactNamesTheToolDoor(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	for i := 0; i < 4; i++ {
+		usage.RecordResult(dir, usage.KindTool, 236, 1, false)
+	}
+
+	var out bytes.Buffer
+	if err := runStatsImpact(&out, dir, false); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "4") {
+		t.Errorf("the report never counts the four tool lines:\n%s", got)
+	}
+	if !strings.Contains(got, "944 B") && !strings.Contains(got, "945 B") {
+		t.Errorf("the report never says what was served:\n%s", got)
+	}
+}
+
+// The ratio line still reads as before when both sides are there.
+func TestImpactKeepsTheRatioWhenRawIsKnown(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	usage.RecordServedSessions(dir, usage.KindRecall, 1000, 2, false, 8000, []string{"a", "b"})
+
+	var out bytes.Buffer
+	if err := runStatsImpact(&out, dir, false); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); !strings.Contains(got, "8× less") {
+		t.Errorf("the distilled ratio is gone:\n%s", got)
+	}
+}

--- a/cmd/deja/stats_impact.go
+++ b/cmd/deja/stats_impact.go
@@ -72,6 +72,12 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 	// (#1652). The verbs are already invariant.
 	fmt.Fprintf(w, "  recalls served     %d agent-initiated recall%s returned matches\n", r.Recalls, pluralS(r.Recalls))
 	fmt.Fprintf(w, "  memory at start    %d session start%s began with project memory\n", r.Injections, pluralS(r.Injections))
+	if r.ServedBytes > 0 && r.RawBytes == 0 {
+		// The tool-time line is recorded with no raw size behind it — it is a
+		// fact about the store rather than a digest of transcripts — so the
+		// ratio block below skipped it and the bytes went unsaid (#2309).
+		fmt.Fprintf(w, "  context served     %s, with no raw transcript size recorded behind it\n", humanBytes(int64(r.ServedBytes)))
+	}
 	if r.RawBytes > 0 && r.ServedBytes > 0 {
 		// The frame, the header and the session lines cost more than the text
 		// they wrap when sessions are short — which is exactly the state a new
@@ -94,10 +100,13 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 	if r.ReusedTwice > 0 {
 		fmt.Fprintf(w, "  knowledge re-used  %d session%s recalled 2+ times — fixes that keep paying\n", r.ReusedTwice, pluralS(r.ReusedTwice))
 	}
+	if r.ToolLines > 0 {
+		fmt.Fprintf(w, "  tool-time lines    %d command%s or file%s deja had seen before\n", r.ToolLines, pluralS(r.ToolLines), pluralS(r.ToolLines))
+	}
 	if r.DejaVuMoments > 0 {
 		fmt.Fprintf(w, "  déjà vu moments    %d prompt%s matched work you had already done\n", r.DejaVuMoments, pluralS(r.DejaVuMoments))
 	}
-	served := r.Recalls + r.Injections + r.DejaVuMoments
+	served := r.Recalls + r.Injections + r.DejaVuMoments + r.ToolLines
 	switch {
 	case credits > 0:
 		fmt.Fprintf(w, "  credited aloud     %d of %d said \"deja-vu recalled\" — memory that was used, not just served\n", credits, served)
@@ -118,5 +127,5 @@ func printImpact(w io.Writer, r usage.ImpactReport, credits int, jsonOut bool) e
 // recorded" while `deja log`, the stats card and this report's own --json
 // listed the injections (#2303).
 func impactHasActivity(r usage.ImpactReport) bool {
-	return r.Recalls > 0 || r.Injections > 0 || r.DejaVuMoments > 0 || r.ServedBytes > 0
+	return r.Recalls > 0 || r.Injections > 0 || r.DejaVuMoments > 0 || r.ToolLines > 0 || r.ServedBytes > 0
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -450,6 +450,7 @@ What deja has actually served on this machine, measured from the usage log:
   "raw_bytes": 150000,
   "reused_twice": 2,
   "dejavu_moments": 1,
+  "tool_lines": 12,
   "since": "2026-07-27T14:33:13Z",
   "credited_aloud": 3
 }
@@ -471,7 +472,9 @@ that block is a summary of what the machine keeps hitting rather than a digest
 of transcripts. `deja stats` counts its bytes, which is the number for
 everything deja handed over. `reused_twice` is
 sessions agents recalled two or more times, `dejavu_moments` prompts matched to
-prior work, and `credited_aloud` the recalls an agent said out loud.
+prior work, `tool_lines` the PreToolUse injections — one line about the command
+or file an agent was about to touch — and `credited_aloud` the recalls an agent
+said out loud.
 
 `since` is the oldest event still in the usage log, so no count above covers
 more than the period from then to now. On a quiet machine that is every event

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -703,6 +703,11 @@ type ImpactReport struct {
 	RawBytes      int64 `json:"raw_bytes"`      // source transcripts those digests distilled
 	ReusedTwice   int   `json:"reused_twice"`   // sessions agents recalled 2+ times
 	DejaVuMoments int   `json:"dejavu_moments"` // prompts matched to prior work
+	// ToolLines counts the PreToolUse injections — one line about the command
+	// or file an agent is about to touch. Their bytes were counted from the
+	// start and no counter named the door, so a machine served only through
+	// that hook read as two zeros (#2309).
+	ToolLines int `json:"tool_lines"`
 	// Since is the oldest event still in the log. The log is rewritten past
 	// 1MB keeping the last 14 days, so every count above is a window and not a
 	// lifetime — one rotation over a 30-day log halved them (#1889). The same
@@ -775,6 +780,9 @@ func Impact(indexDir string) ImpactReport {
 			// starts that began with project memory.
 			if e.Kind == KindHook {
 				r.Injections++
+			}
+			if e.Kind == KindTool {
+				r.ToolLines++
 			}
 			r.ServedBytes += e.Bytes
 			r.RawBytes += e.RawBytes


### PR DESCRIPTION
With only the PreToolUse hook installed, `stats --impact` printed `recalls served 0` and `memory at start 0` and nothing else, while `--json` reported `served_bytes: 945` and the stats card counted four injections.

Two causes: no counter named the tool door (its bytes went into `served_bytes` alone), and the bytes line required `raw_bytes > 0`, which a tool event never has — it is a fact about the store, not a digest of transcripts.

Adds `tool_lines` (additive; docs and the contract test updated), a report line for it, and a bytes line for the raw-less case.

Fixes #2309.