### PR TITLE
fix(friction): say what --limit left out

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -143,6 +143,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		}
 		return nil
 	}
+	total := len(rows)
 	if len(rows) > limit {
 		rows = rows[:limit]
 	}
@@ -155,6 +156,12 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			fmt.Fprintf(stdout, " · last %s", r.when.Local().Format("Jan 2"))
 		}
 		fmt.Fprintln(stdout)
+	}
+	// The header claims to say what this machine keeps tripping over, so a cut
+	// list with nothing after it reads as all of it — the sentence `how` and
+	// `files` print for the same flag (#2311).
+	if total > len(rows) {
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", len(rows), total)
 	}
 	return nil
 }

--- a/cmd/deja/friction_limit_note_test.go
+++ b/cmd/deja/friction_limit_note_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// friction claims to print "what this machine keeps tripping over", so a cut
+// list with nothing after it reads as the whole of it — the sentence `how` and
+// `files` print for the same flag (#2311).
+func TestFrictionSaysWhatTheLimitLeftOut(t *testing.T) {
+	var lines []string
+	errs := []string{
+		"undefined: snorblefunc in vendor/blarg/api.go",
+		"panic: quaxbolt deadline exceeded",
+		"TypeError: cannot read property 'zonk' of undefined",
+	}
+	n := 0
+	for _, e := range errs {
+		for k := 0; k < 3; k++ {
+			lines = append(lines, fmt.Sprintf(
+				`{"type":"user","sessionId":"s%d","cwd":"/w/p","timestamp":"2026-07-2%dT10:00:00Z","message":{"role":"user","content":[{"type":"tool_result","content":%q}]}}`,
+				n, k+1, e))
+			n++
+		}
+	}
+	seedFrictionStore(t, lines)
+
+	var all bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &all); err != nil {
+		t.Fatal(err)
+	}
+	if rows := strings.Count(all.String(), " sessions  "); rows != 3 {
+		t.Fatalf("seeded %d recurring errors, friction found %d:\n%s", len(errs), rows, all.String())
+	}
+
+	said, err := captureRunStderr(t, "friction", "--limit", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(said, "2 of 3") {
+		t.Errorf("friction cut the list without saying so: %q", said)
+	}
+
+	// Nothing held back, nothing announced.
+	said, err = captureRunStderr(t, "friction", "--limit", "9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(said, "showing") {
+		t.Errorf("friction announced a window it did not apply: %q", said)
+	}
+}


### PR DESCRIPTION
`deja friction --limit 2` printed two rows of four and nothing else, under a header that claims to say what the machine keeps tripping over. `how` and `files` print "showing N of M — raise --limit for the rest" for the same flag; friction now does too, on stderr where its policy note already goes.

Fixes #2311.