### PR TITLE
fix(handoff): do not package a synced project matched only by directory name

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -202,6 +202,17 @@ func handoffSource(dir, prefix string) (model.Session, error) {
 		// listing does and what a listing filters (#937). Without this the
 		// pick landed on a session the rule keeps out of recall and packaged
 		// its content for another agent (#953).
+		// Synced work is offered by recall under the looser rule, but handing
+		// it to another agent on a directory-name match is a different act:
+		// from a directory named api, the newest match was a teammate's
+		// clients/acme/api (#2347).
+		var own []model.Session
+		for _, s := range ss {
+			if index.ProjectInScopeStrict(s.Project, name) {
+				own = append(own, s)
+			}
+		}
+		ss = own
 		kept, _ := policyFilterSessionsCounted(policy.ActivationSearch, ss)
 		keptIDs := map[string]bool{}
 		for _, k := range kept {

--- a/cmd/deja/handoff_imported_scope_test.go
+++ b/cmd/deja/handoff_imported_scope_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The scope rule keeps bare-name matching for synced projects on purpose, so a
+// peer's goprojects/svc answers to a local svc. handoff took that as licence to
+// package a teammate's clients/acme/api from a directory named api — content
+// prepared for another agent, picked because it was the newest (#2347).
+func TestHandoffDoesNotPackageASyncedProjectMatchedByDirectoryName(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-20 * time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"mine","timestamp":%q,"cwd":"/work/api",`+
+		`"message":{"role":"user","content":"my own retry budget question"}}`, at)
+	if err := os.WriteFile(filepath.Join(store, "mine.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	rec := index.SyncRecord{
+		Harness: "claude", SessionID: "peer0", Project: "clients/acme/api",
+		Role: "user", Text: "the acme ledger cutover and the client contact list",
+		Time: time.Now().Add(-time.Hour).UTC(),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+
+	work := filepath.Join(tmp, "work", "api")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	out, err := captureRun(t, "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "acme") {
+		t.Errorf("handoff packaged a synced project matched only by directory name:\n%s", out)
+	}
+	if !strings.Contains(out, "retry budget") {
+		t.Errorf("handoff did not pick this project's own session:\n%s", out)
+	}
+}

--- a/internal/index/project_scope_test.go
+++ b/internal/index/project_scope_test.go
@@ -29,3 +29,29 @@ func TestProjectScopeDoesNotMatchOnABareBasename(t *testing.T) {
 		}
 	}
 }
+
+// The strict rule drops the allowance synced work gets: right for recall, wrong
+// for a command that packages one session for another agent (#2347).
+func TestStrictProjectScopeDropsTheSyncedAllowance(t *testing.T) {
+	cases := []struct {
+		project, want string
+		in            bool
+	}{
+		{"work/api", "work/api", true},
+		{"imported:work/api", "work/api", true},
+		{"imported:clients/acme/api", "api", false},
+		{"imported:goprojects/svc", "svc", false},
+		{"imported:svc", "svc", true},
+		{"src/clients/acme/api", "acme/api", true},
+		{"acme/api", "", false},
+	}
+	for _, c := range cases {
+		if got := ProjectInScopeStrict(c.project, c.want); got != c.in {
+			t.Errorf("ProjectInScopeStrict(%q, %q) = %v, want %v", c.project, c.want, got, c.in)
+		}
+	}
+	// And the loose rule still answers the synced case recall depends on.
+	if !ProjectInScope("imported:goprojects/svc", "svc") {
+		t.Error("the loose rule no longer reaches a peer's project by its local name")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -770,6 +770,27 @@ func projectInScope(project, want string) bool {
 	return strings.HasSuffix(p, "/"+w) || strings.HasSuffix(p, `\`+w)
 }
 
+// ProjectInScopeStrict is ProjectInScope without the allowance synced work
+// gets. The loose rule is right for recall — a peer's parent path is not this
+// machine's, so `imported:goprojects/svc` has to answer to a local `svc` — and
+// wrong for a command that packages one session's content for another agent:
+// `deja handoff`, run from a directory named api, picked a teammate's
+// `clients/acme/api` because it was the newest thing ending in /api (#2347).
+func ProjectInScopeStrict(project, want string) bool {
+	if want == "" {
+		return false
+	}
+	p := strings.TrimPrefix(strings.ToLower(project), "imported:")
+	w := strings.ToLower(want)
+	if p == w {
+		return true
+	}
+	if !strings.ContainsAny(w, `/\`) {
+		return false
+	}
+	return strings.HasSuffix(p, "/"+w) || strings.HasSuffix(p, `\`+w)
+}
+
 // ProjectInScope reports whether a session's project is the one a caller is
 // standing in. Exported so the automatic surfaces share one rule: the same
 // question answered three different ways is how a client's project reached a


### PR DESCRIPTION
The scope rule keeps bare-name matching for `imported:` on purpose — a peer's parent path is not this machine's, so `imported:goprojects/svc` answers to a local `svc`, which is what makes a synced index useful. `deja handoff`, run from a directory named `api`, used that to package a teammate's `clients/acme/api` for another agent, picked first because it was the newest thing ending in /api.

Recall offering synced work is the feature; handing one session's content to another agent on a name collision is a different act. New `index.ProjectInScopeStrict` drops the synced allowance and handoff filters with it. The session start is unchanged and still shows synced work, labelled `imported:`.

The wider question — two teammates' projects ending in the same directory name are indistinguishable to every automatic path — stays open in #2347's last paragraph and in the hunt queue.

Fixes #2347.