### PR TITLE
fix(doctor): a peer row names the machine, not only the ssh host

### DIFF
--- a/cmd/deja/doctor_peer_machine_test.go
+++ b/cmd/deja/doctor_peer_machine_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/peers"
+)
+
+// A peer has two names: the ssh host it was added under, and the name the
+// machine calls itself. Recall lines and `deja last` print the second; doctor
+// printed only the first, so the row about "quicksilver" was headed
+// "vlad@10.0.0.7" and nothing on any surface joined them (#2415).
+func TestThePeerRowNamesTheMachineToo(t *testing.T) {
+	now := time.Now()
+	p := peers.Peer{
+		Host:     "vlad@10.0.0.7",
+		Machine:  "quicksilver",
+		LastPull: now.Add(-2 * time.Hour),
+	}
+	line := peerLine(p, 3, now)
+	if !strings.Contains(line, "quicksilver") {
+		t.Errorf("the row about quicksilver's work does not name quicksilver: %q", line)
+	}
+
+	// A machine that calls itself what it was added as says it once.
+	same := peers.Peer{Host: "mini", Machine: "mini", LastPull: now.Add(-time.Hour)}
+	if got := peerLine(same, 1, now); strings.Count(got, "mini") != 0 {
+		t.Errorf("the row repeats a name the header already carries: %q", got)
+	}
+
+	// The user part of an ssh target is not part of the name.
+	prefixed := peers.Peer{Host: "vlad@mini", Machine: "mini", LastPull: now.Add(-time.Hour)}
+	if got := peerLine(prefixed, 1, now); strings.Contains(got, "calls itself") {
+		t.Errorf("the row says a name twice: %q", got)
+	}
+
+	// Nothing to add when the machine has never said what it is called.
+	unknown := peers.Peer{Host: "build-box", LastPull: now.Add(-time.Hour)}
+	if got := peerLine(unknown, 0, now); strings.Contains(got, "(") {
+		t.Errorf("the row invented a name: %q", got)
+	}
+}

--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -69,6 +69,10 @@ func doctorPeers(w io.Writer, dir string, now time.Time) {
 	}
 }
 
+// doctorPeerNameMax bounds the machine name in a peer row. It is a string
+// another machine chose, like the imported line's names (#2364).
+const doctorPeerNameMax = 60
+
 const (
 	// doctorPeerColumn is the narrowest the name column gets, so a machine
 	// called "laptop" does not sit alone against the left margin.
@@ -122,12 +126,33 @@ func peerLine(p peers.Peer, sessions int, now time.Time) string {
 	if sessions > 0 {
 		line += fmt.Sprintf(", %s from there", doctorCount(sessions, "session"))
 	}
+	// A peer has two names — the ssh host it was added under, which heads this
+	// row, and the name it calls itself, which is what `deja last` and the
+	// recall lines print for work that came from it. Nothing joined them, so
+	// the row about quicksilver's sessions was headed vlad@10.0.0.7 (#2415).
+	// Said once: a machine added under the name it calls itself repeats
+	// nothing.
+	if m := strings.TrimSpace(p.Machine); m != "" && !sameMachineName(m, p.Host) {
+		line += fmt.Sprintf(" — calls itself %s", safeForStatusline(m, doctorPeerNameMax))
+	}
 	if p.LastError != "" {
 		// The stored error usually quotes the host back, so it carries whatever
 		// the name carried.
 		line += " — last attempt failed: " + safeForStatusline(p.LastError, 200)
 	}
 	return line
+}
+
+// sameMachineName reports whether a machine's own name is already what the
+// host says. The user part of an ssh target is not part of the name — a peer
+// added as vlad@quicksilver that calls itself quicksilver has one name, not
+// two, and saying it twice is noise.
+func sameMachineName(machine, host string) bool {
+	host = strings.TrimSpace(host)
+	if at := strings.LastIndex(host, "@"); at >= 0 {
+		host = host[at+1:]
+	}
+	return strings.EqualFold(machine, host)
 }
 
 // doctorAgo is a rough age. Anything under a minute is "just now": a sync that


### PR DESCRIPTION
Which of a peer's two names you see depended on the surface:

    $ deja last
    [claude · quicksilver:work/api · … · imported-…] the ledger cutover

    $ deja doctor
    Sync:
      vlad@10.0.0.7 last exchange 9 hours ago, nothing sent yet, 1 session from there

The row that counts quicksilver's sessions was headed with the ssh host, and `deja sync forget` sends readers to this listing by name (#2405). Now:

      vlad@10.0.0.7 … 1 session from there — calls itself quicksilver

Silent when the machine calls itself what it was added as, user prefix included (`vlad@mini` / `mini` says it once), and when the machine has never said.

Fixes #2415.