### PR TITLE
fix(hook-tool): scope the file line to this project, not to a matching basename

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -389,7 +389,17 @@ func fileMetaInScope(meta index.SessionMeta, path string, projects []string) boo
 		if cand == "" {
 			continue
 		}
-		if proj == cand || strings.HasSuffix(proj, "/"+cand) || strings.HasSuffix(cand, "/"+proj) {
+		// The shared rule, so this scope cannot drift from the one the session
+		// start and the handoff use: a bare candidate is a suffix match only
+		// for a peer's project, whose path is not this machine's. Taking it
+		// for a local one answered an edit to /work/api/ledger.go with seven
+		// sessions from a client's acme/api, and their decision (#2339).
+		if index.ProjectInScope(meta.Project, cand) {
+			return true
+		}
+		// The other direction: a store that records the bare project name
+		// ("api") against a candidate that carries the parent ("work/api").
+		if strings.HasSuffix(cand, "/"+proj) {
 			return true
 		}
 	}

--- a/cmd/deja/hook_tool_scope_test.go
+++ b/cmd/deja/hook_tool_scope_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The file line is scoped so that "main.go" does not collect every project's
+// file of that name. The scope took the checkout's bare directory name as a
+// path suffix, so editing /work/api/ledger.go was answered with seven sessions
+// from a client's acme/api — and their decision (#2339).
+func TestFileScopeDoesNotCrossProjectsOnABareName(t *testing.T) {
+	candidates := []string{"work/api", "api"}
+	cases := []struct {
+		project string
+		in      bool
+	}{
+		{"work/api", true},
+		{"acme/api", false},         // another project ending the same way
+		{"imported:work/api", true}, // the same project from a peer
+		{"api", true},               // a store that records the bare name
+		{"imported:acme/api", true}, // a peer's path is not this machine's
+		{"clients/acme/api", false},
+	}
+	for _, c := range cases {
+		meta := index.SessionMeta{Project: c.project}
+		if got := fileMetaInScope(meta, "/work/api/ledger.go", candidates); got != c.in {
+			t.Errorf("fileMetaInScope(project=%q) = %v, want %v", c.project, got, c.in)
+		}
+	}
+	// The exact path always counts, whatever the project says.
+	touched := index.SessionMeta{Project: "acme/api", Touched: []string{"/work/api/ledger.go"}}
+	if !fileMetaInScope(touched, "/work/api/ledger.go", candidates) {
+		t.Errorf("a session that touched this very path is out of scope")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -770,6 +770,12 @@ func projectInScope(project, want string) bool {
 	return strings.HasSuffix(p, "/"+w) || strings.HasSuffix(p, `\`+w)
 }
 
+// ProjectInScope reports whether a session's project is the one a caller is
+// standing in. Exported so the automatic surfaces share one rule: the same
+// question answered three different ways is how a client's project reached a
+// session start (#2333), a handoff (#2336) and a tool-time line (#2339).
+func ProjectInScope(project, want string) bool { return projectInScope(project, want) }
+
 // relevantMetasCounts additionally reports how many terms of ANY frequency
 // each session matched — the noise gate for full-index relevance search,
 // where demanding two rare terms also rejects real answers that pair one


### PR DESCRIPTION
Seven sessions in a client's `acme/api` edit its `ledger.go`. Editing `/work/api/ledger.go` — my project, no ledger.go in its history — the PreToolUse hook answered "ledger.go has been worked on in 7 sessions … prior decision: we decided the acme cutover runs at midnight".

`fileMetaInScope` took the checkout's bare directory name as a path suffix, which is what #2333 and #2336 removed from the session start and the handoff. The rule is now exported as `index.ProjectInScope` and this scope calls it, so the three cannot drift apart again. One allowance stays, for stores that record a bare project name: a candidate that ends with "/"+project.

Unchanged and honest, checked in the same probe: "This machine has run that command in N sessions" is machine-wide in its own words, like `deja how`.

Fixes #2339.