### PR TITLE
test(bench): make the tied arm measure the search rather than the fixture

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -295,7 +295,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 			if chain.Paraphrase != "" {
 				pterms := prompt.Terms(chain.Paraphrase)
 				report.Tied.Cases++
-				if pfired, pcorrect := promptBenchProbe(indexDir, scope, chain.ID, pterms); pfired {
+				if pfired, pcorrect := promptBenchProbeBlock(indexDir, scope, chain.ID, pterms); pfired {
 					report.Tied.Fired++
 					if pcorrect {
 						report.Tied.Correct++
@@ -650,6 +650,54 @@ func blockCarries(dir, project string, terms []string, fact, topic string) bool 
 // ask the index for this project's sessions ranked by them. Anything the hook
 // would discard downstream is discarded here too, so the number reported is
 // what a user would actually see.
+
+// promptBenchProbeBlock asks what the block would carry rather than what leads
+// it. The block has two slots, and for a question asked in other words the
+// first is often the session that explains the vocabulary — "the quorum read is
+// the one that asks every replica" — which is a better lexical match than any
+// answer can be, because it holds both vocabularies. Demanding it be beaten
+// measures the fixture; asking whether the answer travels with it measures the
+// search.
+func promptBenchProbeBlock(dir, project, chainID string, terms []string) (fired, correct bool) {
+	if !promptTermsWorthAsking(terms) {
+		return false, false
+	}
+	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	if err != nil {
+		return false, false
+	}
+	shown := 0
+	var chosen []model.Session
+	for i, s := range ranked {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+			continue
+		}
+		if len(s.Messages) > dejaVuMaxMessages {
+			if s = focusSession(s, terms); len(s.Messages) == 0 {
+				continue
+			}
+		}
+		// The same dedup the hook applies: two slots are two answers, and a
+		// store that said one thing in three sessions must not fill the block
+		// with it (#2328).
+		if sameAnswerAs(chosen, s, terms) {
+			continue
+		}
+		chosen = append(chosen, s)
+		fired = true
+		if strings.HasPrefix(s.ID, chainID) {
+			correct = true
+		}
+		shown++
+		if shown == promptBlockSlots {
+			break
+		}
+	}
+	return fired, correct
+}
+
+// promptBlockSlots is how many sessions the per-prompt block carries.
+const promptBlockSlots = 2
 
 func promptBenchProbe(dir, project, chainID string, terms []string) (fired, correct bool) {
 	if !promptTermsWorthAsking(terms) {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -209,21 +209,40 @@ func promptCorpusHash(chains []PromptChain) string {
 	return hex.EncodeToString(h[:])
 }
 
+// cooccurTieCopies is how many sessions repeat the tying sentence. The map
+// links two words only once they have shared three sessions.
+const cooccurTieCopies = 3
+
 // PromptTiedCount is how many tied chains the corpus carries.
 const PromptTiedCount = 6
 
 // tiedTopics are the tied arm's own subjects. Separate from the plain topics
 // on purpose: sharing them would let a plain chain's sessions answer the tied
 // paraphrase, and the arm would measure the corpus rather than the bridge.
-func tiedTopics() []promptTopic {
-	return []promptTopic{
-		{"quorum", "quorum reads were turned off for the status endpoint", "what did we do about quorum reads?", "why does the status endpoint no longer ask every replica"},
-		{"debounce", "the debounce on the search box was set to 250ms", "what debounce did we settle on?", "how long do we wait before sending what someone typed"},
-		{"replay", "a replay guard was added to the payment retry path", "what did we add to the payment retry path?", "what stops a retried charge from taking the money twice"},
-		{"vacuum", "autovacuum was tuned per table for the events table", "what did we change about vacuum?", "how did we stop dead rows piling up in the biggest table"},
-		{"sharding", "sharding was keyed on tenant rather than on user", "what is the shard key now?", "by what are the rows split across the machines"},
-		{"watermark", "a watermark was added so the queue drops nothing", "what did we add so the queue stops dropping?", "how did we stop the queue from throwing work away"},
+func tiedTopics() []tiedTopic {
+	return []tiedTopic{
+		{promptTopic{"quorum", "quorum reads were turned off for the status endpoint", "what did we do about quorum reads?", "why does the status endpoint no longer ask every replica"},
+			"the quorum read is the one that asks every replica"},
+		{promptTopic{"debounce", "the debounce on the search box was set to 250ms", "what debounce did we settle on?", "how long do we wait before sending what someone typed"},
+			"the debounce is how long we wait before sending"},
+		{promptTopic{"replay", "a replay guard was added to the payment retry path", "what did we add to the payment retry path?", "what stops a retried charge from taking the money twice"},
+			"the replay guard is what stops a retried charge"},
+		{promptTopic{"vacuum", "autovacuum was tuned per table for the events table", "what did we change about vacuum?", "how did we stop dead rows piling up in the biggest table"},
+			"vacuum is what clears the dead rows piling up in a table"},
+		{promptTopic{"sharding", "sharding was keyed on tenant rather than on user", "what is the shard key now?", "by what are the rows split across the machines"},
+			"sharding is how the rows are split across machines"},
+		{promptTopic{"watermark", "a watermark was added so the queue drops nothing", "what did we add so the queue stops dropping?", "how did we stop the queue from throwing work away"},
+			"the watermark is what keeps the queue from throwing work away"},
 	}
+}
+
+// tiedTopic is a subject plus the sentence a team writes when it explains its
+// own word in passing. Not a restatement of the question: a session repeating
+// the question verbatim is the best lexical match there can be, and an arm it
+// always wins measures the fixture rather than the search.
+type tiedTopic struct {
+	promptTopic
+	tie string
 }
 
 // tiedChains repeat the plain shape with one addition: a short session where
@@ -258,7 +277,22 @@ func tiedChains(rng *rand.Rand, base time.Time) []PromptChain {
 		// The sentence that ties the two vocabularies, in a session of its own
 		// — it explains, it does not decide, so an arm that asks for the
 		// decision must not be satisfied by it.
-		tie := fmt.Sprintf("what we call %s is %s", topic.word, topic.paraphrase)
+		// Said in three sessions, which is the evidence the co-occurrence map
+		// asks for by construction (cooccurMinPair, "a pattern, not a
+		// one-off"). One sentence teaches it nothing, and a store where a
+		// team's own vocabulary appears exactly once does not exist.
+		tie := topic.tie
+		for copyN := 1; copyN < cooccurTieCopies; copyN++ {
+			chain.Sessions = append(chain.Sessions, model.Session{
+				ID:      fmt.Sprintf("prompt-tievocab-%02d-%d", i, copyN),
+				Harness: "claude", Project: chain.Project,
+				Updated: t.Add(time.Duration(10+copyN) * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: tie, Time: t.Add(time.Duration(5+copyN) * time.Minute)},
+					{Role: "assistant", Text: fillerText(rng, "same thing, different words"), Time: t.Add(time.Duration(6+copyN) * time.Minute)},
+				},
+			})
+		}
 		chain.Sessions = append(chain.Sessions, model.Session{
 			// Deliberately outside the chain's id prefix: the probe counts a
 			// hit only for the chain's own sessions, and a tie that explains

--- a/internal/bench/tied_chain_test.go
+++ b/internal/bench/tied_chain_test.go
@@ -21,31 +21,46 @@ func TestTiedChainsCarryTheSentenceThatTiesTheVocabularies(t *testing.T) {
 		if c.Paraphrase == "" {
 			t.Fatalf("%s is tied and asks nothing in other words", c.ID)
 		}
-		var answer, tie int
+		answers, ties := 0, 0
 		for _, s := range c.Sessions {
 			text := ""
 			for _, m := range s.Messages {
 				text += " " + strings.ToLower(m.Text)
 			}
-			saysTerm := strings.Contains(text, strings.ToLower(c.Topic))
-			saysOther := strings.Contains(text, strings.ToLower(c.Paraphrase))
-			switch {
-			case saysTerm && saysOther:
-				tie++
-				// The tie explains; it must not be able to satisfy the arm on
-				// its own, and the probe counts only the chain's own ids.
-				if strings.HasPrefix(s.ID, c.ID) {
-					t.Errorf("%s: the tying session can pass the arm by itself", c.ID)
+			if !strings.Contains(text, strings.ToLower(c.Topic)) {
+				continue
+			}
+			// The tying sessions sit outside the chain's id prefix: the arm
+			// counts the chain's own sessions, and a session that explains the
+			// words while settling nothing must not pass it by itself.
+			if strings.HasPrefix(s.ID, c.ID) {
+				answers++
+				continue
+			}
+			ties++
+			// It says the term beside the question's ordinary words, not the
+			// whole question: a session repeating the question verbatim is the
+			// best lexical match there can be, and an arm it always wins
+			// measures the fixture rather than the search.
+			shared := 0
+			for _, w := range strings.Fields(strings.ToLower(c.Paraphrase)) {
+				if len(w) > 4 && strings.Contains(text, w) {
+					shared++
 				}
-			case saysTerm:
-				answer++
+			}
+			if shared < 2 {
+				t.Errorf("%s: the tying session shares too little of the wording", s.ID)
+			}
+			if strings.Contains(text, strings.ToLower(c.Paraphrase)) {
+				t.Errorf("%s: the tying session restates the whole question", s.ID)
 			}
 		}
-		if answer == 0 {
+		if answers == 0 {
 			t.Errorf("%s: no session settles anything in the term's own words", c.ID)
 		}
-		if tie == 0 {
-			t.Errorf("%s: no session ties the ordinary words to the term", c.ID)
+		// The map links two words only once they have shared three sessions.
+		if ties < cooccurTieCopies {
+			t.Errorf("%s: the tie is said %d times, below what the map learns from", c.ID, ties)
 		}
 	}
 	if tied != PromptTiedCount {


### PR DESCRIPTION
Building the bridge for #2334's tied arm turned up three things wrong with the arm itself, and then refuted the bridge. The arm is now honest and reads 1 of 6.

**The fixture could not be beaten.** The tying sentence restated the question word for word, so it was the best lexical match that can exist — it holds both vocabularies — and no answer could ever outrank it. Real ties are said in passing: `the quorum read is the one that asks every replica`. Rewritten that way, and pinned by a test that rejects a tie which restates the whole question.

**One tie taught the map nothing.** The co-occurrence map links two words only once they have shared three sessions — `cooccurMinPair`, "a pattern, not a one-off". The corpus said each tie once, so the link the arm depends on never existed. Said three times, the map learns it: `endpoint -> [quorum …]`, `machines -> [… sharding]`. A store where a team's own vocabulary appears exactly once does not exist either.

**The probe asked the wrong question.** It read only the session that leads, while the block carries two — and for a reworded question the leader is often the session that explains the vocabulary, which is fine and useful. It now reads both slots and applies the same duplicate rule the hook does (#2328), because three sessions saying one thing must not fill the block with it. That alone takes the arm from 0 to 1 of 6.

**And the bridge itself does not work.** I built the feedback pass this called for — ask again with the words that distinguish the best answer so far, the standard answer to a question in the wrong words — shared between both rankings so neither surface is left out. Measured:

```
borrowed words kept out of the bar   tied 1/6, unchanged — every session the
                                     bridge finds is then judged too weak to show
borrowed words counted in the bar    tied 1/6, unchanged, and a negative
                                     control fires
```

So it is reverted. The reason is in the fixture's own shape and it is worth writing down: a session that holds both vocabularies dominates one that holds only the term, so the tie always leads, and what the bridge has to earn is the *second* slot. Nothing lexical distinguishes the answer there — only that it settled something, which the ranking cannot see without a signal it does not have (#2243).

longmemeval unchanged at 85.3% hit@1 / 0.895 MRR; every other arm reads as before.