### PR TITLE
fix(doctor): say what arrived when there is no sync target yet

### DIFF
--- a/cmd/deja/doctor_imports_no_peer_test.go
+++ b/cmd/deja/doctor_imports_no_peer_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// With imports and no configured peer, the Sync section returned early on "no
+// other machines yet" — while the manifest knew which machines the sessions had
+// come from, and recall was answering with them (#2378).
+func TestDoctorNamesTheMachinesThatSentWork(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	importFrom := func(machine string, ids ...string) {
+		t.Helper()
+		batch := t.TempDir()
+		// Written as a batch is written on the wire: `origin` is the machine
+		// that exported it, and its type is unexported here.
+		var lines []string
+		for _, id := range ids {
+			lines = append(lines, fmt.Sprintf(
+				`{"harness":"claude","session_id":%q,"project":"work/app","role":"user",`+
+					`"text":"work from %s","time":%q,"origin":%q}`,
+				id, machine, time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC).Format(time.RFC3339), machine))
+		}
+		if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := runSync(dir, []string{"import", batch}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	importFrom("laptop.local", "a0", "a1", "a2")
+	importFrom("desktop", "b0", "b1")
+
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sync := doctorSection(out, "Sync:")
+	if strings.Contains(sync, "no other machines yet") {
+		t.Errorf("doctor reports no machines while holding work from two:\n%s", sync)
+	}
+	for _, want := range []string{"laptop.local", "desktop"} {
+		if !strings.Contains(sync, want) {
+			t.Errorf("doctor does not name %q as a machine work came from:\n%s", want, sync)
+		}
+	}
+
+	// A machine with neither peers nor imports still says so.
+	hermeticEnv(t)
+	empty := index.DefaultDir()
+	if err := index.Ensure(empty, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(doctorSection(out, "Sync:"), "no other machines yet") {
+		t.Errorf("a machine that has exchanged nothing lost its line:\n%s", doctorSection(out, "Sync:"))
+	}
+}
+
+// doctorSection returns the lines of one section of the report.
+func doctorSection(out, header string) string {
+	i := strings.Index(out, header)
+	if i < 0 {
+		return "(no " + header + " section)"
+	}
+	rest := out[i:]
+	if j := strings.Index(rest[len(header):], "\n\n"); j >= 0 {
+		return rest[:len(header)+j]
+	}
+	return rest
+}

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,11 +30,21 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 		fmt.Fprintf(w, "  %-12s %s could not be read — %s\n", "peers", peers.Path(), safeForStatusline(why, 200))
 		return
 	}
+	from := importsByPeerName(dir)
 	if len(list) == 0 {
+		// A directory import is how a first exchange happens, before any
+		// `sync ssh` exists — and the manifest knows which machine each
+		// session came from. Saying "no other machines yet" while five of
+		// their sessions answer recall is the screen contradicting the store
+		// (#2378).
+		if line := importedFromLine(from); line != "" {
+			fmt.Fprintf(w, "  %-12s %s\n", "imported", line)
+			fmt.Fprintf(w, "  %-12s no sync target yet — `deja sync ssh <host>` once, then `deja sync` keeps them all in step\n", "peers")
+			return
+		}
 		fmt.Fprintf(w, "  %-12s no other machines yet — `deja sync ssh <host>` once, then `deja sync` keeps them all in step\n", "peers")
 		return
 	}
-	from := importsByPeerName(dir)
 	// The column is padded by what the terminal draws, not by how many runes
 	// the name has: %-12s gave a 32-character name no padding at all and
 	// treated a CJK name as one column per character (#1821). A name wider
@@ -189,3 +200,42 @@ func learnPeerMachine(dir, host string, before map[string]int) {
 	// written down.
 	_ = peers.Learn(host, best)
 }
+
+// importedFromLine says what has arrived from machines this one has no sync
+// target for, newest counts first. The names come from another machine, so they
+// are sanitised and bounded like every other borrowed string on this screen.
+func importedFromLine(from map[string]int) string {
+	if len(from) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(from))
+	total := 0
+	for name, n := range from {
+		names = append(names, name)
+		total += n
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if from[names[i]] != from[names[j]] {
+			return from[names[i]] > from[names[j]]
+		}
+		return names[i] < names[j]
+	})
+	shown := names
+	more := 0
+	if len(shown) > doctorImportedNames {
+		more = len(shown) - doctorImportedNames
+		shown = shown[:doctorImportedNames]
+	}
+	for i, name := range shown {
+		shown[i] = safeForStatusline(hostForEcho(name), 60)
+	}
+	line := fmt.Sprintf("%s from %s", doctorCount(total, "session"), strings.Join(shown, ", "))
+	if more > 0 {
+		line += fmt.Sprintf(" and %d more", more)
+	}
+	return line
+}
+
+// doctorImportedNames bounds how many machine names the line carries; the rest
+// are counted rather than listed.
+const doctorImportedNames = 4


### PR DESCRIPTION
Five sessions imported from two machines into a store with no `sync ssh` target, and the screen a reader checks to see whether sync works said:

    Sync:
      peers        no other machines yet — …

The manifest knew better: `index.ImportedByMachine` reads the `From` field, and the peers rows already count with it — but only when a peer list exists. A directory import is how a first exchange happens, before any target is configured.

    Sync:
      imported     5 sessions from laptop.local, laptop
      peers        no sync target yet — `deja sync ssh <host>` once, then `deja sync` keeps them all in step

The names come from another machine, so they are sanitised and bounded — four names, 60 characters each, the rest counted. A store with neither peers nor imports keeps its old line.

Fixes #2378.