### PR TITLE
fix(hook): say whose command the after-error line offers

### DIFF
--- a/cmd/deja/hook_after_scope_wording_test.go
+++ b/cmd/deja/hook_after_scope_wording_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The lookup behind this line is machine-wide on purpose — an error signature
+// is closer to an environment fact than to project history. The sentence said
+// "here", which reads as this project, while offering a command from another
+// one (#2363).
+func TestTheAfterErrorLineSaysWhoseCommandItIs(t *testing.T) {
+	when := time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC)
+	other := fixLine(index.FixPair{
+		Error: "panic: quaxbolt overflow", Command: "make acme-widen-cast",
+		Key: "claude:acme0", When: when, Project: "clients/acme/api",
+	})
+	if other == "" {
+		t.Fatal("no line for a usable pair, so this measures nothing")
+	}
+	if strings.Contains(other, "came up here before") {
+		t.Errorf("the line still calls another project's history this one's: %q", other)
+	}
+	if !strings.Contains(other, "clients/acme/api") {
+		t.Errorf("the line does not say whose command it offers: %q", other)
+	}
+	if !strings.Contains(other, "make acme-widen-cast") {
+		t.Errorf("the command is gone from the line: %q", other)
+	}
+
+	// A pair mined before the project field existed still gets a line — it just
+	// cannot name a project.
+	old := fixLine(index.FixPair{
+		Error: "panic: quaxbolt overflow", Command: "make widen-cast",
+		Key: "claude:s0", When: when,
+	})
+	if old == "" || !strings.Contains(old, "make widen-cast") {
+		t.Errorf("a pair without a project lost its line: %q", old)
+	}
+}

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -298,7 +298,16 @@ func fixLine(p index.FixPair) string {
 	if !p.When.IsZero() {
 		when = " (" + p.When.Local().Format("2006-01-02") + ")"
 	}
-	return "deja: this error came up here before" + when + " — what followed it: " + cmd
+	// "here" read as this project, and the lookup is machine-wide on purpose —
+	// an error signature is closer to an environment fact than to project
+	// history, which is what the command line and the environment block say out
+	// loud. The pair carries its project, so the line can name whose command it
+	// is offering rather than implying it is this checkout's (#2363).
+	where := "on this machine"
+	if project := strings.TrimSpace(search.SafeLine(p.Project)); project != "" {
+		where = "in " + project
+	}
+	return "deja: this error came up " + where + " before" + when + " — what followed it: " + cmd
 }
 
 // exitMarker is the shape a source appends when it knows what a command


### PR DESCRIPTION
Working in `/work/api`, a build failed with an error a client's project had hit before, and the hook said:

    deja: this error came up here before (2026-08-28) — what followed it: make acme-widen-cast

"Here" reads as this project; the command belongs to another one. The lookup is machine-wide on purpose — `fixPairLine` filters by the trust policy alone, and its comment says "the error this machine saw before" — which is the same argument the tool hook's command line and the environment block make out loud. So the scope stays and the sentence changes:

    deja: this error came up in acme/api before (2026-08-28) — what followed it: make acme-widen-cast

A pair mined before `FixPair.Project` existed says "on this machine" instead of naming one.

Fixes #2363.