### PR TITLE
fix(index): one failure is one wall across ports, pids and ids

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -75,6 +75,99 @@ func normalizeFriction(l string) string {
 	return strings.TrimSpace(rest[second+2:])
 }
 
+// volatileDigits is how long a digit run has to be before it reads as something
+// the machine handed out rather than something the error says.
+const volatileDigits = 4
+
+// maskIPv4 replaces a dotted quad with a placeholder. The digit-run rule below
+// cannot reach it: an octet is one to three digits, which is the length an exit
+// code has, so `10.0.0.7` and `10.0.0.9` would stay two different walls for one
+// service being unreachable (#2369).
+func maskIPv4(l string) string {
+	var b strings.Builder
+	b.Grow(len(l))
+	for i := 0; i < len(l); {
+		if l[i] < '0' || l[i] > '9' {
+			b.WriteByte(l[i])
+			i++
+			continue
+		}
+		if end, ok := ipv4At(l, i); ok {
+			b.WriteString("<ip>")
+			i = end
+			continue
+		}
+		// Not a quad: copy the run whole so the scan cannot split a number.
+		j := i
+		for j < len(l) && l[j] >= '0' && l[j] <= '9' {
+			j++
+		}
+		b.WriteString(l[i:j])
+		i = j
+	}
+	return b.String()
+}
+
+// ipv4At reports where a dotted quad starting at i ends. Four groups of one to
+// three digits, separated by dots, not running into another digit or dot.
+func ipv4At(l string, i int) (int, bool) {
+	pos := i
+	for group := 0; group < 4; group++ {
+		if group > 0 {
+			if pos >= len(l) || l[pos] != '.' {
+				return 0, false
+			}
+			pos++
+		}
+		start := pos
+		for pos < len(l) && l[pos] >= '0' && l[pos] <= '9' {
+			pos++
+		}
+		if n := pos - start; n < 1 || n > 3 {
+			return 0, false
+		}
+	}
+	if pos < len(l) && (l[pos] == '.' || (l[pos] >= '0' && l[pos] <= '9')) {
+		return 0, false
+	}
+	return pos, true
+}
+
+// maskVolatileNumbers replaces long digit runs with a placeholder, so one
+// failure is one wall across the numbers a machine hands out: a port, a pid, an
+// epoch, a goroutine id. Without it `dial tcp 10.0.0.7:5432: connect:
+// connection refused` and the same failure on another port are two signatures
+// — one wall each, below the three-session floor `deja friction` needs, below
+// the second sighting a fix pair needs, and invisible to search's error tier,
+// all at once (#2369).
+//
+// Four digits, not two: an exit code and a status code say which failure this
+// is, and `make: *** [build] Error 1` must not become `Error 2`. Ports, pids,
+// epochs and ids are longer than that; 404 and 500 are not.
+func maskVolatileNumbers(l string) string {
+	l = maskIPv4(l)
+	var b strings.Builder
+	b.Grow(len(l))
+	for i := 0; i < len(l); {
+		if l[i] < '0' || l[i] > '9' {
+			b.WriteByte(l[i])
+			i++
+			continue
+		}
+		j := i
+		for j < len(l) && l[j] >= '0' && l[j] <= '9' {
+			j++
+		}
+		if j-i >= volatileDigits {
+			b.WriteString("<n>")
+		} else {
+			b.WriteString(l[i:j])
+		}
+		i = j
+	}
+	return b.String()
+}
+
 // trimLogPrefix drops the prefixes a runner puts in front of a line it did not
 // write: pytest's `E   ` marker on the failing line, and the timestamp docker,
 // journalctl and most CI add to everything. They carry nothing about the error,
@@ -218,8 +311,12 @@ func isFriction(l string) bool {
 }
 
 func frictionHash(line string) uint64 {
+	// Masked here rather than in FrictionLine: the numbers a machine hands out
+	// must not split one failure into a wall per run, and the line a reader is
+	// shown should still be the one that was printed, with its real port in it
+	// (#2369).
 	h := fnv.New64a()
-	_, _ = h.Write([]byte(line))
+	_, _ = h.Write([]byte(maskVolatileNumbers(line)))
 	return h.Sum64()
 }
 

--- a/internal/index/friction_digits_test.go
+++ b/internal/index/friction_digits_test.go
@@ -1,0 +1,33 @@
+package index
+
+import "testing"
+
+// A host and a port inside an error make every occurrence of one failure a
+// different wall: friction never reaches its floor, no fix pair is confirmed
+// twice, and search's error tier matches nothing (#2369).
+func TestOneErrorIsOneWallAcrossHostsAndPorts(t *testing.T) {
+	first, ok := FrictionLine("dial tcp 10.0.0.7:5432: connect: connection refused")
+	if !ok {
+		t.Fatal("the line is not friction at all, so this measures nothing")
+	}
+	second, ok := FrictionLine("dial tcp 10.0.0.9:5433: connect: connection refused")
+	if !ok {
+		t.Fatal("the second line is not friction")
+	}
+	if frictionHash(first) != frictionHash(second) {
+		t.Errorf("one service being down is two walls:\n  %q\n  %q", first, second)
+	}
+}
+
+// The masking stops where the digits carry the meaning: an exit code says which
+// failure this is, and two of them are two failures.
+func TestShortCodesKeepTheirIdentity(t *testing.T) {
+	a, aok := FrictionLine("make: *** [build] Error 1")
+	b, bok := FrictionLine("make: *** [build] Error 2")
+	if !aok || !bok {
+		t.Fatal("the control lines are not friction")
+	}
+	if frictionHash(a) == frictionHash(b) {
+		t.Errorf("two different failures collapsed into one wall:\n  %q\n  %q", a, b)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -62,7 +62,12 @@ import (
 // is one wall however it was printed. A store built before this holds both
 // spellings under different signatures, and nothing re-derives them without
 // the bump — the same shape as 27 and 28 (#1637).
-const version = 29
+// 30: a long digit run inside a line — a port, a pid, an epoch, a goroutine id
+// — is masked before the line is hashed, so one failure is one wall across the
+// numbers the machine hands out. A store built before this holds each run under
+// its own signature, and nothing re-derives them without the bump — the same
+// shape as 27, 28 and 29 (#2369).
+const version = 30
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message


### PR DESCRIPTION
`dial tcp 10.0.0.7:5432: connect: connection refused` and the same failure on another host and port were two signatures — one wall each, below the three-session floor `deja friction` needs, below the second sighting a fix pair needs, and two different answers for search's error tier.

`frictionHash` now masks a dotted quad and any run of four or more digits before hashing. Four digits, not two: an exit code and a status code say which failure this is, so `make: *** [build] Error 1` and `Error 2` stay two walls, and 404 and 500 stay apart. The line a reader is shown is unchanged — it keeps the port that was printed; only the signature is stabilised.

Index version 29 → 30, since a store built before this holds each run under its own signature and nothing re-derives them without the bump.

Scope, noted on the issue too: `deja friction`'s listing groups by the line's text rather than by the signature, so folding those rows onto one is a separate change with its own display question.

Fixes #2369.