### PR TITLE
test(usage): cover the writers that record a digest's projects

### DIFF
--- a/internal/usage/projects_test.go
+++ b/internal/usage/projects_test.go
@@ -1,0 +1,96 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A stored digest outlives the rule it was served under, and the only way to
+// hold it to a later one was recognising project names inside its own prose —
+// which fails as soon as those sessions leave the index. The record names its
+// own projects now (#2324).
+func TestASnapshotNamesTheProjectsItWasBuiltFrom(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordServedFrom(dir, KindRecall, "a digest of two projects", 2, 900,
+		[]string{"claude:abc", "claude:def"},
+		[]string{"work/app", "imported:secretclient/api"}, "local+imported")
+
+	got := lastSnapshot(t, dir)
+	if len(got.Projects) != 2 || got.Projects[0] != "work/app" || got.Projects[1] != "imported:secretclient/api" {
+		t.Errorf("projects = %v, want both, in the order they were served", got.Projects)
+	}
+	if got.Kind != KindRecall || got.Sessions != 2 || got.Policy != "local+imported" {
+		t.Errorf("the rest of the record changed: %+v", got)
+	}
+	// The paired event is written by the same call, stamped alike.
+	events := Events(dir, 0)
+	if len(events) != 1 || !events[0].Time.Equal(got.Time) {
+		t.Errorf("events = %+v, want one stamped like the digest at %s", events, got.Time)
+	}
+}
+
+// The déjà-vu hook knows the receiving session, the terms and the projects.
+func TestADejaVuDigestRecordsTermsAndProjects(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestFrom(dir, KindDejaVu, "a block worth reading", "ses_1234", 1, 400,
+		[]string{"quaxbolt"}, []string{"work/app"}, []string{"claude:abc"})
+
+	got := lastSnapshot(t, dir)
+	if got.Into != "ses_1234" || len(got.Terms) != 1 || len(got.Projects) != 1 {
+		t.Errorf("record = %+v, want the receiver, the terms and the project", got)
+	}
+	if events := Events(dir, 0); len(events) != 1 || events[0].Into != "ses_1234" {
+		t.Errorf("events = %+v, want the receiver on the event too", events)
+	}
+}
+
+// handoff writes a digest of one session under a named policy and no receiver.
+func TestAPolicyDigestWithProjectsOmitsWhatItDoesNotKnow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordDigestPolicyFrom(dir, KindHandoff, "a handoff", "", 1, 100,
+		[]string{"work/app"}, "local-only")
+
+	got := lastSnapshot(t, dir)
+	if got.Into != "" || got.Policy != "local-only" || len(got.Projects) != 1 {
+		t.Errorf("record = %+v", got)
+	}
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `"into"`) || strings.Contains(string(b), `"terms"`) {
+		t.Errorf("empty fields were written out: %s", strings.TrimSpace(string(b)))
+	}
+}
+
+// A writer that knows no projects leaves the field out, so a reader sees what
+// it saw before the field existed.
+func TestASnapshotWithoutProjectsOmitsTheField(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordServedSnapshot(dir, KindRecall, "a digest", 1, 100, []string{"claude:abc"}, "")
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `"projects"`) {
+		t.Errorf("empty projects were written out: %s", strings.TrimSpace(string(b)))
+	}
+}
+
+func lastSnapshot(t *testing.T, dir string) Snapshot {
+	t.Helper()
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	var got Snapshot
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &got); err != nil {
+		t.Fatal(err)
+	}
+	return got
+}


### PR DESCRIPTION
#2326 added RecordServedFrom / RecordDigestFrom / RecordDigestPolicyFrom with no package-level tests, and internal/usage fell to 93.8% against its 95% floor — the check I merged over. Back to 95.6%, and the tests assert what the record should hold: the projects in served order, the paired event sharing the stamp, and empty fields staying out of the line.