### PR TITLE
fix(recall): stop one rare word deciding which session answers

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -214,9 +214,20 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// The one word of the question that identifies something, kept apart for
 	// the test below: asking whether any term was spoken lets "показал" answer
 	// for "v11", and nearly every session says a word like that.
+	// The words of the question that identify something, kept apart for the
+	// test below: asking whether ANY term was spoken lets "показал" answer for
+	// "v11", and nearly every session says a word like that.
+	//
+	// One word was too few. Rareness is measured against this corpus, and in a
+	// small or homogeneous one it crowns whichever ordinary noun happens to be
+	// uncommon: on a seeded store the question "the orders service runs out of
+	// db connections" led on "service", so the session that settled it — which
+	// says "orders worker" and never "service" — was dropped at this gate
+	// while a neighbour about the reporting service was served in its place.
+	// The ranking had already put the right one first with two strong terms.
 	leadTerms := terms
 	if ordered := byIdentifying(terms, idfOf); len(ordered) > 0 {
-		leadTerms = ordered[:1]
+		leadTerms = ordered[:min(len(ordered), leadTermsKept)]
 	}
 	pol := policy.Load()
 	for i, s := range ranked {
@@ -288,6 +299,16 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			if len(s.Messages) == 0 {
 				continue
 			}
+		}
+		// Two slots, two answers. The same content reaches the block from
+		// several sessions all the time — a marathon that was split, a
+		// resumed session, a workflow run again — and spending both slots on
+		// it costs the reader the second answer entirely. Measured on a
+		// seeded store where the question drifted from the wording of the
+		// session that settled it, both slots went to two copies of one
+		// neighbour on every framing but the near-verbatim one.
+		if sameAnswerAs(ss, s, terms) {
+			continue
 		}
 		ss = append(ss, s)
 		if len(ss) == 2 {
@@ -405,6 +426,46 @@ func askedBeforeWhen(s model.Session) string {
 	}
 	return " (" + s.Updated.Local().Format("2006-01-02") + ")"
 }
+
+// sameAnswerAs reports whether this session would say what one already chosen
+// says. Judged on the lines the question actually matched rather than on the
+// whole transcript: two sessions of the same workflow differ everywhere else
+// and agree exactly where it matters.
+func sameAnswerAs(chosen []model.Session, s model.Session, terms []string) bool {
+	next := matchedFingerprint(s, terms)
+	if next == "" {
+		return false
+	}
+	for _, c := range chosen {
+		if matchedFingerprint(c, terms) == next {
+			return true
+		}
+	}
+	return false
+}
+
+// matchedFingerprint is the session's matching lines, normalised, hashed. Empty
+// when nothing matched, which is not a duplicate of anything.
+func matchedFingerprint(s model.Session, terms []string) string {
+	var b strings.Builder
+	for _, m := range s.Messages {
+		if !search.SpeechCarriesAnyTerm(model.Session{Messages: []model.Message{m}}, terms) {
+			continue
+		}
+		b.WriteString(strings.Join(strings.Fields(strings.ToLower(m.Text)), " "))
+		b.WriteByte('\n')
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return blockFingerprint(b.String())
+}
+
+// leadTermsKept is how many of the question's identifying words a session may
+// be judged on. Three rather than one: the gate exists to reject a session
+// that matched only where a tool printed the subject, and three of the rarest
+// words still keep the ordinary ones out.
+const leadTermsKept = 3
 
 // promptTermsWorthAsking is the gate before the index is touched. Two terms
 // were required, which silenced the sharpest prompt there is: "do we need

--- a/cmd/deja/lead_terms_test.go
+++ b/cmd/deja/lead_terms_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The gate that asks whether a session's speech carries the subject was given
+// one word: the rarest by IDF. Rareness is measured against the corpus, and in
+// a small or homogeneous one it crowns whichever ordinary noun happens to be
+// uncommon. Measured on a seeded store, "the orders service runs out of db
+// connections" led on "service", so the session that settled it — which says
+// "orders worker" and never "service" — was dropped here while a neighbour
+// about the reporting service took its place.
+func TestTheLeadIsMoreThanOneWord(t *testing.T) {
+	terms := []string{"orders", "service", "runs", "db", "connections", "traffic"}
+	idf := map[string]float64{
+		"service": 5.54, "orders": 4.90, "traffic": 4.10,
+		"connections": 2.20, "runs": 1.80, "db": 1.10,
+	}
+	ordered := byIdentifying(terms, idf)
+	lead := ordered[:min(len(ordered), leadTermsKept)]
+	if len(lead) < 2 {
+		t.Fatalf("the gate still rests on one word: %v", lead)
+	}
+
+	answered := model.Session{ID: "answered", Messages: []model.Message{
+		{Role: "user", Text: "the orders worker keeps dropping connections under load"},
+		{Role: "assistant", Text: "Decision: default_query_exec_mode=exec on the pgx pool."},
+	}}
+	if !search.SpeechCarriesAnyTerm(answered, lead) {
+		t.Error("the session that settled it is still dropped at the gate")
+	}
+
+	// And the gate keeps doing its job: a session that names the subject only
+	// where a tool printed it is still refused.
+	toolOnly := model.Session{ID: "tool-only", Messages: []model.Message{
+		{Role: "user", Text: "run the suite"},
+		{Role: "tool-output", Text: "orders service traffic connections all over the log"},
+	}}
+	if search.SpeechCarriesAnyTerm(toolOnly, lead) {
+		t.Error("a session that only printed the subject passed the gate")
+	}
+}
+
+// Two slots are two answers. The same content arrives from several sessions all
+// the time — a split marathon, a resumed session, a workflow run again — and
+// spending both on it costs the reader the second answer.
+func TestTwoSlotsDoNotHoldTheSameAnswer(t *testing.T) {
+	terms := []string{"reporting", "connections"}
+	first := model.Session{ID: "a", Messages: []model.Message{
+		{Role: "user", Text: "the reporting service is exhausting its database connections"},
+		{Role: "assistant", Text: "Decision: we moved reporting to a read replica."},
+	}}
+	copyOf := model.Session{ID: "b", Messages: first.Messages}
+	different := model.Session{ID: "c", Messages: []model.Message{
+		{Role: "user", Text: "reporting connections spike after the nightly import"},
+		{Role: "assistant", Text: "Decision: we throttled the import to four workers."},
+	}}
+	if !sameAnswerAs([]model.Session{first}, copyOf, terms) {
+		t.Error("a second copy of the same answer was not recognised")
+	}
+	if sameAnswerAs([]model.Session{first}, different, terms) {
+		t.Error("a different answer was refused as a duplicate")
+	}
+	if sameAnswerAs(nil, first, terms) {
+		t.Error("the first session was called a duplicate of nothing")
+	}
+}


### PR DESCRIPTION
Measured on the end-to-end rig, rebuilt outside `~/.claude/jobs` after #2323 showed every number taken there was void.

The rig: one session that settled something, 300 sessions of unrelated work, and 32 **neighbours** — sessions about pools, connections and pgbouncer that settled something else. Then the same question at four distances from the wording of the session that answers it.

```
                     before   after
near-verbatim          yes      yes
reworded               no       yes
different framing      no       no
almost no shared words no       no
```

**What was wrong.** Both rankings — the hook's and `deja search`'s — put the right session first on the reworded question. It was dropped afterwards, by the gate that asks whether the session's own speech carries the subject. That gate is given one word: the rarest by IDF. Rareness is measured against the corpus, and a small or homogeneous one crowns whichever ordinary noun happens to be uncommon — here `service`. The session that settled it says "orders worker" and never "service"; a neighbour about the *reporting service* did, and took its place. The ranking had already scored the right one with two strong terms.

The gate now sees the three most identifying words instead of one. It still does what it exists for: a session that names the subject only where a tool printed it is still refused, and `bench prompt`'s `tool_only` arm still passes.

**Second, smaller thing found by the same rig.** Both slots of the block went to two copies of one session — the same content reaches recall from several sessions constantly (a split marathon, a resumed session, a workflow run again). The second slot now has to say something different.

Attributed separately: the gate alone produces the `no → yes` above; the dedup alone does not move it, it stops the waste.

Benches unchanged, arm for arm, and longmemeval at 85.3% hit@1 / 0.895 MRR.