### PR TITLE
fix(hook): the environment block names the remedy it already knows

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -94,19 +94,56 @@ func environmentBlockFrom(dir, activation string) (string, []string) {
 	}
 	var b strings.Builder
 	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
+	knownRemedy := false
 	for _, w := range walls {
 		text := w.Text
 		// Same cut, same reason as the conventions line: bytes, not runes, so a
 		// wall recorded in Russian or Chinese reached the model in pieces.
 		text = truncatePlanBytes(text, environmentMax)
 		fmt.Fprintf(&b, "- %d separate sessions hit `%s`\n", len(w.Sessions), text)
+		// What was run after it, when deja knows: the block exists to change
+		// the next tool call, and "find your own way past this" is poor advice
+		// from something holding the way past (#2440). Same source `deja fix`
+		// and the tool hook answer from, under the same rule this block is
+		// filtered by.
+		if fix := environmentRemedy(dir, w.Text, activation); fix != "" {
+			fmt.Fprintf(&b, "  what followed it: `%s`\n", fix)
+			knownRemedy = true
+		}
 	}
 	// Without this line the block reads as trivia. With it the model has
 	// something to do differently on its next tool call, which is the only
 	// reason the block is here.
-	b.WriteString("These are environment facts, not history: the tool or module is still missing. " +
-		"Check or use an alternative before running into them again.")
+	if knownRemedy {
+		b.WriteString("These are environment facts, not history. Where a command is named above, " +
+			"it is what this machine ran after that error before; check the rest or use an alternative " +
+			"before running into them again.")
+	} else {
+		b.WriteString("These are environment facts, not history: the tool or module is still missing. " +
+			"Check or use an alternative before running into them again.")
+	}
 	return b.String(), projects
+}
+
+// environmentRemedy is the command this machine ran after a wall, when one is
+// recorded twice or more — the same bar `deja fix` prints without hedging. The
+// block is bounded, so only the first candidate is named and only when it is
+// short enough to be a command rather than a script.
+func environmentRemedy(dir, wall string, activation string) string {
+	pol := policy.Load()
+	fixes := index.FixesFor(dir, wall, 1, func(project string) bool {
+		return pol.Allows(activation, project)
+	})
+	if len(fixes) == 0 || fixes[0].Candidate {
+		return ""
+	}
+	// Stored with the prompt the transcript showed it with; the block quotes it
+	// as a command to run.
+	cmd := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(fixes[0].Command), "$ "))
+	if cmd == "" || len(cmd) > environmentMax {
+		return ""
+	}
+	return safeForStatusline(cmd, environmentMax)
 }
 
 // environmentSpent is per process, which is what makes "once" countable on

--- a/cmd/deja/environment_remedy_test.go
+++ b/cmd/deja/environment_remedy_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// The block names the walls this machine keeps hitting and then tells the agent
+// to check or use an alternative — while deja already knows what was run after
+// one of them, and says so through `deja fix` and the tool hook. The one place
+// it is silent about the remedy is the block written to change what the agent
+// does next (#2440).
+func TestTheEnvironmentBlockNamesTheRemedyItKnows(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fail := `psql: error: connection to server at "db.internal.example.com" (10.42.0.7), port 5432 failed: Connection refused`
+	for k := 0; k < 4; k++ {
+		var lines []string
+		at := func(m int) string {
+			return time.Now().Add(-time.Duration(300-40*k-m) * time.Minute).UTC().Format(time.RFC3339)
+		}
+		sid := fmt.Sprintf("s%d", k)
+		lines = append(lines,
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -h db.internal -c 'select 1'"}}]}}`, sid, at(0)),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":%q}]}}`, sid, at(1), fail),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"brew services start postgresql@16"}}]}}`, sid, at(2)),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"==> Successfully started postgresql@16"}]}}`, sid, at(3)),
+		)
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	block, _ := environmentBlockFrom(dir, policy.ActivationAuto)
+	if block == "" {
+		t.Fatalf("no environment block on a machine with four sessions on one wall")
+	}
+	if !strings.Contains(block, "psql: error: connection to server") {
+		t.Fatalf("the block does not name the wall:\n%s", block)
+	}
+	if !strings.Contains(block, "brew services start postgresql@16") {
+		t.Errorf("the block tells the agent to find its own way past a wall deja knows the way past:\n%s", block)
+	}
+}


### PR DESCRIPTION
The block lists the walls a machine keeps hitting and closed with "the tool or module is still missing. Check or use an alternative before running into them again" — including for a wall a session already got past. Nothing was missing: the database was down, `brew services start postgresql@16` fixed it, and deja says so through `deja fix` and `hook-tool-after`.

Now:

    - 4 separate sessions hit `psql: error: connection to server at "db.internal…`
      what followed it: `brew services start postgresql@16`
    These are environment facts, not history. Where a command is named above, it is
    what this machine ran after that error before; check the rest or use an
    alternative before running into them again.

The remedy comes from the same source `deja fix` answers from, under the activation the block is already filtered by, and only when the pair is confirmed rather than a candidate.

Fixes #2440.