### PR TITLE
fix(doctor): the JSON peer row says which machine the host is

### DIFF
--- a/cmd/deja/doctor_json_peer_machine_test.go
+++ b/cmd/deja/doctor_json_peer_machine_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The text row says which machine an ssh host turns out to be (#2415), and
+// `sessions_from_there` is counted by that same name. The JSON carried the
+// host alone, so a consumer could not join a peer to the work that came from
+// it (#2423).
+func TestDoctorJSONPeerCarriesTheMachineName(t *testing.T) {
+	tmp := hermeticEnv(t)
+	peersFile := filepath.Join(tmp, "peers.json")
+	t.Setenv("DEJA_PEERS_FILE", peersFile)
+	body := `{"peers":[{"host":"vlad@10.0.0.7","machine":"quicksilver","last_pull":"2026-08-28T10:00:00Z"},` +
+		`{"host":"mini","last_pull":"2026-08-28T09:00:00Z"}]}`
+	if err := os.WriteFile(peersFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _ := captureBoth(t, "doctor", "--json")
+	var report struct {
+		Sync struct {
+			Peers []map[string]any `json:"peers"`
+		} `json:"sync"`
+	}
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("doctor --json is not JSON: %v\n%s", err, out)
+	}
+	if len(report.Sync.Peers) != 2 {
+		t.Fatalf("want two peer rows, got %d", len(report.Sync.Peers))
+	}
+	for _, p := range report.Sync.Peers {
+		switch p["host"] {
+		case "vlad@10.0.0.7":
+			if p["machine"] != "quicksilver" {
+				t.Errorf("the row does not say which machine that host is: %v", p)
+			}
+		case "mini":
+			// A machine that has never said what it calls itself adds nothing.
+			if _, ok := p["machine"]; ok {
+				t.Errorf("the row invented a name: %v", p)
+			}
+		}
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -133,6 +133,12 @@ type doctorImportedReport struct {
 // doctorPeerReport is one machine, carrying what the text line carries.
 type doctorPeerReport struct {
 	Host string `json:"host"`
+	// Machine is the name that host turns out to be — what the sending machine
+	// calls itself, learned from the records a pull brings. It is the name
+	// `sessions_from_there` is counted by and the one every listing prints for
+	// imported work, so without it a consumer cannot join a peer row to the
+	// sessions that came from it (#2423). Absent until the machine has said.
+	Machine string `json:"machine,omitempty"`
 	// The two directions fail apart, and a host that takes what this machine
 	// sends while sending nothing back is a broken sync that reads as a
 	// working one — so they are separate keys rather than one "last exchange".
@@ -173,6 +179,7 @@ func collectDoctorSync(dir string) doctorSyncReport {
 			// which is the reason the text report needs a bound and this does
 			// not.
 			Host:      p.Host,
+			Machine:   p.Machine,
 			Sessions:  peerSessionCount(from, p),
 			LastError: safeForStatusline(p.LastError, 200),
 		}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -360,6 +360,7 @@ appears only after `deja embed` has built a semantic sidecar. The heatmap grid u
     "peers": [
       {
         "host": "laptop",
+        "machine": "quicksilver",
         "last_push": "2026-08-22T10:00:00Z",
         "last_pull": "2026-08-22T10:00:00Z",
         "sessions_from_there": 12
@@ -430,7 +431,10 @@ apart, and a machine that takes what this one sends while sending nothing back
 is a broken sync that reads as a working one. A row carrying neither is a
 machine named once and never reached — the text report says "never exchanged"
 for it — and it is still a row, which is what distinguishes it from a deja too
-old to report peers at all: that one has no `sync` key. `last_error` is why the most
+old to report peers at all: that one has no `sync` key. `machine` is what that host calls itself, learned from the records a pull
+brings; it is the name `sessions_from_there` is counted by and the name every
+listing prints for imported work. Absent until the machine has said, and absent
+for a peer that has never been reached. `last_error` is why the most
 recent exchange failed and is absent once one succeeds. `last_error` is written by
 another machine and can be made arbitrarily long, so it is bounded before it is
 reported. `host` is not: it is a name to act on — `deja sync ssh <host>` — and a


### PR DESCRIPTION
The text row says it (#2415):

    vlad@10.0.0.7 … 1 session from there — calls itself quicksilver

the JSON row did not:

    {"host": "vlad@10.0.0.7", "last_pull": "…", "sessions_from_there": 1}

`sessions_from_there` is counted by the machine name and every listing prints that name for imported work, so a consumer could not join a peer row to the sessions that came from it. `machine` is now on the row, omitted until the machine has said what it calls itself — spelled as the records spell it, the way `host` and `imported[].machine` already are, because a reader may act on it (`deja sync forget <name>`, #2405).

Fixes #2423.