### PR TITLE
fix(view): stop claiming the Recalls tab holds every injection

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -76,6 +76,10 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// RecallCount is how many injections the page carries and TotalRecalls how
+	// many the log holds, for the same reason the two note counts exist.
+	RecallCount  int
+	TotalRecalls int
 	// NoteCount is how many notes the page carries and TotalNotes how many
 	// there are, so the page can say when those differ (#2111).
 	NoteCount  int
@@ -195,8 +199,18 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		}
 		sessions = append(sessions, v)
 	}
-	recalls := make([]viewRecall, 0, viewRecalls)
-	for _, sn := range usage.Snapshots(dir, viewRecalls) {
+	// Every injection there is, so the page can say what it left behind: the
+	// tab used to claim it held all of them while carrying the newest hundred
+	// (#2313). Reading them all costs nothing extra — Snapshots parses the
+	// whole file and cuts at the end either way.
+	allRecalls := usage.Snapshots(dir, 0)
+	page.TotalRecalls = len(allRecalls)
+	if len(allRecalls) > viewRecalls {
+		allRecalls = allRecalls[:viewRecalls]
+	}
+	page.RecallCount = len(allRecalls)
+	recalls := make([]viewRecall, 0, len(allRecalls))
+	for _, sn := range allRecalls {
 		recalls = append(recalls, viewRecall{
 			Time: sn.Time.Local().Format("2006-01-02 15:04"), Kind: sn.Kind,
 			Sessions: sn.Sessions, Bytes: sn.Bytes, Policy: sn.Policy,

--- a/cmd/deja/view_recalls_cap_test.go
+++ b/cmd/deja/view_recalls_cap_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The Recalls tab carries the newest hundred injections and told the reader it
+// carried every one of them — a claim the Notes tab beside it already knows how
+// to qualify (#2313).
+func TestThePageSaysTheRecallsTabIsAWindow(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	for i := 0; i < 130; i++ {
+		usage.RecordDigestInto(dir, usage.KindDejaVu,
+			fmt.Sprintf("<deja-recall>\n  - digest-marker-%03d\n", i), fmt.Sprintf("agent%03d", i), 1, 100,
+			[]string{"quaxbolt"}, "r0")
+	}
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, err := captureRun(t, "view", "--no-open", "--out", out); err != nil {
+		t.Fatal(err)
+	}
+	page, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the newest injection is on the page and an older one is not.
+	if !strings.Contains(string(page), "digest-marker-129") {
+		t.Fatalf("the newest injection is not on the page, so this measures nothing")
+	}
+	if strings.Contains(string(page), "digest-marker-000") {
+		t.Fatalf("the page carries all 130 injections, so nothing is being held back")
+	}
+	if strings.Contains(string(page), "every injection an agent received") {
+		t.Errorf("the page still claims to hold every injection")
+	}
+	if !strings.Contains(string(page), "of 130") {
+		t.Errorf("the page does not say how many injections there are:\n%s", recallNote(string(page)))
+	}
+}
+
+// recallNote is the sentence under the Recalls tab, for a readable failure.
+func recallNote(page string) string {
+	i := strings.Index(page, `id="rlist"`)
+	if i < 0 {
+		return "(no recalls tab)"
+	}
+	end := i + 400
+	if end > len(page) {
+		end = len(page)
+	}
+	return page[i:end]
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -66,7 +66,7 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <p class="note">previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.</p>
 </div>
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
-<p class="note">every injection an agent received, verbatim — the audit trail behind <b>deja log</b>.</p></div>
+<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
 <p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}</p></div>
 </div>


### PR DESCRIPTION
With 130 injections recorded the page embeds 100 and the tab read "every injection an agent received, verbatim". The Notes tab two lines below already qualifies its own cap; the Recalls tab now does the same and mentions that the log itself rotates.

Reading all snapshots costs nothing extra — `usage.Snapshots` parses the whole file and cuts at the end either way.

Fixes #2313.