### PR TITLE
fix(forget): take the digests of what it forgot out of the injection log

### DIFF
--- a/cmd/deja/forget_digests_test.go
+++ b/cmd/deja/forget_digests_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// forget drops the messages and adds tombstones; the injection log kept the
+// digests served from them, so `deja view` republished forgotten text with no
+// trust rule in play (#2325).
+func TestForgetTakesTheDigestsOfWhatItForgot(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	rec := index.SyncRecord{
+		Harness: "claude", SessionID: "peersess", Project: "secretclient/api",
+		Role: "assistant", Text: "the quaxbolt overflow was an int32 cast",
+		Time: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+	usage.RecordServedFrom(dir, usage.KindRecall,
+		"<deja-recall>\n1. the quaxbolt overflow was an int32 cast\n", 1, 400, nil,
+		[]string{"imported:secretclient/api"}, "local+imported")
+	usage.RecordServedFrom(dir, usage.KindRecall,
+		"<deja-recall>\n1. my own connection pool question\n", 1, 400, nil,
+		[]string{"tmp/mine"}, "local+imported")
+
+	if _, err := captureRun(t, "forget", "--project", "imported:secretclient/api"); err != nil {
+		t.Fatal(err)
+	}
+
+	log, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(log), "int32 cast") {
+		t.Errorf("the forgotten project's digest is still in the injection log")
+	}
+	if !strings.Contains(string(log), "my own connection pool question") {
+		t.Errorf("forget took a digest that belongs to another project")
+	}
+	// The events stay: they record that something was served, which is what
+	// the counters read.
+	if events := usage.Events(dir, 0); len(events) != 2 {
+		t.Errorf("events = %d, want both — an event is what happened, not the content", len(events))
+	}
+}
+
+// --dry-run says what it would take and takes nothing.
+func TestForgetDryRunLeavesTheDigestsAlone(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"a question about pools"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	usage.RecordServedFrom(dir, usage.KindRecall, "<deja-recall>\n1. a question about pools\n", 1, 400, nil,
+		[]string{"tmp/mine"}, "")
+
+	out, err := captureRun(t, "forget", "--project", "tmp/mine", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "digest") {
+		t.Errorf("the dry run does not say the digests would go:\n%s", out)
+	}
+	log, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(log), "a question about pools") {
+		t.Errorf("a dry run removed a digest")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2875,6 +2875,9 @@ func runForget(dir string, args []string) error {
 		if line := forgetNotesLine(result); line != "" {
 			fmt.Fprintln(os.Stdout, line)
 		}
+		if n := usage.CountSnapshots(dir, forgetDigestMatcher(o, result.Keys)); n > 0 {
+			fmt.Fprintf(os.Stdout, "would remove: %d stored digest(s) from the injection log\n", n)
+		}
 		// Two transcripts can write the same harness:id, and then one manifest
 		// row holds both conversations. The build says so once (#698); forget
 		// said "1 session" and took two, from two projects (#970).
@@ -2914,6 +2917,15 @@ func runForget(dir string, args []string) error {
 			} else if gone > 0 {
 				fmt.Fprintf(os.Stdout, "removed %d promoted note%s from %s\n", gone, pluralS(gone), sources.NotesFile())
 			}
+		}
+		// The digests those sessions were served in are content too, and the
+		// page publishes them: forget already reaches the note log for the
+		// same reason (#690, #841). The usage log stays — an event is what
+		// happened, not what was said (#2325).
+		if gone, err := usage.ForgetSnapshots(dir, forgetDigestMatcher(o, result.Keys)); err != nil {
+			fmt.Fprintf(os.Stdout, "could not remove stored digests from the injection log: %v\n", err)
+		} else if gone > 0 {
+			fmt.Fprintf(os.Stdout, "removed %d stored digest%s from the injection log\n", gone, pluralS(gone))
 		}
 		n, err := sources.ForgetPromotedTitles(func(src string) bool {
 			return dropped[src]
@@ -3859,4 +3871,35 @@ func joinCapped(items []string, n int) string {
 		return strings.Join(items, ", ")
 	}
 	return strings.Join(items[:n], ", ") + fmt.Sprintf(", +%d more", len(items)-n)
+}
+
+// forgetDigestMatcher decides which stored digests belong to what a forget just
+// took. A record written since #2324 names its own projects, which is exact; an
+// older one is recognised by the ids and project name inside its text, the same
+// weaker test the view page falls back to.
+func forgetDigestMatcher(o index.ForgetOptions, keys []string) func(usage.Snapshot) bool {
+	ids := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if _, id, ok := strings.Cut(k, ":"); ok && id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return func(s usage.Snapshot) bool {
+		if o.Project != "" {
+			for _, p := range s.Projects {
+				if p == o.Project {
+					return true
+				}
+			}
+			if len(s.Projects) == 0 && strings.Contains(s.Digest, o.Project) {
+				return true
+			}
+		}
+		for _, id := range ids {
+			if strings.Contains(s.Digest, id) {
+				return true
+			}
+		}
+		return false
+	}
 }

--- a/internal/usage/projects_test.go
+++ b/internal/usage/projects_test.go
@@ -94,3 +94,53 @@ func lastSnapshot(t *testing.T, dir string) Snapshot {
 	}
 	return got
 }
+
+// forget takes the messages and the notes' borrowed titles; the digests served
+// from those sessions stayed, so a page republished forgotten text (#2325).
+func TestForgetSnapshotsDropsWhatItIsToldAndNothingElse(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	RecordServedFrom(dir, KindRecall, "a peer digest", 1, 100, nil, []string{"imported:client/api"}, "")
+	RecordServedFrom(dir, KindRecall, "my own digest", 1, 100, nil, []string{"work/app"}, "")
+
+	match := func(s Snapshot) bool {
+		for _, p := range s.Projects {
+			if p == "imported:client/api" {
+				return true
+			}
+		}
+		return false
+	}
+	if n := CountSnapshots(dir, match); n != 1 {
+		t.Fatalf("CountSnapshots = %d, want the one record that matches", n)
+	}
+	gone, err := ForgetSnapshots(dir, match)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gone != 1 {
+		t.Errorf("dropped %d records, want 1", gone)
+	}
+	left := Snapshots(dir, 0)
+	if len(left) != 1 || left[0].Digest != "my own digest" {
+		t.Errorf("what is left = %+v, want the other project's digest", left)
+	}
+	// The events stay: they say something was served, not what it said.
+	if events := Events(dir, 0); len(events) != 2 {
+		t.Errorf("events = %d, want both", len(events))
+	}
+	// A sweep that matches nothing rewrites nothing.
+	if n, err := ForgetSnapshots(dir, match); err != nil || n != 0 {
+		t.Errorf("second sweep dropped %d (err %v), want 0", n, err)
+	}
+}
+
+// An empty log is not an error, and there is nothing to count in it.
+func TestForgetSnapshotsOnAnEmptyLog(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	if n, err := ForgetSnapshots(dir, func(Snapshot) bool { return true }); err != nil || n != 0 {
+		t.Errorf("ForgetSnapshots on an empty log = %d, %v", n, err)
+	}
+	if n := CountSnapshots(dir, func(Snapshot) bool { return true }); n != 0 {
+		t.Errorf("CountSnapshots on an empty log = %d", n)
+	}
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -463,3 +463,59 @@ func boundTerms(terms []string) []string {
 	}
 	return out
 }
+
+// ForgetSnapshots drops the stored digests a predicate names and returns how
+// many went. `deja forget` takes the messages out of the index and the notes'
+// borrowed titles out of the note log (#690, #841); the digests served from
+// those sessions stayed here, and `deja view` published the text again with no
+// trust rule in play (#2325).
+//
+// The usage log is left alone on purpose: it records that something was served,
+// at a size, at a time — an event rather than the content, which is what keeps
+// the counters honest after a forget.
+//
+// Like the rotation, this rewrites the file from what the reader accepts, so a
+// line deja could not have written goes with it — the side effect #1946 named
+// rather than left to be discovered.
+func ForgetSnapshots(indexDir string, drop func(Snapshot) bool) (int, error) {
+	p := SnapshotPath(indexDir)
+	snaps := snapshotsFrom(p, 0) // last appended first
+	if len(snaps) == 0 {
+		return 0, nil
+	}
+	var buf bytes.Buffer
+	gone := 0
+	// Back to the order the file was written in, so the surviving records keep
+	// their positions: the rotation and `--last` both read this file as
+	// appended (#2140).
+	for i := len(snaps) - 1; i >= 0; i-- {
+		if drop(snaps[i]) {
+			gone++
+			continue
+		}
+		b, err := marshalSnapshot(snaps[i])
+		if err != nil {
+			continue
+		}
+		buf.Write(append(b, '\n'))
+	}
+	if gone == 0 {
+		return 0, nil
+	}
+	if err := atomicfile.Write(p, buf.Bytes(), 0o600); err != nil {
+		return 0, err
+	}
+	return gone, nil
+}
+
+// CountSnapshots says how many stored digests a predicate names, without
+// touching the file — what `forget --dry-run` reports.
+func CountSnapshots(indexDir string, match func(Snapshot) bool) int {
+	n := 0
+	for _, s := range snapshotsFrom(SnapshotPath(indexDir), 0) {
+		if match(s) {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
`deja forget --project X` dropped the messages and added tombstones; the digests served from those sessions stayed in the injection log, and `deja view` published the text again — no trust rule involved.

forget already reaches past the manifest for this reason: it removes a promoted note when the reader named its session (#841) and always strips the title a note borrowed from a forgotten one (#690). The digest log is now part of that sweep, matched exactly by the `projects` field from #2324 and, for older records, by the ids and project name inside the digest text.

The usage event log stays: it records that something was served, at a size, at a time — an event, not the content — which is what keeps `stats` and the impact report honest after a forget. `--dry-run` says what would go and touches nothing.

Fixes #2325.