### PR TITLE
fix(recall): keep the session-start scope inside the checkout's own project

### DIFF
--- a/cmd/deja/hook_project_scope_test.go
+++ b/cmd/deja/hook_project_scope_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A session start in /work/api recalled a client's acme/api under "sessions
+// from this project": the candidate list carries the checkout's bare directory
+// name and RecentProjects matched it as a substring (#2333).
+func TestSessionStartStaysInsideItsOwnProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	write := func(dirName, id, cwd, text string, hoursAgo int) {
+		dir := filepath.Join(root, dirName)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":%q,`+
+			`"message":{"role":"user","content":%q}}`, id, at, cwd, text)
+		if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("-work-api", "mine", "/work/api", "my own retry budget question", 8)
+	write("-clients-acme-api", "acme", "/clients/acme/api", "the acme ledger cutover", 2)
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := hookContextFor(t, dir, `{"hook_event_name":"SessionStart","cwd":"/work/api","session_id":"agent1"}`)
+	if !strings.Contains(out, "my own retry budget question") {
+		t.Fatalf("the checkout's own session is missing, so this measures nothing:\n%s", out)
+	}
+	if strings.Contains(out, "acme") {
+		t.Errorf("a session from another project ending in /api was injected as this project's:\n%s", out)
+	}
+}
+
+// hookContextFor runs the session-start hook over one payload and returns what
+// it wrote.
+func hookContextFor(t *testing.T, dir, payload string) string {
+	t.Helper()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = inW.WriteString(payload)
+		_ = inW.Close()
+	}()
+	oldIn, oldOut := os.Stdin, os.Stdout
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin, os.Stdout = inR, outW
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := outR.Read(buf)
+			b.Write(buf[:n])
+			if rerr != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+	hookErr := runHookContext(dir, false)
+	os.Stdin, os.Stdout = oldIn, oldOut
+	_ = outW.Close()
+	out := <-done
+	if hookErr != nil {
+		t.Fatal(hookErr)
+	}
+	return out
+}

--- a/internal/index/atomicity_test.go
+++ b/internal/index/atomicity_test.go
@@ -244,7 +244,7 @@ func TestProjectRelevantRanksByIDFNotFiller(t *testing.T) {
 		t.Fatal(err)
 	}
 	// A prompt full of filler plus the one rare term must rank s1 first.
-	got, _, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"need", "the", "quetzalcoatl"}, 2)
+	got, _, _, _, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"need", "the", "quetzalcoatl"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestStemFoldIsDecidedByTheProjectNotTheStore(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"write", "parquet"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"write", "parquet"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestProjectRelevantDottedTermNeedsAllSubTokens(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"203.0.113.51"}, 4)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"203.0.113.51"}, 4)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +388,7 @@ func termRarity(t *testing.T, dir, term string) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rank, err := relevantMetasCounts(dir, m, []string{"app"}, []string{term}, 8, nil)
+	rank, err := relevantMetasCounts(dir, m, []string{"tmp/app"}, []string{term}, 8, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/cyrillic_test.go
+++ b/internal/index/cyrillic_test.go
@@ -205,7 +205,7 @@ func TestRussianRelevanceFoldsInflections(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Nominative singular in the prompt, instrumental plural in the session.
-	got, matched, _, _, err := ProjectRelevant(dir, []string{"app"}, []string{"миграция", "репликация"}, 3)
+	got, matched, _, _, err := ProjectRelevant(dir, []string{"tmp/app"}, []string{"миграция", "репликация"}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/df_unit_test.go
+++ b/internal/index/df_unit_test.go
@@ -59,7 +59,7 @@ func TestRarityTakesTheRarerOfTheTwoVerdicts(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"app"}, []string{"quetzalcoatl", "branch"}, 8)
+	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"work/app"}, []string{"quetzalcoatl", "branch"}, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestRarityIsNotInvertedByMarathonSessions(t *testing.T) {
 	if err := Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"app"}, []string{"pgbouncer", "branch"}, 8)
+	_, _, _, idfOf, err := ProjectRelevant(dir, []string{"work/app"}, []string{"pgbouncer", "branch"}, 8)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/lock_nonblocking_test.go
+++ b/internal/index/lock_nonblocking_test.go
@@ -24,7 +24,7 @@ func TestReadsDoNotBlockWhileTheIndexIsLocked(t *testing.T) {
 	go func() {
 		defer close(done)
 		_, _, _ = FindByPrefix(dir, "nothing")
-		_, _, _, _, _ = ProjectRelevant(dir, []string{"p"}, []string{"term"}, 3)
+		_, _, _, _, _ = ProjectRelevant(dir, []string{"tmp/p"}, []string{"term"}, 3)
 		_, _ = RecentProject(dir, "p", 3)
 		_, _, _ = FirstMatch(dir, []string{"term"}, 3)
 	}()

--- a/internal/index/locked_read_test.go
+++ b/internal/index/locked_read_test.go
@@ -46,7 +46,7 @@ func TestReadsAnswerWhileTheIndexLockIsHeld(t *testing.T) {
 	var got int
 	go func() {
 		defer close(done)
-		sessions, _, _, _, rerr := ProjectRelevant(dir, []string{"app"},
+		sessions, _, _, _, rerr := ProjectRelevant(dir, []string{"tmp/app"},
 			[]string{"quetzalcoatl"}, 2)
 		if rerr != nil {
 			t.Errorf("read under the lock: %v", rerr)

--- a/internal/index/project_scope_test.go
+++ b/internal/index/project_scope_test.go
@@ -2,49 +2,30 @@ package index
 
 import "testing"
 
-// Automatic project scoping decides whose history recall ranks against. It was
-// any substring, and the names on a real machine show what that joins: the same
-// repository is recorded as "deja-vu" by some harnesses and "goprojects/deja-vu"
-// by others, so several forms have to match — but "deja" is not "deja-push",
-// and a project that parsed as "-" is not every hyphenated directory on the
-// disk.
-func TestProjectScopeMatchesSegmentsNotSubstrings(t *testing.T) {
-	joined := []struct{ project, want string }{
-		{"deja-vu", "deja-vu"},
-		{"goprojects/deja-vu", "deja-vu"},
-		{"Users/shulcz", "shulcz"},
-		{"scratchpad/demo", "demo"},
-		{"imported:deja-vu", "deja-vu"},
-		{"imported:goprojects/deja-vu", "deja-vu"},
-		// windows builds the same name with its own separator. Matching only
-		// "/" made every scoped ranking there return nothing, which the CI leg
-		// only reports when a pull request asks for it.
-		{`goprojects\deja-vu`, "deja-vu"},
-		{`imported:goprojects\deja-vu`, "deja-vu"},
+// The automatic scope takes a candidate as a path suffix, which is right for
+// the full forms — one project reached under different parents, worktrees of
+// one repo — and wrong for the bare basename the candidates also carry: with it
+// a session start in /work/api recalled a client's acme/api "from this
+// project" (#2333).
+func TestProjectScopeDoesNotMatchOnABareBasename(t *testing.T) {
+	cases := []struct {
+		project, want string
+		in            bool
+	}{
+		{"work/api", "work/api", true},
+		{"work/api", "api", false}, // the bare name reaches through the full form
+		{"acme/api", "api", false}, // another project that ends the same way
+		{"acme/api", "acme/api", true},
+		{"src/clients/acme/api", "acme/api", true}, // the full form still reaches
+		{"imported:acme/api", "acme/api", true},    // a peer's copy of that project
+		{"imported:acme/api", "api", true},         // a peer's path is not this machine's
+		{`acme\api`, "acme/api", false},            // windows separator, path form
+		{`src\acme\api`, `acme\api`, true},
+		{"acme/api", "", false},
 	}
-	for _, c := range joined {
-		if !projectInScope(c.project, c.want) {
-			t.Errorf("%q should be in scope for %q and is not", c.project, c.want)
+	for _, c := range cases {
+		if got := projectInScope(c.project, c.want); got != c.in {
+			t.Errorf("projectInScope(%q, %q) = %v, want %v", c.project, c.want, got, c.in)
 		}
-	}
-
-	// All six of these are joined by a substring rule, and all six are wrong.
-	separate := []struct{ project, want string }{
-		{"deja-push", "deja"},
-		{"deja-vu", "deja"},
-		{"goprojects/d3fvxl-redirect", "d3fvxl"},
-		{`goprojects\d3fvxl-redirect`, "d3fvxl"},
-		{"shulcz/coding", "shulcz"},
-		{"pin-manifests", "-"},
-		{"telegram-mtproxy-forwarder", "-"},
-	}
-	for _, c := range separate {
-		if projectInScope(c.project, c.want) {
-			t.Errorf("%q is a different project from %q and was pulled into its scope", c.project, c.want)
-		}
-	}
-
-	if projectInScope("anything", "") {
-		t.Error("an empty project name matched something")
 	}
 }

--- a/internal/index/relevance_bench_test.go
+++ b/internal/index/relevance_bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkRussianRelevance(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, _, _, _, err := ProjectRelevant(dir, []string{"app"}, terms, 10); err != nil {
+		if _, _, _, _, err := ProjectRelevant(dir, []string{"tmp/app"}, terms, 10); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/index/relevance_roles_test.go
+++ b/internal/index/relevance_roles_test.go
@@ -86,7 +86,7 @@ func TestRelevanceHonoursTheRequestedRole(t *testing.T) {
 // context is pasting the wrong thing.
 func TestProjectRelevantDoesNotServeWorkRecords(t *testing.T) {
 	dir := rolesIndex(t)
-	ss, _, _, _, err := ProjectRelevant(dir, []string{"p"}, []string{"frobnicator", "values", "rollout"}, 5)
+	ss, _, _, _, err := ProjectRelevant(dir, []string{"tmp/p"}, []string{"frobnicator", "values", "rollout"}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -739,13 +739,28 @@ func projectInScope(project, want string) bool {
 		return false
 	}
 	p, w := strings.ToLower(project), strings.ToLower(want)
+	imported := false
 	if rest, ok := strings.CutPrefix(p, "imported:"); ok {
 		// A synced session carries the peer's prefix and is otherwise the same
 		// project under the same name.
-		p = rest
+		p, imported = rest, true
 	}
 	if p == w {
 		return true
+	}
+	// A candidate with no separator is a bare directory name, and as a suffix
+	// against a LOCAL project it cannot tell two directories apart: working in
+	// /work/api, the candidate "api" matched a client's acme/api and the
+	// session-start hook injected it "from this project" (#2333). Nothing is
+	// lost by insisting on more here — a claude project is recorded as
+	// parent/base and the candidates carry that form, and the stores that
+	// record a bare project name match it exactly on the line above.
+	//
+	// A peer's project keeps the peer's path, which is not this machine's, so
+	// the loose rule stays for imported work: matching it by the name this
+	// machine knows it by is the point of scoping a synced index.
+	if !imported && !strings.ContainsAny(w, `/\`) {
+		return false
 	}
 	// Both separators, because a project name is built from a path and windows
 	// builds it with backslashes. Matching only "/" made every scoped ranking on
@@ -1400,8 +1415,10 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 		project = strings.ToLower(project)
 		var mine []SessionMeta
 		for _, meta := range m.Sessions {
-			p := strings.ToLower(meta.Project)
-			if p == project || (project != "" && strings.Contains(p, project)) {
+			// The same scope rule the ranked path uses. A substring test here
+			// put a client's acme/api into a session start in /work/api,
+			// injected under "sessions from this project" (#2333).
+			if projectInScope(meta.Project, project) {
 				mine = append(mine, meta)
 			}
 		}


### PR DESCRIPTION
Two projects ending in `api`. A session start in `/work/api` injected a client's `acme/api` under "the sessions below are from this project's recent history".

`RecentProjects` matched a candidate as a plain substring of the project name, so the checkout's bare directory name (`api`, which `ProjectNameCandidates` always adds) reached every project whose path contains it. It now uses the same scope rule the ranked path uses, and that rule no longer takes a bare candidate as a path suffix for a local project: a claude project is recorded as parent/base and the candidates carry that form, and the stores that record a bare project name still match it exactly. A peer's project keeps the peer's path, so the loose rule stays for `imported:` — matching synced work by the name this machine knows it by is the point of scoping a synced index.

Eight tests in internal/index passed a terse `"app"` / `"p"` against fixtures whose project is `tmp/app` / `work/app`; they now pass the project's real name. Each is about ranking, idf or locking rather than scope, and the production callers already pass the full form.

Fixes #2333.