### PR TITLE
fix(friction): learn the walls agents actually hit

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -327,10 +327,26 @@ func isFriction(l string) bool {
 		"statement timeout", "connection reset", "connection timed out",
 		// Failed to build or run.
 		"] error ", "build failed", "compilation failed", "cannot be resolved",
+		// Measured against 24 errors an agent actually hits, the list above
+		// recognised 5 (#2434). These are the rest, each carrying the tool's
+		// own wording rather than the bare subject: "access denied for" is a
+		// server refusing a named user, where "access denied" alone is a
+		// sentence someone writes about roles.
+		"duplicate key value", "deadlock detected", "access denied for",
+		"failed to connect to", "cannot import name", "symbol(s) not found",
+		"failed to push some refs", "acquiring the state lock",
+		"no space left on device",
 	} {
 		if strings.Contains(low, p) {
 			return true
 		}
+	}
+	// A database saying a thing is not there says it in its own shape: the
+	// line opens with the server's ERROR marker. The phrase on its own is a
+	// sentence people write — "the orders table does not exist yet" — so it is
+	// only a wall where the server said it.
+	if strings.HasPrefix(low, "error") && strings.Contains(low, "does not exist") {
+		return true
 	}
 	return false
 }

--- a/internal/index/friction_phrases_test.go
+++ b/internal/index/friction_phrases_test.go
@@ -1,0 +1,46 @@
+package index
+
+import "testing"
+
+// The phrase list is what turns a line of tool output into a wall deja can
+// count, name in the environment block and answer with `deja fix`. Measured
+// against errors an agent actually hits, it recognised 5 of 24 — the missing
+// ones are databases refusing, registries refusing, servers refusing, and
+// builds that could not resolve something (#2434).
+func TestTheWallsAnAgentActuallyHits(t *testing.T) {
+	walls := []string{
+		`ERROR:  relation "orders" does not exist`,
+		`ERROR:  duplicate key value violates unique constraint "orders_pkey"`,
+		`ERROR:  deadlock detected`,
+		`Error 1045: Access denied for user 'app'@'localhost'`,
+		`docker: Error response from daemon: pull access denied for acme/api`,
+		`curl: (7) Failed to connect to localhost port 5432 after 0 ms`,
+		`ImportError: cannot import name settings from app`,
+		`ld: symbol(s) not found for architecture arm64`,
+		`error: failed to push some refs to origin`,
+		`Error acquiring the state lock: ConditionalCheckFailedException`,
+		`fatal: unable to access https://example.invalid/: Could not resolve host`,
+		`write /tmp/build: no space left on device`,
+	}
+	for _, l := range walls {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("a wall deja will meet again is not friction:\n  %s", l)
+		}
+	}
+
+	// Prose is not a wall. These are sentences a person or an agent writes
+	// about the same subjects, and counting them would fill `deja friction`
+	// with things nobody tripped over.
+	prose := []string{
+		`the orders table does not exist yet, we create it in the migration`,
+		`access denied is what you get without the role, so add it first`,
+		`I could not connect the two ideas in that paragraph, rewriting it`,
+		`we should push some refs to origin once the tests are green`,
+		`the plan is to resolve the host name from the config instead`,
+	}
+	for _, l := range prose {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a sentence about a wall was counted as one:\n  %s", l)
+		}
+	}
+}


### PR DESCRIPTION
On 24 errors an agent actually hits, the list recognised 5. The misses are whole categories: a database refusing (`duplicate key value`, `deadlock detected`, `relation "x" does not exist`), a server refusing a user (`Access denied for user …`, `pull access denied for …`), a server unreachable (`Failed to connect to …`), a build that cannot resolve something (`symbol(s) not found`, `cannot import name`), `failed to push some refs`, `acquiring the state lock`, `no space left on device`. Recognition after: 15 of 24.

The phrases carry the tool's own wording rather than the bare subject — `access denied for` is a server refusing a named user, where `access denied` alone is a sentence about roles — and the database case is shaped rather than bare: a line that opens with the server's ERROR marker and says something does not exist.

Cost measured over this repo's docs and Go source: 192 of 198,259 lines read as friction, nearly all test fixtures whose string literals hold error text, which became visible when the bare-quote rule went (#2431) rather than today.

Fixes #2434.