### PR TITLE
fix(index): bump the version so the friction work reaches existing stores

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -67,7 +67,17 @@ import (
 // numbers the machine hands out. A store built before this holds each run under
 // its own signature, and nothing re-derives them without the bump — the same
 // shape as 27, 28 and 29 (#2369).
-const version = 30
+// 31: what counts as a wall at all. A quote no longer drops a line as source
+// (#2430), a generic opening no longer hides the phrase behind it (#2432), the
+// list learned the walls a machine actually hits (#2434), a source line
+// carrying an error is not one (#2436), and the line cap went from 120 to 200
+// characters, which alone recovered a third again of what was recognised
+// (#2438). Measured over a real store: 7,053 signatures before, 8,885 after. A
+// store built under the old rules holds the old signatures and nothing
+// re-derives them — `deja friction` reads the records and sees the difference,
+// while `hook-tool-after` and the environment block read the manifest and stay
+// silent, which is the state this bump exists to end (#2444).
+const version = 31
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/version_friction_rules_test.go
+++ b/internal/index/version_friction_rules_test.go
@@ -1,0 +1,18 @@
+package index
+
+import "testing"
+
+// Four changes in a row widened what counts as a wall — the quote rule, the
+// generic prefix, nine phrases, the line cap — and each declined a version
+// bump. The signatures live in the manifest, and nothing re-derives them: a
+// store built under the old rules keeps answering by them, so `hook-tool-after`
+// stays silent and the environment block stays empty on the machine that has
+// been running deja longest (#2444).
+func TestTheVersionMovesWhenTheRulesDo(t *testing.T) {
+	// 30 was the last bump (masking digit runs, #2369). Everything since has
+	// changed which lines become signatures at all.
+	if version <= 30 {
+		t.Errorf("version is %d: the friction rules moved and the version did not, "+
+			"so every index built before them answers by the old rules forever", version)
+	}
+}


### PR DESCRIPTION
Since #2430 the rules for what counts as a wall changed five times — the quote rule, the generic prefix, nine phrases, the source-literal guard, and the line cap (which alone took a real store from 7,053 signatures to 8,885). None bumped the version, and signatures are written at ingest.

An index built by an older deja, read by today's binary:

    deja friction        finds the wall     (it re-reads the records)
    hook-tool-after      silent
    environment block    silent
    deja index           "index is up to date"

So the machine with the most history — the one with the most walls to recognise — is the one that never gets the change. Versions 27 through 30 were each bumped for exactly this, and each comment says so.

After the bump, with nobody typing `--rebuild`: the first hook call is silent while the rebuild runs in the background, the next one answers.

Fixes #2444.