### PR TITLE
test(doctor): make the stale-readonly state on disk, not in a struct

### DIFF
--- a/cmd/deja/stale_readonly_state_test.go
+++ b/cmd/deja/stale_readonly_state_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The state where memory quietly stops growing: the index is behind the stores
+// and the directory a rebuild writes into is read-only, so `deja index` fails
+// the same way every time. Three surfaces have to agree — doctor's JSON state,
+// its freshness line, and the session start, which serves what it has and says
+// why it is not newer. Only the rendering was covered; the state itself was
+// built by hand in a report struct rather than on disk.
+func TestAStaleIndexNobodyCanRebuildIsNamedEverywhere(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(tmp, "store")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(store, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	write := func(id, text string, hoursAgo int) {
+		t.Helper()
+		d := filepath.Join(root, "-work-app")
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		at := time.Now().Add(-time.Duration(hoursAgo) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app",`+
+			`"message":{"role":"user","content":%q}}`, id, at, text)
+		if err := os.WriteFile(filepath.Join(d, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("m0", "the retry budget on this project", 5)
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A session arrives, and then nowhere to put the rebuild.
+	write("m9", "a brand new topic nobody has indexed", 1)
+	if err := os.Chmod(store, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(store, 0o755) })
+
+	raw, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report struct {
+		Index struct {
+			State string `json:"state"`
+		} `json:"index"`
+	}
+	if err := json.Unmarshal([]byte(raw), &report); err != nil {
+		t.Fatalf("doctor --json is not JSON: %v", err)
+	}
+	if report.Index.State != "stale-readonly" {
+		t.Errorf("index state = %q, want stale-readonly", report.Index.State)
+	}
+
+	human, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(human, "cannot be written") {
+		t.Errorf("the report does not say the index cannot be written:\n%s", doctorSection(human, "Index:"))
+	}
+
+	// And the session start serves what it has rather than going quiet.
+	out := hookContextFor(t, dir, `{"hook_event_name":"SessionStart","cwd":"/work/app","session_id":"a1"}`)
+	if !strings.Contains(out, "retry budget") {
+		t.Errorf("the hook served nothing from an index it can still read:\n%s", out)
+	}
+	if !strings.Contains(out, "not writable") {
+		t.Errorf("the hook does not say why the index is not newer:\n%s", out)
+	}
+}


### PR DESCRIPTION
An old note suspected `stale-readonly` was nearly unreachable, since deja chmods its own index directory back on every lock. Measured: the directory's own bits decide nothing (a rebuild writes a sibling and renames), and the state fires where it matters — a new session on disk and the directory a rebuild writes into read-only:

    doctor  freshness 1 store changed since last build, and the index cannot be written — …
    json    "state": "stale-readonly"
    index   deja: cannot write the index at … — check the directory's permissions …
    hook    deja is serving the index as it was — it cannot be updated because …/store is not writable

Three surfaces agree, and the hook still serves what it has. Verdict: not a bug.

The derivation was unpinned: the one test that mentions the state builds the report struct by hand and checks the rendering. This makes the state on disk and holds all three surfaces; it fails when the stale-readonly branch is disabled.

Test only.