### PR TITLE
fix(view): keep withheld projects out of the Notes tab

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -76,6 +76,8 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// NotesWithheld is how many promoted notes a trust rule kept off the page.
+	NotesWithheld int
 	// RecallsWithheld is how many stored digests a trust rule kept off the page.
 	RecallsWithheld int
 	// RecallCount is how many injections the page carries and TotalRecalls how
@@ -228,6 +230,12 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		})
 	}
 	loaded := sources.LoadPromotedNotes()
+	// A promoted note is a session's decision in the reader's own words, and it
+	// keeps the project it came from — so a note promoted from an imported
+	// session stayed on this page after a local-only rule withheld that project
+	// from search, the listing and the agent. Same gap as the digests above,
+	// with the project known exactly rather than recognised in prose (#2317).
+	loaded, page.NotesWithheld = notesAllowedOnPage(loaded)
 	// By date, newest first: LoadPromotedNotes returns them in the order they
 	// were first written to the file, so cutting that keeps an arbitrary set
 	// rather than the newest — and the page's own order was the file's.
@@ -383,4 +391,19 @@ func withoutHiddenProjects(snaps []usage.Snapshot, hidden map[string]bool) ([]us
 		}
 	}
 	return kept, len(snaps) - len(kept)
+}
+
+// notesAllowedOnPage drops the promoted notes whose project a rule withholds,
+// and says how many went. Browsing, so the search activation governs it — the
+// same activation the session list on this page is filtered by.
+func notesAllowedOnPage(notes []sources.PromotedNote) ([]sources.PromotedNote, int) {
+	p := policy.Load()
+	kept := make([]sources.PromotedNote, 0, len(notes))
+	for _, n := range notes {
+		if n.Project != "" && !p.Allows(policy.ActivationSearch, n.Project) {
+			continue
+		}
+		kept = append(kept, n)
+	}
+	return kept, len(notes) - len(kept)
 }

--- a/cmd/deja/view_note_policy_test.go
+++ b/cmd/deja/view_note_policy_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A note promoted from an imported session keeps that project. The session list
+// obeys a local-only rule and the Notes tab rendered the note whole — the same
+// gap #2315 closed for digests, one tab over (#2317).
+func TestViewWithholdsNotesFromHiddenProjects(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	rec := index.SyncRecord{
+		Harness: "claude", SessionID: "peersess", Project: "secretclient/api",
+		Role: "assistant", Text: "the quaxbolt overflow was an int32 cast",
+		Time: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+	// One note from the peer's project, one from the machine's own.
+	lines := []map[string]any{
+		{"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
+			"session": "claude:imported-1", "state": "accepted", "project": "imported:secretclient/api",
+			"title": "peer decision", "text": "the quaxbolt overflow was an int32 cast"},
+		{"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
+			"session": "claude:minesess", "state": "accepted", "project": "tmp/mine",
+			"title": "my decision", "text": "my own connection pool question"},
+	}
+	var buf strings.Builder
+	for _, l := range lines {
+		enc, err := json.Marshal(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(enc)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(notes, []byte(buf.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	if page := readFileString(t, out); !strings.Contains(page, "peer decision") {
+		t.Fatalf("the peer's note is not on the page with no policy set, so this measures nothing")
+	}
+
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	if strings.Contains(page, "peer decision") || strings.Contains(page, "secretclient") {
+		t.Errorf("the page carries a note from a project the policy withholds")
+	}
+	if !strings.Contains(page, "my decision") {
+		t.Errorf("the page dropped the machine's own note")
+	}
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -68,7 +68,7 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
 <p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} {{.RecallsWithheld}} more are held back by the trust policy.{{end}}</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
-<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}</p></div>
+<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}{{if .NotesWithheld}} {{.NotesWithheld}} more are held back by the trust policy.{{end}}</p></div>
 </div>
 <script>
 const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};


### PR DESCRIPTION
Same gap as #2316, one tab over. Promote a peer's imported session, then tighten to local-only: search, the listing and the session list on the page all withhold it, and the Notes tab still carried the note's project and text.

A promoted note keeps its `Project`, so this one is an exact check rather than the name-matching the digests need. The page reports how many notes were held back, and the count it prints as the total is now the total the reader is allowed to see.

The conventions hook is unaffected: it picks notes whose project matches the current checkout, so a peer's note never reaches an agent that way.

Fixes #2317.