### PR TITLE
fix(hook): say when recall reached past this project

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -56,7 +56,7 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "{}")
 		return nil
 	}
-	digest = frameRecall(antigravityLead + digest)
+	digest = frameRecall(startLead(antigravityLead) + digest)
 	usage.RecordDigestPolicy(dir, usage.KindHook, digest, sessions, raw,
 		policy.Load().Describe(policy.ActivationAuto))
 	b, err := json.Marshal(antigravityHookResponse{

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -302,7 +302,7 @@ func runHookContext(dir string, plain bool) error {
 	}
 	// One actionable line so injected memory leads somewhere: models that see
 	// bare data tend to ignore it.
-	lead := sessionStartLead
+	lead := startLead(sessionStartLead)
 	if input.Source == "compact" {
 		lead = "Context was just compacted. The project memory below is from deja's index and survived the compaction; call recall_context with a term from it to restore any details you lost.\n"
 		// The generic digest is about the project. What a compacted session
@@ -1040,5 +1040,21 @@ func indexCanCatchUp(dir string) bool {
 	fresh, _ := index.UpToDate(dir, "")
 	return fresh
 }
+
+// startLead swaps a "from this project" lead for the wide one when recall is
+// set to reach past the checkout. The mode replaces the lookup names with the
+// projects of the machine's recent sessions (see hookDigestResultFor), and
+// every harness lead said "this project" either way — so a client's sessions
+// arrived described as this project's history (#2343).
+func startLead(narrow string) string {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("DEJA_RECALL")), search.RecallAggressive) {
+		return wideRecallLead
+	}
+	return narrow
+}
+
+// wideRecallLead is sessionStartLead for DEJA_RECALL=aggressive, where the
+// sessions come from this machine rather than from this checkout.
+const wideRecallLead = "The sessions below are recent work on this machine, not only in this project — deja is set to recall widely. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, tell the user in one short line what deja-vu recalled and how you reused it; otherwise do not mention it.\n"
 
 const sessionStartLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, tell the user in one short line what deja-vu recalled and how you reused it; otherwise do not mention it.\n"

--- a/cmd/deja/hook_lead_mode_test.go
+++ b/cmd/deja/hook_lead_mode_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Aggressive recall reaches past the checkout on purpose. The lead sentence
+// said "from this project's recent history" either way, so a client's sessions
+// arrived described as this project's (#2343).
+func TestTheLeadSaysHowWideTheRecallReached(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	write := func(dirName, id, cwd, text string, hoursAgo int) {
+		d := filepath.Join(root, dirName)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":%q,`+
+			`"message":{"role":"user","content":%q}}`, id, at, cwd, text)
+		if err := os.WriteFile(filepath.Join(d, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("-work-api", "mine", "/work/api", "my own retry budget question, long enough to rank", 20)
+	for i := 0; i < 3; i++ {
+		write("-clients-acme-api", fmt.Sprintf("acme%d", i), "/clients/acme/api",
+			"the acme ledger cutover and the client contact list", i+1)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"hook_event_name":"SessionStart","cwd":"/work/api","session_id":"a1"}`
+
+	out := hookContextFor(t, dir, payload)
+	if !strings.Contains(out, "from this project's recent history") {
+		t.Fatalf("the default lead changed, so this measures nothing:\n%s", out)
+	}
+
+	t.Setenv("DEJA_RECALL", "aggressive")
+	wide := hookContextFor(t, dir, payload)
+	if !strings.Contains(wide, "acme") {
+		t.Fatalf("aggressive recall did not reach past the checkout, so this measures nothing:\n%s", wide)
+	}
+	if strings.Contains(wide, "from this project's recent history") {
+		t.Errorf("another project's sessions are described as this project's:\n%s", wide)
+	}
+	if !strings.Contains(wide, "this machine") {
+		t.Errorf("the wide lead does not say how far it reached:\n%s", wide)
+	}
+}

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -112,7 +112,7 @@ func refreshAiderContext(dir string) error {
 	digest, sessions, _, _, _ := cachedHookDigest(dir)
 	body := digest
 	if sessions > 0 {
-		body = frameRecall(aiderLead + digest)
+		body = frameRecall(startLead(aiderLead) + digest)
 	}
 	if strings.TrimSpace(body) == "" {
 		// No history for this project yet. An empty file still has to exist:

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -348,7 +348,7 @@ func refreshGooseHintsFor(cwd string) error {
 	digest, sessions, _, _, _ := cachedHookDigestFor(index.DefaultDir(), cwd)
 	body := digest
 	if sessions > 0 {
-		body = frameRecall(gooseLead + digest)
+		body = frameRecall(startLead(gooseLead) + digest)
 	}
 	if strings.TrimSpace(body) == "" {
 		body = "No matching history yet.\n"


### PR DESCRIPTION
`DEJA_RECALL=aggressive` replaces the checkout's project candidates with the projects of the machine's twelve most recent sessions — deliberate — while the lead sentence stayed "The sessions below are from this project's recent history". With a client's project on the same machine, its sessions arrived described as this project's.

One helper now picks the lead, and the three other harness leads (antigravity, goose, aider), which build the same digest, go through it too.

Fixes #2343.