### PR TITLE
fix(doctor): contract the home path the issue template asks you to redact

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -189,12 +189,12 @@ func doctorHooks(w io.Writer) {
 	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
 	b, err := os.ReadFile(path)
 	if err != nil {
-		fmt.Fprintf(w, "  %-12s missing      %s\n", "claude-code", path)
+		fmt.Fprintf(w, "  %-12s missing      %s\n", "claude-code", reportPath(path))
 		return
 	}
 	var root map[string]any
 	if json.Unmarshal(b, &root) != nil {
-		fmt.Fprintf(w, "  %-12s unreadable   %s\n", "claude-code", path)
+		fmt.Fprintf(w, "  %-12s unreadable   %s\n", "claude-code", reportPath(path))
 		return
 	}
 	hooks, _ := root["hooks"].(map[string]any)
@@ -203,7 +203,7 @@ func doctorHooks(w io.Writer) {
 	if precompact {
 		status = "wired"
 	}
-	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
+	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, reportPath(path))
 }
 
 // doctorWiringExe reports configs that name a binary which is no longer there.
@@ -239,7 +239,7 @@ func doctorCodexHook(w io.Writer) {
 				"codex-hook", "plugin", hooksPath)
 			return
 		}
-		fmt.Fprintf(w, "  %-12s missing      %s\n", "codex-hook", hooksPath)
+		fmt.Fprintf(w, "  %-12s missing      %s\n", "codex-hook", reportPath(hooksPath))
 		return
 	}
 	cfgPath := filepath.Join(sources.CodexHome(), "config.toml")
@@ -604,7 +604,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 		// A store path can come from the environment (DEJA_NOTES_FILE) or from
 		// disk. On a fixed-width row a newline in it prints a line of its own
 		// that reads as one of doctor's.
-		line := fmt.Sprintf("  %-12s %-9s %s", name, status, search.SafePath(path))
+		line := fmt.Sprintf("  %-12s %-9s %s", name, status, reportPath(path))
 		if detail != "" {
 			line += "  (" + detail + ")"
 		}
@@ -764,7 +764,9 @@ func doctorCursorPresent() bool {
 }
 
 func doctorCursorLocation() string {
-	return strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, ", ")
+	// Contracted here rather than by the row: this location is two paths in one
+	// string, and the row's own contraction only reaches the first (#2360).
+	return strings.Join([]string{reportPath(sources.CursorUserRoot()), reportPath(sources.CursorCLIRoot())}, ", ")
 }
 
 func doctorAiderLocation() string {
@@ -861,7 +863,7 @@ func doctorPolicy(w io.Writer, dir string) {
 		// was local-only, on the one screen someone opens to find out what is
 		// allowed (#939).
 		if pol := policy.Load(); pol.Describe(policy.ActivationAuto) != "local+imported" {
-			fmt.Fprintf(w, "  %-12s no file at %s\n", "default", policy.Path())
+			fmt.Fprintf(w, "  %-12s no file at %s\n", "default", reportPath(policy.Path()))
 			withheld, total := policyWithheldCounts(dir)
 			for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
 				line := pol.Describe(activation)
@@ -873,7 +875,7 @@ func doctorPolicy(w io.Writer, dir string) {
 			fmt.Fprintf(w, "  %-12s DEJA_AUTORECALL_LOCAL_ONLY is set in this environment\n", "from env")
 			return
 		}
-		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", policy.Path())
+		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", reportPath(policy.Path()))
 		// Except one thing, which is in force with or without a file and is
 		// the reason a directory can be missing from recall (#2050).
 		printIgnored(w, policy.Load())
@@ -882,7 +884,7 @@ func doctorPolicy(w io.Writer, dir string) {
 	if err != nil {
 		// The permissive default is what is actually in force, and that is the
 		// part worth saying out loud: the file reads like a restriction.
-		fmt.Fprintf(w, "  %-12s %s: %v\n", "unreadable", policy.Path(), err)
+		fmt.Fprintf(w, "  %-12s %s: %v\n", "unreadable", reportPath(policy.Path()), err)
 		fmt.Fprintf(w, "  %-12s every origin activates everywhere until it parses\n", "in force")
 		return
 	}
@@ -934,7 +936,7 @@ func doctorMCP(w io.Writer) {
 		if status != "wired" && c.name == "codex" && codexPluginInstalled() {
 			status = "plugin"
 		}
-		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), c.path)
+		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), reportPath(c.path))
 		// "Wired" says the server is declared, not that it can start. A config
 		// naming a binary that is gone — a restored backup, a hand edit, a
 		// machine where deja moved and one file was fixed by hand — read as
@@ -1243,7 +1245,7 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 	if loc == "" {
 		loc = dir
 	}
-	fmt.Fprintf(w, "  location %s\n", loc)
+	fmt.Fprintf(w, "  location %s\n", reportPath(loc))
 	fmt.Fprintf(w, "  exclusions %d active patterns\n", len(sources.ExclusionPatterns()))
 	// A precise non-claim: users deciding what to trust deserve to read the
 	// boundary in the tool itself, not only in the security docs.
@@ -1432,6 +1434,41 @@ func doctorVersion(w io.Writer, lookup doctorVersionLookup) {
 	if current == "dev" || current == "" {
 		fmt.Fprintln(w, "  status   dev build")
 	}
+}
+
+// reportPath is how the human report names a file: control characters
+// sanitised, and a home-prefixed path contracted to ~. The issue template asks
+// a reporter to "run deja doctor and redact local paths before pasting", which
+// is work this report can do for them — ~/.claude/projects is as actionable as
+// the absolute form for the person who ran it (#2360). --json keeps the real
+// path: a tool reading it may need one, and nobody pastes JSON by hand.
+func reportPath(p string) string {
+	if p == "" {
+		return p
+	}
+	// Some rows carry several paths in one string — a store deja looks for in
+	// two places, or a root list from the environment. Contracting the whole
+	// string would only reach the first, which is how the cursor row came out
+	// half in ~ and half in /Users/… .
+	parts := strings.Split(p, string(os.PathListSeparator))
+	for i, part := range parts {
+		parts[i] = search.SafePath(underHome(part))
+	}
+	return strings.Join(parts, string(os.PathListSeparator))
+}
+
+// underHome contracts a home-prefixed path to ~, and leaves everything else
+// alone. The boundary check keeps /home/alicia out of alice's tilde.
+func underHome(p string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" || !strings.HasPrefix(p, home) {
+		return p
+	}
+	rest := strings.TrimPrefix(p, home)
+	if rest == "" || rest[0] == '/' || rest[0] == '\\' {
+		return "~" + rest
+	}
+	return p
 }
 
 func doctorCount(n int, noun string) string {

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -104,16 +104,16 @@ func doctorAutoRecall(w io.Writer) {
 			if note == "" || note == "v"+kimiPluginVersion {
 				note = "the Kimi Code plugin recalls on every prompt"
 			}
-			fmt.Fprintf(w, "  %-12s %-11s %s  (%s)\n", a.name, "plugin", path, note)
+			fmt.Fprintf(w, "  %-12s %-11s %s  (%s)\n", a.name, "plugin", reportPath(path), note)
 			continue
 		}
 		switch {
 		case err != nil:
-			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "missing", path, note)
+			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "missing", reportPath(path), note)
 		case a.marker != "" && !strings.Contains(string(b), a.marker):
-			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", path, a.marker)
+			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", reportPath(path), a.marker)
 		default:
-			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", path, note)
+			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", reportPath(path), note)
 		}
 	}
 }

--- a/cmd/deja/doctor_dead_command_test.go
+++ b/cmd/deja/doctor_dead_command_test.go
@@ -59,7 +59,9 @@ func TestDoctorNamesAConfigPointingAtAMissingBinary(t *testing.T) {
 	if !strings.Contains(out, gone) {
 		t.Errorf("doctor does not name the binary the config points at:\n%s", out)
 	}
-	if !strings.Contains(out, p) {
+	// The report contracts a home path to ~ (#2360), so the row names the file
+	// in that form. What matters here is that it names it at all.
+	if !strings.Contains(out, reportPath(p)) {
 		t.Errorf("doctor does not name the config that points there:\n%s", out)
 	}
 }

--- a/cmd/deja/doctor_home_path_test.go
+++ b/cmd/deja/doctor_home_path_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The issue template asks a reporter to run `deja doctor` and redact the local
+// paths before pasting. The report is the one command that fills itself with
+// them, and deja already contracts a home path to ~ in its progress lines
+// (#2360).
+func TestDoctorContractsTheHomePath(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "projects", "-work-app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(home, ".claude", "projects"))
+
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "~/.claude/projects") && !strings.Contains(out, `~\.claude\projects`) {
+		t.Errorf("doctor does not contract the home path:\n%s", storeLines(out))
+	}
+	if strings.Contains(out, home) {
+		t.Errorf("doctor still prints the home directory:\n%s", storeLines(out))
+	}
+
+	// --json keeps the real path: a tool reading it may need one, and nobody
+	// pastes JSON into an issue by hand.
+	raw, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("doctor --json is not JSON: %v", err)
+	}
+	if !strings.Contains(raw, home) {
+		t.Errorf("doctor --json lost the real path")
+	}
+}
+
+// storeLines is the part of the report that names paths, for a readable
+// failure.
+func storeLines(out string) string {
+	var keep []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "claude") || strings.Contains(line, "index") {
+			keep = append(keep, line)
+		}
+	}
+	return strings.Join(keep, "\n")
+}


### PR DESCRIPTION
The issue template says: "Run `deja doctor` and redact local paths before pasting." The report is the one command that fills itself with them — every store row, every wiring row, the index location and the policy lines.

deja already had the contraction (`displayPath`, used by the index progress lines). The report now writes `~/.claude/projects`, which is as actionable for the person who ran it and is exactly what the template asks them to type by hand. Contraction is per path-list element, so the rows built from two locations (cursor, aider with DEJA_AIDER_ROOTS) do not come out half in ~ and half absolute.

`--json` keeps the real paths: a tool reading it may need one, and nobody pastes JSON into an issue by hand.

One existing assertion moved with it — `doctor_dead_command_test.go` checked that the report names the config pointing at a missing binary, and now checks for the same file in the form the report writes.

Fixes #2360.