### PR TITLE
test(usage): a blank line in the events log is not a lost record

### DIFF
--- a/internal/usage/events_concurrent_test.go
+++ b/internal/usage/events_concurrent_test.go
@@ -48,9 +48,18 @@ func TestTheEventsLogStaysReadableUnderWriters(t *testing.T) {
 	seen := map[string]int{}
 	stale := 0
 	for i, line := range strings.Split(strings.TrimRight(string(body), "\n"), "\n") {
+		// A blank line is not a lost record: the writers close a line they
+		// find open before appending (#1901), and a rotation landing between
+		// that check and the write leaves the newline with nothing after it.
+		// The reader skips what it cannot parse, so an empty line costs
+		// nothing — what would cost something is a record cut in half, which
+		// is a non-empty line that will not parse.
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 		var e Event
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			t.Fatalf("line %d is not a record deja can read: %v\n%.200s", i+1, err, line)
+			t.Fatalf("line %d is a record cut in half: %v\n%.200s", i+1, err, line)
 		}
 		if strings.HasPrefix(e.Kind, "seed") {
 			stale++


### PR DESCRIPTION
The pin merged in #2426 asserted every line of the events log parses. CI disagreed on ubuntu: `line 307 is not a record deja can read: unexpected end of JSON input`.

That is the newline an appender writes to close a line it found open (#1901) with a rotation landing between the check and the write — a blank line, not a record cut in half. `read()` skips what it cannot parse, so a blank line costs nothing; the assertion was stricter than the format's own contract.

The pin now skips blank lines and still fails on a non-empty line that will not parse, which is the case that would cost a record.