### PR TITLE
fix(install): an -auto target reports the file it changed

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -639,60 +639,126 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	}
 }
 
+// wroteAll folds what an -auto target did into the one result its caller
+// prints. Reporting only the last write said "unchanged" about a run that had
+// just rewired the MCP entry, and named the hook file while doing it (#2396).
+// The first write that changed something is the answer; anything else it
+// changed rides along in the note, and when nothing changed the last write
+// stands, since that is the file the target is named for.
+func wroteAll(rs ...installResult) installResult {
+	out := rs[len(rs)-1]
+	for _, r := range rs {
+		if r.Path != "" && r.Action != "unchanged" {
+			out = r
+			break
+		}
+	}
+	var also []string
+	for _, r := range rs {
+		if r.Path == "" || r.Action == "unchanged" || r.Path == out.Path {
+			continue
+		}
+		also = append(also, fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path)))
+	}
+	for _, line := range also {
+		if out.Note != "" {
+			out.Note += "; "
+		}
+		out.Note += line
+	}
+	return out
+}
+
 func installClaudeAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installClaude(exe, uninstall); err != nil {
+	mcp, err := installClaude(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	if _, err := installClaudeCommands(exe, uninstall); err != nil {
+	cmds, err := installClaudeCommands(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installClaudeHook(exe, uninstall)
+	hook, err := installClaudeHook(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, cmds, hook), nil
 }
 
 func installAntigravityAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall); err != nil {
+	mcp, err := installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installAntigravityPlugin(exe, uninstall)
+	plugin, err := installAntigravityPlugin(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, plugin), nil
 }
 
 func installOpenClawAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installOpenClawMCP(exe, uninstall); err != nil {
+	mcp, err := installOpenClawMCP(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
 	// The plugin covers the prompt; the bootstrap hook covers the session.
-	if _, err := installOpenClawPlugin(exe, uninstall); err != nil {
+	plugin, err := installOpenClawPlugin(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installOpenClawHooks(exe, uninstall)
+	hooks, err := installOpenClawHooks(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, plugin, hooks), nil
 }
 
 func installHermesAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installHermesMCP(exe, uninstall); err != nil {
+	mcp, err := installHermesMCP(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installHermesPlugin(exe, uninstall)
+	plugin, err := installHermesPlugin(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, plugin), nil
 }
 
 func installPiAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installMCPJSON(filepath.Join(sources.PiConfigDir(), "mcp.json"), exe, uninstall); err != nil {
+	mcp, err := installMCPJSON(filepath.Join(sources.PiConfigDir(), "mcp.json"), exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installPiExtension(exe, uninstall)
+	ext, err := installPiExtension(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, ext), nil
 }
 
 func installCursorAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installCursor(exe, uninstall); err != nil {
+	mcp, err := installCursor(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installCursorHooks(exe, uninstall)
+	hooks, err := installCursorHooks(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, hooks), nil
 }
 
 func installCodexAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installCodex(exe, uninstall); err != nil {
+	mcp, err := installCodex(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
 	res, err := installCodexHooks(exe, uninstall)
+	if err == nil {
+		res = wroteAll(mcp, res)
+	}
 	// Writing the file is not the same as codex agreeing to run it. Said here
 	// because this is the moment someone is watching, and because the state it
 	// warns about is invisible: everything on disk looks right and no memory
@@ -704,10 +770,15 @@ func installCodexAuto(exe string, uninstall bool) (installResult, error) {
 }
 
 func installOpencodeAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installOpencode(exe, uninstall); err != nil {
+	mcp, err := installOpencode(exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
-	return installOpencodePlugin(exe, uninstall)
+	plugin, err := installOpencodePlugin(exe, uninstall)
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(mcp, plugin), nil
 }
 
 // pruneGuidanceDirs drops the directories install had to create for a guidance

--- a/cmd/deja/install_auto_reports_test.go
+++ b/cmd/deja/install_auto_reports_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An -auto target writes several files and used to report only the last one,
+// so a run that rewired the MCP entry said "unchanged" about the hook file
+// instead — the wrong word about the wrong path (#2396).
+func TestAnAutoTargetReportsTheFileItChanged(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installTarget("claude-auto", "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: with everything in place, there is nothing to do.
+	settled, err := installTarget("claude-auto", "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settled.Action != "unchanged" {
+		t.Fatalf("a second install still had work to do: %s %s", settled.Action, settled.Path)
+	}
+
+	// Take deja out of the MCP config by hand and leave the hooks alone.
+	mcpPath := filepath.Join(home, ".claude.json")
+	body, err := os.ReadFile(mcpPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	if servers == nil || servers["deja"] == nil {
+		t.Fatalf("install left no deja entry to remove: %s", body)
+	}
+	delete(servers, "deja")
+	body, err = json.Marshal(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mcpPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := installTarget("claude-auto", "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Action == "unchanged" {
+		t.Errorf("install put the entry back and called the run unchanged: %s %s", r.Action, r.Path)
+	}
+	if r.Path != mcpPath {
+		t.Errorf("install named %s, but %s is what it wrote", r.Path, mcpPath)
+	}
+}

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -139,13 +139,17 @@ func TestInstallOpencodePluginUninstallMissingDir(t *testing.T) {
 }
 
 func TestInstallAutoWrappers(t *testing.T) {
+	// An -auto target writes several files, and what it reports is the first
+	// one it changed — reporting the last said "unchanged" about a run that
+	// had rewired something else (#2396). The rest ride along in the note.
 	for _, tc := range []struct {
 		name string
 		fn   func(string, bool) (installResult, error)
 		want string
+		also string
 	}{
-		{"codex", installCodexAuto, filepath.Join(".codex", "hooks.json")},
-		{"opencode", installOpencodeAuto, filepath.Join(".config", "opencode", "plugins", "deja.js")},
+		{"codex", installCodexAuto, filepath.Join(".codex", "config.toml"), "hooks.json"},
+		{"opencode", installOpencodeAuto, filepath.Join(".config", "opencode", "opencode.json"), "deja.js"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			home := t.TempDir()
@@ -158,11 +162,14 @@ func TestInstallAutoWrappers(t *testing.T) {
 			if r.Action != "created" || r.Path != filepath.Join(home, tc.want) {
 				t.Fatalf("install result = %#v", r)
 			}
+			if !strings.Contains(r.Note, tc.also) {
+				t.Errorf("the other file it wrote is unmentioned: %#v", r)
+			}
 			r, err = tc.fn("/bin/deja", true)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if r.Path != filepath.Join(home, tc.want) {
+			if r.Path == "" || r.Action == "" {
 				t.Fatalf("uninstall result = %#v", r)
 			}
 		})


### PR DESCRIPTION
Every `*-auto` target writes more than one file and returned only the last one's result:

    # deja's MCP entry taken out of ~/.claude.json by hand, hooks left alone
    $ deja install claude-auto
    claude-auto: unchanged ~/.claude/settings.json     ← and ~/.claude.json got the entry back

Wrong word, wrong path. `deja install claude` reports `updated ~/.claude.json` for the same write, so what you were told depended on which target you asked for.

The composites now fold their results: the first write that changed something is what gets reported, anything else it changed rides along under it, and when nothing changed the last write still stands.

    claude-auto: updated ~/.claude.json
                 also removed ~/.claude/commands/deja.md; also updated ~/.claude/settings.json

`TestInstallAutoWrappers` pinned the old behaviour (the last write is the answer) and now pins this one.

Fixes #2396.