### PR TITLE
fix(fix): name the error deja does hold instead of calling the machine empty

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
@@ -85,6 +86,17 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			fmt.Fprintln(stdout, "deja: one session ran something after that error, and nothing has confirmed it worked — deja waits for a second sighting before naming a remedy")
 			return nil
 		}
+		// The lookup hashes whole error lines, so the head of one — what a
+		// person types — is a different signature and matches nothing. Saying
+		// the machine never saw it is then a claim about the store rather than
+		// about the wording, and the store may hold exactly what was asked for
+		// (#2365).
+		if near := nearestRecordedError(dir, text, func(project string) bool {
+			return pol.Allows(policy.ActivationSearch, project)
+		}); near != "" {
+			fmt.Fprintf(stdout, "deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:\n  %s\ntry: deja fix %q\n", near, near)
+			return nil
+		}
 		fmt.Fprintln(stdout, "deja: no session on this machine ran a command after that error")
 		return nil
 	}
@@ -97,4 +109,32 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "  ran next: %s\n", search.SafeCommand(p.Command))
 	}
 	return nil
+}
+
+// nearestRecordedError names a recorded error line that contains what the
+// reader typed, newest first. Containment rather than similarity: the miss this
+// answers is a whole line typed short, and a reader who typed something else
+// entirely deserves the plain "nothing recorded" rather than a guess.
+func nearestRecordedError(dir, text string, allow func(string) bool) string {
+	want := strings.ToLower(strings.TrimSpace(text))
+	if len(want) < 8 {
+		return ""
+	}
+	best := ""
+	var bestWhen time.Time
+	for _, p := range index.ReadFixes(dir) {
+		if p.Candidate || p.Error == "" {
+			continue
+		}
+		if allow != nil && !allow(p.Project) {
+			continue
+		}
+		if !strings.Contains(strings.ToLower(p.Error), want) {
+			continue
+		}
+		if best == "" || p.When.After(bestWhen) {
+			best, bestWhen = p.Error, p.When
+		}
+	}
+	return search.SafeLine(best)
 }

--- a/cmd/deja/fix_near_miss_test.go
+++ b/cmd/deja/fix_near_miss_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The lookup hashes whole error lines, so the shortened form a person types
+// matches nothing — and the answer blamed the machine for it while the store
+// held the pair (#2365).
+func TestFixNamesTheErrorItDoesHold(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-clients-acme-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		base := time.Now().Add(-time.Duration(6+i) * time.Hour).UTC()
+		rows := []string{
+			fmt.Sprintf(`{"type":"assistant","sessionId":"acme%d","timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make acme-migrate"}}]}}`,
+				i, base.Format(time.RFC3339)),
+			fmt.Sprintf(`{"type":"user","sessionId":"acme%d","timestamp":%q,"cwd":"/clients/acme/api","message":{"role":"user","content":[{"type":"tool_result","content":"panic: quaxbolt overflow in ledger/quaxbolt.go"}]}}`,
+				i, base.Add(2*time.Minute).Format(time.RFC3339)),
+			fmt.Sprintf(`{"type":"assistant","sessionId":"acme%d","timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make acme-widen-cast"}}]}}`,
+				i, base.Add(5*time.Minute).Format(time.RFC3339)),
+		}
+		name := fmt.Sprintf("acme%d.jsonl", i)
+		if err := os.WriteFile(filepath.Join(store, name), []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: the whole line answers.
+	whole, err := captureRun(t, "fix", "panic: quaxbolt overflow in ledger/quaxbolt.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(whole, "make acme-widen-cast") {
+		t.Fatalf("the pair is not in the store, so this measures nothing:\n%s", whole)
+	}
+
+	// The head of it is what a person types.
+	short, err := captureRun(t, "fix", "panic: quaxbolt overflow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(short, "no session on this machine ran a command after that error") {
+		t.Errorf("deja reports the machine empty for an error it holds:\n%s", short)
+	}
+	if !strings.Contains(short, "ledger/quaxbolt.go") {
+		t.Errorf("deja does not name the error it does hold:\n%s", short)
+	}
+
+	// A line nothing resembles still gets the plain answer.
+	none, err := captureRun(t, "fix", "connection refused talking to the widget service")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(none, "no session on this machine ran a command after that error") {
+		t.Errorf("an error nothing recorded lost its answer:\n%s", none)
+	}
+}


### PR DESCRIPTION
`deja fix` hashes whole error lines. Typing the head of one — which is what a person does — is a different signature and matched nothing, and the answer was "no session on this machine ran a command after that error" while the store held the pair the PostToolUse hook had just served.

On a miss it now names the closest recorded line and how to ask for it:

    deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:
      panic: quaxbolt overflow in ledger/quaxbolt.go
    try: deja fix "panic: quaxbolt overflow in ledger/quaxbolt.go"

Containment, not similarity: the miss this answers is a whole line typed short, and someone who typed something else entirely still gets the plain answer. The scan skips unconfirmed candidates (the branch above it already speaks for those) and applies the same trust policy as the lookup.

Fixes #2365.