### PR TITLE
fix(log): record the projects a digest was built from

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -103,7 +103,7 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(os.Stderr, "deja: note — this session is %s; if you meant newer work, pass an id-prefix (see `deja last`)\n", age)
 	}
 	digest := digest.Handoff(s, handoffBudget)
-	usage.RecordDigest(dir, usage.KindHandoff, digest, 1, rawSize([]model.Session{s}))
+	usage.RecordDigestPolicyFrom(dir, usage.KindHandoff, digest, "", 1, rawSize([]model.Session{s}), projectsOf(s), "")
 	if !doExec {
 		printSanitized(stdout, digest)
 		if pasteOnly {

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -344,8 +344,8 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	out := frameRecall(body)
 	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
 	rememberInjected(dir, input.SessionID, ss)
-	usage.RecordDigestInto(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
-		terms, sessionIDs(ss)...)
+	usage.RecordDigestFrom(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
+		terms, sessionProjects(ss), sessionIDs(ss))
 	if plain {
 		fmt.Fprintln(stdout, out)
 		return nil
@@ -1018,6 +1018,22 @@ func densestMessages(msgs []model.Message, low, terms []string, cap int) []model
 		if keep[i] {
 			out = append(out, m)
 		}
+	}
+	return out
+}
+
+// sessionProjects names the projects behind a served digest, deduped in order.
+// The digest log records them so a rule tightened later can be applied to the
+// stored text without the sessions still being in the index (#2324).
+func sessionProjects(ss []model.Session) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if s.Project == "" || seen[s.Project] {
+			continue
+		}
+		seen[s.Project] = true
+		out = append(out, s.Project)
 	}
 	return out
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -307,11 +307,11 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// first recall of every session — the one an agent plans against — over
 		// the cap by its own length (#1806).
 		env, deliverEnv := environmentOnce(dir)
-		text, sessions, raw, ids, err := recallTextResult(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), recallMCPBudget-recallFrameOverhead-len(env))
+		text, sessions, raw, ids, projects, err := recallTextResultFrom(dir, a.Query, a.Harness, int(a.Limit), int(a.Offset), recallMCPBudget-recallFrameOverhead-len(env))
 		if err == nil {
 			text = frameRecall(text) + env
 			deliverEnv()
-			usage.RecordServedSnapshot(dir, usage.KindRecall, text, sessions, raw, ids, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedFrom(dir, usage.KindRecall, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "recall_context":
@@ -331,10 +331,10 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if line := buildingNowForAgent(dir); line != "" {
 			return frameRecall(line), nil
 		}
-		text, sessions, raw, ids, err := recallContextResult(dir, a.Query, a.Harness)
+		text, sessions, raw, ids, projects, err := recallContextResultFrom(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead))
-			usage.RecordServedSnapshot(dir, usage.KindContext, text, sessions, raw, ids, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedFrom(dir, usage.KindContext, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "blame":
@@ -887,14 +887,23 @@ func twinSessionsFor(dir string) map[string][]string {
 	return index.TwinSessions(metas)
 }
 
+// recallTextResult keeps the four-value shape its callers and tests read.
 func recallTextResult(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, error) {
+	text, sessions, raw, ids, _, err := recallTextResultFrom(dir, q, harness, limit, offset, budget)
+	return text, sessions, raw, ids, err
+}
+
+// recallTextResultFrom is recallTextResult plus the projects the answer was
+// built from, which the digest log records so a stored digest can be checked
+// against a rule tightened later (#2324).
+func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (string, int, int64, []string, []string, error) {
 	if limit <= 0 {
 		limit = 5
 	}
 	o := search.Options{Query: nfcfold.Compose(q), Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	stale, err := index.EnsureForSearchStale(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	}
 	if stale {
 		// A store rewrote itself (cline, cursor); rebuilding inline would
@@ -904,7 +913,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -923,7 +932,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(q), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	}
 	hits, policyHidden := policyFilterHitsCounted(policy.ActivationMCP, hits)
 	if os.Getenv("DEJA_EMBED") != "off" {
@@ -939,7 +948,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	}
 	o.Semantic = semantic
 	if len(hits) == 0 {
-		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
+		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil, nil
 	}
 	// Before the page is cut, not after: demoting inside the page is a no-op
 	// when every hit on it was rejected, and then the approaches the reader did
@@ -952,7 +961,7 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	demoted := demoteRejected(hits)
 	if offset > 0 {
 		if offset >= total {
-			return fmt.Sprintf("No more matches for %q: %d total, offset %d.", clampEcho(q), total, offset), 0, 0, nil, nil
+			return fmt.Sprintf("No more matches for %q: %d total, offset %d.", clampEcho(q), total, offset), 0, 0, nil, nil, nil
 		}
 		hits = hits[offset:]
 	}
@@ -1153,16 +1162,25 @@ func recallTextResult(dir, q, harness string, limit, offset, budget int) (string
 	out += more
 	var raw int64
 	var ids []string
+	// The projects behind the served hits, deduped in the order they appear —
+	// what the digest log records so a later rule can be applied to the digest
+	// without the sessions still being in the index (#2324).
+	var projects []string
+	seenProject := map[string]bool{}
 	for i, h := range hits {
 		if i >= served {
 			break
 		}
 		ids = append(ids, h.Session.ID)
+		if p := h.Session.Project; p != "" && !seenProject[p] {
+			seenProject[p] = true
+			projects = append(projects, p)
+		}
 		for _, m := range h.Session.Messages {
 			raw += int64(len(m.Text))
 		}
 	}
-	return out, served, raw, ids, nil
+	return out, served, raw, ids, projects, nil
 }
 
 // cutMarker ends a line the page budget cut, matching what an excerpt
@@ -1238,16 +1256,24 @@ func contextByID(dir, q string) (string, idContext, bool) {
 	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole})}, true
 }
 
+// recallContextResult keeps the four-value shape its callers and tests read.
 func recallContextResult(dir, q, harness string) (string, int, int64, []string, error) {
+	text, sessions, raw, ids, _, err := recallContextResultFrom(dir, q, harness)
+	return text, sessions, raw, ids, err
+}
+
+// recallContextResultFrom is recallContextResult plus the project behind the
+// session it served, for the reason recallTextResultFrom exists (#2324).
+func recallContextResultFrom(dir, q, harness string) (string, int, int64, []string, []string, error) {
 	o := search.Options{Query: nfcfold.Compose(q), Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	if stale, err := index.EnsureForSearchStale(dir, o, mcpProgress()); err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	} else if stale {
 		requestWarmup(dir)
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -1266,7 +1292,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(q), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
-		return "", 0, 0, nil, err
+		return "", 0, 0, nil, nil, err
 	}
 	hits, policyHidden := policyFilterHitsCounted(policy.ActivationMCP, hits)
 	var semantic bool
@@ -1285,9 +1311,9 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 		// After the search, like the CLI does since #1614: there is no answer
 		// left for the id to shadow.
 		if text, id, ok := contextByID(dir, q); ok {
-			return text, 1, id.size, []string{id.session}, nil
+			return text, 1, id.size, []string{id.session}, nil, nil
 		}
-		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil
+		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil, nil
 	}
 	// The same order the search screen shows: this handed the agent a session
 	// the reader had rejected, while search demoted it and said why (#1099).
@@ -1307,7 +1333,7 @@ func recallContextResult(dir, q, harness string) (string, int, int64, []string, 
 	if hits[0].Tier != search.TierExact {
 		text = "[" + hits[0].Tier + "]\n" + text
 	}
-	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, nil
+	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole), nil
 }
 
 func mcpProgress() io.Writer {
@@ -1421,4 +1447,13 @@ func buildingNowForBlockingTool(dir string) string {
 	// version, an index directory nobody can write — is the same sentence the
 	// reading tools get, so it is answered in one place rather than copied.
 	return buildingNowForAgent(dir)
+}
+
+// projectsOf names the project a session belongs to, as a list, for the digest
+// record. Empty for a session that carries none.
+func projectsOf(s model.Session) []string {
+	if s.Project == "" {
+		return nil
+	}
+	return []string{s.Project}
 }

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -114,7 +114,7 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	text := frameRecall(b.String())
 	// It also left no trace: a whole session reached the agent and `deja log`
 	// stayed empty — the gap #682 closed for blame.
-	usage.RecordServedSnapshot(dir, usage.KindResource, text, 1, rawSize([]model.Session{s}), []string{s.ID}, policy.Load().Describe(policy.ActivationMCP))
+	usage.RecordServedFrom(dir, usage.KindResource, text, 1, rawSize([]model.Session{s}), []string{s.ID}, projectsOf(s), policy.Load().Describe(policy.ActivationMCP))
 	return map[string]any{"contents": []map[string]any{{
 		"uri":      uri,
 		"mimeType": "text/markdown",

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -380,23 +380,37 @@ func openInBrowser(path string) {
 // says how many went. Substring rather than equality: the digest renders the
 // project inside a line of prose, and the name is what a reader would see.
 func withoutHiddenProjects(snaps []usage.Snapshot, hidden map[string]bool) ([]usage.Snapshot, int) {
-	if len(hidden) == 0 {
-		return snaps, 0
-	}
+	pol := policy.Load()
 	kept := make([]usage.Snapshot, 0, len(snaps))
 	for _, sn := range snaps {
-		withheld := false
-		for project := range hidden {
-			if strings.Contains(sn.Digest, project) {
-				withheld = true
-				break
-			}
+		if snapshotWithheld(pol, sn, hidden) {
+			continue
 		}
-		if !withheld {
-			kept = append(kept, sn)
-		}
+		kept = append(kept, sn)
 	}
 	return kept, len(snaps) - len(kept)
+}
+
+// snapshotWithheld decides whether a stored digest may go on the page. A record
+// that names its own projects is answered by the policy alone, which is what
+// makes it right when the sessions behind it have left the index (#2324). One
+// written before that field existed can only be recognised by the names of the
+// projects a rule is hiding now, and that is the older, weaker test.
+func snapshotWithheld(pol policy.Policy, sn usage.Snapshot, hidden map[string]bool) bool {
+	if len(sn.Projects) > 0 {
+		for _, project := range sn.Projects {
+			if !pol.Allows(policy.ActivationSearch, project) {
+				return true
+			}
+		}
+		return false
+	}
+	for project := range hidden {
+		if strings.Contains(sn.Digest, project) {
+			return true
+		}
+	}
+	return false
 }
 
 // notesAllowedOnPage drops the promoted notes whose project a rule withholds,

--- a/cmd/deja/view_recall_forgotten_project_test.go
+++ b/cmd/deja/view_recall_forgotten_project_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// #2316 recognises a withheld project by its name, learned from the sessions in
+// the index. Forget those sessions and the name is unknown, so the digest went
+// back onto the page. The record now carries the projects it was built from,
+// which the policy can answer for on its own (#2324).
+func TestViewWithholdsADigestWhoseProjectIsGone(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// A digest served from a peer's project, with no session of that project
+	// left in the index — forgotten, or simply never indexed here again.
+	usage.RecordServedFrom(dir, usage.KindRecall,
+		"<deja-recall>\n1. [claude] a peer project · the quaxbolt overflow was an int32 cast\n",
+		1, 400, nil, []string{"imported:secretclient/api"}, "local+imported")
+	usage.RecordServedFrom(dir, usage.KindRecall,
+		"<deja-recall>\n1. [claude] tmp/mine · my own connection pool question\n",
+		1, 400, nil, []string{"tmp/mine"}, "local+imported")
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	if page := readFileString(t, out); !strings.Contains(page, "int32 cast") {
+		t.Fatalf("the peer's digest is not on the page with no rule set, so this measures nothing")
+	}
+
+	policyPath := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	if strings.Contains(page, "int32 cast") {
+		t.Errorf("a digest from a withheld project is on the page, though no session of it is left to name it")
+	}
+	if !strings.Contains(page, "my own connection pool question") {
+		t.Errorf("the page dropped a digest about the machine's own work")
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -537,8 +537,10 @@ never disagree about whether something happened.
 `deja log --last --json` is a different shape: one object, the most recent
 injected digest itself. It carries `t` and `kind` as above, the `digest` text,
 `bytes`, and — each omitted when empty — `sessions`, the `policy` that allowed
-the injection, the `terms` behind a déjà vu firing, and `into`, the agent session
-it went to. It is `null` when no digest has been recorded: one object is the
+the injection, the `terms` behind a déjà vu firing, `into`, the agent session
+it went to, and `projects`, the projects the digest was built from. `projects`
+is absent on records written before it existed and on injections whose writer
+does not know them. It is `null` when no digest has been recorded: one object is the
 shape, and that is how a missing one is spelled.
 
 ## `deja blame <path> --json`

--- a/internal/usage/log_json_contract_test.go
+++ b/internal/usage/log_json_contract_test.go
@@ -47,8 +47,11 @@ func TestLogJSONShapesAreStable(t *testing.T) {
 	// went to, which the log never recorded. Without it the only measure of
 	// whether a recall was used is the sentence the block asks the agent to
 	// say — 22 of 1218 injections on a real store, which counts reporting.
+	// "projects" is additive and optional: the trust policy answers for a
+	// project name with no index at all, so a record that names its own
+	// projects can be held to a rule tightened after it was written (#2324).
 	assertShape(t, "Snapshot", topLevelJSONKeys(Snapshot{}), map[string]bool{
 		"t": true, "kind": true, "sessions": true, "bytes": true,
-		"policy": true, "terms": true, "into": true, "digest": true,
+		"policy": true, "terms": true, "into": true, "projects": true, "digest": true,
 	})
 }

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -34,8 +34,13 @@ type Snapshot struct {
 	// tell whether a recall was used is the sentence the block asks the agent
 	// to say — measured on a real store, that sentence appears after 22 of 1218
 	// injections, which measures reporting rather than use.
-	Into   string `json:"into,omitempty"`
-	Digest string `json:"digest"`
+	Into string `json:"into,omitempty"`
+	// Projects names the projects the digest was built from. The trust policy
+	// answers for a project name with no index at all, so a record that names
+	// its own projects can be checked against a rule tightened after it was
+	// written — even when the sessions behind it are gone (#2324).
+	Projects []string `json:"projects,omitempty"`
+	Digest   string   `json:"digest"`
 }
 
 const (
@@ -104,6 +109,22 @@ func RecordDigestTerms(indexDir, kind, digest string, sessions int, raw int64, t
 	RecordDigestInto(indexDir, kind, digest, "", sessions, raw, terms, ids...)
 }
 
+// RecordDigestFrom is RecordDigestInto plus the projects the digest was built
+// from, for the reason RecordServedFrom exists.
+func RecordDigestFrom(indexDir, kind, digest, into string, sessions int, raw int64, terms, projects, ids []string) {
+	at := time.Now().UTC()
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, "", terms, projects, at)
+}
+
+// RecordDigestPolicyFrom is RecordDigestPolicyInto for a caller that knows the
+// projects behind the digest, for the reason RecordServedFrom exists.
+func RecordDigestPolicyFrom(indexDir, kind, digest, into string, sessions int, raw int64, projects []string, policyName string) {
+	at := time.Now().UTC()
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, nil, into, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, projects, at)
+}
+
 // RecordDigestInto is RecordDigestTerms knowing which agent session received
 // the injection, so a later reading of the store can ask whether it was used.
 func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int64, terms []string, ids ...string) {
@@ -112,7 +133,7 @@ func RecordDigestInto(indexDir, kind, digest, into string, sessions int, raw int
 	// with nothing else to join them on (#2294).
 	at := time.Now().UTC()
 	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at)
-	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, "", terms, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, "", terms, nil, at)
 }
 
 // RecordDigestPolicy is RecordDigest plus the name of the policy that allowed
@@ -129,7 +150,7 @@ func RecordDigestPolicy(indexDir, kind, digest string, sessions int, raw int64, 
 func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, raw int64, policyName string) {
 	at := time.Now().UTC()
 	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, nil, into, at)
-	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, nil, at)
 }
 
 // RecordServedSnapshot writes the counting event and the digest snapshot for
@@ -137,9 +158,17 @@ func RecordDigestPolicyInto(indexDir, kind, digest, into string, sessions int, r
 // writers back to back, which took two instants for one act and left `deja
 // log` and `deja log --last` disagreeing about when it happened (#2294).
 func RecordServedSnapshot(indexDir, kind, digest string, sessions int, raw int64, ids []string, policyName string) {
+	RecordServedFrom(indexDir, kind, digest, sessions, raw, ids, nil, policyName)
+}
+
+// RecordServedFrom is RecordServedSnapshot for a caller that knows which
+// projects the digest was built from. Without them a stored digest can only be
+// checked against a later rule by recognising project names inside its own
+// prose, which fails as soon as the sessions behind it leave the index (#2324).
+func RecordServedFrom(indexDir, kind, digest string, sessions int, raw int64, ids, projects []string, policyName string) {
 	at := time.Now().UTC()
 	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, "", at)
-	snapshotWriteIntoAt(indexDir, kind, digest, "", sessions, policyName, nil, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, "", sessions, policyName, nil, projects, at)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for
@@ -205,12 +234,12 @@ func runeBoundaryAt(s string, n int) int {
 }
 
 func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policyName string, terms []string) {
-	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, terms, time.Now().UTC())
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, terms, nil, time.Now().UTC())
 }
 
 // snapshotWriteIntoAt is snapshotWriteInto with the instant supplied, so a
 // caller writing both logs for one injection can stamp them alike (#2294).
-func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, policyName string, terms []string, at time.Time) {
+func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, policyName string, terms, projects []string, at time.Time) {
 	if digest == "" {
 		return
 	}
@@ -219,7 +248,8 @@ func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, poli
 		return
 	}
 	b, err := marshalSnapshot(Snapshot{Time: at, Kind: kind, Sessions: sessions,
-		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into, Digest: clipDigest(digest)})
+		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into,
+		Projects: projects, Digest: clipDigest(digest)})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
#2316 keeps withheld projects off the view page by recognising their names inside the digest text, and it learns those names from the sessions still in the index. Forget the sessions and the name is unknown, so the digest goes back on the page.

A snapshot now records the projects behind it, which the trust policy can answer for with no index at all. The page prefers that and falls back to the old name match for records written earlier. Additive field; contract test and docs updated.

Carried by the paths that serve content from other projects — MCP recall, recall_context, resource reads, handoff and the prompt hook. The session-start hook digests are about the checkout you are in, so they keep the old behaviour.

Found alongside it and filed separately as #2325: forget drops the messages and the injection log keeps the text, so the page republishes forgotten content with no rule in play.

Fixes #2324.