### PR TITLE
fix(forget): match a digest where it names a project, not anywhere in its text

### DIFF
--- a/cmd/deja/forget_digest_match_test.go
+++ b/cmd/deja/forget_digest_match_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The fallback for records written before projects were recorded matched the
+// project name anywhere in the digest, so `forget --project api` deleted a
+// digest about work/web that said "a late api call" (#2330).
+func TestForgetMatchesTheProjectWhereADigestNamesIt(t *testing.T) {
+	match := forgetDigestMatcher(index.ForgetOptions{Project: "api"}, nil)
+
+	elsewhere := usage.Snapshot{Digest: "<deja-recall>\n1. [claude] work/web · claude:b0 · 2 matches\n   the layout shift came from a late api call\n"}
+	if match(elsewhere) {
+		t.Errorf("a digest about work/web was matched because its text says \"api\"")
+	}
+	listed := usage.Snapshot{Digest: "<deja-recall>\n1. [claude] api · claude:a0 · 2 matches\n   the gateway timeout was a read deadline\n"}
+	if !match(listed) {
+		t.Errorf("a digest whose listing names the project was not matched")
+	}
+	hookBlock := usage.Snapshot{Digest: "<deja-recall>\n- **api** `a0` · 2026-08-28\n  the gateway timeout was a read deadline\n"}
+	if !match(hookBlock) {
+		t.Errorf("a hook digest naming the project was not matched")
+	}
+	// The recorded field still wins, and it is exact.
+	recorded := usage.Snapshot{Projects: []string{"work/web"}, Digest: "1. [claude] api · anything\n"}
+	if match(recorded) {
+		t.Errorf("a record that names its own projects was matched by its text")
+	}
+	if !match(usage.Snapshot{Projects: []string{"api"}, Digest: "no project in the text at all"}) {
+		t.Errorf("a record that names the project in its field was not matched")
+	}
+}
+
+// Session ids are matched the same way: where the digest names one, not
+// wherever the string happens to appear.
+func TestForgetMatchesSessionIDsWhereADigestNamesThem(t *testing.T) {
+	match := forgetDigestMatcher(index.ForgetOptions{Session: "a0"}, []string{"claude:a0"})
+	if !match(usage.Snapshot{Digest: "1. [claude] api · claude:a0 · 2 matches\n"}) {
+		t.Errorf("a digest listing the forgotten session was not matched")
+	}
+	if match(usage.Snapshot{Digest: "1. [claude] work/web · claude:b0 · 2 matches\n   we set a0 to 3 in the config\n"}) {
+		t.Errorf("a digest was matched because its prose contains the id")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3878,8 +3878,15 @@ func joinCapped(items []string, n int) string {
 // older one is recognised by the ids and project name inside its text, the same
 // weaker test the view page falls back to.
 func forgetDigestMatcher(o index.ForgetOptions, keys []string) func(usage.Snapshot) bool {
-	ids := make([]string, 0, len(keys))
+	// Both spellings: a listing renders `claude:abc` and a hook block quotes
+	// the bare id, so a sweep that knew only one of them missed half the
+	// records it was meant to take.
+	ids := make([]string, 0, 2*len(keys))
 	for _, k := range keys {
+		if k == "" {
+			continue
+		}
+		ids = append(ids, k)
 		if _, id, ok := strings.Cut(k, ":"); ok && id != "" {
 			ids = append(ids, id)
 		}
@@ -3891,15 +3898,77 @@ func forgetDigestMatcher(o index.ForgetOptions, keys []string) func(usage.Snapsh
 					return true
 				}
 			}
-			if len(s.Projects) == 0 && strings.Contains(s.Digest, o.Project) {
+			if len(s.Projects) == 0 && digestNames(s.Digest, o.Project) {
 				return true
 			}
 		}
 		for _, id := range ids {
-			if strings.Contains(s.Digest, id) {
+			if digestNames(s.Digest, id) {
 				return true
 			}
 		}
 		return false
+	}
+}
+
+// digestNames reports whether a digest names a project or a session where it
+// renders one, rather than anywhere in its text. Searching the whole text made
+// `forget --project api` delete a digest about work/web whose prose read "a
+// late api call": the reader forgot one project and lost another's record
+// (#2330). The two shapes deja writes are the recall listing,
+//
+//  1. [claude] work/app · claude:abc · 2 matches
+//
+// and the hook block,
+//
+//   - **work/app** `abc` · 2026-08-28
+//
+// A digest in neither shape names nothing, so a sweep keeps it: with `projects`
+// recorded since #2324 the guess is only needed for older records, and deleting
+// one on a guess cannot be undone.
+func digestNames(digest, want string) bool {
+	if want == "" {
+		return false
+	}
+	for _, line := range strings.Split(digest, "\n") {
+		for _, field := range digestNamedFields(line) {
+			if field == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// digestNamedFields pulls the project and id positions out of one rendered
+// line: the fields that follow the harness in brackets, and anything a hook
+// block emphasises or quotes.
+func digestNamedFields(line string) []string {
+	var out []string
+	if _, after, ok := strings.Cut(line, "] "); ok {
+		for _, field := range strings.Split(after, " · ") {
+			out = append(out, strings.TrimSpace(field))
+		}
+	}
+	out = append(out, betweenAll(line, "**")...)
+	out = append(out, betweenAll(line, "`")...)
+	return out
+}
+
+// betweenAll returns every substring wrapped by the given marker.
+func betweenAll(s, marker string) []string {
+	var out []string
+	for {
+		i := strings.Index(s, marker)
+		if i < 0 {
+			return out
+		}
+		rest := s[i+len(marker):]
+		j := strings.Index(rest, marker)
+		if j < 0 {
+			return out
+		}
+		out = append(out, strings.TrimSpace(rest[:j]))
+		s = rest[j+len(marker):]
 	}
 }

--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -413,6 +413,12 @@ func snapshotWithheld(pol policy.Policy, sn usage.Snapshot, hidden map[string]bo
 	return false
 }
 
+// The page and `deja forget` read an old record differently on purpose. Here a
+// name anywhere in the text is enough, because the cost of a wrong match is a
+// digest of your own work missing from a page you can regenerate. forget looks
+// only where a digest renders a project, because there the cost is deleting a
+// record that cannot come back (#2330).
+
 // notesAllowedOnPage drops the promoted notes whose project a rule withholds,
 // and says how many went. Browsing, so the search activation governs it — the
 // same activation the session list on this page is filtered by.


### PR DESCRIPTION
The fallback added with #2329 searched the whole digest, so `deja forget --project api` removed a digest belonging to `work/web` that said "a late api call" — one project forgotten, another's record lost, and the dry run promised the same thing.

forget now looks only where a digest renders a project or an id: the recall listing (`1. [claude] work/app · claude:abc · 2 matches`) and the hook block (`- **work/app** \`abc\``). A record in neither shape names nothing and is kept — records written since #2324 carry their projects, so the guess only covers older ones, and deleting one on a guess cannot be undone.

The view page keeps the looser test on purpose, with the reason in a comment beside it: a wrong match there costs an entry on a page you can regenerate, here it costs a record.

Fixes #2330.