### PR TITLE
test(sync): a peer's work stays put when this machine exports its own

### DIFF
--- a/internal/index/export_mixed_test.go
+++ b/internal/index/export_mixed_test.go
@@ -1,0 +1,86 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A machine that has imported a peer's work and then exports its own must send
+// only its own: what arrived from elsewhere belongs to the machine it came
+// from, and a second hop would spread it past whoever agreed to the first.
+// The roundtrip test holds this for an index that carries nothing else
+// (TestSyncRoundtripAllHarnesses); this is the case a filter would actually
+// break — local work and imported work side by side (#2450).
+func TestAnExportCarriesOwnWorkAndNotAPeersToo(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "index.db")
+	store := filepath.Join(root, "claude", "-work-ownwork")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(root, "claude"))
+	setHome(t, root)
+	at := time.Now().Add(-30 * time.Minute).UTC().Format(time.RFC3339)
+	own := `{"type":"user","sessionId":"own1","timestamp":"` + at + `","cwd":"/work/ownwork",` +
+		`"message":{"role":"user","content":"the retry budget on main"}}`
+	if err := os.WriteFile(filepath.Join(store, "own1.jsonl"), []byte(own+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	batch := filepath.Join(root, "peer-batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	peer := `{"harness":"claude","session_id":"peer1","project":"work/peerwork","role":"user",` +
+		`"text":"the client ledger cutover on the other machine","time":"` + at + `","origin":"bravo"}`
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(peer+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := Import(dir, batch); err != nil || n == 0 {
+		t.Fatalf("import n=%d err=%v", n, err)
+	}
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(root, "outgoing")
+	n, err := ExportFull(dir, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Fatalf("the machine's own work did not go out at all")
+	}
+	files, err := filepath.Glob(filepath.Join(out, "*.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		body, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+			if line == "" {
+				continue
+			}
+			var rec struct {
+				Project string `json:"project"`
+				Text    string `json:"text"`
+			}
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				t.Fatalf("a batch line does not decode: %v", err)
+			}
+			if strings.Contains(rec.Project, "peerwork") || strings.Contains(rec.Text, "other machine") {
+				t.Errorf("a peer's session went out in this machine's export: %s", rec.Project)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two machines and a policy, walked end to end: bravo exports, alpha imports and has work of its own, alpha exports onward — one record, its own. Under a local-only rule alpha's recall hides the imported session and its export sends nothing new; beta's doctor names the sending machine and counts what arrived; an invalid policy file says so on every command and fails open.

All correct. The onward rule rests on one line in `exportRecordsDeferred` (`if r.SourcePath == syncImportPath`), and the test that holds it exports from an index carrying *only* imported records — so a filter that quietly became conditional on there being nothing local would still pass it.

This pins the ordinary case: local work and a peer's side by side, export carries the first and not the second. Sabotaging that line fails this and passes the roundtrip test.

Fixes #2450.