### PR TITLE
fix(handoff): pick from the checkout's own project, not one that ends the same way

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -194,7 +194,7 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 	// work in this project rather than handing over older work in silence.
 	var hiddenNewest time.Time
 	for _, name := range digest.ProjectNameCandidates(cwd) {
-		ss, err := index.RecentProject(dir, name, 3)
+		ss, err := index.RecentInProject(dir, name, 3)
 		if err != nil || len(ss) == 0 {
 			continue
 		}

--- a/cmd/deja/handoff_project_scope_test.go
+++ b/cmd/deja/handoff_project_scope_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// handoff with no id picks a session from this directory's project. It walked
+// the same bare directory name #2333 fixed for the session start, through
+// RecentProject, and packaged a client's acme/api for another agent (#2336).
+func TestHandoffPicksFromTheCheckoutsOwnProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	write := func(dirName, id, cwd, text string, hoursAgo int) {
+		dir := filepath.Join(root, dirName)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":%q,`+
+			`"message":{"role":"user","content":%q}}`, id, at, cwd, text)
+		if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("-work-api", "mine", "/work/api", "my own retry budget question", 9)
+	write("-clients-acme-api", "acme", "/clients/acme/api", "the acme ledger cutover", 1)
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from a directory whose basename is the ambiguous one.
+	work := filepath.Join(tmp, "work", "api")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	out, err := captureRun(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "acme") {
+		t.Errorf("handoff packaged another project's session:\n%s", out)
+	}
+	if !strings.Contains(out, "retry budget") {
+		t.Errorf("handoff did not pick this project's own session:\n%s", out)
+	}
+}

--- a/internal/index/recent_in_project_test.go
+++ b/internal/index/recent_in_project_test.go
@@ -1,0 +1,74 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// RecentInProject is the scoped sibling of RecentProject: it answers with the
+// sessions of this project, not of every project whose name contains the
+// string. `deja handoff` packaged a client's acme/api from a directory named
+// api through the loose one (#2336).
+func TestRecentInProjectStaysInsideTheProject(t *testing.T) {
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	write := func(dirName, id, cwd string, hoursAgo int) {
+		d := filepath.Join(root, dirName)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":%q,`+
+			`"message":{"role":"user","content":"a question about %s"}}`, id, at, cwd, id)
+		if err := os.WriteFile(filepath.Join(d, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Three sessions in the client's project, all newer than the one that
+	// belongs to this checkout: a window taken before scoping would hold none
+	// of ours.
+	write("-clients-acme-api", "acme1", "/clients/acme/api", 1)
+	write("-clients-acme-api", "acme2", "/clients/acme/api", 2)
+	write("-clients-acme-api", "acme3", "/clients/acme/api", 3)
+	write("-work-api", "mine", "/work/api", 9)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	loose, err := RecentProject(dir, "api", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loose) != 4 {
+		t.Fatalf("the loose helper found %d sessions, want all four — otherwise this measures nothing", len(loose))
+	}
+
+	got, err := RecentInProject(dir, "work/api", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "mine" {
+		t.Fatalf("RecentInProject = %v, want this checkout's own session", got)
+	}
+	// The limit still applies within the project.
+	got, err = RecentInProject(dir, "acme/api", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != "acme1" {
+		t.Fatalf("RecentInProject with a limit = %v, want the two newest of that project", got)
+	}
+	// A name nothing answers to is empty rather than everything.
+	got, err = RecentInProject(dir, "nothing/here", 5)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("RecentInProject for an unknown project = %v, err %v", got, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1277,6 +1277,46 @@ func displayPath(p string) string {
 	return p
 }
 
+// RecentInProject is RecentProject under the scope rule the automatic paths
+// use: a session belongs to this project or it does not. `deja handoff`, which
+// picks a session for another agent when nobody named one, walked the loose
+// helper and packaged a client's acme/api from a directory named api (#2336) —
+// the shape #2333 closed on the session-start hook.
+func RecentInProject(dir, project string, n int) ([]model.Session, error) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	unlock, ok, err := tryLockDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		defer unlock()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil, err
+	}
+	// Scoped before the cut, not after: filtering a window of the loose
+	// helper's answer would drop this project's sessions whenever another
+	// project's newer ones filled it.
+	var metas []SessionMeta
+	for _, meta := range m.Sessions {
+		if projectInScope(meta.Project, project) {
+			metas = append(metas, meta)
+		}
+	}
+	sort.Slice(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
+	if n > 0 && len(metas) > n {
+		metas = metas[:n]
+	}
+	return sessionsForMetas(dir, metas)
+}
+
+// RecentProject finds sessions whose project name contains the given string —
+// a browsing helper, loose on purpose, the way `--project` is on the surfaces a
+// person types. A caller deciding on its own which sessions belong to the
+// directory it is standing in wants RecentInProject instead (#2336).
 func RecentProject(dir, project string, n int) ([]model.Session, error) {
 	if dir == "" {
 		dir = DefaultDir()


### PR DESCRIPTION
`deja handoff` with no id, run from a directory named `api`, handed another agent a client's `acme/api` session. It walks the checkout's project-name candidates through `index.RecentProject`, whose substring match is deliberately loose — a browsing helper, the way `--project` is on the surfaces a person types, and two existing tests pin that.

New `index.RecentInProject` applies the scope rule the automatic paths use (#2333) and filters before the cut, so this project's sessions are not pushed out of the window by another project's newer ones. handoff calls it; `RecentProject` keeps its semantics and a doc comment saying which of the two a caller wants.

Fixes #2336.