### PR TITLE
test(fix): a command that cannot be a remedy is not stored as one

### DIFF
--- a/internal/index/fixpair_trivial_test.go
+++ b/internal/index/fixpair_trivial_test.go
@@ -1,0 +1,53 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Five changes widened what counts as a wall, so more errors now look for a
+// command to pair with — and the next command after an error is usually the
+// session moving on, not a remedy. Measured over the store on this machine
+// after the widening: 24 walls, 12 with a pair, every one of them confirmed and
+// none of them navigation. This holds the part that keeps it that way (#2448).
+func TestACommandThatCannotBeARemedyIsNotStoredAsOne(t *testing.T) {
+	now := time.Now()
+	wall := "psql: error: connection to server at db-a, port 5432 failed: Connection refused"
+	for _, cmd := range []string{
+		"cd ../service",
+		"ls -la internal/handler",
+		"cat internal/handler/orders.go",
+		"pwd",
+		"git status",
+	} {
+		ms := []model.Message{
+			{Role: roleCommand, Text: "psql -h db-a -c 'select 1'", Time: now},
+			{Role: roleToolOutput, Text: wall, Time: now.Add(time.Minute)},
+			{Role: roleCommand, Text: cmd, Time: now.Add(2 * time.Minute)},
+			{Role: roleToolOutput, Text: "ok", Time: now.Add(3 * time.Minute)},
+		}
+		for _, p := range fixPairsIn(ms, "claude:s1", "work/app") {
+			if strings.Contains(p.Command, cmd) {
+				t.Errorf("`%s` was stored as what fixes a refused connection", cmd)
+			}
+		}
+	}
+
+	// And the control: a command that changes something is still stored.
+	ms := []model.Message{
+		{Role: roleCommand, Text: "psql -h db-a -c 'select 1'", Time: now},
+		{Role: roleToolOutput, Text: wall, Time: now.Add(time.Minute)},
+		{Role: roleCommand, Text: "brew services start postgresql@16", Time: now.Add(2 * time.Minute)},
+		{Role: roleToolOutput, Text: "==> Successfully started postgresql@16", Time: now.Add(3 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "work/app")
+	if len(pairs) == 0 {
+		t.Fatalf("the command that fixed it was not stored at all")
+	}
+	if !strings.Contains(pairs[0].Command, "brew services start postgresql@16") {
+		t.Errorf("stored %q", pairs[0].Command)
+	}
+}


### PR DESCRIPTION
The friction widening means more errors look for a command to pair with. Measured over the store on this machine afterwards:

    24 walls at or above the threshold
    12 carry a pair, all 12 confirmed, 14 pairs in all
    remedies that are only navigation or a read: 0

The rules that keep it that way live in `fixPairsIn` — a command that failed is not a remedy, reading something is not fixing it — and neither was held by a test. This pins the second: `cd`, `ls`, `cat`, `pwd` and `git status` after a refused connection are not stored as what fixed it, while `brew services start postgresql@16` still is.

Fixes #2448.