### PR TITLE
fix(friction): stop dropping the errors that carry a path

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -36,7 +36,16 @@ const (
 	// field costs 2.7 KB across that corpus — the exactness is nearly free.
 	frictionSessionCap = 256
 	frictionLineMin    = 20
-	frictionLineMax    = 120
+	// The cap is about recognising a line, not about how much of it fits on a
+	// screen — every surface that prints one clips it to the width it has. Set
+	// at 120 it dropped the errors that carry a path: a build naming a module
+	// and a file, a registry naming an image, a database naming a host. Over
+	// the store on this machine that was 2,319 lines naming a wall the list
+	// knows, against 7,053 it recognised — a third again, thrown away for
+	// length alone, and 1,406 of them fit inside 160 (#2438). A bound there
+	// still is: a page of output pasted as one line is nobody's recognisable
+	// wall, and hashing it makes a new wall every run.
+	frictionLineMax = 200
 	// FrictionMinSessions is how many separate sessions must hit an error
 	// before it is worth saying. Twice is a coincidence.
 	FrictionMinSessions = 3

--- a/internal/index/friction_long_test.go
+++ b/internal/index/friction_long_test.go
@@ -1,0 +1,36 @@
+package index
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line bound was set to what a person can recognise, and real errors carry
+// paths: a go build error naming a module and a file, a docker pull naming a
+// registry, a k8s message naming a namespace and a pod. Measured over the store
+// on this machine, the 120-character cap dropped 2,319 lines that name a wall
+// the list knows — a third again of the 7,053 it recognised (#2438).
+func TestALongErrorIsStillAWall(t *testing.T) {
+	walls := []string{
+		`/Users/someone/code/service/internal/handler/orders.go:118:24: undefined: repository.FindOrderByExternalReference in the orders package`,
+		`docker: Error response from daemon: pull access denied for registry.example.internal/team/service, repository does not exist or may require authorisation`,
+		`psql: error: connection to server at "db.internal.example.com" (10.42.0.7), port 5432 failed: Connection refused — is the server running there?`,
+	}
+	for _, l := range walls {
+		// Longer than the bound these were dropped by, so each case still
+		// stands for the errors that carry a path.
+		if n := len([]rune(l)); n <= 120 {
+			t.Fatalf("this case no longer tests the bound it was written for: %d runes", n)
+		}
+		if _, ok := FrictionLine(l); !ok {
+			t.Errorf("a wall was dropped for its length (%d runes):\n  %s", len([]rune(l)), l)
+		}
+	}
+
+	// A bound there still is: a whole page of output pasted as one line is not
+	// a wall anyone can recognise, and hashing it would make a wall of its own
+	// every run.
+	if _, ok := FrictionLine("connection refused " + strings.Repeat("x", 400)); ok {
+		t.Errorf("a line with no bound at all was counted as a wall")
+	}
+}

--- a/internal/index/friction_script_test.go
+++ b/internal/index/friction_script_test.go
@@ -16,8 +16,8 @@ func TestFrictionBoundsCountCharactersNotBytes(t *testing.T) {
 	// Carries an English marker, as most real error lines do, so only the
 	// length decides.
 	for _, l := range []string{
-		"ОШИБКА при развёртывании: connection refused при подключении к очереди повторов",
-		"ОШИБКА при развёртывании сервиса доставки: connection refused при подключении к очереди",
+		"ОШИБКА при развёртывании сервиса доставки заказов: connection refused при подключении к очереди повторов на резервном узле",
+		"ОШИБКА при развёртывании сервиса доставки заказов и уведомлений: connection refused при подключении к очереди повторов узла",
 	} {
 		if n := utf8.RuneCountInString(l); n > frictionLineMax {
 			t.Fatalf("the fixture is %d characters, past the bound itself", n)


### PR DESCRIPTION
Measured over the store already indexed on this machine — 1,812,638 lines of tool output, 516 sessions:

    at 120:  7,053 walls recognised;  2,319 lines naming a known wall dropped for length
    at 200:  8,885 walls recognised;    428 still dropped, none under 240 characters

The lines that run long are the ones carrying a path or a host: a build naming a module and a file, a registry naming an image, a database naming a host and a port.

The cap's own comment is about how much of a line a person can recognise, and every surface that prints one already clips to its width. What the cap is really for — a page of output pasted as one line, which hashes to a new wall every run — holds at 200 as it did at 120.

Two tests moved with it: the runes-vs-bytes fixture needed longer strings to sit between the byte and rune bounds, and the new test names 120 in its own guard, since that is the bound its cases were written against.

Fixes #2438.