### PR TITLE
feat(index): index the service commands that fix a refused connection

### DIFF
--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -481,7 +481,12 @@ func IndexCommands() bool { return os.Getenv("DEJA_INDEX_COMMANDS") != "0" }
 // ecosystem: `git status` and `git log` missed it 2,270 times, and a person
 // working in LaTeX, Python or the JVM saw nothing at all. Widening it takes the
 // same store from 6,770 commands to 12,661, and 1.03 MB to 1.41 MB.
-var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run|mod|get|install|generate|work|clean)|brew (install|upgrade|uninstall|reinstall|tap)|golangci-lint|gofmt|pytest|python3? -m|uv (run|pip)|pip install|ruff|mypy|npm|npx|pnpm|yarn|bun |cargo |make\b|cmake|ctest|ninja|meson|bazel|buck2|gh (pr|run|release|issue|workflow|api)|git [a-z-]+|docker|kubectl|helm|terraform|psql|mysql|latexmk|mvn|gradle|dotnet|swift (build|test)|bundle exec|rails|rake|rspec|phpunit|composer (install|update|require)|tox|nox|jest|vitest|playwright|cypress|deno|tsc|sbt|stack (build|test|run|exec)|cabal|ghc|dune|zig|nix|rustc|clang\+\+|clang|g\+\+|gcc|pdm run|poetry run|deja )`)
+//
+// The service family — brew services, systemctl, launchctl, service — is here
+// for the same reason go mod tidy is: "start the thing that is not running" is
+// the answer to a refused connection, and it was the one remedy the list did
+// not carry while `brew install`, two words away, was carried (#2373).
+var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run|mod|get|install|generate|work|clean)|brew (install|upgrade|uninstall|reinstall|tap|services)|systemctl|launchctl|service [a-z0-9_.-]+ (start|stop|restart|reload|status)|golangci-lint|gofmt|pytest|python3? -m|uv (run|pip)|pip install|ruff|mypy|npm|npx|pnpm|yarn|bun |cargo |make\b|cmake|ctest|ninja|meson|bazel|buck2|gh (pr|run|release|issue|workflow|api)|git [a-z-]+|docker|kubectl|helm|terraform|psql|mysql|latexmk|mvn|gradle|dotnet|swift (build|test)|bundle exec|rails|rake|rspec|phpunit|composer (install|update|require)|tox|nox|jest|vitest|playwright|cypress|deno|tsc|sbt|stack (build|test|run|exec)|cabal|ghc|dune|zig|nix|rustc|clang\+\+|clang|g\+\+|gcc|pdm run|poetry run|deja )`)
 
 var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
 

--- a/internal/sources/service_commands_test.go
+++ b/internal/sources/service_commands_test.go
@@ -1,0 +1,39 @@
+package sources
+
+import "testing"
+
+// "Start the thing that is not running" is the commonest answer to a refused
+// connection, and it was the one remedy the command allowlist did not carry —
+// while `brew install`, two words away, was carried (#2373).
+func TestServiceCommandsAreIndexed(t *testing.T) {
+	for _, cmd := range []string{
+		"brew services start postgresql",
+		"brew services restart redis",
+		"systemctl restart postgresql",
+		"sudo systemctl start nginx",
+		"systemctl --user restart syncthing",
+		"service postgresql restart",
+		"launchctl load ~/Library/LaunchAgents/redis.plist",
+		"launchctl kickstart -k gui/501/homebrew.mxcl.postgresql",
+	} {
+		if !worthIndexing(cmd) {
+			t.Errorf("a remedy deja fix exists to name is not indexed: %q", cmd)
+		}
+	}
+}
+
+// The list stays an allowlist: navigation and one-shot surgery on a number that
+// changes every run are not remedies another session can repeat.
+func TestTheAllowlistStaysNarrow(t *testing.T) {
+	for _, cmd := range []string{
+		"kill -9 4711",
+		"lsof -ti :5432",
+		"cd services",
+		"ls /etc/service",
+		"cat service.log",
+	} {
+		if worthIndexing(cmd) {
+			t.Errorf("the allowlist let in something that is not a remedy: %q", cmd)
+		}
+	}
+}


### PR DESCRIPTION
Four sessions hit `connect: connection refused` and each ran `brew services start postgresql` after it; `deja fix` found nothing, because the stored session held two messages and not three. Commands are indexed through an allowlist, and the service family was not on it — while `brew install`, two words away, was.

    false  "brew services start postgresql"      true  "brew install postgresql"
    false  "systemctl restart postgresql"        true  "sudo systemctl start docker"   ← passed only because "docker" is listed
    false  "service postgresql restart"
    false  "launchctl load ~/Library/LaunchAgents/redis.plist"

The list's own comment says this is how it grows, and it was widened once before for `go mod tidy`, `go get` and `brew install` as "the remedies deja fix exists to name" (#1635). With #2372's signature change, `deja fix` now answers a refused connection from a run that never happened on this machine.

Not added: `kill -9 <pid>` and `lsof -ti :<port>` — inspection and one-shot surgery on a number that changes every run, not a remedy another session can repeat.

Known and unchanged: like every other alternative in this list, the new ones match anywhere in a segment, so a sentence that quotes a command ("the service postgresql restart command") is indexed as one. That is the allowlist's existing shape, not something these four introduce.

Fixes #2373.