### PR TITLE
fix(view): name the rule that held things back, not just the count

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -76,6 +76,11 @@ type viewPage struct {
 	RecallsJSON   template.JS
 	NotesJSON     template.JS
 	PreviewCount  int
+	// PolicyRule names the rule that held things back, as the CLI note names
+	// it — the activation and what it allows. Not the file it lives in: that
+	// path sits under the reader's home directory and this page is meant to be
+	// passed around (#2354).
+	PolicyRule string
 	// SessionsWithheld is how many sessions a trust rule kept off the page.
 	SessionsWithheld int
 	// NotesWithheld is how many promoted notes a trust rule kept off the page.
@@ -190,6 +195,7 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		// at and passes on, and a page a rule emptied read as a machine with
 		// no history at all — the misread #2319 closed on friction (#2321).
 		SessionsWithheld: policyHidden,
+		PolicyRule:       policy.Load().Describe(policy.ActivationSearch),
 	}
 	if len(metas) > 0 {
 		page.DateEnd = metas[0].Updated.Local().Format("2006-01-02")

--- a/cmd/deja/view_policy_rule_test.go
+++ b/cmd/deja/view_policy_rule_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The page said how much a rule had hidden and never which rule, while the CLI
+// names it. It is also the artifact that leaves the machine, so it names the
+// rule and not the file the rule lives in (#2354).
+func TestThePageNamesTheRuleThatHidThings(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own connection pool question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	batch := t.TempDir()
+	rec := index.SyncRecord{
+		Harness: "claude", SessionID: "peersess", Project: "secretclient/api",
+		Role: "user", Text: "the client ledger cutover",
+		Time: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSync(dir, []string{"import", batch}); err != nil {
+		t.Fatal(err)
+	}
+
+	policyPath := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyPath, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyPath)
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	if !strings.Contains(page, "Held back by the trust policy") {
+		t.Fatalf("nothing was held back, so this measures nothing:\n%s", pageStatsBlock(page))
+	}
+	if !strings.Contains(page, "local-only") {
+		t.Errorf("the page does not name the rule that hid them:\n%s", pageStatsBlock(page))
+	}
+	// The rule, not the file it lives in: the page is passed around and the
+	// path sits under the reader's home directory.
+	if strings.Contains(page, policyPath) {
+		t.Errorf("the page carries the path of the policy file")
+	}
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -63,12 +63,12 @@ input[type=search]:focus{outline:none;border-color:var(--ph)}
 <div id="tab-sessions">
 <input type="search" id="q" placeholder="filter sessions — title, project, harness, preview text">
 <div id="list"></div>
-<p class="note">{{if .TotalSessions}}previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.{{else}}no sessions on this page.{{end}}{{if .SessionsWithheld}} Held back by the trust policy: {{.SessionsWithheld}}.{{end}}</p>
+<p class="note">{{if .TotalSessions}}previews embedded for the {{.PreviewCount}} most recent sessions and capped — full-text search lives in <b>deja "query"</b> and the agents' recall tool.{{else}}no sessions on this page.{{end}}{{if .SessionsWithheld}} Held back by the trust policy ({{.PolicyRule}}): {{.SessionsWithheld}}.{{end}}</p>
 </div>
 <div id="tab-recalls" style="display:none"><div id="rlist"></div>
-<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} Held back by the trust policy: {{.RecallsWithheld}}.{{end}}</p></div>
+<p class="note">the injections agents received, verbatim — the audit trail behind <b>deja log</b>.{{if lt .RecallCount .TotalRecalls}} The {{.RecallCount}} most recent of {{.TotalRecalls}} are on this page; older ones stay in the log until it rotates.{{end}}{{if .RecallsWithheld}} Held back by the trust policy ({{.PolicyRule}}): {{.RecallsWithheld}}.{{end}}</p></div>
 <div id="tab-notes" style="display:none"><div id="nlist"></div>
-<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}{{if .NotesWithheld}} Held back by the trust policy: {{.NotesWithheld}}.{{end}}</p></div>
+<p class="note">curated notes from <b>deja promote</b> / <b>deja remember</b>; lifecycle states shown as badges.{{if lt .NoteCount .TotalNotes}} The {{.NoteCount}} most recent notes of {{.TotalNotes}} are on this page — the rest answer through <b>deja "query"</b> and the agents' recall tool.{{end}}{{if .NotesWithheld}} Held back by the trust policy ({{.PolicyRule}}): {{.NotesWithheld}}.{{end}}</p></div>
 </div>
 <script>
 const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};


### PR DESCRIPTION
The CLI says "the trust policy hides 4 matching sessions on this path (search: local-only) — see /…/policy.json". The page said "Held back by the trust policy: 4" and stopped, on all three tabs, so a reader could not tell a rule they set on purpose from one they forgot.

The page now names the rule — "Held back by the trust policy (local-only): 4" — and deliberately not the file: `policy.Path()` sits under the reader's home directory and this page is the artifact that leaves the machine.

Fixes #2354.