### PR TITLE
fix(hook): record the projects a session-start digest came from

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -40,14 +40,25 @@ const (
 // received error text drawn from the sessions that denial had just hidden, plus
 // the harnesses and dates behind it (#659). The block reads the manifest
 // directly, so nothing upstream could have filtered it.
+// environmentBlock is environmentBlockFrom without the projects, for callers
+// that only print it.
 func environmentBlock(dir, activation string) string {
+	text, _ := environmentBlockFrom(dir, activation)
+	return text
+}
+
+// environmentBlockFrom also reports the projects whose sessions the walls came
+// from. The block names none of them in its text — it is about the machine —
+// so a record without them could not be reached when one of those projects was
+// forgotten (#2349).
+func environmentBlockFrom(dir, activation string) (string, []string) {
 	// Origin is a property of the sessions the walls came from, so the gate has
 	// to be per wall rather than one check up front: a machine can hold both
 	// local and imported sessions hitting the same error.
 	pol := policy.Load()
 	walls := index.TopFriction(dir, environmentWalls, nil)
 	if len(walls) == 0 {
-		return ""
+		return "", nil
 	}
 	var allowed []index.Friction
 	for _, w := range walls {
@@ -65,9 +76,22 @@ func environmentBlock(dir, activation string) string {
 		}
 	}
 	if len(allowed) == 0 {
-		return ""
+		return "", nil
 	}
 	walls = allowed
+	// The projects behind the walls, deduped in the order they appear: the
+	// block's own text names the errors and not where they came from.
+	var projects []string
+	seen := map[string]bool{}
+	for _, w := range walls {
+		for _, sess := range w.Sessions {
+			if sess.Project == "" || seen[sess.Project] {
+				continue
+			}
+			seen[sess.Project] = true
+			projects = append(projects, sess.Project)
+		}
+	}
 	var b strings.Builder
 	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
 	for _, w := range walls {
@@ -82,7 +106,7 @@ func environmentBlock(dir, activation string) string {
 	// reason the block is here.
 	b.WriteString("These are environment facts, not history: the tool or module is still missing. " +
 		"Check or use an alternative before running into them again.")
-	return b.String()
+	return b.String(), projects
 }
 
 // environmentSpent is per process, which is what makes "once" countable on

--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -51,13 +51,13 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	// The payload, and nothing written back into the environment: deja used to
 	// export the workspace here, which carried this call's project into the
 	// next one in the same process and decided nothing else (#2185).
-	digest, sessions, raw, _, _ := cachedHookDigestFor(dir, workspace)
+	digest, sessions, raw, _, _, projects := cachedHookDigestFor(dir, workspace)
 	if digest == "" {
 		fmt.Fprintln(stdout, "{}")
 		return nil
 	}
 	digest = frameRecall(startLead(antigravityLead) + digest)
-	usage.RecordDigestPolicy(dir, usage.KindHook, digest, sessions, raw,
+	usage.RecordDigestPolicyFrom(dir, usage.KindHook, digest, "", sessions, raw, projects,
 		policy.Load().Describe(policy.ActivationAuto))
 	b, err := json.Marshal(antigravityHookResponse{
 		InjectSteps: []antigravityInjectStep{{EphemeralMessage: digest}},

--- a/cmd/deja/hook_antigravity_stdin_test.go
+++ b/cmd/deja/hook_antigravity_stdin_test.go
@@ -35,7 +35,7 @@ func TestHookAntigravityBoundsStdinWithoutInjectingOnEveryTurn(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("fixture has no digest to inject")
 	}
 

--- a/cmd/deja/hook_cache_orphan_test.go
+++ b/cmd/deja/hook_cache_orphan_test.go
@@ -45,7 +45,7 @@ func TestHookAsksForARebuildWhenTheIndexIsGone(t *testing.T) {
 	spawnWarmup = func(exe, sentinel string) error { spawned++; return nil }
 	t.Cleanup(func() { spawnWarmup = saved })
 
-	digest, sessions, _, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(digest, "pool exhausted") || sessions != 1 {
 		t.Errorf("the cached digest was dropped rather than served: %q (%d sessions)", digest, sessions)
 	}

--- a/cmd/deja/hook_cache_test.go
+++ b/cmd/deja/hook_cache_test.go
@@ -28,7 +28,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
 
-	d1, s1, _, _, _ := cachedHookDigest(dir)
+	d1, s1, _, _, _, _ := cachedHookDigest(dir)
 	if d1 == "" || s1 == 0 {
 		t.Fatal("first call must build a digest")
 	}
@@ -40,7 +40,7 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	d2, _, _, _, _ := cachedHookDigest(dir)
+	d2, _, _, _, _, _ := cachedHookDigest(dir)
 	if d2 != d1 {
 		t.Fatal("within TTL the cached digest must be served verbatim")
 	}
@@ -60,20 +60,20 @@ func TestCachedHookDigestServesWithinTTLAndInvalidates(t *testing.T) {
 	if err := os.WriteFile(cachePath, nb, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	d3, _, _, _, _ := cachedHookDigest(dir)
+	d3, _, _, _, _, _ := cachedHookDigest(dir)
 	if d3 != d1 {
 		t.Fatalf("expired cache must serve stale instantly, got:\n%s", d3)
 	}
 	// The refresh itself must produce the fresh view.
 	runHookRefresh(dir)
-	d3b, _, _, _, _ := cachedHookDigest(dir)
+	d3b, _, _, _, _, _ := cachedHookDigest(dir)
 	if !strings.Contains(d3b, "marker_beta") {
 		t.Fatalf("refresh must rebuild with fresh sessions:\n%s", d3b)
 	}
 	d3 = d3b
 	// A different cwd must never reuse another project's cache.
 	t.Setenv("CLAUDE_PROJECT_DIR", filepath.Join(t.TempDir(), "elsewhere"))
-	d4, _, _, _, _ := cachedHookDigest(dir)
+	d4, _, _, _, _, _ := cachedHookDigest(dir)
 	if d4 == d3 && d3 != "" {
 		t.Fatal("cache must be scoped to cwd")
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -239,15 +239,18 @@ func runHookContext(dir string, plain bool) error {
 	// environment, so a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
 	// none (#759).
-	digest, sessions, raw, taskMatched, withheld := cachedHookDigestFor(dir, input.CWD)
+	digest, sessions, raw, taskMatched, withheld, projects := cachedHookDigestFor(dir, input.CWD)
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
 		// checkout — and exactly where knowing what this machine is missing
 		// helps most. The block is about the machine, not the project, so it
 		// does not depend on the digest having found anything.
-		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
+		if env, from := environmentBlockFrom(dir, policy.ActivationAuto); env != "" {
 			out := frameRecall(env)
-			usage.RecordDigestPolicyInto(dir, usage.KindHook, out, input.SessionID, 0, 0, policy.Load().Describe(policy.ActivationAuto))
+			// The block is about the machine and names no project, so without
+			// the projects behind its walls a forget of one of them could not
+			// reach the stored text (#2349).
+			usage.RecordDigestPolicyFrom(dir, usage.KindHook, out, input.SessionID, 0, 0, from, policy.Load().Describe(policy.ActivationAuto))
 			if plain {
 				fmt.Fprintln(os.Stdout, out)
 				return nil
@@ -319,7 +322,7 @@ func runHookContext(dir string, plain bool) error {
 	}
 	digest = frameRecall(digest)
 	polName := policy.Load().Describe(policy.ActivationAuto)
-	usage.RecordDigestPolicyInto(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName)
+	usage.RecordDigestPolicyFrom(dir, usage.KindHook, digest, input.SessionID, sessions, raw, projects, polName)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -523,6 +526,11 @@ type hookCacheEntry struct {
 	Gate     string `json:"gate,omitempty"`
 	Digest   string `json:"digest"`
 	Sessions int    `json:"sessions"`
+	// Projects names what went into the digest, so the injection log can
+	// record it and a later forget or trust rule can be applied to the stored
+	// text without reading its prose (#2349). Old entries decode as none,
+	// which is what they carried.
+	Projects []string `json:"projects,omitempty"`
 	// Withheld counts the candidates the trust policy dropped for this
 	// digest. Old entries decode as zero, which reads as "nothing withheld"
 	// and is what they meant.
@@ -542,7 +550,11 @@ func hookCachePath(dir, cwd string) string {
 // hookDigestResult, which a cache hit never reaches.
 func hookGate() string {
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
-	return mode + "|" + policy.Load().Describe(policy.ActivationAuto)
+	// The gate carries what the entry was built under, and the shape of the
+	// entry itself is part of that: an entry written before the digest recorded
+	// its projects would be served for its whole TTL and logged as a digest
+	// that came from nowhere (#2349).
+	return "v2|" + mode + "|" + policy.Load().Describe(policy.ActivationAuto)
 }
 
 // hookCWD is where the hook is standing: what the payload says, else the
@@ -570,7 +582,7 @@ func hookCWD(fromPayload string) string {
 	return cwd
 }
 
-func cachedHookDigest(dir string) (string, int, int64, []string, int) {
+func cachedHookDigest(dir string) (string, int, int64, []string, int, []string) {
 	return cachedHookDigestFor(dir, "")
 }
 
@@ -578,10 +590,10 @@ func cachedHookDigest(dir string) (string, int, int64, []string, int) {
 // project the call is about. The payload is that authority: deja used to write
 // it into its own environment and read it back, which answered a second payload
 // in the same process with the first one's project (#2182, #2185).
-func cachedHookDigestFor(dir, fromPayload string) (string, int, int64, []string, int) {
+func cachedHookDigestFor(dir, fromPayload string) (string, int, int64, []string, int, []string) {
 	cwd := hookCWD(fromPayload)
 	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	// Before the cache read: a hit returns without reaching the version guard
 	// in hookDigestResult, so an index left behind by an upgrade was served
@@ -605,19 +617,19 @@ func cachedHookDigestFor(dir, fromPayload string) (string, int, int64, []string,
 				// the cache off the startup path.
 				requestHookRefresh(dir, cwd)
 			}
-			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld
+			return e.Digest, e.Sessions, e.Raw, e.TaskMatched, e.Withheld, e.Projects
 		}
 	}
-	digest, sessions, raw, taskMatched, withheld := hookDigestResultFor(dir, cwd)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
-	return digest, sessions, raw, taskMatched, withheld
+	digest, sessions, raw, taskMatched, withheld, projects := hookDigestResultFor(dir, cwd)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld, projects)
+	return digest, sessions, raw, taskMatched, withheld, projects
 }
 
-func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string, withheld int) {
+func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatched []string, withheld int, projects []string) {
 	if digest == "" {
 		return
 	}
-	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld}); err == nil {
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld, Projects: projects}); err == nil {
 		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
 	}
 }
@@ -672,17 +684,17 @@ func runHookRefresh(dir string) {
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		return
 	}
-	digest, sessions, raw, taskMatched, withheld := hookDigestResult(dir)
-	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld)
+	digest, sessions, raw, taskMatched, withheld, projects := hookDigestResult(dir)
+	writeHookCache(dir, cwd, digest, sessions, raw, taskMatched, withheld, projects)
 	_ = os.Remove(hookCachePath(dir, cwd) + ".refreshing")
 }
 
 func hookDigest(dir string) string {
-	digest, _, _, _, _ := hookDigestResult(dir)
+	digest, _, _, _, _, _ := hookDigestResult(dir)
 	return digest
 }
 
-func hookDigestResult(dir string) (string, int, int64, []string, int) {
+func hookDigestResult(dir string) (string, int, int64, []string, int, []string) {
 	return hookDigestResultFor(dir, "")
 }
 
@@ -690,7 +702,7 @@ func hookDigestResult(dir string) (string, int, int64, []string, int) {
 // project the call is about, rather than one reading it back out of the
 // environment, where a project deja itself had written stayed for every later
 // call in the process (#2182, #2185).
-func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string, int) {
+func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string, int, []string) {
 	withheld := 0
 	defer func() { _ = recover() }()
 	trace := os.Getenv("DEJA_TRACE") == "1"
@@ -704,7 +716,7 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	_ = mark
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL")))
 	if mode == search.RecallOff {
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	// A store from an older index version must be rebuilt before it is read:
 	// this path never calls Ensure, so otherwise the first prompts after an
@@ -713,7 +725,7 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	// manifest still describes, and this path answers from them (#800).
 	if !index.HasManifest(dir) || !index.IsCurrentVersion(dir) || index.Damaged(dir) {
 		requestWarmup(dir)
-		return "", 0, 0, nil, 0
+		return "", 0, 0, nil, 0, nil
 	}
 	cwd := fromPayload
 	if cwd == "" {
@@ -723,7 +735,7 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 		var err error
 		cwd, err = os.Getwd()
 		if err != nil {
-			return "", 0, 0, nil, 0
+			return "", 0, 0, nil, 0, nil
 		}
 	}
 	// The two git probes (worktree list for identity, status/log for the
@@ -786,11 +798,13 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 		// The standing decisions still apply, so serve them alone rather than
 		// going out empty.
 		if conventions != "" {
-			return conventions, 0, 0, nil, withheld
+			// The conventions carry the project they belong to: this is the
+			// checkout's own memory even when no session survives to show it.
+			return conventions, 0, 0, nil, withheld, allowedNames
 		}
 		// withheld travels even with nothing to show: it is the only thing
 		// that separates "the rule hid all of it" from "no history here".
-		return "", 0, 0, nil, withheld
+		return "", 0, 0, nil, withheld, nil
 	}
 	scores, matched := taskScores(ss, taskFiles)
 	sort.Slice(ss, func(i, j int) bool {
@@ -826,9 +840,11 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	// Inside the cached result, not after it: this costs a manifest scan plus
 	// one session read, which is ten times the rest of the hook, and the
 	// clusters it reports change over weeks rather than turns.
+	var envFrom []string
 	if !environmentServedRecently(dir) {
-		if env := environmentBlock(dir, policy.ActivationAuto); env != "" {
+		if env, from := environmentBlockFrom(dir, policy.ActivationAuto); env != "" {
 			text += "\n" + env + "\n"
+			envFrom = from
 			// Stamped on the way out rather than by the check: the check is
 			// also made by callers that may not deliver (#1806).
 			stampEnvironmentServed(dir)
@@ -846,7 +862,31 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	// The candidates that never made it into the digest were never served:
 	// counting their transcripts here inflated the distillation ratio deja
 	// prints about itself (1 session distilled, 3 sessions' bytes claimed).
-	return text, result.Sessions, result.RawBytes, matched, withheld
+	// The projects behind what actually went out, so the injection log can be
+	// held to a rule or a forget without reading the digest's prose (#2349).
+	return text, result.Sessions, result.RawBytes, matched, withheld, digestProjects(ss, envFrom)
+}
+
+// digestProjects names the projects a session-start digest was built from: the
+// sessions it shows, plus the ones behind the environment block, which names
+// none of them in its own text.
+func digestProjects(ss []model.Session, env []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(p string) {
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	for _, s := range ss {
+		add(s.Project)
+	}
+	for _, p := range env {
+		add(p)
+	}
+	return out
 }
 
 // warmupDeadAfter is how long a warmup may go without publishing progress

--- a/cmd/deja/hook_conventions_test.go
+++ b/cmd/deja/hook_conventions_test.go
@@ -90,7 +90,7 @@ func TestSessionStartSurfacesADecisionTheDigestDropped(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	text, _, _, _, _ := hookDigestResult(dir)
+	text, _, _, _, _, _ := hookDigestResult(dir)
 	if !strings.Contains(text, "standing decisions in this project") {
 		t.Fatalf("no standing-decisions block was injected:\n%s", text)
 	}
@@ -126,7 +126,7 @@ func TestStandingDecisionsRespectTheTrustPolicy(t *testing.T) {
 	// Deny local memory for auto-activation.
 	writePolicyFile(t, `{"activations":{"auto":{"local":false}}}`)
 
-	text, _, _, _, _ := hookDigestResult(dir)
+	text, _, _, _, _, _ := hookDigestResult(dir)
 	if strings.Contains(text, "pgxpolicymarker") {
 		t.Fatalf("a policy-denied project's decision was injected into the hook:\n%s", text)
 	}

--- a/cmd/deja/hook_digest_projects_test.go
+++ b/cmd/deja/hook_digest_projects_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The environment block is built from every project's walls and names none of
+// them, and the hook recorded it with no projects — so forgetting the project
+// it came from left the text in the injection log (#2349).
+func TestTheEnvironmentBlockRecordsWhereItCameFrom(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-clients-acme-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 4; i++ {
+		at := time.Now().Add(-time.Duration(2+i) * time.Hour).UTC().Format(time.RFC3339)
+		rows := []string{
+			fmt.Sprintf(`{"type":"user","sessionId":"acme%d","timestamp":%q,"cwd":"/clients/acme/api",`+
+				`"message":{"role":"user","content":"the acme cutover keeps failing"}}`, i, at),
+			fmt.Sprintf(`{"type":"user","sessionId":"acme%d","timestamp":%q,"cwd":"/clients/acme/api",`+
+				`"message":{"role":"user","content":[{"type":"tool_result","content":"panic: acme ledger overflow in ledger/quaxbolt.go"}]}}`, i, at),
+		}
+		name := fmt.Sprintf("acme%d.jsonl", i)
+		if err := os.WriteFile(filepath.Join(store, name), []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := filepath.Join(tmp, "fresh", "checkout")
+	if err := os.MkdirAll(fresh, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out := hookContextFor(t, dir, fmt.Sprintf(
+		`{"hook_event_name":"SessionStart","cwd":%q,"session_id":"a1"}`, fresh))
+	if !strings.Contains(out, "acme ledger overflow") {
+		t.Fatalf("the environment block did not fire, so this measures nothing:\n%s", out)
+	}
+
+	// The record knows which project the walls came from.
+	snaps := usage.Snapshots(dir, 0)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want the one the hook just wrote", len(snaps))
+	}
+	if len(snaps[0].Projects) == 0 {
+		t.Errorf("the environment block records no projects, so forget cannot reach it")
+	}
+
+	// And forgetting that project takes the stored text with it.
+	if _, err := captureRun(t, "forget", "--project", "acme/api"); err != nil {
+		t.Fatal(err)
+	}
+	left, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(left), "acme ledger overflow") {
+		t.Errorf("the forgotten project's wall is still in the injection log")
+	}
+}
+
+// A digest of the project's own sessions records that project too, so the same
+// sweep reaches it without reading its prose.
+func TestTheSessionStartDigestRecordsItsProjects(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		at := time.Now().Add(-time.Duration(3+i) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":"mine%d","timestamp":%q,"cwd":"/work/api",`+
+			`"message":{"role":"user","content":"my own retry budget question %d"}}`, i, at, i)
+		if err := os.WriteFile(filepath.Join(store, fmt.Sprintf("mine%d.jsonl", i)), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := hookContextFor(t, dir, `{"hook_event_name":"SessionStart","cwd":"/work/api","session_id":"a1"}`)
+	if !strings.Contains(out, "retry budget") {
+		t.Fatalf("the project digest did not fire, so this measures nothing:\n%s", out)
+	}
+	snaps := usage.Snapshots(dir, 0)
+	if len(snaps) != 1 {
+		t.Fatalf("snapshots = %d, want one", len(snaps))
+	}
+	if got, _ := json.Marshal(snaps[0].Projects); !strings.Contains(string(got), "work/api") {
+		t.Errorf("projects = %s, want the project the digest was built from", got)
+	}
+}

--- a/cmd/deja/hook_raw_denominator_test.go
+++ b/cmd/deja/hook_raw_denominator_test.go
@@ -58,7 +58,7 @@ func TestHookRawCountsOnlyTheSessionsItServed(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(back) })
 
-	digest, served, raw, _, _ := hookDigestResult(dir)
+	digest, served, raw, _, _, _ := hookDigestResult(dir)
 	if digest == "" || served == 0 {
 		t.Skip("no memory to recall in this environment")
 	}

--- a/cmd/deja/hook_stale_format_test.go
+++ b/cmd/deja/hook_stale_format_test.go
@@ -48,8 +48,8 @@ func TestStaleFormatHooksAskForARebuild(t *testing.T) {
 	// request has to happen ahead of the cache read — and the cached digest is
 	// the user's own history, so it must still be served.
 	cwd, _ := os.Getwd()
-	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil, 0)
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	writeHookCache(dir, cwd, "an earlier digest", 1, 10, nil, 0, nil)
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Error("a cache hit stopped serving the user's own history")
 	}
 	if spawned != 2 {
@@ -106,7 +106,7 @@ func TestDamagedIndexHooksAskForARebuild(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "warmup.sentinel")); err != nil {
 		t.Fatal(err)
 	}
-	if d, _, _, _, _ := hookDigestResult(dir); d != "" {
+	if d, _, _, _, _, _ := hookDigestResult(dir); d != "" {
 		t.Errorf("hook-context answered from a damaged index: %q", d)
 	}
 	if spawned != 2 {

--- a/cmd/deja/hook_task_test.go
+++ b/cmd/deja/hook_task_test.go
@@ -137,7 +137,7 @@ func TestHookContextReceiptNamesTaskFiles(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_PROJECT_DIR", repo)
 
-	digest, sessions, _, matched, _ := hookDigestResult(dir)
+	digest, sessions, _, matched, _, _ := hookDigestResult(dir)
 	if sessions == 0 || digest == "" {
 		t.Fatal("expected recall output")
 	}

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -109,7 +109,7 @@ func refreshAiderContext(dir string) error {
 	// In-process rather than shelling out to hook-context: the wrapper stands
 	// between the user and their editor, and a subprocess here would also make
 	// the installer depend on its own binary being runnable.
-	digest, sessions, _, _, _ := cachedHookDigest(dir)
+	digest, sessions, _, _, _, _ := cachedHookDigest(dir)
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(startLead(aiderLead) + digest)

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -345,7 +345,7 @@ func refreshGooseHints() error {
 // project the call is about; "" leaves the chain to answer, which is what the
 // wrapper and the installer want (#2187).
 func refreshGooseHintsFor(cwd string) error {
-	digest, sessions, _, _, _ := cachedHookDigestFor(index.DefaultDir(), cwd)
+	digest, sessions, _, _, _, _ := cachedHookDigestFor(index.DefaultDir(), cwd)
 	body := digest
 	if sessions > 0 {
 		body = frameRecall(startLead(gooseLead) + digest)

--- a/cmd/deja/onboarding_test.go
+++ b/cmd/deja/onboarding_test.go
@@ -129,7 +129,7 @@ func TestHookMissingManifestRequestsWarmup(t *testing.T) {
 	oldSpawn := spawnWarmup
 	spawnWarmup = func(_, _ string) error { called = true; return nil }
 	defer func() { spawnWarmup = oldSpawn }()
-	if digest, sessions, _, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
+	if digest, sessions, _, _, _, _ := hookDigestResult(index.DefaultDir()); digest != "" || sessions != 0 {
 		t.Fatalf("missing-manifest digest = %q, sessions=%d", digest, sessions)
 	}
 	if !called {

--- a/cmd/deja/policy_leak_test.go
+++ b/cmd/deja/policy_leak_test.go
@@ -46,11 +46,11 @@ func policyLeakIndex(t *testing.T) string {
 // keep injecting after it is set.
 func TestHookCacheHonorsRecallOff(t *testing.T) {
 	dir := policyLeakIndex(t)
-	if d, _, _, _, _ := cachedHookDigest(dir); d == "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d == "" {
 		t.Fatal("expected a digest before the kill switch")
 	}
 	t.Setenv("DEJA_RECALL", "off")
-	if d, _, _, _, _ := cachedHookDigest(dir); d != "" {
+	if d, _, _, _, _, _ := cachedHookDigest(dir); d != "" {
 		t.Fatalf("cache served a digest with DEJA_RECALL=off:\n%s", d)
 	}
 }
@@ -61,18 +61,18 @@ func TestHookCacheRefusesEntryFromAnotherPolicy(t *testing.T) {
 	dir := policyLeakIndex(t)
 	cwd := os.Getenv("CLAUDE_PROJECT_DIR")
 	// Warm the cache under the permissive policy.
-	warm, _, _, _, _ := cachedHookDigest(dir)
+	warm, _, _, _, _, _ := cachedHookDigest(dir)
 	if warm == "" {
 		t.Fatal("expected a digest to cache")
 	}
 	// Plant a recognizable entry as if it had been built then.
 	planted := "PLANTED-UNDER-OLD-POLICY"
-	writeHookCache(dir, cwd, planted, 1, 10, nil, 0)
-	if got, _, _, _, _ := cachedHookDigest(dir); got != planted {
+	writeHookCache(dir, cwd, planted, 1, 10, nil, 0, nil)
+	if got, _, _, _, _, _ := cachedHookDigest(dir); got != planted {
 		t.Fatalf("cache did not serve its own entry back: %q", got)
 	}
 	t.Setenv("DEJA_AUTORECALL_LOCAL_ONLY", "1")
-	if got, _, _, _, _ := cachedHookDigest(dir); got == planted {
+	if got, _, _, _, _, _ := cachedHookDigest(dir); got == planted {
 		t.Fatal("cache served an entry built under a policy that no longer applies")
 	}
 }


### PR DESCRIPTION
#2324 gave a stored digest its `projects` and wired recall, recall_context, resource reads, handoff and the prompt hook, leaving the session-start and antigravity hooks on the argument that their digests are about the checkout you are in. The environment block is the counter-example: it is aggregated from every project's walls, names none of them in its text, and so survived `deja forget --project X` — the sweep in #2329 can only match by the field or by a project name in the prose.

`environmentBlockFrom` now reports the projects behind its walls, the digest path carries them (through the hook cache, whose gate gained a shape marker so an entry written by an older binary is not served as a digest from nowhere), and both recorders pass them on.

Fixes #2349.