### PR TITLE
fix(hook): keep both ends of a wall in the environment block

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 )
@@ -96,10 +97,14 @@ func environmentBlockFrom(dir, activation string) (string, []string) {
 	b.WriteString("This machine, from deja's index of past sessions across every agent used here:\n")
 	knownRemedy := false
 	for _, w := range walls {
-		text := w.Text
-		// Same cut, same reason as the conventions line: bytes, not runes, so a
-		// wall recorded in Russian or Chinese reached the model in pieces.
-		text = truncatePlanBytes(text, environmentMax)
+		// Cut from the middle, not the right. What names a failure is usually
+		// at both ends — the tool at the front, what it could not do at the
+		// back — and a right-hand cut kept `connection to server at "…", port
+		// 5432 failed:` while dropping the "Connection refused" that says what
+		// happened (#2442). Bytes, not runes, for the reason the conventions
+		// line gives: a wall recorded in Russian or Chinese reached the model
+		// in pieces.
+		text := elideMiddleBytes(w.Text, environmentMax)
 		fmt.Fprintf(&b, "- %d separate sessions hit `%s`\n", len(w.Sessions), text)
 		// What was run after it, when deja knows: the block exists to change
 		// the next tool call, and "find your own way past this" is poor advice
@@ -123,6 +128,60 @@ func environmentBlockFrom(dir, activation string) (string, []string) {
 			"Check or use an alternative before running into them again.")
 	}
 	return b.String(), projects
+}
+
+// elideMiddleBytes keeps the head and the tail of a line, with an ellipsis
+// between them, inside a byte budget. A tail matters here because the phrase
+// that names a failure — "Connection refused", "no such file or directory",
+// "undefined: X" — is as often at the end of a line as at the front, while the
+// middle is a path or a host.
+func elideMiddleBytes(text string, limit int) string {
+	if limit <= 0 || len(text) <= limit {
+		if limit <= 0 {
+			return ""
+		}
+		return text
+	}
+	const ellipsis = "…"
+	if limit <= len(ellipsis) {
+		return ""
+	}
+	room := limit - len(ellipsis)
+	// A little more of the front than the back: the tool's own name and the
+	// first words are what a reader matches against, and the tail only has to
+	// carry the failing phrase.
+	head := room * 3 / 5
+	tail := room - head
+	return cutBytes(text, head) + ellipsis + cutBytesRight(text, tail)
+}
+
+// cutBytes and cutBytesRight take whole runes from each end.
+func cutBytes(text string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if len(text) <= n {
+		return text
+	}
+	out := text[:n]
+	for len(out) > 0 && !utf8.ValidString(out) {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+func cutBytesRight(text string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if len(text) <= n {
+		return text
+	}
+	out := text[len(text)-n:]
+	for len(out) > 0 && !utf8.ValidString(out) {
+		out = out[1:]
+	}
+	return out
 }
 
 // environmentRemedy is the command this machine ran after a wall, when one is

--- a/cmd/deja/environment_long_wall_test.go
+++ b/cmd/deja/environment_long_wall_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// The errors that carry a path run long, and the block cuts them from the left
+// — so a wall reached the agent as a host and a port with the failure itself
+// gone: "connection to server at … port 5432 failed:" and nothing about what
+// failed (#2442).
+func TestALongWallKeepsWhatNamesIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wall := `psql: error: connection to server at "db.internal.example.com" (10.42.0.7), port 5432 failed: Connection refused`
+	for k := 0; k < 4; k++ {
+		sid := fmt.Sprintf("s%d", k)
+		at := time.Now().Add(-time.Duration(200-20*k) * time.Minute).UTC().Format(time.RFC3339)
+		lines := []string{
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -h db.internal"}}]}}`, sid, at),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"/work/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":%q}]}}`, sid, at, wall),
+		}
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	block, _ := environmentBlockFrom(index.DefaultDir(), policy.ActivationAuto)
+	if block == "" {
+		t.Fatalf("no block on a machine with four sessions on one wall")
+	}
+	if !strings.Contains(block, "Connection refused") {
+		t.Errorf("the block kept the host and dropped the failure:\n%s", block)
+	}
+	// Still bounded: the block goes into every session start.
+	for _, line := range strings.Split(block, "\n") {
+		if len(line) > 200 {
+			t.Errorf("a %d-byte line in a block injected on every session start:\n%s", len(line), line)
+		}
+	}
+}


### PR DESCRIPTION
Each wall is clipped to 96 bytes so the block stays small enough for every session start. Cut from the right, that kept the host and dropped what happened:

    before  `psql: error: connection to server at "db.internal.example.com" (10.42.0.7), port 5432 failed:…`
    after   `psql: error: connection to server at "db.internal.examp…, port 5432 failed: Connection refused`

Same for a build error: the file survived and `undefined: repository.FindOrder…` did not. The identifying phrase sits at the end as often as at the front, so the cut takes the middle — the tool's name at the head, the failure at the tail, inside the same budget.

#2438 raised the friction cap to 200 characters, so long walls reach this line more often than before.

Fixes #2442.