### PR TITLE
fix(view): the Notes tab carries decisions that arrived by sync

### DIFF
--- a/cmd/deja/view.go
+++ b/cmd/deja/view.go
@@ -251,6 +251,13 @@ func writeViewHTML(dir, out string) (string, int, error) {
 	// from search, the listing and the agent. Same gap as the digests above,
 	// with the project known exactly rather than recognised in prose (#2317).
 	loaded, page.NotesWithheld = notesAllowedOnPage(loaded)
+	// A decision promoted on another machine arrives as a session carrying its
+	// state, and recall and the tool hook both read it as a decision (#975).
+	// The tab that holds decisions was built from this machine's notes file
+	// alone, so the one place a synced decision is named as one was the one
+	// place it did not appear (#2421). metas is already filtered by the same
+	// rule the local notes are.
+	loaded = append(loaded, importedDecisions(metas)...)
 	// By date, newest first: LoadPromotedNotes returns them in the order they
 	// were first written to the file, so cutting that keeps an arbitrary set
 	// rather than the newest — and the page's own order was the file's.
@@ -427,6 +434,32 @@ func snapshotWithheld(pol policy.Policy, sn usage.Snapshot, hidden map[string]bo
 // digest of your own work missing from a page you can regenerate. forget looks
 // only where a digest renders a project, because there the cost is deleting a
 // record that cannot come back (#2330).
+
+// importedDecisions turns the sessions that arrived carrying a lifecycle state
+// into notes the page can render beside the local ones. The session's own text
+// opens with the state and the source, which the note fields carry separately,
+// so the title is the state's own note and the text is what the other machine
+// wrote.
+func importedDecisions(metas []model.Session) []sources.PromotedNote {
+	out := make([]sources.PromotedNote, 0)
+	for _, m := range metas {
+		if m.Lifecycle == "" || !sources.NoteStates[m.Lifecycle] {
+			continue
+		}
+		when := m.Updated
+		if t, err := time.Parse(time.RFC3339, m.LifecycleAt); err == nil {
+			when = t
+		}
+		text := m.LifecycleNote
+		if strings.TrimSpace(text) == "" {
+			text = m.Title
+		}
+		out = append(out, sources.PromotedNote{
+			Project: m.Project, State: m.Lifecycle, Title: m.Title, Text: text, At: when,
+		})
+	}
+	return out
+}
 
 // notesAllowedOnPage drops the promoted notes whose project a rule withholds,
 // and says how many went. Browsing, so the search activation governs it — the

--- a/cmd/deja/view_imported_decision_test.go
+++ b/cmd/deja/view_imported_decision_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A decision promoted on one machine travels: it arrives as a session carrying
+// its lifecycle state, recall ranks it as a decision and the tool hook honours
+// it (#975). The page's Notes tab is built from this machine's notes file
+// alone, so the tab that holds decisions held none of the ones that came from
+// elsewhere (#2421).
+func TestThePageCarriesADecisionThatArrivedBySync(t *testing.T) {
+	tmp := hermeticEnv(t)
+	batch := filepath.Join(tmp, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	rec := `{"harness":"deja","session_id":"deja-note-claude-a1","project":"work/api","role":"user",` +
+		`"text":"[accepted] retry budget stays at 5 (from claude:a1)","time":"` + at + `",` +
+		`"origin":"quicksilver","lifecycle":"accepted","lifecycle_note":"retry budget stays at 5",` +
+		`"lifecycle_at":"` + at + `"}`
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(rec+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	captureBoth(t, "sync", "import", batch)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(tmp, "page.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	m := regexp.MustCompile(`(?s)const S=(.*?),R=(.*?),N=(.*?);\n`).FindStringSubmatch(page)
+	if m == nil {
+		t.Fatalf("the page's script no longer starts with the three arrays")
+	}
+	var carried []map[string]any
+	if err := json.Unmarshal([]byte(m[3]), &carried); err != nil {
+		t.Fatalf("the notes array does not decode: %v", err)
+	}
+	found := false
+	for _, n := range carried {
+		text, _ := n["text"].(string)
+		state, _ := n["state"].(string)
+		if strings.Contains(text, "retry budget stays at 5") {
+			found = true
+			if state != "accepted" {
+				t.Errorf("the decision arrived without its state: %v", n)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("a decision that arrived by sync is on no tab that holds decisions:\n%s", m[3])
+	}
+}


### PR DESCRIPTION
Two machines, a real exchange: alpha promotes a decision and exports, beta imports. On beta the decision is searchable and keeps its state (#975) —

    [deja] imported:work/api · today · imported-…2d69fbeba4 — 2 matches
      [accepted] retry budget stays at 5 (from claude:a1, 2026-08-28)

— and beta's Notes tab was empty, because it is built from this machine's notes.jsonl and beta has none. The decision arrived as an indexed session carrying `lifecycle`, `lifecycle_note` and `lifecycle_at`; recall reads it and `hook-tool` honours the state.

Those sessions now render as notes beside the local ones. Everything else in the exchange already read the same on both sides.

Fixes #2421.