### PR TITLE
fix(view): say on the page when a trust rule emptied it

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -76,6 +76,8 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// SessionsWithheld is how many sessions a trust rule kept off the page.
+	SessionsWithheld int
 	// NotesWithheld is how many promoted notes a trust rule kept off the page.
 	NotesWithheld int
 	// RecallsWithheld is how many stored digests a trust rule kept off the page.
@@ -184,6 +186,10 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		GeneratedAt:   time.Now().Format("2006-01-02 15:04"),
 		TotalSessions: report.TotalSessions,
 		Harnesses:     len(report.Harnesses),
+		// On the page too, not only on stderr: the file is what someone looks
+		// at and passes on, and a page a rule emptied read as a machine with
+		// no history at all — the misread #2319 closed on friction (#2321).
+		SessionsWithheld: policyHidden,
 	}
 	if len(metas) > 0 {
 		page.DateEnd = metas[0].Updated.Local().Format("2006-01-02")

--- a/cmd/deja/view_all_withheld_test.go
+++ b/cmd/deja/view_all_withheld_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A page a rule emptied read as a machine with no history: no sessions, a bare
+// arrow for the date range, and a note counting zero "most recent sessions".
+// The reason was on stderr, and the file is the thing people look at (#2321).
+func TestViewSaysWhenARuleEmptiedThePage(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":false,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	if strings.Contains(page, "connection pool question") {
+		t.Fatalf("the withheld session is on the page, so this measures nothing")
+	}
+	if !strings.Contains(page, "trust policy") {
+		t.Errorf("the page does not say a rule emptied it:\n%s", pageStatsBlock(page))
+	}
+	if strings.Contains(page, "the 0 most recent sessions") {
+		t.Errorf("the page counts zero most-recent sessions:\n%s", pageStatsBlock(page))
+	}
+	if strings.Contains(page, "<b> → </b>") {
+		t.Errorf("the page renders an empty date range:\n%s", pageStatsBlock(page))
+	}
+}
+
+// pageStatsBlock is the head of the page body, for a readable failure.
+func pageStatsBlock(page string) string {
+	i := strings.Index(page, `class="stats"`)
+	if i < 0 {
+		return "(no stats block)"
+	}
+	end := i + 600
+	if end > len(page) {
+		end = len(page)
+	}
+	return page[i:end]
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -53,7 +53,7 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <div class="stats">
 <div class="stat"><b>{{.TotalSessions}}</b><span>sessions</span></div>
 <div class="stat"><b>{{.Harnesses}}</b><span>agents</span></div>
-<div class="stat"><b>{{.DateStart}} → {{.DateEnd}}</b><span>covered</span></div>
+<div class="stat"><b>{{if .DateStart}}{{.DateStart}} → {{.DateEnd}}{{else}}—{{end}}</b><span>covered</span></div>
 </div>
 <div class="tabs">
 <button class="on" data-tab="sessions">Sessions</button>
@@ -63,12 +63,12 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <div id="tab-sessions">
 <input type="search" id="q" placeholder="filter sessions — title, project, harness, preview text">
 <div id="list"></div>
-<p class="note">previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.</p>
+<p class="note">{{if .TotalSessions}}previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.{{else}}no sessions on this page.{{end}}{{if .SessionsWithheld}} Held back by the trust policy: {{.SessionsWithheld}}.{{end}}</p>
 </div>
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
-<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} {{.RecallsWithheld}} more are held back by the trust policy.{{end}}</p></div>
+<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} Held back by the trust policy: {{.RecallsWithheld}}.{{end}}</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
-<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}{{if .NotesWithheld}} {{.NotesWithheld}} more are held back by the trust policy.{{end}}</p></div>
+<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}{{if .NotesWithheld}} Held back by the trust policy: {{.NotesWithheld}}.{{end}}</p></div>
 </div>
 <script>
 const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};


### PR DESCRIPTION
With a policy that activates nothing for browsing, the page came out with 0 sessions, `→` for the covered range and "previews embedded for the 0 most recent sessions". The reason was on stderr, and the page is the thing that gets looked at and passed on — the misread #2319 closed on friction.

The page now carries the withheld count, says "no sessions on this page. Held back by the trust policy: N.", and renders "—" for an empty range. The Recalls and Notes sentences from #2316/#2318 were reworded to the same plural-free form.

Checked and unchanged: with 260 local and 5 imported sessions the page embeds 265 rows, 200 previews and reads 265 sessions / 2 agents; local-only gives 260 / 1 with the same 200 previews.

Fixes #2321.