### PR TITLE
fix(doctor): report git in --json, not only in the text report

### DIFF
--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -36,7 +36,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 	documented := map[string]bool{
 		// doctorReport
 		"schema_version": true, "stores": true, "index": true, "mcp": true,
-		"sqlite3": true, "version": true, "embed": true, "policy": true,
+		"sqlite3": true, "git": true, "version": true, "embed": true, "policy": true,
 		"ingest_health": true, "ingest_files": true, "deep": true,
 		// doctorStore
 		"name": true, "state": true, "paths": true, "files": true,

--- a/cmd/deja/doctor_json_git_test.go
+++ b/cmd/deja/doctor_json_git_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The human report names two tools deja needs and says what each one is for.
+// The JSON carried one of them, so a machine checking this install could see
+// that sqlite3 was missing and not that git was (#2411).
+func TestDoctorJSONReportsBothTools(t *testing.T) {
+	tmp := hermeticEnv(t)
+	_ = tmp
+	out, _ := captureBoth(t, "doctor", "--json")
+
+	var report map[string]any
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("doctor --json emitted something that is not JSON: %v\n%s", err, out)
+	}
+	for _, tool := range []string{"sqlite3", "git"} {
+		component, ok := report[tool].(map[string]any)
+		if !ok {
+			t.Errorf("the report says nothing about %s: %v", tool, report[tool])
+			continue
+		}
+		state, _ := component["state"].(string)
+		switch state {
+		case "ok", "missing":
+		default:
+			t.Errorf("%s.state = %q, want ok or missing", tool, state)
+		}
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -77,15 +78,20 @@ type doctorVersionReport struct {
 }
 
 type doctorReport struct {
-	SchemaVersion int                            `json:"schema_version"`
-	Stores        []doctorStore                  `json:"stores"`
-	Index         doctorIndexReport              `json:"index"`
-	MCP           []doctorMCPStatus              `json:"mcp"`
-	SQLite3       doctorComponent                `json:"sqlite3"`
-	Version       doctorVersionReport            `json:"version"`
-	Embed         *doctorEmbedReport             `json:"embed,omitempty"`
-	Policy        doctorPolicyReport             `json:"policy"`
-	Ingest        map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
+	SchemaVersion int               `json:"schema_version"`
+	Stores        []doctorStore     `json:"stores"`
+	Index         doctorIndexReport `json:"index"`
+	MCP           []doctorMCPStatus `json:"mcp"`
+	SQLite3       doctorComponent   `json:"sqlite3"`
+	// Git is the other tool the text report names, and what it is needed for
+	// degrades in silence: changed-file notes, worktree names, the task signal.
+	// A machine checking this install could see a missing sqlite3 and not a
+	// missing git (#2411).
+	Git     doctorComponent                `json:"git"`
+	Version doctorVersionReport            `json:"version"`
+	Embed   *doctorEmbedReport             `json:"embed,omitempty"`
+	Policy  doctorPolicyReport             `json:"policy"`
+	Ingest  map[string]index.HarnessIngest `json:"ingest_health,omitempty"`
 	// IngestFiles is where those counts came from. Without it the pointer at
 	// the end of doctor's ingest line led back to the numbers it had just
 	// printed, and the file to fix was never named (#2189).
@@ -292,6 +298,10 @@ func collectDoctorReport(lookup doctorVersionLookup, dir string) doctorReport {
 	report.SQLite3.State = "missing"
 	if sources.SQLite3Available() {
 		report.SQLite3.State = "ok"
+	}
+	report.Git.State = "missing"
+	if _, err := exec.LookPath("git"); err == nil {
+		report.Git.State = "ok"
 	}
 	report.Policy = collectDoctorPolicy(dir)
 	report.Sync = collectDoctorSync(dir)

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -288,6 +288,9 @@
   "sqlite3": {
     "state": "missing"
   },
+  "git": {
+    "state": "missing"
+  },
   "version": {
     "state": "update-available",
     "current": "1.0.0",

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -327,6 +327,7 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
     }
   ],
   "sqlite3": {"state": "ok"},
+  "git": {"state": "ok"},
   "version": {
     "state": "ok",
     "current": "0.14.1",
@@ -394,6 +395,11 @@ values are `ok`, `missing`, `unreadable`, `parsed-zero`, `denied` (which adds a
 but empty store directory reports `missing`. A store also carries `indexed_sessions`
 and, when it holds peer-synced work, `indexed_from_elsewhere`; a store whose
 permission walk was cut short or blocked carries `partial` or `unchecked`.
+`sqlite3` and `git` are the two tools deja shells out to, each `ok` or
+`missing`: sqlite3 reads the opencode, Cursor, grok, hermes, goose and zed
+stores, and git supplies changed-file notes, worktree names and the task
+signal. Both degrade quietly, which is why the report names them.
+
 Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 `--offline`), or `unknown`. `policy.state` is `default`, `active` or
 `unreadable` (which adds an `error`); `activations` keys are `search`, `mcp` and


### PR DESCRIPTION
The text report names both tools deja shells out to:

    Tools:
      sqlite3      found (needed for opencode and Cursor IDE stores)
      git          found (needed for changed-file notes, worktree names and the task signal)

The JSON carried `sqlite3` alone, so a script checking an install saw one missing dependency and not the other — and what git is missing costs degrades quietly, which is why the text report names it (#796).

Adds `"git": {"state": "ok"|"missing"}` beside `sqlite3`, documented and pinned by the contract test and the golden.

Fixes #2411.