### PR TITLE
fix(blame): stop quoting deja's own output as a file's history

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -144,7 +144,15 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		}
 		var mentions []mention
 		for _, message := range session.Messages {
-			count, level := mentionScore(message.Text, base, forms)
+			// The transcript's record of a past `deja blame` names the file in
+			// every line of its own output, so blame ranked its own answer as
+			// the history of the file and quoted it back. Recall was fixed for
+			// this in #2068 and blame reads the same transcripts: measured on
+			// the paths agents actually asked about, the top snippet came back
+			// as "=== deja blame internal/index/retrieval.go …" — deja's own
+			// output, written into the transcript by an agent exercising it.
+			text := withoutOwnReport(withoutOwnCallLog(message.Text))
+			count, level := mentionScore(text, base, forms)
 			if count == 0 {
 				continue
 			}
@@ -152,7 +160,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			if level > specificity {
 				specificity = level
 			}
-			mentions = append(mentions, mention{message.Text, count, level, message.Role})
+			mentions = append(mentions, mention{text, count, level, message.Role})
 		}
 		// A path-shaped mention outranks a bare filename however often the bare
 		// name is repeated; among equally specific ones, the message that keeps

--- a/internal/search/blame_own_report_test.go
+++ b/internal/search/blame_own_report_test.go
@@ -1,0 +1,71 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An agent exercising deja from a shell writes deja's own output into its
+// transcript, and every line of a blame report names the file it is about. So
+// blame ranked its own answer as that file's history: measured on this
+// repository's sources, two of eighty-two snippets came back as
+// `=== deja blame internal/index/retrieval.go ===` and the report under it.
+//
+// The same rule the report guard and the fix miner already apply (#2067,
+// #2068, #2169).
+func TestBlameDoesNotQuoteItsOwnOutput(t *testing.T) {
+	now := "2026-01-02T03:04:05Z"
+	_ = now
+	sessions := []model.Session{{
+		ID: "shell", Harness: "claude", Project: "app",
+		Messages: []model.Message{
+			{Role: "user", Text: "check the tool"},
+			{Role: "tool-output", Text: "=== deja blame internal/index/retrieval.go ===\n" +
+				"2026-07-18 · claude · file-00 · have a look at internal/index/retrieval.go"},
+		},
+	}, {
+		ID: "real", Harness: "claude", Project: "app",
+		Messages: []model.Message{
+			{Role: "user", Text: "internal/index/retrieval.go keeps losing the idf map between passes"},
+			{Role: "assistant", Text: "Fixed: internal/index/retrieval.go now returns it with the ranking."},
+		},
+	}}
+	target, err := ResolveBlamePath("internal/index/retrieval.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits := Blame(sessions, target, BlameOptions{All: true})
+	for _, h := range hits {
+		for _, s := range h.Snippets {
+			if strings.Contains(s, "=== deja ") {
+				t.Errorf("blame quoted its own output: %q", strings.TrimSpace(s)[:min(len(s), 80)])
+			}
+		}
+		// The report body is still matched — only the command echo is
+		// dropped — so such a session can still appear. What it may not do is
+		// hand deja's own words back as the file's history, which is the line
+		// a reader acts on.
+	}
+	found := false
+	for _, h := range hits {
+		if h.Session.ID == "real" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the session that actually discussed the file was dropped")
+	}
+}
+
+// The report body is left alone: `deja: ` opens deja's own messages to a
+// terminal, and it is also how a person writes about deja.
+func TestBlameKeepsALineThatMerelyNamesDeja(t *testing.T) {
+	if withoutOwnReport("deja: no sessions mention nope.go") == "" {
+		t.Error("a line addressed by deja was dropped from matching")
+	}
+	if got := withoutOwnReport("=== deja blame x.go ===\nkept"); strings.Contains(got, "=== deja") {
+		t.Errorf("the command echo survived: %q", got)
+	}
+}

--- a/internal/search/toolcall.go
+++ b/internal/search/toolcall.go
@@ -63,3 +63,38 @@ func isOwnCallLine(line string) bool {
 	}
 	return false
 }
+
+// dejaReportLine reports whether a transcript line is deja's own output rather
+// than someone talking about a file. An agent exercising deja from a shell
+// writes headers and results into its own transcript — `=== deja blame
+// internal/index/retrieval.go ===` and the report under it — and every one of
+// those lines names the file, so blame ranked them as that file's history and
+// quoted them back. Measured on this store: the top two snippets for
+// `internal/index/retrieval.go` were deja's own help output.
+//
+// The same rule the report guard and the fix miner already apply (#2067,
+// #2068, #2169): deja's own words must not become what it knows.
+//
+// Only the command echo, not the report body: a line opening `deja: ` is how
+// deja addresses a terminal, but it is also how a person writes about deja,
+// and dropping it changed nothing measurable here.
+func dejaReportLine(line string) bool {
+	l := strings.TrimSpace(line)
+	return strings.HasPrefix(l, "=== deja ") || strings.HasPrefix(l, "$ deja ")
+}
+
+// withoutOwnReport drops those lines, leaving everything a person wrote.
+func withoutOwnReport(text string) string {
+	if !strings.Contains(text, "deja") {
+		return text
+	}
+	lines := strings.Split(text, "\n")
+	kept := lines[:0]
+	for _, l := range lines {
+		if dejaReportLine(l) {
+			continue
+		}
+		kept = append(kept, l)
+	}
+	return strings.Join(kept, "\n")
+}


### PR DESCRIPTION
Asked what a file's history is, blame answered with its own past output.

```
snippet 1: … компare/fixes · делай задачи в next.md === deja blame internal/index/retrieval.go 2026-07-18 · claude · file-00 …
snippet 2: === deja blame internal/index/retrieval.go 2026-07-18 · claude · file-00 · have a look at internal/index/retrieval.go …
```

An agent exercising deja from a shell writes deja's output into its own transcript, and **every line of a blame report names the file it is about** — so the report scores as that file's richest history and is handed back as evidence. Measured across this repository's own sources, two of eighty-two snippets. It appears in three separate session files here, including the hunt worktree's, so it is not one stray run.

This is the fourth instance of one rule the codebase already states three times — deja's own words must not become what it knows (#2067, #2068, #2169) — and the narrowest version of it: only the command echo, `=== deja …` and `$ deja …`.

Deliberately **not** filtered: a line opening `deja: `. That is how deja addresses a terminal, and it is also how a person writes about deja; dropping it changed nothing measurable here, so it stays.

What the change guarantees is what the test asserts: the snippet a reader acts on is no longer deja quoting itself. A session that only ran deja can still appear on the list — the report body is still matched — and the session that actually discussed the file is still found.

Two false starts worth recording, since both cost a measurement: `withoutOwnCallLog` from #2068 does not cover this, because it removes *tool-call* lines rather than the CLI's printed output; and a sample of the paths agents ask about most is the wrong place to see this, because the contamination lives on deja's own sources, where deja is the thing being exercised.