### PR TITLE
fix(install): name the replaced entry on the .jsonc path too

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -159,7 +159,7 @@ func TestInstallWriteAndJSONEdges(t *testing.T) {
 	if _, _, err := updateOpencodeJSON([]byte(`{"mcp":`), "/bin/deja", false); err == nil {
 		t.Fatal("expected malformed opencode json error")
 	}
-	if b, err := updateOpencodeJSONC([]byte("{}\n"), "/bin/deja", true); err != nil || string(b) != "{}\n" {
+	if b, _, err := updateOpencodeJSONC([]byte("{}\n"), "/bin/deja", true); err != nil || string(b) != "{}\n" {
 		t.Fatalf("jsonc uninstall no mcp = %q err=%v", b, err)
 	}
 }

--- a/cmd/deja/coverage_final_test.go
+++ b/cmd/deja/coverage_final_test.go
@@ -51,7 +51,7 @@ func TestInstallClaudeHookMalformedExisting(t *testing.T) {
 }
 
 func TestUpdateOpencodeJSONCEmptyUninstall(t *testing.T) {
-	b, err := updateOpencodeJSONC(nil, "/bin/deja", true)
+	b, _, err := updateOpencodeJSONC(nil, "/bin/deja", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1471,7 +1471,7 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 	var note string
 	var err error
 	if strings.HasSuffix(path, ".jsonc") {
-		next, err = updateOpencodeJSONC(old, exe, uninstall)
+		next, note, err = updateOpencodeJSONC(old, exe, uninstall)
 		if err != nil {
 			return installResult{}, err
 		}
@@ -1569,14 +1569,14 @@ func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end
 	return strings.TrimSpace(b.String()), inBlock, end
 }
 
-func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error) {
+func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string, error) {
 	line := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
 	s := string(old)
 	if strings.TrimSpace(s) == "" {
 		if uninstall {
-			return []byte("{}\n"), nil
+			return []byte("{}\n"), "", nil
 		}
-		return []byte("{\n  \"mcp\": {\n" + line + "\n  }\n}\n"), nil
+		return []byte("{\n  \"mcp\": {\n" + line + "\n  }\n}\n"), "", nil
 	}
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	start, end := -1, -1
@@ -1595,11 +1595,21 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 		}
 	}
 	if start >= 0 && end > start {
-		var body []string
+		// The lines this drops are the entry that was already here. Naming what
+		// it ran is the same sentence the .json writer prints (#2390); without
+		// it, what install told you depended on which of the two names the
+		// config had (#2392).
+		var body, dropped []string
 		for _, l := range lines[start+1 : end] {
-			if !strings.Contains(l, `"deja"`) {
-				body = append(body, l)
+			if strings.Contains(l, `"deja"`) {
+				dropped = append(dropped, l)
+				continue
 			}
+			body = append(body, l)
+		}
+		note := ""
+		if !uninstall {
+			note = replacedJSONCLineNote(dropped, line)
 		}
 		if !uninstall {
 			// Only the last line that carries content decides whether a comma
@@ -1617,10 +1627,10 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 		out := append([]string{}, lines[:start+1]...)
 		out = append(out, body...)
 		out = append(out, lines[end:]...)
-		return []byte(strings.Join(out, "\n") + "\n"), nil
+		return []byte(strings.Join(out, "\n") + "\n"), note, nil
 	}
 	if uninstall {
-		return []byte(strings.Join(lines, "\n") + "\n"), nil
+		return []byte(strings.Join(lines, "\n") + "\n"), "", nil
 	}
 	// An "mcp" key exists but brace-counting could not bound it — its opening
 	// brace is on a later line, or the braces are unbalanced. Adding a fresh
@@ -1628,7 +1638,7 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 	// user's other servers. Refuse rather than corrupt a config that cannot be
 	// rebuilt; the caller surfaces this so the user can wire deja by hand.
 	if start >= 0 || opencodeHasMCPKey(lines) {
-		return nil, fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
+		return nil, "", fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
 	}
 	insert := len(lines) - 1
 	comma := ""
@@ -1643,7 +1653,44 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, error)
 	out := append([]string{}, lines[:insert]...)
 	out = append(out, mcp...)
 	out = append(out, lines[insert:]...)
-	return []byte(strings.Join(out, "\n") + "\n"), nil
+	return []byte(strings.Join(out, "\n") + "\n"), "", nil
+}
+
+// replacedJSONCLineNote names the deja entry a line-editing write dropped.
+// The lines are text rather than a decoded entry, so the comparison is the
+// text deja would have written: same line, nothing replaced. Empty when the
+// entry was absent or already deja's own.
+func replacedJSONCLineNote(dropped []string, line string) string {
+	if len(dropped) == 0 {
+		return ""
+	}
+	if len(dropped) == 1 && strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(dropped[0]), ",")) ==
+		strings.TrimSpace(line) {
+		return ""
+	}
+	was := jsoncEntryCommand(strings.Join(dropped, " "))
+	if was == "" {
+		return "replaced the deja entry that was already here"
+	}
+	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
+}
+
+// jsoncEntryCommand pulls the command out of an entry deja did not write. It
+// reads the text rather than the JSON: the block may carry comments and
+// trailing commas, which is why this writer exists at all.
+func jsoncEntryCommand(text string) string {
+	i := strings.Index(text, `"command"`)
+	if i < 0 {
+		return ""
+	}
+	rest := text[i+len(`"command"`):]
+	if j := strings.IndexAny(rest, `"`); j >= 0 {
+		rest = rest[j+1:]
+		if k := strings.IndexByte(rest, '"'); k > 0 {
+			return rest[:k]
+		}
+	}
+	return ""
 }
 
 // opencodeHasMCPKey reports whether any line declares an "mcp" key, so the

--- a/cmd/deja/install_jsonc_replaced_test.go
+++ b/cmd/deja/install_jsonc_replaced_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The .json writer names the entry it replaced (#2390). Opencode's second
+// writer edits lines so comments survive, and said nothing — so what install
+// told you depended on which of the two names your config had (#2392).
+func TestInstallSaysWhatItReplacedInAJSONCConfig(t *testing.T) {
+	cases := []struct {
+		name   string
+		before string
+		want   string // "" means: say nothing besides the action
+	}{
+		{"an entry someone pointed at their own wrapper", `{
+  // my settings
+  "mcp": {
+    "mine": {"type":"local","command":["/usr/bin/mine"]},
+    "deja": {"type":"local","command":["/home/me/bin/deja-wrapper","mcp","--quiet"]}
+  }
+}
+`, "/home/me/bin/deja-wrapper"},
+		{"no deja entry at all", `{
+  "mcp": {
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  }
+}
+`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
+			dir := filepath.Join(home, ".config", "opencode")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "opencode.jsonc")
+			if err := os.WriteFile(path, []byte(tc.before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			r, err := installTarget("opencode", "/usr/local/bin/deja", false)
+			if err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			if tc.want == "" {
+				if r.Note != "" {
+					t.Errorf("install spoke about an entry nobody had: %q", r.Note)
+				}
+				return
+			}
+			if !strings.Contains(r.Note, tc.want) {
+				t.Errorf("install replaced their wiring without naming it: note %q", r.Note)
+			}
+			// The comment is why this writer exists at all.
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(body), "// my settings") {
+				t.Errorf("the comment did not survive the write:\n%s", body)
+			}
+		})
+	}
+}

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -1087,14 +1087,14 @@ func TestRunInstallAllExistingAndJSONCEdges(t *testing.T) {
 		{"top trailing", "{\n  \"theme\": \"dark\",\n}\n", `"mcp"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := updateOpencodeJSONC([]byte(tc.old), "/bin/deja", false)
+			got, _, err := updateOpencodeJSONC([]byte(tc.old), "/bin/deja", false)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !strings.Contains(string(got), tc.want) || !strings.Contains(string(got), `"deja"`) {
 				t.Fatalf("jsonc got:\n%s\nwant contains %q", got, tc.want)
 			}
-			un, err := updateOpencodeJSONC(got, "/bin/deja", true)
+			un, _, err := updateOpencodeJSONC(got, "/bin/deja", true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1108,7 +1108,7 @@ func TestRunInstallAllExistingAndJSONCEdges(t *testing.T) {
 	// "mcp" keys and drop the user's other servers, so it errors instead.
 	t.Run("mcp brace on next line errors, not corrupts", func(t *testing.T) {
 		braceNext := "{\n  \"mcp\":\n  {\n    \"other\": {\"type\":\"local\"}\n  }\n}\n"
-		if _, err := updateOpencodeJSONC([]byte(braceNext), "/bin/deja", false); err == nil {
+		if _, _, err := updateOpencodeJSONC([]byte(braceNext), "/bin/deja", false); err == nil {
 			t.Fatal("expected an error rather than a duplicate mcp block")
 		}
 	})

--- a/cmd/deja/opencode_jsonc_test.go
+++ b/cmd/deja/opencode_jsonc_test.go
@@ -113,7 +113,7 @@ func TestOpencodeJSONCKeepsTrailingCommasValid(t *testing.T) {
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {
-			out, err := updateOpencodeJSONC([]byte(in+"\n"), "/usr/local/bin/deja", false)
+			out, _, err := updateOpencodeJSONC([]byte(in+"\n"), "/usr/local/bin/deja", false)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
#2390 taught install to say when it overwrote a deja entry someone had changed. That went into the writers that edit a decoded map; opencode's second writer edits lines so comments survive, and stayed silent — so the same config reported the replacement as `opencode.json` and said nothing as `opencode.jsonc`.

    opencode: updated ~/.config/opencode/opencode.jsonc
              replaced the deja entry that was already here, which ran /home/me/bin/deja-wrapper

The writer already had the old entry in hand: it drops every line carrying `"deja"` while rebuilding the block. The note reads those lines as text, since the point of this writer is that the file may carry comments and trailing commas. Silent when the entry was absent or already deja's own.

Fixes #2392.