### PR TITLE
fix(friction): stop dropping an error because it quotes what it could not find

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -264,10 +264,21 @@ func isFriction(l string) bool {
 	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
 	// deploy script reached second place on the first run: it is a line about
 	// an error, not an error.
-	for _, source := range []string{"echo ", "\"", "$(", "=~", "print("} {
+	for _, source := range []string{"echo ", "printf ", "$(", "=~", "print("} {
 		if strings.Contains(l, source) {
 			return false
 		}
+	}
+	// A bare double quote used to be on that list, and it cost more than it
+	// caught: tools quote the thing they could not find — `relation "orders"
+	// does not exist`, `repository "…" not found`, `pull access denied for
+	// "acme/api"` — so the same psql failure was friction without its quotes
+	// and invisible with them (#2431). What the quote was there to reject is
+	// still rejected by the markers above and by the two shapes below: a line
+	// that opens with a quoted string, and a JSON pair, which is what a
+	// payload printed into tool output looks like.
+	if strings.HasPrefix(l, "\"") || strings.Contains(l, "\": \"") {
+		return false
 	}
 	// A comment about an error is source too, and the wider marker list in
 	// #729 made these reachable: `// panic: this is a comment about panics`

--- a/internal/index/friction_quoted_test.go
+++ b/internal/index/friction_quoted_test.go
@@ -1,0 +1,35 @@
+package index
+
+import "testing"
+
+// A double quote anywhere in a line dropped it as source code. Tools quote the
+// thing they could not find — a relation, a branch, a module, an image — so the
+// rule threw away the errors an agent trips over most, while the same error
+// without quotes was learned (#2431).
+func TestAnErrorThatQuotesWhatItCouldNotFind(t *testing.T) {
+	// Both of these are in the phrase list already — "connection refused" and
+	// "fatal:" — and were dropped for their quotes alone.
+	friction := []string{
+		`psql: error: connection to server at "localhost", port 5432 failed: Connection refused`,
+		`fatal: repository "https://example.invalid/x.git" not found`,
+	}
+	for _, l := range friction {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("an error deja will keep seeing is not friction:\n  %s", l)
+		}
+	}
+
+	// Source is still source: a line that quotes an error is not one.
+	source := []string{
+		`echo "connection refused" >&2`,
+		`  "message": "connection refused",`,
+		`// panic: connection refused`,
+		`printf "permission denied\n"`,
+		`if [[ $out =~ "connection refused" ]]; then`,
+	}
+	for _, l := range source {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a line about an error was read as one:\n  %s", l)
+		}
+	}
+}


### PR DESCRIPTION
`isFriction` rejected any line with a double quote as source. Tools quote what they could not find, so:

    friction=false  psql: error: connection to server at "localhost", port 5432 failed: Connection refused
    friction=true   psql: error: connection to server at localhost, port 5432 failed: Connection refused

Same failure, same phrase from the list, opposite answers — and everything downstream goes with it: three sessions hitting that error in a row left `deja friction` empty, and `hook-tool-after` said nothing when a fourth hit it.

The bare quote is replaced by the two shapes it was actually there for — a line that opens with a quoted string, and a JSON pair — with `printf ` joining `echo ` on the source markers. After: friction counts the wall and the after-hook answers "this error came up in home/work before … what followed it: brew services start postgresql@16".

Fixes #2430.