### PR TITLE
fix(view): keep withheld projects out of the Recalls tab

### DIFF
--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -57,6 +57,21 @@ func policyFilterSessionsCounted(activation string, ss []model.Session) ([]model
 	return kept, before - len(kept)
 }
 
+// policyHiddenProjects names the projects a rule is withholding right now. The
+// view page needs them by name rather than by session: a stored digest carries
+// no project field, so the only way to keep withheld content off a shareable
+// page is to recognise the names inside it (#2315).
+func policyHiddenProjects(activation string, ss []model.Session) map[string]bool {
+	p := policy.Load()
+	hidden := map[string]bool{}
+	for _, s := range ss {
+		if s.Project != "" && !p.Allows(activation, s.Project) {
+			hidden[s.Project] = true
+		}
+	}
+	return hidden
+}
+
 // denyPolicyHidden stops a direct-access command (show, share, handoff) from
 // revealing a session a trust rule withholds. Naming an exact id is still
 // browsing under the search activation — ctx already refuses here (#1026), and

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -76,6 +76,8 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// RecallsWithheld is how many stored digests a trust rule kept off the page.
+	RecallsWithheld int
 	// RecallCount is how many injections the page carries and TotalRecalls how
 	// many the log holds, for the same reason the two note counts exist.
 	RecallCount  int
@@ -170,6 +172,7 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	// consulted the policy and this one did not: it embedded imported sessions
 	// a local-only rule had already withheld from search, the listing, stats
 	// and the agent. Browsing, so the search activation governs it (#937).
+	hiddenProjects := policyHiddenProjects(policy.ActivationSearch, metas)
 	metas, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, metas)
 	if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
 		fmt.Fprint(os.Stderr, note)
@@ -204,6 +207,13 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	// (#2313). Reading them all costs nothing extra — Snapshots parses the
 	// whole file and cuts at the end either way.
 	allRecalls := usage.Snapshots(dir, 0)
+	// A digest is titles, project names and message text already assembled —
+	// the three things the filter above keeps off this page — and it outlives
+	// the rule it was served under: content recalled while imported sessions
+	// were allowed stayed on the page after a local-only rule withheld them
+	// everywhere else (#2315). The record has no project field, so what is
+	// recognisable is the name of a project being withheld now.
+	allRecalls, page.RecallsWithheld = withoutHiddenProjects(allRecalls, hiddenProjects)
 	page.TotalRecalls = len(allRecalls)
 	if len(allRecalls) > viewRecalls {
 		allRecalls = allRecalls[:viewRecalls]
@@ -350,4 +360,27 @@ func openInBrowser(path string) {
 		cmd = exec.Command("xdg-open", path)
 	}
 	_ = cmd.Start()
+}
+
+// withoutHiddenProjects drops the digests that name a withheld project, and
+// says how many went. Substring rather than equality: the digest renders the
+// project inside a line of prose, and the name is what a reader would see.
+func withoutHiddenProjects(snaps []usage.Snapshot, hidden map[string]bool) ([]usage.Snapshot, int) {
+	if len(hidden) == 0 {
+		return snaps, 0
+	}
+	kept := make([]usage.Snapshot, 0, len(snaps))
+	for _, sn := range snaps {
+		withheld := false
+		for project := range hidden {
+			if strings.Contains(sn.Digest, project) {
+				withheld = true
+				break
+			}
+		}
+		if !withheld {
+			kept = append(kept, sn)
+		}
+	}
+	return kept, len(snaps) - len(kept)
 }

--- a/cmd/deja/view_recall_policy_test.go
+++ b/cmd/deja/view_recall_policy_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A digest served while imported content was allowed keeps the peer's project
+// and text. The session list on the page obeys a later local-only rule and the
+// Recalls tab embedded the same three things — titles, project names, message
+// text — verbatim (#2315).
+func TestViewWithholdsRecallsFromHiddenProjects(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	rec := index.SyncRecord{
+		Harness: "claude", SessionID: "peersess", Project: "secretclient/api",
+		Role: "assistant", Text: "the quaxbolt overflow was an int32 cast in the client's ledger",
+		Time: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The digest as it was served while imported content was allowed.
+	usage.RecordDigestPolicy(dir, usage.KindRecall,
+		"<deja-recall>\n1. [claude] imported:secretclient/api · the quaxbolt overflow was an int32 cast\n",
+		1, 400, "local+imported")
+	// And one about the machine's own work, which nothing withholds.
+	usage.RecordDigestPolicy(dir, usage.KindRecall,
+		"<deja-recall>\n1. [claude] tmp/mine · my own connection pool question\n",
+		1, 400, "local+imported")
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	if page := readFileString(t, out); !strings.Contains(page, "int32 cast") {
+		t.Fatalf("the peer's digest is not on the page with no policy set, so this measures nothing")
+	}
+
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	if strings.Contains(page, "int32 cast") || strings.Contains(page, "secretclient") {
+		t.Errorf("the page embeds a digest from a project the policy withholds")
+	}
+	// The reader's own recall is still there — the rule hides a project, not
+	// the tab.
+	if !strings.Contains(page, "my own connection pool question") {
+		t.Errorf("the page dropped a digest about the machine's own work")
+	}
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -66,7 +66,7 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <p class="note">previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.</p>
 </div>
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
-<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}</p></div>
+<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} {{.RecallsWithheld}} more are held back by the trust policy.{{end}}</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
 <p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}</p></div>
 </div>


### PR DESCRIPTION
The session list on the view page is filtered by the trust policy — #937's reasoning, in the comment above it. The Recalls tab rendered every stored digest verbatim, and a digest is titles, project names and message text already assembled. Serve a peer's sessions while imported content is allowed, then tighten to local-only: search, stats and the agent withhold them, the page still carried them.

A stored digest has no project field, so the page recognises the names of the projects being withheld right now and drops the digests that carry them, reporting the count. Two limits worth stating: matching is by name inside the text, and a withheld project with no sessions left in the index cannot be recognised at all.

Fixes #2315.