### PR TITLE
fix(install): drop a multi-line deja entry whole, not just its first line

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1512,6 +1512,29 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	return append(next, '\n'), note, nil
 }
 
+// dropJSONCEntry takes the deja entry out of an "mcp" block written as lines,
+// and hands back what is left beside what it removed. An entry spelled across
+// lines carries `"deja"` on its first one only; dropping just that line left
+// the rest of it in the block and the config stopped parsing (#2394), so the
+// entry is bounded by counting braces the way the block itself is.
+func dropJSONCEntry(lines []string) (body, dropped []string) {
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if !strings.Contains(l, `"deja"`) {
+			body = append(body, l)
+			continue
+		}
+		dropped = append(dropped, l)
+		depth := strings.Count(l, "{") - strings.Count(l, "}")
+		for depth > 0 && i+1 < len(lines) {
+			i++
+			dropped = append(dropped, lines[i])
+			depth += strings.Count(lines[i], "{") - strings.Count(lines[i], "}")
+		}
+	}
+	return body, dropped
+}
+
 // jsoncLastCodeLine finds the last line of a .jsonc block that a parser would
 // read as code, and where that code ends on it. It returns -1 when the block
 // holds nothing but comments and blank lines.
@@ -1599,14 +1622,7 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		// it ran is the same sentence the .json writer prints (#2390); without
 		// it, what install told you depended on which of the two names the
 		// config had (#2392).
-		var body, dropped []string
-		for _, l := range lines[start+1 : end] {
-			if strings.Contains(l, `"deja"`) {
-				dropped = append(dropped, l)
-				continue
-			}
-			body = append(body, l)
-		}
+		body, dropped := dropJSONCEntry(lines[start+1 : end])
 		note := ""
 		if !uninstall {
 			note = replacedJSONCLineNote(dropped, line)

--- a/cmd/deja/install_jsonc_multiline_test.go
+++ b/cmd/deja/install_jsonc_multiline_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The .jsonc writer drops the deja entry by looking for the string on a line.
+// An entry written across lines carries it on the first one only, so the rest
+// stayed behind and the config stopped parsing (#2394).
+func TestInstallDropsAWholeMultilineEntry(t *testing.T) {
+	before := `{
+  // my settings
+  "mcp": {
+    "mine": {"type":"local","command":["/usr/bin/mine"]},
+    "deja": {
+      "type": "local",
+      "command": ["/home/me/bin/deja-wrapper", "mcp"]
+    }
+  }
+}
+`
+	next, note, err := updateOpencodeJSONC([]byte(before), "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got := string(next)
+	if !strings.Contains(got, "// my settings") {
+		t.Errorf("the comment did not survive:\n%s", got)
+	}
+	if !strings.Contains(note, "/home/me/bin/deja-wrapper") {
+		t.Errorf("the note did not name what it replaced: %q", note)
+	}
+	if strings.Contains(got, "deja-wrapper") {
+		t.Errorf("the old entry is still in the file:\n%s", got)
+	}
+
+	var root struct {
+		MCP map[string]json.RawMessage `json:"mcp"`
+	}
+	stripped := regexp.MustCompile(`(?m)//.*$`).ReplaceAllString(got, "")
+	if err := json.Unmarshal([]byte(stripped), &root); err != nil {
+		t.Fatalf("the config no longer parses: %v\n%s", err, got)
+	}
+	if len(root.MCP) != 2 || root.MCP["mine"] == nil || root.MCP["deja"] == nil {
+		t.Errorf("the block should hold their server and deja's, got %d entries:\n%s", len(root.MCP), got)
+	}
+}


### PR DESCRIPTION
The .jsonc writer rebuilds the `"mcp"` block line by line and dropped every line containing `"deja"`. An entry written across lines carries that string on its first line only, so the body stayed behind:

    "mine": {"type":"local","command":["/usr/bin/mine"]},
      "type": "local",
      "command": ["/home/me/bin/deja-wrapper", "mcp"]
    },
    "deja": {"type":"local","command":["/usr/local/bin/deja","mcp"]}

Comments stripped, a JSON parser gives `Extra data: line 10 column 1` — opencode gets a broken config and deja's own wiring goes down with it.

The entry is now bounded by counting braces from the line that opens it, which is what this function already does for the `"mcp"` block itself. The .json writer was never affected; it edits a decoded map.

Fixes #2394.