### PR TITLE
fix(mcp): say when a resource read answered from one of several matches

### DIFF
--- a/cmd/deja/mcp_resource_ambiguous_test.go
+++ b/cmd/deja/mcp_resource_ambiguous_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every door a person types names an ambiguous prefix before answering from
+// one of the matches. The resource read — the door an agent uses — picked the
+// newest silently, which is a wrong answer nobody can see (#2388).
+func TestTheResourceReadNamesAnAmbiguousPrefix(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, id := range []string{"dupe-one", "dupe-two"} {
+		at := time.Now().Add(-time.Duration(3+i) * time.Hour).UTC().Format(time.RFC3339)
+		line := fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app",`+
+			`"message":{"role":"user","content":"local work in %s"}}`, id, at, id)
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: a whole id answers with no such note.
+	whole, code, msg := mcpResourceRead(dir, "deja://session/dupe-one")
+	if code != 0 {
+		t.Fatalf("a whole id was refused: %d %s", code, msg)
+	}
+	if strings.Contains(resourceText(t, whole), "sessions match") {
+		t.Errorf("an unambiguous read carries an ambiguity note")
+	}
+
+	got, code, msg := mcpResourceRead(dir, "deja://session/dupe")
+	if code != 0 {
+		t.Fatalf("an ambiguous prefix was refused rather than answered: %d %s", code, msg)
+	}
+	text := resourceText(t, got)
+	if !strings.Contains(text, "dupe-one") {
+		t.Fatalf("the read did not answer from the newest match:\n%s", text)
+	}
+	if !strings.Contains(text, "2 sessions match") {
+		t.Errorf("the reader is not told another session matched:\n%s", text)
+	}
+}

--- a/cmd/deja/mcp_resource_ambiguous_test.go
+++ b/cmd/deja/mcp_resource_ambiguous_test.go
@@ -52,7 +52,13 @@ func TestTheResourceReadNamesAnAmbiguousPrefix(t *testing.T) {
 	if !strings.Contains(text, "dupe-one") {
 		t.Fatalf("the read did not answer from the newest match:\n%s", text)
 	}
-	if !strings.Contains(text, "2 sessions match") {
-		t.Errorf("the reader is not told another session matched:\n%s", text)
+	note := strings.Index(text, "2 sessions match")
+	if note < 0 {
+		t.Fatalf("the reader is not told another session matched:\n%s", text)
+	}
+	// deja's own words, not recalled text: the note belongs above the frame the
+	// served transcript is wrapped in.
+	if frame := strings.Index(text, "<deja-recall>"); frame >= 0 && note > frame {
+		t.Errorf("the note sits inside the untrusted-data frame:\n%s", text)
 	}
 }

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -107,20 +107,22 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	if !policy.Load().Allows(policy.ActivationMCP, s.Project) {
 		return nil, -32602, "blocked by trust policy"
 	}
-	var b bytes.Buffer
 	// Every door a person types says when a prefix reached more than one
 	// session; this one picked the newest in silence, which is a wrong answer
-	// an agent cannot see (#2388). The note goes inside the served text: the
-	// resources surface has nowhere else to put it.
+	// an agent cannot see (#2388). On the CLI the note goes to stderr, beside
+	// the transcript rather than inside it; here it goes above the recall
+	// frame, so it reads as deja's own words and not as recalled text.
+	note := ""
 	if n := index.PrefixMatches(dir, id); n > 1 {
-		fmt.Fprintf(&b, "deja: %d sessions match %q — this is the most recent; ask for a longer prefix to read another.\n\n",
+		note = fmt.Sprintf("deja: %d sessions match %q — this is the most recent; ask for a longer prefix to read another.\n\n",
 			n, neutralizeFrameMarkers(safeForStatusline(id, mcpResourceNameMax)))
 	}
+	var b bytes.Buffer
 	search.PrintContext(&b, s, "")
 	// Same transcript, same frame as recall_context. Reading a session through
 	// the resources surface used to skip the untrusted-data wrapper and the
 	// marker neutralisation entirely (#1077).
-	text := frameRecall(b.String())
+	text := note + frameRecall(b.String())
 	// It also left no trace: a whole session reached the agent and `deja log`
 	// stayed empty — the gap #682 closed for blame.
 	usage.RecordServedFrom(dir, usage.KindResource, text, 1, rawSize([]model.Session{s}), []string{s.ID}, projectsOf(s), policy.Load().Describe(policy.ActivationMCP))

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -108,6 +108,14 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 		return nil, -32602, "blocked by trust policy"
 	}
 	var b bytes.Buffer
+	// Every door a person types says when a prefix reached more than one
+	// session; this one picked the newest in silence, which is a wrong answer
+	// an agent cannot see (#2388). The note goes inside the served text: the
+	// resources surface has nowhere else to put it.
+	if n := index.PrefixMatches(dir, id); n > 1 {
+		fmt.Fprintf(&b, "deja: %d sessions match %q — this is the most recent; ask for a longer prefix to read another.\n\n",
+			n, neutralizeFrameMarkers(safeForStatusline(id, mcpResourceNameMax)))
+	}
 	search.PrintContext(&b, s, "")
 	// Same transcript, same frame as recall_context. Reading a session through
 	// the resources surface used to skip the untrusted-data wrapper and the


### PR DESCRIPTION
Two sessions whose ids share a prefix:

    deja://session/dupe-one       → the session
    deja://session/nosuchsession  → error, "no session matches …"
    deja://session/<imported>     → error, "blocked by trust policy"
    deja://session/dupe           → the newest of the two, silently

The last is the one an agent asks for, and nothing in the reply said another session matched — while `deja show dupe` prints "2 sessions match \"dupe\" — showing the most recent; use a longer prefix for another" and `ctx`, `handoff` and the rest share that helper.

The served text now carries the same sentence, sanitised the way the not-found message is. The other three answers were already right.

Fixes #2388.