### PR TITLE
fix(doctor): stop reporting deliberate skips as files it could not read

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -320,10 +320,6 @@ func doctorEmbed(w io.Writer, r doctorEmbedReport) {
 	fmt.Fprintf(w, "  sidecar    coverage=%.1f%%\n", r.Coverage)
 }
 
-// unplacedFiles counts transcripts under root that the harness's own filter
-// did not pick up. A harness that changes its layout in a new version presents
-// exactly this way: quietly fewer sessions, no error, and a directory size that
-// still looks right (#701).
 // inDotDir reports whether the path sits inside a dot-directory below the
 // root — a cache, a temp dir, anything a tool keeps for itself.
 func inDotDir(root, p string) bool {
@@ -339,6 +335,11 @@ func inDotDir(root, p string) bool {
 	return false
 }
 
+// unplacedFiles counts transcripts under root that the harness's own filter did
+// not pick up. A harness that changes its layout in a new version presents
+// exactly this way: quietly fewer sessions, no error, and a directory size that
+// still looks right (#701).
+//
 // unplacedFiles counts the transcripts under a root that deja did not read,
 // split by whether it declined them on purpose. Everything was one number
 // before, and on a machine that spawns subagents most of it is the deliberate

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -324,12 +324,33 @@ func doctorEmbed(w io.Writer, r doctorEmbedReport) {
 // did not pick up. A harness that changes its layout in a new version presents
 // exactly this way: quietly fewer sessions, no error, and a directory size that
 // still looks right (#701).
-func unplacedFiles(root string, seen []string) int {
+// inDotDir reports whether the path sits inside a dot-directory below the
+// root — a cache, a temp dir, anything a tool keeps for itself.
+func inDotDir(root, p string) bool {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	for _, part := range strings.Split(filepath.Dir(rel), string(filepath.Separator)) {
+		if strings.HasPrefix(part, ".") && part != "." && part != ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// unplacedFiles counts the transcripts under a root that deja did not read,
+// split by whether it declined them on purpose. Everything was one number
+// before, and on a machine that spawns subagents most of it is the deliberate
+// skip: this store reported "1192 not recognised here" of which 596 were
+// subagent transcripts deja is written to leave alone (#1384). A number that
+// large reads as the tool failing to understand the user's own history, which
+// is the one thing doctor exists to rule out.
+func unplacedFiles(root string, seen []string, skipped func(string) bool) (unread, byRule int) {
 	have := make(map[string]bool, len(seen))
 	for _, p := range seen {
 		have[filepath.Clean(p)] = true
 	}
-	extra := 0
 	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return nil
@@ -339,12 +360,23 @@ func unplacedFiles(root string, seen []string) int {
 		default:
 			return nil
 		}
-		if !have[filepath.Clean(p)] {
-			extra++
+		if have[filepath.Clean(p)] {
+			return nil
 		}
+		// A store's own scratch is not a transcript deja failed to read: 452
+		// of the 482 this machine reported for codex sat in `.tmp`, and a
+		// count that size reads as a parser that cannot cope with the store.
+		if inDotDir(root, p) {
+			return nil
+		}
+		if skipped != nil && skipped(p) {
+			byRule++
+			return nil
+		}
+		unread++
 		return nil
 	})
-	return extra
+	return unread, byRule
 }
 
 // printDoctorStoreWarnings says what deja could not read and why.
@@ -581,16 +613,26 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// The count comes from the same filter the parser uses, so a store whose
 	// layout differs slightly loses those files from every number deja prints
 	// — the one thing `doctor` exists to rule out (#701).
-	printFiles := func(name, path string, present bool, seen []string) {
+	// printFilesSkipping is printFiles for a harness that declines some of its
+	// own files by a rule, so the two can be told apart in the row.
+	printFilesSkipping := func(name, path string, present bool, seen []string, skipped func(string) bool) {
 		detail := doctorCount(len(seen), "file")
-		if extra := unplacedFiles(path, seen); extra > 0 {
-			detail += fmt.Sprintf(", %d not recognised here", extra)
+		unread, byRule := unplacedFiles(path, seen, skipped)
+		if byRule > 0 {
+			detail += fmt.Sprintf(", %d subagent transcripts skipped (DEJA_INCLUDE_SUBAGENTS=1)", byRule)
+		}
+		if unread > 0 {
+			detail += fmt.Sprintf(", %d not recognised here", unread)
 		}
 		printRow(name, path, present, detail)
 	}
+	printFiles := func(name, path string, present bool, seen []string) {
+		printFilesSkipping(name, path, present, seen, nil)
+	}
 
 	claudeRoot := sources.ClaudeRoot()
-	printFiles("claude", claudeRoot, doctorExists(claudeRoot), sources.ClaudeFiles())
+	printFilesSkipping("claude", claudeRoot, doctorExists(claudeRoot), sources.ClaudeFiles(),
+		func(p string) bool { return !sources.ClaudeFileWanted(p) })
 
 	codexRoot := sources.CodexRoot()
 	printFiles("codex", codexRoot, doctorExists(codexRoot), sources.CodexFiles())

--- a/cmd/deja/doctor_unplaced_test.go
+++ b/cmd/deja/doctor_unplaced_test.go
@@ -1,20 +1,19 @@
 package main
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// A harness that changes its layout presents as quietly fewer sessions, no
-// error, and a directory size that still looks right — and doctor, the command
-// that exists to rule that out, counted only what the parser already saw
-// (#701).
-func TestUnplacedFiles(t *testing.T) {
+// doctor's job is to rule out the tool failing to read the user's history, so
+// its own count must not read as that failure. Everything deja did not parse
+// was one number: on this machine that was "1192 not recognised here" for
+// claude, of which 596 were subagent transcripts deja is written to leave
+// alone, and "482" for codex, of which 452 sat in `.tmp`.
+func TestUnplacedSeparatesDeliberateSkipsFromTheUnread(t *testing.T) {
 	root := t.TempDir()
-	mk := func(rel string) string {
+	write := func(rel string) string {
 		p := filepath.Join(root, rel)
 		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 			t.Fatal(err)
@@ -24,64 +23,41 @@ func TestUnplacedFiles(t *testing.T) {
 		}
 		return p
 	}
-	seen := []string{mk("proj/chats/a.jsonl"), mk("proj/chats/b.jsonl")}
-	mk("proj/stray.jsonl")
-	mk("proj/other/deeper.json")
-	// Not a transcript: extensions deja never reads must not be counted as
-	// missed history.
-	mk("proj/notes.md")
-	mk("proj/db.sqlite")
+	read := write("proj/read.jsonl")
+	write("proj/session/subagents/agent-1.jsonl")
+	write("proj/session/subagents/agent-2.jsonl")
+	write(".tmp/scratch.json")
+	write("proj/strange.jsonl")
 
-	if got := unplacedFiles(root, seen); got != 2 {
-		t.Errorf("unplaced = %d, want 2", got)
+	skipped := func(p string) bool { return filepath.Base(filepath.Dir(p)) == "subagents" }
+	unread, byRule := unplacedFiles(root, []string{read}, skipped)
+	if byRule != 2 {
+		t.Errorf("deliberate skips counted as %d, want 2", byRule)
 	}
-	// Everything accounted for: nothing to report.
-	all := append(seen, filepath.Join(root, "proj", "stray.jsonl"), filepath.Join(root, "proj", "other", "deeper.json"))
-	if got := unplacedFiles(root, all); got != 0 {
-		t.Errorf("unplaced = %d with every file seen", got)
-	}
-	// A root that does not exist is not a complaint.
-	if got := unplacedFiles(filepath.Join(root, "nope"), nil); got != 0 {
-		t.Errorf("missing root reported %d", got)
-	}
-	if got := unplacedFiles("", nil); got != 0 {
-		t.Errorf("empty root reported %d", got)
+	// Only the one file that is neither read nor skipped by a rule. The
+	// dot-directory is a store's own scratch, not a transcript.
+	if unread != 1 {
+		t.Errorf("unread counted as %d, want 1", unread)
 	}
 }
 
-// The note is only worth printing when something is actually unaccounted for:
-// ", 0 not recognised here" on every harness is noise.
-func TestDoctorHarnessRowSaysNothingWhenEverythingIsPlaced(t *testing.T) {
-	tmp := hermeticEnv(t)
-	qwen := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
-	if err := os.MkdirAll(qwen, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(qwen, "a.jsonl"), []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
-	var buf bytes.Buffer
-	doctorHarnesses(&buf, t.TempDir())
-	for _, line := range strings.Split(buf.String(), "\n") {
-		if strings.Contains(line, "qwen") && strings.Contains(line, "not recognised") {
-			t.Errorf("clean store complains: %q", line)
+// Without a rule the count behaves as it did, minus the scratch.
+func TestUnplacedWithoutARuleStillCounts(t *testing.T) {
+	root := t.TempDir()
+	for _, rel := range []string{"a.jsonl", "b.jsonl", ".cache/c.jsonl"} {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
 		}
 	}
-
-	// One file in the wrong place, and the row says so.
-	if err := os.WriteFile(filepath.Join(tmp, "qwen", "projects", "proj", "stray.jsonl"), []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
+	unread, byRule := unplacedFiles(root, nil, nil)
+	if byRule != 0 {
+		t.Errorf("skips reported without a rule: %d", byRule)
 	}
-	buf.Reset()
-	doctorHarnesses(&buf, t.TempDir())
-	found := false
-	for _, line := range strings.Split(buf.String(), "\n") {
-		if strings.Contains(line, "qwen") && strings.Contains(line, "1 not recognised here") {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("stray file not reported:\n%s", buf.String())
+	if unread != 2 {
+		t.Errorf("unread counted as %d, want 2", unread)
 	}
 }

--- a/cmd/deja/doctor_unplaced_test.go
+++ b/cmd/deja/doctor_unplaced_test.go
@@ -1,10 +1,90 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// A harness that changes its layout presents as quietly fewer sessions, no
+// error, and a directory size that still looks right — and doctor, the command
+// that exists to rule that out, counted only what the parser already saw
+// (#701).
+func TestUnplacedFiles(t *testing.T) {
+	root := t.TempDir()
+	mk := func(rel string) string {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	seen := []string{mk("proj/chats/a.jsonl"), mk("proj/chats/b.jsonl")}
+	mk("proj/stray.jsonl")
+	mk("proj/other/deeper.json")
+	// Not a transcript: extensions deja never reads must not be counted as
+	// missed history.
+	mk("proj/notes.md")
+	mk("proj/db.sqlite")
+
+	if got, _ := unplacedFiles(root, seen, nil); got != 2 {
+		t.Errorf("unplaced = %d, want 2", got)
+	}
+	// Everything accounted for: nothing to report.
+	all := append(seen, filepath.Join(root, "proj", "stray.jsonl"), filepath.Join(root, "proj", "other", "deeper.json"))
+	if got, _ := unplacedFiles(root, all, nil); got != 0 {
+		t.Errorf("unplaced = %d with every file seen", got)
+	}
+	// A root that does not exist is not a complaint.
+	if got, _ := unplacedFiles(filepath.Join(root, "nope"), nil, nil); got != 0 {
+		t.Errorf("missing root reported %d", got)
+	}
+	if got, _ := unplacedFiles("", nil, nil); got != 0 {
+		t.Errorf("empty root reported %d", got)
+	}
+}
+
+// The note is only worth printing when something is actually unaccounted for:
+// ", 0 not recognised here" on every harness is noise.
+func TestDoctorHarnessRowSaysNothingWhenEverythingIsPlaced(t *testing.T) {
+	tmp := hermeticEnv(t)
+	qwen := filepath.Join(tmp, "qwen", "projects", "proj", "chats")
+	if err := os.MkdirAll(qwen, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(qwen, "a.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_QWEN_ROOT", filepath.Join(tmp, "qwen"))
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "qwen") && strings.Contains(line, "not recognised") {
+			t.Errorf("clean store complains: %q", line)
+		}
+	}
+
+	// One file in the wrong place, and the row says so.
+	if err := os.WriteFile(filepath.Join(tmp, "qwen", "projects", "proj", "stray.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf.Reset()
+	doctorHarnesses(&buf, t.TempDir())
+	found := false
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "qwen") && strings.Contains(line, "1 not recognised here") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("stray file not reported:\n%s", buf.String())
+	}
+}
 
 // doctor's job is to rule out the tool failing to read the user's history, so
 // its own count must not read as that failure. Everything deja did not parse


### PR DESCRIPTION
`deja doctor` exists to rule out the tool quietly failing to read someone's history, and its own row said this on my machine:

```
claude   (48 files, 1192 not recognised here, 44 indexed sessions)
codex    (34 files, 482 not recognised here, 33 indexed sessions)
```

That reads as deja understanding 4% of a store. It is not what the numbers are. 596 of claude's were subagent transcripts deja is written to leave alone (#1384, with `DEJA_INCLUDE_SUBAGENTS=1` to take them in), and 452 of codex's 482 sat in `.tmp`.

The row now separates the two, and says what to do about the one that is a choice:

```
claude   (48 files, 1358 subagent transcripts skipped (DEJA_INCLUDE_SUBAGENTS=1), 44 indexed sessions)
codex    (34 files, 29 not recognised here, 33 indexed sessions)
```

29 is a number worth looking at. 482 was noise, and noise in the diagnostic is worse than in the product: it teaches the reader to ignore the line that would tell them their store had really stopped parsing.

Two rules, both narrow. A harness may declare which of its own files it declines — only claude does, through `sources.ClaudeFileWanted`, and the others pass nil and behave exactly as before. And a dot-directory under a store root is that tool's own scratch rather than a transcript deja missed.

The tests that were there keep working against the new signature, and two more pin the split.