### PR TITLE
fix(restore): honour -o with one span, and say when it was not used

### DIFF
--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -93,6 +93,13 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "no replaced spans recorded for %q\n", path)
 		return nil
 	}
+	if want == 0 && out != "" && len(spans) == 1 {
+		// `-o` says where the bytes go, and with one span there is nothing to
+		// choose: asking for `--span 1` as well is asking someone to name the
+		// only door in the room. Without this the listing printed and the file
+		// was never written, which is the state #2253 closed one step over.
+		want = 1
+	}
 	if want == 0 {
 		fmt.Fprintf(stdout, "%d replaced spans recorded for %s\n", len(spans), path)
 		// The row carries a date, a harness, a session id and a size, and on a
@@ -112,6 +119,13 @@ func runRestore(dir string, args []string, stdout io.Writer) error {
 			fmt.Fprintf(stdout, "  %d  %s  %s %s  %d B replaced%s\n",
 				i+1, s.when.Format("Jan 02 15:04"), harness, shortID(s.session),
 				len(s.body), redactionNote(s.body))
+		}
+		if out != "" {
+			// The flag was given and could not be honoured. Silence here read
+			// as a file written (#2417).
+			fmt.Fprintf(stdout, "\nnothing was written to %s — name the span you want:\ndeja restore %s --span 1 -o %s\n",
+				out, path, out)
+			return nil
 		}
 		fmt.Fprintf(stdout, "\ndeja restore %s --span 1 -o recovered.txt\n", path)
 		return nil

--- a/cmd/deja/restore_out_without_span_test.go
+++ b/cmd/deja/restore_out_without_span_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// `-o` says where the bytes should go. Without `--span` it was accepted and
+// ignored: the listing printed, nothing was written, and nothing said so —
+// the state #2253 closed one step over (#2417).
+func TestRestoreSaysWhatItDidWithTheFileItWasGiven(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	edit := func(sid, old string, ago time.Duration) string {
+		at := time.Now().Add(-ago).UTC().Format(time.RFC3339)
+		return `{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at + `","cwd":"/work/app",` +
+			`"message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":` +
+			`{"file_path":"/work/app/retry.go","old_string":"` + old + `","new_string":"// replaced\n"}}]}}`
+	}
+	dir := index.DefaultDir()
+
+	t.Run("one span goes where it was asked to go", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(store, "one.jsonl"),
+			[]byte(edit("one", "func Budget() int { return 3 }", time.Hour)+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := index.Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+		out := filepath.Join(tmp, "recovered.go")
+		var buf bytes.Buffer
+		if err := runRestore(dir, []string{"retry.go", "-o", out}, &buf); err != nil {
+			t.Fatal(err)
+		}
+		body, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("the file deja was handed was never written: %v\n%s", err, buf.String())
+		}
+		if !strings.Contains(string(body), "return 3") {
+			t.Errorf("the span did not land in the file:\n%s", body)
+		}
+	})
+
+	t.Run("several spans say which one to name", func(t *testing.T) {
+		if err := os.WriteFile(filepath.Join(store, "two.jsonl"),
+			[]byte(edit("two", "func Budget() int { return 5 }", 30*time.Minute)+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := index.Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+		out := filepath.Join(tmp, "ambiguous.go")
+		var buf bytes.Buffer
+		if err := runRestore(dir, []string{"retry.go", "-o", out}, &buf); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(out); err == nil {
+			t.Errorf("deja picked a span on its own")
+		}
+		if !strings.Contains(buf.String(), "--span") || !strings.Contains(buf.String(), out) {
+			t.Errorf("nothing said the file was not written:\n%s", buf.String())
+		}
+	})
+}


### PR DESCRIPTION
`deja restore retry.go -o recovered.go` printed the listing and returned. Nothing was written and nothing said so — the state #2253 closed one step over.

With one span there is nothing to choose, so `-o` is honoured (the guards below it — never over the span's own file, never over an existing file without `--force` — are unchanged). With several:

    3 replaced spans recorded for retry.go
      1  …
    nothing was written to recovered.go — name the span you want:
    deja restore retry.go --span 1 -o recovered.go

Fixes #2417.