### PR TITLE
fix(statusline): say when the index cannot answer

### DIFF
--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -78,6 +78,17 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 	// true together (#2224).
 	n := usage.StatusCounters(dir)
 	recalls, bytes, injected := n.Recalls, n.Bytes, n.Injected
+	// An index that cannot answer on a machine that has history to answer
+	// from: a cleared cache, a directory someone moved, a volume not mounted,
+	// or a store the last build left damaged. Recall answers nothing until it
+	// is rebuilt, and this line — the surface somebody is already watching —
+	// read as an ordinary quiet day (#2419). The history is what separates it
+	// from a fresh install, where there is nothing to index and the session
+	// start already says so (#2407).
+	if indexNeedsRebuild(dir) && !noAgentHistoryFound() {
+		fmt.Fprint(stdout, withFileMemory(dir, in, "deja · the index cannot answer · recall is quiet until `deja index` rebuilds it"))
+		return nil
+	}
 	if recalls == 0 {
 		// Injections are not recalls, but they are the whole day for someone
 		// who lives on auto-recall: saying "0 B injected" while memory has

--- a/cmd/deja/statusline_no_index_test.go
+++ b/cmd/deja/statusline_no_index_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The statusline is the one surface a person watches all day, and it already
+// speaks up for a build in flight and for a rule that turns memory off. An
+// index that is gone — a cleared cache, a moved directory, an unmounted volume
+// — left it reporting an ordinary day while recall could answer nothing (#2419).
+func TestTheStatuslineSaysWhenThereIsNoIndex(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-08-28T10:00:00Z","cwd":"/work/app",` +
+		`"message":{"role":"user","content":"the retry budget on main"}}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The premise: with an index in place the line is the ordinary one.
+	var ok bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(`{"session_id":"s1","cwd":"/work/app"}`), &ok); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(ok.String(), "index") {
+		t.Fatalf("a healthy machine already talks about the index: %q", ok.String())
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	var gone bytes.Buffer
+	if err := runStatusline(dir, strings.NewReader(`{"session_id":"s1","cwd":"/work/app"}`), &gone); err != nil {
+		t.Fatal(err)
+	}
+	got := gone.String()
+	if strings.Contains(got, "recalls yet today") || strings.Contains(got, "injected") {
+		t.Errorf("the index is gone and the line reads as a quiet day: %q", got)
+	}
+	if !strings.Contains(got, "index") {
+		t.Errorf("the line says nothing about the index: %q", got)
+	}
+}


### PR DESCRIPTION
The statusline speaks up for a build in flight (#879, #925) and for a rule that turns memory off (#1012), and said nothing when the index itself was gone:

    $ deja statusline
    deja · no agent recalls today · 1.8 KB injected
    $ rm -rf ~/.cache/deja/index.db
    $ deja statusline
    deja · no agent recalls today · 1.8 KB injected      ← recall answers nothing now

Now, when the index cannot answer and the machine has history to answer from:

    deja · the index cannot answer · recall is quiet until `deja index` rebuilds it

The history is what separates it from a fresh install, which has no index either and is not a fault — session start already says so (#2407). Ordinary lines and their cost are unchanged (7-9 ms per call in the probe, either way).

Fixes #2419.