### PR TITLE
fix(forget): stop the sweep writing over injections appended while it runs

### DIFF
--- a/internal/usage/forget_race_test.go
+++ b/internal/usage/forget_race_test.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The injection log is append-only so agents can write to it at once. A forget
+// sweep reads the whole file, drops what matched and writes the rest back, and
+// anything appended in between was written over — the record of an injection an
+// agent had already received, gone with no sign (#2413).
+func TestAnInjectionAppendedDuringAForgetSurvivesIt(t *testing.T) {
+	for round := 0; round < 3; round++ {
+		dir := filepath.Join(t.TempDir(), "index.db")
+		for i := 0; i < 300; i++ {
+			RecordDigestInto(dir, "hook", fmt.Sprintf("digest for gone %d", i), "gone-"+fmt.Sprint(i), 1, 100, []string{"t"})
+		}
+		const appended = 200
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < appended; i++ {
+				RecordDigestInto(dir, "hook", fmt.Sprintf("digest for keep %d", i), "keep-"+fmt.Sprint(i), 1, 100, []string{"t"})
+			}
+		}()
+		gone, err := ForgetSnapshots(dir, func(s Snapshot) bool {
+			return strings.Contains(s.Digest, "gone")
+		})
+		wg.Wait()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gone == 0 {
+			t.Fatalf("round %d: the sweep matched nothing, so it never rewrote the file", round)
+		}
+		kept := 0
+		for _, s := range Snapshots(dir, 0) {
+			if strings.Contains(s.Digest, "keep") {
+				kept++
+			}
+		}
+		if kept != appended {
+			t.Errorf("round %d: %d of %d injections were written over by the sweep", round, appended-kept, appended)
+		}
+	}
+}

--- a/internal/usage/lock.go
+++ b/internal/usage/lock.go
@@ -1,0 +1,66 @@
+package usage
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// logLockWait is how long a writer waits for another one to finish
+	// rewriting a log. Both rewrites — a rotation and a forget sweep — are one
+	// pass over a file bounded to a few hundred kilobytes, so a wait this long
+	// only happens when something is wrong.
+	logLockWait = time.Second
+	// logLockStale is when a lock counts as left behind by a process that
+	// died. Nothing holds it across anything that can block.
+	logLockStale = 10 * time.Second
+	// logLockPoll is how often the wait looks again.
+	logLockPoll = 2 * time.Millisecond
+)
+
+// withLogLock serialises one process's write of a log against another's
+// rewrite of the same file.
+//
+// The logs are append-only precisely so that agents can write to them at once,
+// and the two operations that are not appends — the rotation and the forget
+// sweep — read the whole file and write it back. An injection appended in that
+// window was written over: a record of memory an agent had already received,
+// gone with nothing to show it (#2413).
+//
+// A write is never refused for want of the lock. Waiting is bounded, a lock
+// left by a dead process is taken over, and a directory that cannot hold one
+// runs the write unlocked, which is what deja did before this existed — a
+// racing write beats a lost injection.
+func withLogLock(path string, fn func()) {
+	lock := path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lock), 0o700); err != nil {
+		fn()
+		return
+	}
+	deadline := time.Now().Add(logLockWait)
+	for {
+		f, err := os.OpenFile(lock, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = f.Close()
+			defer func() { _ = os.Remove(lock) }()
+			fn()
+			return
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			fn()
+			return
+		}
+		if fi, serr := os.Stat(lock); serr == nil && time.Since(fi.ModTime()) > logLockStale {
+			_ = os.Remove(lock)
+			continue
+		}
+		if time.Now().After(deadline) {
+			fn()
+			return
+		}
+		time.Sleep(logLockPoll)
+	}
+}

--- a/internal/usage/lock_test.go
+++ b/internal/usage/lock_test.go
@@ -1,0 +1,70 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A write is never refused for want of the lock: every way of failing to take
+// it ends in the write happening anyway (#2413).
+func TestTheLogLockNeverRefusesAWrite(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("a lock left by a dead process is taken over", func(t *testing.T) {
+		p := filepath.Join(dir, "stale.jsonl")
+		lock := p + ".lock"
+		if err := os.WriteFile(lock, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		old := time.Now().Add(-logLockStale - time.Second)
+		if err := os.Chtimes(lock, old, old); err != nil {
+			t.Fatal(err)
+		}
+		ran := false
+		withLogLock(p, func() { ran = true })
+		if !ran {
+			t.Error("a stale lock stopped the write")
+		}
+		if _, err := os.Stat(lock); err == nil {
+			t.Error("the lock outlived the write that took it over")
+		}
+	})
+
+	t.Run("a lock somebody is holding does not stop the write", func(t *testing.T) {
+		p := filepath.Join(dir, "held.jsonl")
+		lock := p + ".lock"
+		if err := os.WriteFile(lock, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Remove(lock) }()
+		start := time.Now()
+		ran := false
+		withLogLock(p, func() { ran = true })
+		if !ran {
+			t.Error("the write was dropped rather than raced")
+		}
+		if waited := time.Since(start); waited < logLockPoll {
+			t.Errorf("it did not wait at all: %s", waited)
+		}
+		if _, err := os.Stat(lock); err != nil {
+			t.Error("the writer removed a lock it never took")
+		}
+	})
+
+	t.Run("a directory that cannot hold a lock", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root writes anywhere")
+		}
+		ro := filepath.Join(dir, "readonly")
+		if err := os.MkdirAll(ro, 0o500); err != nil {
+			t.Fatal(err)
+		}
+		ran := false
+		withLogLock(filepath.Join(ro, "log.jsonl"), func() { ran = true })
+		if !ran {
+			t.Error("a directory deja cannot lock stopped the write")
+		}
+	})
+}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -277,23 +277,27 @@ func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, poli
 	if err != nil {
 		return
 	}
-	// The record's own size decides how much room the rotation has to leave.
-	rotateSnapshots(p, len(b)+1)
-	// O_RDWR rather than O_WRONLY: the append needs to read the last byte, for
-	// the reason the usage log opens the same way (#1901).
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-	// A process killed between a record and its newline costs that record. It
-	// cost every later one too: appended onto the partial line, the new digest
-	// parsed as nothing either, and `deja log --last` reported no injection at
-	// all on a machine that had just served two (#1965).
-	if atomicfile.EndsMidLine(f) {
-		b = append([]byte{'\n'}, b...)
-	}
-	_, _ = f.Write(append(b, '\n'))
+	// Under the lock with the rotation: both are this file's writers, and a
+	// forget sweep rewriting it in between wrote the append away (#2413).
+	withLogLock(p, func() {
+		// The record's own size decides how much room the rotation has to leave.
+		rotateSnapshots(p, len(b)+1)
+		// O_RDWR rather than O_WRONLY: the append needs to read the last byte, for
+		// the reason the usage log opens the same way (#1901).
+		f, err := os.OpenFile(p, os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+		if err != nil {
+			return
+		}
+		defer func() { _ = f.Close() }()
+		// A process killed between a record and its newline costs that record. It
+		// cost every later one too: appended onto the partial line, the new digest
+		// parsed as nothing either, and `deja log --last` reported no injection at
+		// all on a machine that had just served two (#1965).
+		if atomicfile.EndsMidLine(f) {
+			b = append([]byte{'\n'}, b...)
+		}
+		_, _ = f.Write(append(b, '\n'))
+	})
 }
 
 func rotateSnapshots(p string, incoming int) {
@@ -503,6 +507,16 @@ func boundTerms(terms []string) []string {
 // rather than left to be discovered.
 func ForgetSnapshots(indexDir string, drop func(Snapshot) bool) (int, error) {
 	p := SnapshotPath(indexDir)
+	var gone int
+	var err error
+	// The read and the replace are one operation: an injection appended
+	// between them was written over, and an agent's record of what it received
+	// went with it (#2413).
+	withLogLock(p, func() { gone, err = forgetSnapshotsLocked(p, drop) })
+	return gone, err
+}
+
+func forgetSnapshotsLocked(p string, drop func(Snapshot) bool) (int, error) {
 	snaps := snapshotsFrom(p, 0) // last appended first
 	if len(snaps) == 0 {
 		return 0, nil


### PR DESCRIPTION
The injection log is append-only so agents can write at once. `deja forget` read the whole file, dropped what matched and wrote the rest back; anything appended in between went with it — 1-3 of 200 appends per run:

    round 0: 3 of 200 injections were written over by the sweep
    round 1: 2 of 200
    round 2: 1 of 200

What is lost is deja's own record that an agent received a digest, and nothing reports it.

A lock file beside the log now covers the append (with its rotation) and the sweep, the way the peers list is already covered (#1883): bounded wait, a stale lock is taken over, and a directory that cannot hold one runs unlocked rather than refusing the write. Measured on the hook path: 14.0 ms → 14.4 ms per `hook-context`, 30 runs each.

Fixes #2413.