### PR TITLE
fix(friction): name the rule, not the machine, when a policy empties it

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -134,6 +134,14 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			// someone lands when recall feels thin, so it is the worst place
 			// to say the history is not there (#1044).
 			fmt.Fprintln(stdout, strings.TrimPrefix(emptyIndexHint("nothing recurring"), "deja: "))
+		case len(sessions) == 0 && len(withheldSessions) > 0:
+			// The sessions that recorded tool output are exactly the ones a
+			// rule took away, and saying the machine never had them is a claim
+			// about the store rather than about the rule — the misread #637
+			// and #1044 closed elsewhere. The stderr note above says the same
+			// thing, and stdout is what a redirect keeps (#2319).
+			fmt.Fprintf(stdout, "nothing recurring — the trust policy withheld the %d session%s that recorded tool output, which is what friction reads errors from\n",
+				len(withheldSessions), pluralS(len(withheldSessions)))
 		case len(sessions) == 0:
 			fmt.Fprintf(stdout, "nothing recurring — none of the %d indexed session%s recorded tool output, which is what friction reads errors from\n",
 				total, pluralS(total))

--- a/cmd/deja/friction_policy_empty_test.go
+++ b/cmd/deja/friction_policy_empty_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// With every tool-output session withheld by a rule, friction said the machine
+// had never recorded any — a claim about the store, on the surface someone
+// reaches for when recall feels thin (#2319).
+func TestFrictionNamesTheRuleThatEmptiedIt(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own question, no commands run"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	var buf bytes.Buffer
+	for j := 0; j < 3; j++ {
+		rec := index.SyncRecord{
+			Harness: "claude", SessionID: "peer" + string(rune('0'+j)), Project: "secretclient/api",
+			Role: "tool-output", Text: "panic: quaxbolt overflow in ledger/quaxbolt.go",
+			Time: time.Date(2026, 8, 4, 12, j, 0, 0, time.UTC),
+		}
+		b, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: without a rule, friction has something to report.
+	var open bytes.Buffer
+	if err := runFriction(dir, nil, &open); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(open.String(), "quaxbolt") {
+		t.Fatalf("the imported error is not recurring even with no rule set:\n%s", open.String())
+	}
+
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	var closed bytes.Buffer
+	if err := runFriction(dir, nil, &closed); err != nil {
+		t.Fatal(err)
+	}
+	got := closed.String()
+	if strings.Contains(got, "quaxbolt") {
+		t.Fatalf("the withheld error is still on screen:\n%s", got)
+	}
+	if strings.Contains(got, "none of the") {
+		t.Errorf("friction still says the machine recorded no tool output:\n%s", got)
+	}
+	if !strings.Contains(got, "trust policy") {
+		t.Errorf("friction does not name the rule that emptied it:\n%s", got)
+	}
+}


### PR DESCRIPTION
Under a local-only rule with the tool-output sessions imported, friction printed "none of the 6 indexed sessions recorded tool output" — while its own stderr note said the policy was hiding three. Redirect stdout and only the wrong explanation survives.

The withheld count was already collected for that note; the empty branch now uses it. The mixed case (something readable, nothing recurring) keeps its sentence, which speaks about the sessions it read rather than about the machine.

Fixes #2319.