### PR TITLE
fix(hook): say there is no history rather than claim to be reading it

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -180,6 +180,16 @@ func rewireNote(targets []string) string {
 // (#927).
 func buildNotice(dir string) string {
 	if st := readWarmupStatus(dir); st != nil {
+		// On a machine no agent has written to, "indexing your history —
+		// recall comes online in a few seconds" is deja's first word to an
+		// agent and none of it is so: there is nothing to read, and recall
+		// starts when some agent writes a transcript, not in a few seconds
+		// (#2407). Same claim the CLI makes about the same machine. A build
+		// that has counted work to do is believed over the store walk: it is
+		// reading something, whatever a later look at the stores finds.
+		if st.Total <= 0 && noAgentHistoryFound() {
+			return "deja: no agent history was found on this machine yet — recall starts once an agent writes a session here; `deja sources` shows where deja looked"
+		}
 		return st.line()
 	}
 	// A rebuild is pending either because one was asked for or because the

--- a/cmd/deja/hook_context_no_history_test.go
+++ b/cmd/deja/hook_context_no_history_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The first thing deja says to an agent on a machine with no agent history was
+// "indexing your history — recall comes online in a few seconds". There is no
+// history to index and recall does not come online in a few seconds: it comes
+// online when some agent writes a transcript (#2407).
+func TestSessionStartOnAMachineWithNoHistory(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+
+	dir := index.DefaultDir()
+	// The state the probe caught: a build running, its progress published, and
+	// nothing on this machine for it to find.
+	st := warmupStatus{Phase: "finding transcripts", Updated: time.Now().UnixNano(), Started: time.Now().UnixNano()}
+	b, err := json.Marshal(st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(warmupStatusPath(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(warmupStatusPath(dir), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notice := buildNotice(dir)
+
+	if strings.Contains(notice, "indexing your history") {
+		t.Errorf("deja claimed to be reading a history this machine does not have: %q", notice)
+	}
+	if notice == "" {
+		t.Errorf("session start said nothing at all on a fresh machine")
+	}
+	if !strings.Contains(notice, "no agent history") {
+		t.Errorf("the notice does not say what is actually so: %q", notice)
+	}
+}


### PR DESCRIPTION
First session start on a machine no agent has written to:

    deja: indexing your history (finding transcripts) — recall comes online in a few seconds

There is nothing to read and recall does not arrive in a few seconds; it arrives when an agent writes a transcript. The CLI already says so on the same machine (`deja last`, `deja index`), and the second session start is silent — so the false sentence was deja's first word to an agent, uncorrected.

Now, when the build has counted nothing to do and no store holds anything:

    deja: no agent history was found on this machine yet — recall starts once an agent writes a session here; `deja sources` shows where deja looked

A build that has counted work is believed over the store walk, so a real history still reports progress as before.

Fixes #2407.