### PR TITLE
fix(friction): let the phrase list see a line that opens with Error:

### DIFF
--- a/internal/index/fixpair_test.go
+++ b/internal/index/fixpair_test.go
@@ -128,11 +128,25 @@ func TestFixPairsKeepTheRetryAfterAFailedAttempt(t *testing.T) {
 		{Role: "tool-output", Text: "200 OK", Time: now.Add(4 * time.Minute)},
 	}
 	pairs := fixPairsIn(ms, "claude:s1", "p")
-	if len(pairs) != 1 {
-		t.Fatalf("want the retry stored, got %d pairs: %+v", len(pairs), pairs)
+	// Both errors in the sequence are walls — the missing command and the
+	// permission denied the first attempt hit — and the retry is what followed
+	// each of them. Counted rather than pinned at one: the second used to be
+	// invisible, because a line opening with "Error: " never reached the
+	// phrase list (#2432).
+	if len(pairs) == 0 {
+		t.Fatalf("the retry was not stored for either error")
 	}
-	if pairs[0].Command != "curl --max-time 5 example.internal" {
-		t.Errorf("wrong command stored: %q", pairs[0].Command)
+	byError := map[string]string{}
+	for _, p := range pairs {
+		byError[p.Error] = p.Command
+	}
+	if got := byError["command not found: timeout"]; got != "curl --max-time 5 example.internal" {
+		t.Errorf("the retry after the missing command is %q", got)
+	}
+	for _, p := range pairs {
+		if p.Command == "brew install coreutils" {
+			t.Errorf("the attempt whose own output failed was stored as a fix: %+v", p)
+		}
 	}
 }
 

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -253,13 +253,14 @@ func isFriction(l string) bool {
 	if namedTestFailure(l) {
 		return true
 	}
-	for _, generic := range []string{
-		"Traceback (most recent", "Error: ", "error: ", "FAIL\t", "--- FAIL",
-	} {
-		if strings.HasPrefix(l, generic) {
-			return false
-		}
-	}
+	// A generic opening — "Error: ", "error: ", a traceback header, a go test
+	// summary line — used to end the question here. It says nothing on its
+	// own, which is why it was listed, but the check ran before the phrase
+	// list and so also threw away every line that goes on to name a wall the
+	// list knows: `Error: Cannot find module ./config` was dropped while
+	// `Cannot find module ./config` was kept (#2432). Nothing is needed in its
+	// place — a line with only a generic opening matches no phrase below and
+	// falls through to false, which is where it belonged.
 	// Tool output carries source as often as it carries results — a `cat` of a
 	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
 	// deploy script reached second place on the first run: it is a line about

--- a/internal/index/friction_generic_prefix_test.go
+++ b/internal/index/friction_generic_prefix_test.go
@@ -1,0 +1,34 @@
+package index
+
+import "testing"
+
+// The bare-prefix rule drops a line for opening with "Error: ", because that
+// alone says nothing. It ran before the phrase list, so it also dropped the
+// lines that go on to say something the list knows — a missing module, a
+// refused connection — and those are the ones an agent hits twice (#2432).
+func TestAGenericPrefixWithSomethingBehindIt(t *testing.T) {
+	said := []string{
+		`Error: Cannot find module ./config`,
+		`error: cannot find package "example.com/x" in any of the module caches`,
+		`Error: connection refused while dialing the pool`,
+		`error: permission denied while trying to connect to the Docker daemon socket`,
+	}
+	for _, l := range said {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("a line naming a wall the list knows was dropped for its prefix:\n  %s", l)
+		}
+	}
+
+	// A prefix with nothing behind it is still nothing: these say only that
+	// something failed, which every run says differently.
+	bare := []string{
+		`Error: 1`,
+		`error: exit status 2`,
+		`Error: something went wrong, see above`,
+	}
+	for _, l := range bare {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a line that names nothing was read as a wall:\n  %s", l)
+		}
+	}
+}


### PR DESCRIPTION
A generic opening — `Error: `, `error: `, a traceback header, a go test summary — ended the question before the phrase list ran:

    friction=false  Error: Cannot find module ./config
    friction=true   Cannot find module ./config

`cannot find` is in the list; the prefix dropped the line anyway. Same for `error: cannot find package …`, `Error: connection refused …`, `error: permission denied …`.

Nothing replaces the rule: a line carrying only the generic opening matches no phrase and returns false, which is where it belonged.

One existing test moved with it — `TestFixPairsKeepTheRetryAfterAFailedAttempt` pinned exactly one pair, and the sequence has two walls now that `Error: Permission denied @ dir_s_mkdir` is one. It asserts the retry against each error by name instead of counting, and still holds that the attempt whose own output failed is not stored.

Fixes #2432.