### PR TITLE
fix(doctor): report in --json what arrived from a machine with no peer row

### DIFF
--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -55,6 +55,8 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		"sync": true, "peers": true, "host": true,
 		"last_push": true, "last_pull": true, "sessions_from_there": true,
 		"stamped_ahead": true,
+		// doctorImportedReport: the machines with no peer row of their own.
+		"imported": true, "machine": true, "sessions": true,
 		// index.HarnessIngest
 		"malformed_lines": true, "clipped_messages": true,
 		// index.FileIngest

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -109,6 +109,19 @@ type doctorSyncReport struct {
 	State string             `json:"state"`
 	Error string             `json:"error,omitempty"`
 	Peers []doctorPeerReport `json:"peers"`
+	// Imported is what arrived from machines with no peer row — the state a
+	// first exchange leaves, before `deja sync ssh` names a target. The text
+	// report says it since #2379, and a tool reading this saw a machine that
+	// had never exchanged anything (#2382). Omitted when there is none, so a
+	// reader can tell "nothing arrived" from a deja too old to report it.
+	Imported []doctorImportedReport `json:"imported,omitempty"`
+}
+
+// doctorImportedReport is one machine that sent work this one keeps, named as
+// the records name it.
+type doctorImportedReport struct {
+	Machine  string `json:"machine"`
+	Sessions int    `json:"sessions"`
 }
 
 // doctorPeerReport is one machine, carrying what the text line carries.
@@ -165,6 +178,27 @@ func collectDoctorSync(dir string) doctorSyncReport {
 		}
 		row.Ahead = peerStampedAhead(p.Last(), time.Now())
 		out.Peers = append(out.Peers, row)
+		// Counted against a peer row, so the imported list below carries what
+		// is left: the machines this one has no target for.
+		delete(from, peers.Identity(p.Host))
+		if p.Machine != "" {
+			delete(from, peers.Identity(p.Machine))
+		}
+	}
+	names := make([]string, 0, len(from))
+	for name := range from {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if from[names[i]] != from[names[j]] {
+			return from[names[i]] > from[names[j]]
+		}
+		return names[i] < names[j]
+	})
+	for _, name := range names {
+		// The name as the records spell it, for the reason Host is: a reader
+		// may act on it, and the encoder escapes what a terminal would obey.
+		out.Imported = append(out.Imported, doctorImportedReport{Machine: name, Sessions: from[name]})
 	}
 	return out
 }

--- a/cmd/deja/doctor_sync_imported_json_test.go
+++ b/cmd/deja/doctor_sync_imported_json_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The text report says what arrived from a machine there is no peer row for
+// (#2379); `doctor --json` said nothing, so a tool watching sync saw a machine
+// that had never exchanged anything (#2382).
+func TestDoctorJSONReportsWhatArrivedWithoutAPeerRow(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	importFrom := func(machine string, ids ...string) {
+		t.Helper()
+		batch := t.TempDir()
+		var lines []string
+		for _, id := range ids {
+			lines = append(lines, fmt.Sprintf(
+				`{"harness":"claude","session_id":%q,"project":"work/app","role":"user",`+
+					`"text":"work from %s","time":%q,"origin":%q}`,
+				id, machine, time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC).Format(time.RFC3339), machine))
+		}
+		if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := runSync(dir, []string{"import", batch}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	importFrom("laptop.local", "a0", "a1", "a2")
+	importFrom("desktop", "b0", "b1")
+
+	raw, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Sync struct {
+			Peers    []map[string]any `json:"peers"`
+			Imported []struct {
+				Machine  string `json:"machine"`
+				Sessions int    `json:"sessions"`
+			} `json:"imported"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("doctor --json is not JSON: %v", err)
+	}
+	if len(report.Sync.Peers) != 0 {
+		t.Fatalf("a peer row appeared from nowhere: %+v", report.Sync.Peers)
+	}
+	got := map[string]int{}
+	for _, im := range report.Sync.Imported {
+		got[im.Machine] = im.Sessions
+	}
+	if got["laptop.local"] != 3 || got["desktop"] != 2 {
+		t.Errorf("the machines that sent work are missing or miscounted: %+v", report.Sync.Imported)
+	}
+
+	// A machine that has exchanged nothing says nothing rather than an empty
+	// list, so a reader can tell it from a deja too old to report this.
+	hermeticEnv(t)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw, `"imported"`) {
+		t.Errorf("a store with no imports carries an imported key:\n%s", raw)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -369,6 +369,9 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
         "sessions_from_there": 0,
         "last_error": "ssh build-box: exit status 255"
       }
+    ],
+    "imported": [
+      {"machine": "desktop", "sessions": 5}
     ]
   }
 }
@@ -428,6 +431,14 @@ reported. `host` is not: it is a name to act on — `deja sync ssh <host>` — a
 bounded name names no machine, so it is reported exactly as the config file
 spells it, however long. Neither can carry a raw control byte into a terminal:
 the JSON encoder escapes those in any string.
+`sync.imported` names the machines whose work is in this index without a peer
+row of their own — the state a first exchange leaves, when a batch was carried
+by hand or by a shared folder and no `deja sync ssh` target has been named yet.
+A machine counted in a `peers` row is not repeated here. The key is absent when
+nothing has arrived that way, so a reader can tell that from a deja too old to
+report it, and `machine` is the name the records carry, reported as they spell
+it for the reason `host` is.
+
 `stamped_ahead` appears when the newer of the two timestamps is more than a
 minute later than this machine's clock: the age would be negative and the row
 would otherwise read as a sync that just happened, so a consumer should treat


### PR DESCRIPTION
Five sessions imported from two machines, no sync target:

    $ deja doctor            Sync: imported 5 sessions from laptop.local, laptop
    $ deja doctor --json     {"state":"ok","peers":[]}

The text report learned this in #2379 and the JSON did not, so a tool watching sync saw a machine that had never exchanged anything while the manifest knew the origins.

`sync.imported` is a new optional array of `{machine, sessions}`, carrying the machines that have no peer row of their own — a machine already counted in a `peers` row is not repeated. Absent when nothing arrived that way, so a reader can tell that from a deja too old to report it. Docs and the key-contract test updated.

Clean in the same pass, and recorded rather than re-probed later: per-peer export watermarks, `deja sync` with no peers, and `sync forget` for a real host, an unknown one (exit 1) and with no argument (exit 1).

Fixes #2382.