### PR TITLE
fix(view): name the door the rule governs, not just the rule

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -195,7 +195,10 @@ func writeViewHTML(dir, out string) (string, int, error) {
 		// at and passes on, and a page a rule emptied read as a machine with
 		// no history at all — the misread #2319 closed on friction (#2321).
 		SessionsWithheld: policyHidden,
-		PolicyRule:       policy.Load().Describe(policy.ActivationSearch),
+		// The activation as well as the rule, the way the CLI note reads it:
+		// on a machine whose activations differ, "local-only" alone reads as
+		// deja's one rule rather than the browsing one (#2367).
+		PolicyRule: policy.ActivationSearch + ": " + policy.Load().Describe(policy.ActivationSearch),
 	}
 	if len(metas) > 0 {
 		page.DateEnd = metas[0].Updated.Local().Format("2006-01-02")

--- a/cmd/deja/view_policy_rule_test.go
+++ b/cmd/deja/view_policy_rule_test.go
@@ -55,8 +55,11 @@ func TestThePageNamesTheRuleThatHidThings(t *testing.T) {
 	if !strings.Contains(page, "Held back by the trust policy") {
 		t.Fatalf("nothing was held back, so this measures nothing:\n%s", pageStatsBlock(page))
 	}
-	if !strings.Contains(page, "local-only") {
-		t.Errorf("the page does not name the rule that hid them:\n%s", pageStatsBlock(page))
+	// The activation as well as the rule, the way the CLI note reads: on a
+	// machine whose activations differ, "local-only" alone reads as deja's one
+	// rule (#2367).
+	if !strings.Contains(page, "search: local-only") {
+		t.Errorf("the page does not name the rule and the door it governs:\n%s", pageStatsBlock(page))
 	}
 	// The rule, not the file it lives in: the page is passed around and the
 	// path sits under the reader's home directory.


### PR DESCRIPTION
#2354 put the rule on the page. This is the other half of that sentence: the CLI note reads "the trust policy hides 2 matching sessions on this path (search: local-only)", the page read "Held back by the trust policy (local-only)".

On a machine where the activations differ — browsing local-only, the MCP door local+imported — the shorter form reads as deja's one rule, while the reader's own injection log records the hidden digest as served under another (`policy: local+imported`). The page now names the activation it filters by.

Fixes #2367.