### PR TITLE
fix(install): refuse an MCP block that is not an object

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1055,6 +1055,11 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	}
 	m, _, err := mcpBlock(root, "mcpServers", path)
 	if err != nil {
+		// On the way out there is nothing of deja's in a block it never wrote,
+		// and refusing here would leave the rest of the target wired (#2399).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
 	if m == nil {
@@ -1455,6 +1460,11 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	m, _, err := mcpBlock(root, "mcpServers", path)
 	if err != nil {
+		// On the way out there is nothing of deja's in a block it never wrote,
+		// and refusing here would leave the rest of the target wired (#2399).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
 	if m == nil {
@@ -1497,6 +1507,9 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	mcp, _, err := mcpBlock(root, "mcp", path)
 	if err != nil {
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
 	if mcp == nil {
@@ -1505,6 +1518,9 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	servers, _, err := mcpBlock(mcp, "servers", path)
 	if err != nil {
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
 	if servers == nil {
@@ -1539,6 +1555,11 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	}
 	m, _, err := mcpBlock(root, "mcpServers", path)
 	if err != nil {
+		// On the way out there is nothing of deja's in a block it never wrote,
+		// and refusing here would leave the rest of the target wired (#2399).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
 	if m == nil {
@@ -1601,6 +1622,9 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	}
 	m, _, err := mcpBlock(root, "mcp", "")
 	if err != nil {
+		if uninstall {
+			return old, "", nil
+		}
 		return nil, "", err
 	}
 	if m == nil {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -858,6 +858,29 @@ func configParseError(path string, err error) error {
 	return fmt.Errorf("%s: %w", path, err)
 }
 
+// mcpBlock reads the object an MCP config keeps its servers in. A missing key
+// is an empty block deja fills in; a key holding something else — a list, a
+// string, null — is a config deja does not understand, and building a fresh
+// object over it dropped whatever was there and reported an ordinary write
+// (#2399). A config that will not parse is already refused this way, and the
+// wrong shape is the case where something is actually lost.
+func mcpBlock(root map[string]any, key, path string) (map[string]any, bool, error) {
+	v, ok := root[key]
+	if !ok || v == nil {
+		return nil, false, nil
+	}
+	m, isObject := v.(map[string]any)
+	if !isObject {
+		// The writers that edit a file they opened themselves name it here;
+		// the one that hands bytes back to its caller leaves the naming to it.
+		if path == "" {
+			return nil, false, fmt.Errorf("%q is not an object deja can edit — left as it was", key)
+		}
+		return nil, false, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, key)
+	}
+	return m, true, nil
+}
+
 // mentionsDeja reports whether a config snapshot carries deja's own wiring.
 // The markers are what every generator writes: the subcommands the hooks call,
 // and the name of the MCP server and extension entries.
@@ -1030,7 +1053,10 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	m, _ := root["mcpServers"].(map[string]any)
+	m, _, err := mcpBlock(root, "mcpServers", path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if m == nil {
 		// Adding the empty block on the way out rewrites a config that never
 		// mentioned deja, and leaves a .bak of it besides (#676).
@@ -1427,7 +1453,10 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	m, _ := root["mcpServers"].(map[string]any)
+	m, _, err := mcpBlock(root, "mcpServers", path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if m == nil {
 		// Adding the empty block on the way out rewrites a config that never
 		// mentioned deja, and leaves a .bak of it besides (#676).
@@ -1466,12 +1495,18 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	mcp, _ := root["mcp"].(map[string]any)
+	mcp, _, err := mcpBlock(root, "mcp", path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if mcp == nil {
 		mcp = map[string]any{}
 		root["mcp"] = mcp
 	}
-	servers, _ := mcp["servers"].(map[string]any)
+	servers, _, err := mcpBlock(mcp, "servers", path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if servers == nil {
 		servers = map[string]any{}
 		mcp["servers"] = servers
@@ -1502,7 +1537,10 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	m, _ := root["mcpServers"].(map[string]any)
+	m, _, err := mcpBlock(root, "mcpServers", path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if m == nil {
 		// Adding the empty block on the way out rewrites a config that never
 		// mentioned deja, and leaves a .bak of it besides (#676).
@@ -1543,14 +1581,11 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 	var err error
 	if strings.HasSuffix(path, ".jsonc") {
 		next, note, err = updateOpencodeJSONC(old, exe, uninstall)
-		if err != nil {
-			return installResult{}, err
-		}
 	} else {
 		next, note, err = updateOpencodeJSON(old, exe, uninstall)
-		if err != nil {
-			return installResult{}, err
-		}
+	}
+	if err != nil {
+		return installResult{}, configParseError(path, err)
 	}
 	a, err := writeIfChanged(path, old, next)
 	return installResult{Path: path, Action: a, Note: note}, err
@@ -1564,7 +1599,10 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return nil, "", err
 	}
-	m, _ := root["mcp"].(map[string]any)
+	m, _, err := mcpBlock(root, "mcp", "")
+	if err != nil {
+		return nil, "", err
+	}
 	if m == nil {
 		m = map[string]any{}
 		root["mcp"] = m

--- a/cmd/deja/install_wrong_shape_test.go
+++ b/cmd/deja/install_wrong_shape_test.go
@@ -56,6 +56,15 @@ func TestInstallRefusesABlockOfTheWrongShape(t *testing.T) {
 					t.Errorf("%s went out with the write:\n%s", k, body)
 				}
 			}
+
+			// On the way out there is nothing of deja's in a block it never
+			// wrote, and refusing would leave the rest of the target wired.
+			r, err := installTarget(tc.target, "/usr/local/bin/deja", true)
+			if err != nil {
+				t.Errorf("uninstall refused a block it had nothing to remove from: %v", err)
+			} else if r.Action != "unchanged" {
+				t.Errorf("uninstall = %s %s, want unchanged", r.Action, r.Path)
+			}
 		})
 	}
 }

--- a/cmd/deja/install_wrong_shape_test.go
+++ b/cmd/deja/install_wrong_shape_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A config deja cannot parse is refused and left alone. A config it can parse
+// whose MCP block is a list was rewritten instead, and the servers in it went
+// out with the write (#2399).
+func TestInstallRefusesABlockOfTheWrongShape(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		rel    string
+		before string
+		keep   []string
+	}{
+		{"claude, mcpServers as a list", "claude", ".claude.json",
+			`{"theme":"dark","mcpServers":[{"name":"mine","command":"/usr/bin/mine"}]}`,
+			[]string{"/usr/bin/mine", `"theme"`}},
+		{"opencode, mcp as a list", "opencode", ".config/opencode/opencode.json",
+			`{"model":"theirs/model","mcp":["mine"]}`,
+			[]string{`"mine"`, "theirs/model"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
+			path := filepath.Join(home, filepath.FromSlash(tc.rel))
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := installTarget(tc.target, "/usr/local/bin/deja", false)
+			if err == nil {
+				t.Fatalf("install rewrote a block it did not understand")
+			}
+			if !strings.Contains(err.Error(), path) {
+				t.Errorf("the refusal does not name the file: %v", err)
+			}
+			body, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			for _, k := range tc.keep {
+				if !strings.Contains(string(body), k) {
+					t.Errorf("%s went out with the write:\n%s", k, body)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The writers read their block with `root["mcpServers"].(map[string]any)` and treated a failed assertion like a missing key — fresh object, write, `updated`:

    {"theme":"dark","mcpServers":[{"name":"mine",...},{"name":"theirs",...}]}

    $ deja install claude
    claude: updated ~/.claude.json      ← both servers gone

A config deja cannot parse is already refused and left alone; the wrong shape was the case where it wrote anyway, and the case where something is actually lost. Now:

    claude: ~/.claude.json: "mcpServers" is not an object deja can edit — left as it was

Same for opencode's `mcp`, openclaw's `mcp.servers`, and the generic `mcpServers` writer. A missing key still means an empty block deja fills in.

Fixes #2399.