### PR TITLE
test(bench): measure the reworded question the store can actually answer

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -153,6 +153,13 @@ type promptReport struct {
 	// it was measured by hand on a live store that had absorbed the questions
 	// being asked of it (#2120).
 	Paraphrase promptArmReport `json:"paraphrase"`
+	// Tied is the same question in someone else's words, on a store that also
+	// holds the sentence tying those words to the term of art. Separate from
+	// Paraphrase because that arm has a ceiling: measured over the corpus, no
+	// message anywhere says both vocabularies for any of the five it fails,
+	// so nothing lexical can reach them. This arm is the reachable half, and
+	// what a working bridge (#2331) would move.
+	Tied promptArmReport `json:"paraphrase_tied"`
 	// What the block actually shows. Every other arm scores which session was
 	// chosen; none of them looks at the lines inside it, which is how a recall
 	// that had found the right session came to open with "продолжай дальше"
@@ -233,6 +240,10 @@ func runBenchPrompt(args []string) error {
 		report.Fresh.Fired, report.Fresh.Cases, report.Fresh.Correct, report.Fresh.Precision)
 	fmt.Printf("negative controls  %2d/%-2d  —        false fires: %d\n",
 		report.Negative.Fired, report.Negative.Cases, report.Negative.FalseFires)
+	fmt.Printf("reworded           %2d/%-2d  %2d       %.2f\n",
+		report.Paraphrase.Fired, report.Paraphrase.Cases, report.Paraphrase.Correct, report.Paraphrase.Precision)
+	fmt.Printf("reworded, tied     %2d/%-2d  %2d       %.2f\n",
+		report.Tied.Fired, report.Tied.Cases, report.Tied.Correct, report.Tied.Precision)
 	return nil
 }
 
@@ -275,6 +286,25 @@ func measurePrompt(seed int64) (promptReport, error) {
 		scope := chain.Project
 		if chain.Kind == "bucket-answer" {
 			scope = bench.PromptBucketProject
+		}
+		// A tied chain exists for the reworded arm alone: its store carries a
+		// sentence that explains the words without settling anything, which is
+		// the point of it. Counting it as a plain question would report the
+		// bridge's absence as a failure of the ordinary case.
+		if chain.Tied {
+			if chain.Paraphrase != "" {
+				pterms := prompt.Terms(chain.Paraphrase)
+				report.Tied.Cases++
+				if pfired, pcorrect := promptBenchProbe(indexDir, scope, chain.ID, pterms); pfired {
+					report.Tied.Fired++
+					if pcorrect {
+						report.Tied.Correct++
+					} else {
+						report.Tied.FalseFires++
+					}
+				}
+			}
+			continue
 		}
 		fired, correct := promptBenchProbe(indexDir, scope, chain.ID, terms)
 		arm := &report.Real
@@ -421,13 +451,14 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		if chain.Paraphrase != "" {
 			pterms := prompt.Terms(chain.Paraphrase)
-			report.Paraphrase.Cases++
+			arm := &report.Paraphrase
+			arm.Cases++
 			if pfired, pcorrect := promptBenchProbe(indexDir, scope, chain.ID, pterms); pfired {
-				report.Paraphrase.Fired++
+				arm.Fired++
 				if pcorrect {
-					report.Paraphrase.Correct++
+					arm.Correct++
 				} else {
-					report.Paraphrase.FalseFires++
+					arm.FalseFires++
 				}
 			}
 		}
@@ -482,6 +513,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.OffTopic, nil)
 	finishPromptArm(&report.Russian, nil)
 	finishPromptArm(&report.Paraphrase, nil)
+	finishPromptArm(&report.Tied, nil)
 	for _, q := range absentSubjectQuestions() {
 		report.AbsentSubject.Cases++
 		if fired, _ := promptBenchProbe(indexDir, bench.PromptHaystackProject, "no-such-chain", prompt.Terms(q)); fired {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -30,8 +30,15 @@ type PromptChain struct {
 	Fact string
 	// Paraphrase is Question asked in someone else's words.
 	Paraphrase string
-	Sessions   []model.Session
-	Negative   bool
+	// Tied says this chain's store also holds the sentence that ties the
+	// paraphrase's ordinary words to the term of art — the one every real
+	// store has and this corpus did not. Measured: for all five paraphrases
+	// the arm fails on, no message anywhere in the corpus says both, so no
+	// lexical method can reach them and the arm's 15 of 20 is a ceiling
+	// rather than a defect. A chain marked Tied is the reachable case (#2331).
+	Tied     bool
+	Sessions []model.Session
+	Negative bool
 	// Kind names what this chain is here to measure: "" for the plain case,
 	// "marathon" for a chain whose sessions are long enough to be skipped
 	// wholesale, "fresh" for one worked on minutes ago, "bucket" for filler
@@ -202,6 +209,73 @@ func promptCorpusHash(chains []PromptChain) string {
 	return hex.EncodeToString(h[:])
 }
 
+// PromptTiedCount is how many tied chains the corpus carries.
+const PromptTiedCount = 6
+
+// tiedTopics are the tied arm's own subjects. Separate from the plain topics
+// on purpose: sharing them would let a plain chain's sessions answer the tied
+// paraphrase, and the arm would measure the corpus rather than the bridge.
+func tiedTopics() []promptTopic {
+	return []promptTopic{
+		{"quorum", "quorum reads were turned off for the status endpoint", "what did we do about quorum reads?", "why does the status endpoint no longer ask every replica"},
+		{"debounce", "the debounce on the search box was set to 250ms", "what debounce did we settle on?", "how long do we wait before sending what someone typed"},
+		{"replay", "a replay guard was added to the payment retry path", "what did we add to the payment retry path?", "what stops a retried charge from taking the money twice"},
+		{"vacuum", "autovacuum was tuned per table for the events table", "what did we change about vacuum?", "how did we stop dead rows piling up in the biggest table"},
+		{"sharding", "sharding was keyed on tenant rather than on user", "what is the shard key now?", "by what are the rows split across the machines"},
+		{"watermark", "a watermark was added so the queue drops nothing", "what did we add so the queue stops dropping?", "how did we stop the queue from throwing work away"},
+	}
+}
+
+// tiedChains repeat the plain shape with one addition: a short session where
+// somebody writes the sentence that names the thing and describes it in the
+// same breath. That is what a real store holds — nobody writes only the term
+// of art or only the ordinary words — and it is the material the
+// co-occurrence map is built from. Without it the map has nothing to learn
+// and a question in other words cannot be bridged by anything lexical.
+func tiedChains(rng *rand.Rand, base time.Time) []PromptChain {
+	topics := tiedTopics()
+	out := make([]PromptChain, 0, PromptTiedCount)
+	for i := 0; i < PromptTiedCount && i < len(topics); i++ {
+		topic := topics[i]
+		chain := PromptChain{
+			ID:         fmt.Sprintf("prompt-tied-%02d", i),
+			Project:    fmt.Sprintf("promptbenchtied%02d", i),
+			Topic:      topic.word,
+			Question:   topic.question,
+			Paraphrase: topic.paraphrase,
+			Tied:       true,
+		}
+		t := base.Add(time.Duration(500+i*10) * time.Minute)
+		// The session that settled it, in the term's own words.
+		chain.Sessions = append(chain.Sessions, model.Session{
+			ID: chain.ID + "-answer", Harness: "claude", Project: chain.Project,
+			Updated: t.Add(20 * time.Minute),
+			Messages: []model.Message{
+				{Role: "user", Text: fmt.Sprintf("we decided %s", topic.fact), Time: t},
+				{Role: "assistant", Text: fillerText(rng, "wrote it down and moved on"), Time: t.Add(time.Minute)},
+			},
+		})
+		// The sentence that ties the two vocabularies, in a session of its own
+		// — it explains, it does not decide, so an arm that asks for the
+		// decision must not be satisfied by it.
+		tie := fmt.Sprintf("what we call %s is %s", topic.word, topic.paraphrase)
+		chain.Sessions = append(chain.Sessions, model.Session{
+			// Deliberately outside the chain's id prefix: the probe counts a
+			// hit only for the chain's own sessions, and a tie that explains
+			// the words while settling nothing must not be able to pass the
+			// arm on its own. It is there to be learned from, not returned.
+			ID: fmt.Sprintf("prompt-tievocab-%02d", i), Harness: "claude", Project: chain.Project,
+			Updated: t.Add(10 * time.Minute),
+			Messages: []model.Message{
+				{Role: "user", Text: tie, Time: t.Add(5 * time.Minute)},
+				{Role: "assistant", Text: fillerText(rng, "noted, that is the same thing"), Time: t.Add(6 * time.Minute)},
+			},
+		})
+		out = append(out, chain)
+	}
+	return out
+}
+
 // promptShapeChain builds one chain with a given session length and start
 // time, so a gate can be measured instead of argued about.
 func promptShapeChain(rng *rand.Rand, i int, kind string, topic promptTopic, start time.Time, turns int) PromptChain {
@@ -241,7 +315,7 @@ func GeneratePrompt(seed int64) PromptCorpus {
 	// session was touched, and a corpus dated in the future reads as newer
 	// than now and is withheld wholesale.
 	base := time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC)
-	chains := make([]PromptChain, 0, len(topics)+PromptNegativeCount)
+	chains := make([]PromptChain, 0, len(topics)+PromptNegativeCount+PromptTiedCount)
 	for i, topic := range topics {
 		chain := PromptChain{
 			ID:         fmt.Sprintf("prompt-chain-%02d", i),
@@ -764,5 +838,6 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	chains = append(chains, tiedChains(rng, base)...)
 	return PromptCorpus{Chains: chains, Hash: promptCorpusHash(chains)}
 }

--- a/internal/bench/tied_chain_test.go
+++ b/internal/bench/tied_chain_test.go
@@ -1,0 +1,69 @@
+package bench
+
+import (
+	"strings"
+	"testing"
+)
+
+// The reworded arm has a ceiling nobody had measured: for all five questions it
+// fails, no message anywhere in the corpus says both the ordinary words and the
+// term of art, so nothing lexical can bridge them. The tied chains are the half
+// that is reachable — a store where somebody wrote the sentence tying the two,
+// which is what every real store has.
+func TestTiedChainsCarryTheSentenceThatTiesTheVocabularies(t *testing.T) {
+	corpus := GeneratePrompt(1)
+	tied := 0
+	for _, c := range corpus.Chains {
+		if !c.Tied {
+			continue
+		}
+		tied++
+		if c.Paraphrase == "" {
+			t.Fatalf("%s is tied and asks nothing in other words", c.ID)
+		}
+		var answer, tie int
+		for _, s := range c.Sessions {
+			text := ""
+			for _, m := range s.Messages {
+				text += " " + strings.ToLower(m.Text)
+			}
+			saysTerm := strings.Contains(text, strings.ToLower(c.Topic))
+			saysOther := strings.Contains(text, strings.ToLower(c.Paraphrase))
+			switch {
+			case saysTerm && saysOther:
+				tie++
+				// The tie explains; it must not be able to satisfy the arm on
+				// its own, and the probe counts only the chain's own ids.
+				if strings.HasPrefix(s.ID, c.ID) {
+					t.Errorf("%s: the tying session can pass the arm by itself", c.ID)
+				}
+			case saysTerm:
+				answer++
+			}
+		}
+		if answer == 0 {
+			t.Errorf("%s: no session settles anything in the term's own words", c.ID)
+		}
+		if tie == 0 {
+			t.Errorf("%s: no session ties the ordinary words to the term", c.ID)
+		}
+	}
+	if tied != PromptTiedCount {
+		t.Fatalf("tied chains: %d, want %d", tied, PromptTiedCount)
+	}
+}
+
+// Tied chains have their own subjects. Sharing them with the plain topics would
+// let a plain chain's sessions answer the tied question, and the arm would
+// measure the corpus rather than the bridge.
+func TestTiedTopicsAreTheirOwn(t *testing.T) {
+	plain := map[string]bool{}
+	for _, tp := range promptTopics() {
+		plain[tp.word] = true
+	}
+	for _, tp := range tiedTopics() {
+		if plain[tp.word] {
+			t.Errorf("tied topic %q is also a plain topic", tp.word)
+		}
+	}
+}


### PR DESCRIPTION
The reworded arm reads 15 of 20 and I went looking for the five. They are all the same shape — the question describes the subject instead of naming it:

```
tls            ->  верификация сертификатов во внутренней сети
backpressure   ->  how did we stop the queue from throwing messages away
шардирование   ->  по какому признаку данные разложены между узлами
```

Then I checked whether anything in the corpus could bridge them, and the answer is no:

```
сертификат ↔ tls            messages saying both: 0
throwing messages away ↔ backpressure: 0
признаку данные разложены ↔ шардирование: 0
достучаться ↔ вебхук: 0
сбрасываем сохранённые ↔ кеш: 0
```

So **15 of 20 is a ceiling, not a defect**. No lexical method reaches those five, because no message in the store uses both vocabularies; only an external synonym source could. Work aimed at that arm is work aimed at an impossibility, and nothing said so.

This adds the half that *is* reachable. Six chains whose store also holds the sentence tying the ordinary words to the term of art — the sentence every real store has, because nobody writes only the term or only the description. It is the material the co-occurrence map is built from, and #2331 measured that map already learning `proxy -> pgbouncer` from three such sentences.

```
reworded           15/20  correct 15
reworded, tied      6/6   correct  0
```

Zero, and firing every time: the question in other words reaches the tying sentence and returns *it* instead of the session that settled anything. That is exactly the gap in #2331, now with a number that can move.

Two things the shape of the fixture has to get right, both pinned by tests: the tying session sits outside the chain's id prefix, so it cannot satisfy the arm by itself — it is there to be learned from, not returned; and the tied chains have their own subjects, or a plain chain's sessions would answer the tied question and the arm would measure the corpus rather than the bridge.

Every existing arm reads exactly as before — real questions 13/13, reworded 15/20, negative controls 0 false fires.