### PR TITLE
test(view): hold the page to what bounds its digests

### DIFF
--- a/cmd/deja/view_recall_page_size_test.go
+++ b/cmd/deja/view_recall_page_size_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The page bounds its transcripts (viewPreviewBytes) and its notes (#2111).
+// Digest text has no bound of its own: what keeps it small is the injection
+// log's own rotation, which rewrites past 512 KB keeping the last records — so
+// however much is written, the tab can only carry what the log still holds.
+//
+// This holds the page to that. Four megabytes of digests go in; the page stays
+// one fast file, and the log is left with a handful of records rather than the
+// five hundred that were written.
+func TestThePageIsBoundedByTheInjectionLogsRotation(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-mine", "m.jsonl"), "minesess", []string{
+		`{"type":"user","sessionId":"minesess","timestamp":"2026-08-03T12:00:00Z","message":{"role":"user","content":"my own question"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Each digest the size of the largest a writer records — a whole-session
+	// read over deja://session/… measured 8,216 bytes.
+	body := strings.Repeat("the migration kept failing on the ledger table. ", 170)
+	const wrote = 500
+	for i := 0; i < wrote; i++ {
+		usage.RecordDigestPolicy(dir, usage.KindResource, "<deja-recall>\n"+body+"\n", 1, 400, "local+imported")
+	}
+
+	kept := usage.Snapshots(dir, 0)
+	if len(kept) >= wrote {
+		t.Errorf("the log kept %d of %d digests — rotation is what bounds the page", len(kept), wrote)
+	}
+
+	out := filepath.Join(t.TempDir(), "view.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The bound the notes cap is held to.
+	if n := len(page); n > 3<<20 {
+		t.Errorf("the page is %d bytes after %d digests were written", n, wrote)
+	}
+	if !strings.Contains(string(page), "the migration kept failing") {
+		t.Fatal("no digest text reached the page, so this measures nothing")
+	}
+}


### PR DESCRIPTION
Probed what a digest can do inside the page. Injection is handled — a digest carrying `</script><img src=x onerror=…>` lands as `\u003c/script\u003e…`, the only literal `</script>` in the file is the page's own, and `esc()` escapes again at render time.

Size is the other half: digest text has no bound on the page, where notes have one (#2111) and previews have another. What keeps it small is the injection log's own rotation — measured, five whole-session reads over `deja://session/…` record 8 KB each, and 500 such digests leave the log holding a handful.

So the page is bounded by a fact about another file, and nothing said so. This writes 4 MB of digests, holds the page under the bound the notes cap uses, and asserts the log kept far fewer records than were written; it fails when rotation is disabled.

Test only.