### PR TITLE
fix(show): count an ambiguous prefix under the rule the reader searches by

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1812,7 +1812,12 @@ func isSubcommand(word string) bool {
 // resolve the same way and still picked in silence — promote records a state
 // against whichever session it chose (#872).
 func noteAmbiguousPrefix(dir, id, action string) {
-	n := index.PrefixMatches(dir, id)
+	// Counted under the rule the reader is searching by: a session the policy
+	// withholds is not one they can reach with a longer prefix (#2401).
+	pol := policy.Load()
+	n := index.PrefixMatchesAllowed(dir, id, func(project string) bool {
+		return pol.Allows(policy.ActivationSearch, project)
+	})
 	if n <= 1 {
 		return
 	}

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -113,7 +113,10 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	// the transcript rather than inside it; here it goes above the recall
 	// frame, so it reads as deja's own words and not as recalled text.
 	note := ""
-	if n := index.PrefixMatches(dir, id); n > 1 {
+	pol := policy.Load()
+	if n := index.PrefixMatchesAllowed(dir, id, func(project string) bool {
+		return pol.Allows(policy.ActivationMCP, project)
+	}); n > 1 {
 		note = fmt.Sprintf("deja: %d sessions match %q — this is the most recent; ask for a longer prefix to read another.\n\n",
 			n, neutralizeFrameMarkers(safeForStatusline(id, mcpResourceNameMax)))
 	}

--- a/cmd/deja/show_ambiguous_policy_test.go
+++ b/cmd/deja/show_ambiguous_policy_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The ambiguity note counted every session a prefix reached, including the
+// ones the trust policy withholds — so a rule that hides a peer's work still
+// announced that it exists, and the advice led to a session nobody could
+// open (#2401).
+func TestTheAmbiguityNoteCountsWhatTheRuleAllows(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	line := `{"type":"user","sessionId":"shared-local","timestamp":"` + at + `","cwd":"/work/app",` +
+		`"message":{"role":"user","content":"the retry budget on main"}}`
+	if err := os.WriteFile(filepath.Join(store, "shared-local.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	peer := `{"harness":"claude","session_id":"shared-peer","project":"secretclient/api","role":"user",` +
+		`"text":"the client ledger cutover","time":"` + time.Now().Add(-time.Hour).UTC().Format(time.RFC3339) + `","origin":"laptop"}`
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(peer+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	captureBoth(t, "sync", "import", batch)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile,
+		[]byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	_, errOut := captureBoth(t, "show", "shared")
+	if strings.Contains(errOut, "2 sessions match") {
+		t.Errorf("the note counted a session the rule withholds:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "sessions match") {
+		t.Errorf("with one session reachable there is nothing ambiguous:\n%s", errOut)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1611,6 +1611,16 @@ func idFoldMatches(id, p string) bool {
 // reader had no way to know they were looking at a choice rather than at the
 // only answer.
 func PrefixMatches(dir, p string) int {
+	return PrefixMatchesAllowed(dir, p, nil)
+}
+
+// PrefixMatchesAllowed counts the same way for the sessions a caller is
+// allowed to see. The note a reader gets about an ambiguous prefix used to
+// count every match, so a rule withholding a peer's work still announced that
+// the work exists, and the advice — reach for a longer prefix — led to a
+// session that answers with the rule instead (#2401). A nil allow counts
+// everything, which is what a caller with no rules of its own wants.
+func PrefixMatchesAllowed(dir, p string, allow func(project string) bool) int {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -1627,6 +1637,9 @@ func PrefixMatches(dir, p string) int {
 	// with the sign flipped.
 	n := 0
 	for _, meta := range m.Sessions {
+		if allow != nil && !allow(meta.Project) {
+			continue
+		}
 		if meta.OrigID != "" && strings.HasPrefix(meta.OrigID, p) {
 			n++
 			continue
@@ -1639,6 +1652,9 @@ func PrefixMatches(dir, p string) int {
 		// The count and the resolver have to agree, or a reader is told an id
 		// matches nothing and then watches it open (#853).
 		for _, meta := range m.Sessions {
+			if allow != nil && !allow(meta.Project) {
+				continue
+			}
 			if idLooselyMatches(meta.ID, p) {
 				n++
 			}
@@ -1647,6 +1663,9 @@ func PrefixMatches(dir, p string) int {
 	if n == 0 {
 		// Same last rung as the resolver: the id in the other case (#1620).
 		for _, meta := range m.Sessions {
+			if allow != nil && !allow(meta.Project) {
+				continue
+			}
 			if idFoldMatches(meta.ID, p) || (meta.OrigID != "" && idFoldMatches(meta.OrigID, p)) {
 				n++
 			}


### PR DESCRIPTION
With a local-only rule and a peer session sharing the prefix:

    $ deja last
    [claude · work/app · 2026-08-28 · shared-local] the retry budget on main

    $ deja show shared
    deja: 2 sessions match "shared" — showing the most recent; use a longer prefix for another

    $ deja show shared-p
    deja: the trust policy hides 1 matching session on this path (search: local-only)

`last` says one, `show` says two, and the advice leads to a session that answers with the rule. The note now counts what the reader can actually reach: `PrefixMatchesAllowed` takes an allow predicate, `noteAmbiguousPrefix` passes the search activation (show, ctx, promote, handoff, resume, share all go through it) and the MCP resource read passes its own.

Fixes #2401.