### PR TITLE
fix(sync): forget takes the machine name too, not just the ssh host

### DIFF
--- a/internal/peers/forget_machine_test.go
+++ b/internal/peers/forget_machine_test.go
@@ -1,0 +1,36 @@
+package peers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A peer carries the ssh host and the name the machine calls itself, and every
+// surface that shows where work came from prints the machine name. Forget
+// matched the host alone, so the word a reader had in front of them was
+// answered with "deja does not know a machine called that" (#2405).
+func TestForgetTakesTheMachineNameToo(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", path)
+	body := `{"peers":[{"host":"vlad@10.0.0.7","machine":"quicksilver"},{"host":"mini"}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := Forget("quicksilver")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatalf("forget did not know the machine name deja prints everywhere else")
+	}
+	left := Load()
+	if len(left) != 1 || left[0].Host != "mini" {
+		t.Fatalf("forget took the wrong row: %+v", left)
+	}
+
+	if found, err := Forget("QuickSilver"); err != nil || found {
+		t.Errorf("a machine already forgotten came back: found=%v err=%v", found, err)
+	}
+}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -288,7 +288,13 @@ func forgetLocked(host string) (bool, error) {
 	out := list[:0:0]
 	found := false
 	for _, p := range list {
-		if identity(p.Host) == identity(host) {
+		// Either name reaches the row. The ssh host is what the peer was added
+		// under; the machine name is what it calls itself, and it is the word
+		// every surface prints for work that came from there — `deja last`,
+		// recall lines, the doctor imported rows — so it is the word a reader
+		// is likeliest to have in hand (#2405).
+		if identity(p.Host) == identity(host) ||
+			(p.Machine != "" && identity(p.Machine) == identity(host)) {
 			found = true
 			continue
 		}


### PR DESCRIPTION
A peer row carries the ssh host and the name the machine calls itself. Every surface that shows where work came from prints the machine name:

    $ deja last
    [claude · quicksilver:work/api · 2026-08-28 · imported-dd4bbac84078] the ledger cutover

    $ deja sync forget quicksilver
    deja: deja does not know a machine called "quicksilver" — `deja doctor` lists the ones it does

It does know it — that is the peer's `machine` field and the origin on every session imported from there. Forget now matches either name.

Fixes #2405.