### PR TITLE
fix(redact): mask a private key that has no END marker

### DIFF
--- a/internal/redact/open_private_key_test.go
+++ b/internal/redact/open_private_key_test.go
@@ -1,0 +1,40 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// A private key pasted into a transcript is usually not pasted whole: the
+// output was truncated, the session ended, the tail landed in another message.
+// The pattern required the closing marker, so the case where the body survives
+// was the case deja let through (#2409).
+func TestAPrivateKeyWithNoEndMarker(t *testing.T) {
+	body := strings.Repeat("b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gt\n", 3)
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"whole", "here is the key:\n-----BEGIN OPENSSH PRIVATE KEY-----\n" + body +
+			"-----END OPENSSH PRIVATE KEY-----\nthat is all"},
+		{"cut off", "the deploy key got cut off:\n-----BEGIN OPENSSH PRIVATE KEY-----\n" + body +
+			"(output truncated)"},
+		{"cut off at the end of the message", "-----BEGIN RSA PRIVATE KEY-----\n" + body},
+	}
+	for _, tc := range cases {
+		got, counts := Text(tc.text)
+		if strings.Contains(got, "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQ") {
+			t.Errorf("%s: key material survived redaction:\n%s", tc.name, got)
+		}
+		if counts["private-key"] == 0 {
+			t.Errorf("%s: nothing was counted as a private key: %v", tc.name, counts)
+		}
+	}
+
+	// The words around a key are not a key: redaction that eats the prose
+	// around it takes the session's meaning with it.
+	kept, _ := Text("we generate one with ssh-keygen -t ed25519 and store it in the vault")
+	if !strings.Contains(kept, "ssh-keygen -t ed25519") {
+		t.Errorf("ordinary text about keys was redacted: %q", kept)
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -74,7 +74,7 @@ var (
 	// At least one body line: a bare header carries nothing, and eating it
 	// alone would hide the marker that lets the whole-block pattern pair it
 	// with a body that arrives in the next field.
-	pemPrivateOpenRE = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----(?:[ \t]*\r?\n[A-Za-z0-9+/=]{16,}[ \t]*)+[ \t]*\r?\n?`)
+	pemPrivateOpenRE = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----(?:[ \t]*\r?\n[A-Za-z0-9+/=]{16,}[ \t]*)+`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
 	// sk-<alnum> keys. xai- stays alphanumeric-only: real xAI keys have no

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -65,6 +65,16 @@ var (
 	// authentication failed" has no quoted value and matches nothing.
 	quotedSecretRE = regexp.MustCompile(`(?i)\b(password|passwd|pwd|secret|token|api[_-]?key)(\s+(?:is\s+|was\s+|for\s+)?)(\\*["'` + "`" + `])([^"'` + "`" + `\n]{6,80})(\\*["'` + "`" + `])`)
 	pemPrivateRE   = regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----.*?-----END [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----`)
+	// A key pasted into a transcript is often not pasted whole: the output was
+	// truncated, the session ended, the tail landed in another message. The
+	// closing marker was required, so the half that carries the key material
+	// was the half that went through (#2409). This runs after the whole-block
+	// pattern and takes the header plus the base64 lines under it — the lines,
+	// not the rest of the message, so the prose around a key survives.
+	// At least one body line: a bare header carries nothing, and eating it
+	// alone would hide the marker that lets the whole-block pattern pair it
+	// with a body that arrives in the next field.
+	pemPrivateOpenRE = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]*PRIVATE KEY[A-Z0-9 ]*-----(?:[ \t]*\r?\n[A-Za-z0-9+/=]{16,}[ \t]*)+[ \t]*\r?\n?`)
 	// Provider prefixes. sk- allows internal hyphens/underscores so modern
 	// hyphenated formats (sk-ant-…, sk-proj-…) are covered, not just legacy
 	// sk-<alnum> keys. xai- stays alphanumeric-only: real xAI keys have no
@@ -179,6 +189,7 @@ func Text(s string) (string, Counts) {
 	lower := strings.ToLower(s)
 	if strings.Contains(s, "-----BEGIN") {
 		s = replaceWhole(s, pemPrivateRE, "private-key", counts)
+		s = replaceWhole(s, pemPrivateOpenRE, "private-key", counts)
 	}
 	if strings.Contains(s, "://") {
 		s = replaceSubmatch(s, connURLRE, "url-credentials", counts, func(m []string) string {


### PR DESCRIPTION
The PEM pattern required the closing marker, so the truncated case — the usual way a key lands in a transcript — went through:

    BEGIN + body + END                    → masked, counted as private-key
    BEGIN + body + "(output truncated)"   → indexed verbatim, exported verbatim

A new pattern takes the header plus the base64 lines under it, after the whole-block one. It requires at least one body line: `exportPromoted` redacts a note's title and text and relies on a bare header in one field pairing with the body in the next, which an existing test caught when the first version allowed zero.

Fixes #2409.