### PR TITLE
fix(policy): honour the ignore rule on every surface, not just deja search

### DIFF
--- a/internal/index/ignore_paths_test.go
+++ b/internal/index/ignore_paths_test.go
@@ -1,0 +1,72 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A directory the trust policy says is not to be recalled must be unreachable
+// from every surface, not from the one that happens to filter. `WithoutIgnored`
+// was called at a single call site — the CLI's own search — so `deja doctor`
+// printed "not recalled */.claude/jobs/*" while the per-prompt hook injected
+// those sessions into every message.
+func TestIgnoredSessionsAreOutOfReachEverywhere(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "home", ".claude", "jobs", "abc", "projects")
+	proj := filepath.Join(root, "-w-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(role, text string) string {
+		return `{"type":"` + role + `","sessionId":"scratch","cwd":"/w/app",` +
+			`"timestamp":"2026-01-02T03:04:05Z","message":{"role":"` + role +
+			`","content":"` + text + `"}}`
+	}
+	if err := os.WriteFile(filepath.Join(proj, "scratch.jsonl"),
+		[]byte(strings.Join([]string{
+			line("user", "the frobnicator keeps dropping its widgets under load"),
+			line("assistant", "Decision: we pinned the frobnicator to one shard."),
+		}, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The scoring path, which is what `deja search` walks.
+	r, err := SearchWithRecoveryDetailed(dir, query.Options{Query: "frobnicator", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Sessions) != 0 {
+		t.Errorf("an ignored session came back from search: %d", len(r.Sessions))
+	}
+
+	// The relevance path, which is what a sentence-shaped question reaches.
+	r, err = SearchWithRecoveryDetailed(dir,
+		query.Options{Query: "why does the frobnicator drop widgets under load", All: true}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Sessions) != 0 {
+		t.Errorf("an ignored session came back from the relevance tier: %d", len(r.Sessions))
+	}
+
+	// The per-prompt hook's own ranking, which is the most automatic surface
+	// deja has and the one this rule most has to hold on.
+	ss, _, _, _, err := ProjectRelevantSkipping(dir, []string{"w/app", "app"},
+		[]string{"frobnicator", "widgets"}, 12, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 0 {
+		t.Errorf("an ignored session was ranked for injection: %d", len(ss))
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
 )
 
@@ -1294,6 +1295,30 @@ func sessionsServable(dir string, metas []SessionMeta, o query.Options) ([]model
 	return out, nil
 }
 
+// ignoredByPolicy is the trust rule that says a directory's sessions are not
+// to be recalled. It was applied at one call site — the CLI's own search — so
+// `deja doctor` printed "not recalled */.claude/jobs/*" while the per-prompt
+// hook injected those sessions into every message, which is the most automatic
+// surface deja has and the one where the rule matters most. The same shape as
+// #2070: a rule in one path of several is a rule half the callers do not have.
+//
+// Applied here because this is where every tier and every surface turns a
+// manifest entry into a session it can serve.
+func ignoredByPolicy(ss []model.Session) []model.Session {
+	pol := policy.Load()
+	if len(pol.IgnorePatterns()) == 0 {
+		return ss
+	}
+	out := ss[:0:0]
+	for _, s := range ss {
+		if pol.Ignored(s.Path, s.Project) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // sessionsForMetas loads full sessions for the given metas in ONE pass over
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
@@ -1323,7 +1348,7 @@ func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) 
 	for i := range out {
 		orderPromotedNote(&out[i])
 	}
-	return out, nil
+	return ignoredByPolicy(out), nil
 }
 
 // RecentProjects is RecentProject for several project names at once: one
@@ -1868,7 +1893,9 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		orderPromotedNote(s)
 		out = append(out, *s)
 	}
-	return out, nil
+	// The scoring and relevance tiers build their sessions here rather than
+	// through sessionsForMetas, so the ignore rule has to hold at both.
+	return ignoredByPolicy(out), nil
 }
 
 func cutPostingsBySession(posts []posting, m Manifest, o query.Options) []posting {


### PR DESCRIPTION
Found while building an end-to-end rig on a live agent, when `deja search` returned nothing for a store the per-prompt hook was happily injecting.

`deja doctor` prints:

```
not recalled */.claude/jobs/* (default)
```

and the rule was applied at exactly one call site — `cmd/deja/main.go`, the CLI's own search. So the sessions a user has told deja not to recall were still ranked and injected on **every message**, which is the most automatic surface deja has and the one where the rule matters most.

Measured on the rig, same store, same prompt:

```
before   hook injects an ignored session: yes (930 chars)
after    hook injects an ignored session: no
```

The same shape as #2070 and as the scratch filter that prompted #2050: a rule in one path of several is a rule half the callers do not have. It now sits at the two points where a manifest entry becomes a session anything can serve — `sessionsForMetas` for the hook's ranking and the relevance tier, and `scanRecordsWithVariants` for the scoring path, which builds its sessions separately. The test walks all three so a third path cannot quietly grow past it.

No cost when nothing is configured: the filter returns early when the policy has no patterns. longmemeval unchanged at 85.3% hit@1 / 0.895 MRR.