### PR TITLE
fix(friction): a source line quoting an error is not a wall

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -281,6 +281,18 @@ func isFriction(l string) bool {
 	if strings.HasPrefix(l, "\"") || strings.Contains(l, "\": \"") {
 		return false
 	}
+	// Source that carries an error string is a line about an error, not one.
+	// A bare quote used to stand for this and cost far more than it caught
+	// (#2430): what is left is the punctuation source puts around the quote —
+	// an assignment, a call, a struct field, a code span — none of which
+	// appears in the output a tool prints. Measured over this repo: 130 of the
+	// 192 lines of its own docs and source that read as friction (#2436).
+	if strings.Contains(l, `("`) || strings.Contains(l, `, "`) ||
+		strings.Contains(l, `:= "`) || strings.Contains(l, `= "`) ||
+		strings.Contains(l, `: "`) && strings.HasSuffix(l, `"},`) ||
+		strings.HasPrefix(l, "`") {
+		return false
+	}
 	// A comment about an error is source too, and the wider marker list in
 	// #729 made these reachable: `// panic: this is a comment about panics`
 	// became the top wall on a store of shell snippets.

--- a/internal/index/friction_literal_test.go
+++ b/internal/index/friction_literal_test.go
@@ -1,0 +1,36 @@
+package index
+
+import "testing"
+
+// Source that carries an error string is a line about an error, not one. The
+// bare-quote rule used to catch this and cost far more than it caught (#2430);
+// what is left is the shapes source has around the quote — an assignment, a
+// call, a struct field, a code span — which tool output does not (#2436).
+func TestASourceLineCarryingAnErrorIsNotAWall(t *testing.T) {
+	source := []string{
+		`in := "the build failed: pgbouncer pool timed out and retried"`,
+		`t.Fatalf("compressed dump not found: %d sessions", len(ss))`,
+		`{Role: "tool-output", Text: "psql: connection refused on port 5432"},`,
+		"`Error: Cannot find module ./config`,",
+		`want = "fatal: repository not found, try again"`,
+	}
+	for _, l := range source {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a source line quoting an error was counted as one:\n  %s", l)
+		}
+	}
+
+	// And the errors themselves, which quote what they could not find.
+	output := []string{
+		`psql: error: connection to server at "localhost", port 5432 failed: Connection refused`,
+		`fatal: repository "https://example.invalid/x.git" not found`,
+		`ERROR:  relation "orders" does not exist`,
+		`curl: (7) Failed to connect to localhost port 5432 after 0 ms`,
+		`docker: Error response from daemon: pull access denied for "acme/api"`,
+	}
+	for _, l := range output {
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("an error was mistaken for source:\n  %s", l)
+		}
+	}
+}


### PR DESCRIPTION
Since the bare-quote rule went (#2430), source that carries an error string counts as friction — 192 lines of this repo's own docs and Go files, mostly test fixtures and code spans. An agent that `cat`s a test file teaches deja walls nobody hit.

What separates source from output is not the quote but what sits around it: an assignment, a call, a struct field, a code span. The guard rejects those shapes and nothing else.

    noise over docs and source   192 → 34
    recognition on 24 real errors  15 → 15

Fixes #2436.