### PR TITLE
fix(friction): count one failure once, however its numbers differ

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -51,8 +51,14 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		sessions map[string]bool
 		harness  map[string]bool
 		last     time.Time
+		// text is the occurrence to show. One failure prints differently on
+		// every run — a port, a pid, an ip — and the signature is what folds
+		// them together, so the row needs one of the texts to name: the newest,
+		// because the port it printed last is the port the reader will see next
+		// (#2375).
+		text string
 	}
-	found := map[string]*seen{}
+	found := map[uint64]*seen{}
 	sessions := map[string]bool{}
 	// friction reads across the whole store, so a peer's recurring errors — its
 	// hosts, its infra IPs — surfaced here even when the trust policy withheld
@@ -74,19 +80,20 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		key := meta.Harness + ":" + meta.ID
 		sessions[key] = true
 		for _, line := range strings.Split(r.Text, "\n") {
-			line, ok := index.FrictionLine(line)
+			line, sig, ok := index.FrictionSignature(line)
 			if !ok {
 				continue
 			}
-			s := found[line]
+			s := found[sig]
 			if s == nil {
-				s = &seen{sessions: map[string]bool{}, harness: map[string]bool{}}
-				found[line] = s
+				s = &seen{sessions: map[string]bool{}, harness: map[string]bool{}, text: line}
+				found[sig] = s
 			}
 			s.sessions[key] = true
 			s.harness[meta.Harness] = true
-			if r.Time.After(s.last) {
+			if r.Time.After(s.last) || s.text == "" {
 				s.last = r.Time
+				s.text = line
 			}
 		}
 	}); err != nil {
@@ -103,7 +110,8 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		harnesses []string
 	}
 	var rows []row
-	for line, s := range found {
+	for _, s := range found {
+		line := s.text
 		if len(s.sessions) < index.FrictionMinSessions {
 			continue
 		}

--- a/cmd/deja/friction_signature_test.go
+++ b/cmd/deja/friction_signature_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// One failure whose port and host differ per run was a row per run, each row
+// holding one session, so none reached the three-session floor and the report
+// left out the thing the machine hits most (#2375).
+func TestFrictionGroupsOneFailureAcrossItsNumbers(t *testing.T) {
+	var lines []string
+	for i := 0; i < 4; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"user","sessionId":"s%d","cwd":"/w/p","timestamp":"2026-07-2%dT10:00:00Z",`+
+				`"message":{"role":"user","content":[{"type":"tool_result","content":"dial tcp 10.0.0.%d:%d: connect: connection refused"}]}}`,
+			i, i+1, 7+i, 5432+i))
+	}
+	seedFrictionStore(t, lines)
+
+	var out bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "4 sessions") {
+		t.Errorf("the four runs are not one wall:\n%s", got)
+	}
+	if strings.Count(got, "connection refused") != 1 {
+		t.Errorf("one failure is listed more than once:\n%s", got)
+	}
+	// The newest occurrence is what a reader can act on.
+	if !strings.Contains(got, "10.0.0.10:5435") {
+		t.Errorf("the row does not show the newest of the four:\n%s", got)
+	}
+}
+
+// Two failures that differ in more than a number stay two rows.
+func TestFrictionKeepsDifferentFailuresApart(t *testing.T) {
+	var lines []string
+	for i := 0; i < 3; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"user","sessionId":"a%d","cwd":"/w/p","timestamp":"2026-07-2%dT10:00:00Z",`+
+				`"message":{"role":"user","content":[{"type":"tool_result","content":"dial tcp 10.0.0.%d:5432: connect: connection refused"}]}}`,
+			i, i+1, 7+i))
+		lines = append(lines, fmt.Sprintf(
+			`{"type":"user","sessionId":"b%d","cwd":"/w/p","timestamp":"2026-07-2%dT11:00:00Z",`+
+				`"message":{"role":"user","content":[{"type":"tool_result","content":"psql: FATAL: sorry, too many clients already"}]}}`,
+			i, i+1))
+	}
+	seedFrictionStore(t, lines)
+
+	var out bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "connection refused") || !strings.Contains(got, "too many clients") {
+		t.Errorf("two different failures did not both survive:\n%s", got)
+	}
+}

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -42,6 +42,19 @@ const (
 	FrictionMinSessions = 3
 )
 
+// FrictionSignature is FrictionLine plus the signature the line hashes to, for
+// a caller that groups runs of one failure rather than lines of text. The
+// numbers a machine hands out — a port, a pid, an ip — are masked in the
+// signature and kept in the line, so a listing can count the runs together and
+// still show one that was really printed (#2375).
+func FrictionSignature(l string) (string, uint64, bool) {
+	line, ok := FrictionLine(l)
+	if !ok {
+		return line, 0, false
+	}
+	return line, frictionHash(line), true
+}
+
 // FrictionLine reports whether a line of tool output names something specific
 // that went wrong, and returns it in the form two sessions can be compared on.
 func FrictionLine(l string) (string, bool) {


### PR DESCRIPTION
Four sessions hit `connect: connection refused` on four ports; `deja friction` reported none of them and listed only the error whose text never changes. The listing grouped by the line's text, so each run was a row holding one session, below the three-session floor.

It groups by the signature now — the one #2372 made stable across ports, pids and ips — through a new `index.FrictionSignature`. Each row shows the newest occurrence's text, because the port it printed last is the port the reader will see next.

This also brings the listing in line with the environment block, which has grouped by signature all along (`TopFriction`); the two disagreed about what counts as one wall.

    what this machine keeps tripping over — 7 sessions read
       4 sessions  dial tcp 10.0.0.7:5432: connect: connection refused
       3 sessions  panic: quaxbolt overflow in ledger/quaxbolt.go

Fixes #2375.