### PR TITLE
fix(policy): say where recall happens that a rule does nothing

### DIFF
--- a/cmd/deja/policy_inert_warning_test.go
+++ b/cmd/deja/policy_inert_warning_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A policy file that will not parse warns on every command, because loading
+// fails open and the rule someone wrote stops holding (#1088). A rule that
+// parses and names something deja never consults fails open the same way — the
+// project stays in every answer — and only `doctor` said so (#2452).
+func TestARuleThatDoesNothingSaysSoWhereRecallHappens(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", path)
+
+	// The shape someone writes when they mean "keep this project out": the
+	// keys deja consults are origins, not projects.
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"work/secretclient":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	warnBrokenPolicy("search", &out)
+	got := out.String()
+	if !strings.Contains(got, "work/secretclient") {
+		t.Errorf("the rule that does nothing is named nowhere but doctor:\n%q", got)
+	}
+	if !strings.Contains(got, "does nothing") && !strings.Contains(got, "no effect") {
+		t.Errorf("the warning does not say the rule is inert:\n%q", got)
+	}
+
+	// A policy that says what deja understands says nothing extra.
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"local":true,"imported":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	warnBrokenPolicy("search", &out)
+	if out.Len() != 0 {
+		t.Errorf("a policy deja understands produced a warning:\n%q", out.String())
+	}
+
+	// And doctor keeps reporting it in full rather than being warned at.
+	out.Reset()
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"work/secretclient":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	warnBrokenPolicy("doctor", &out)
+	if out.Len() != 0 {
+		t.Errorf("doctor was warned at about the file it prints in full:\n%q", out.String())
+	}
+}

--- a/cmd/deja/policy_warn.go
+++ b/cmd/deja/policy_warn.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/policy"
 )
@@ -21,12 +22,47 @@ func warnBrokenPolicy(cmd string, w io.Writer) {
 	case "doctor", "version", "completion":
 		return
 	}
-	exists, _, err := policy.Diagnose()
-	if !exists || err == nil {
+	exists, unknown, err := policy.Diagnose()
+	if !exists {
 		return
 	}
-	fmt.Fprintf(w, "deja: warning the trust policy at %s %s — every origin activates until it loads\n",
-		policy.Path(), policyFailureReason(err))
+	if err != nil {
+		fmt.Fprintf(w, "deja: warning the trust policy at %s %s — every origin activates until it loads\n",
+			policy.Path(), policyFailureReason(err))
+		return
+	}
+	// A rule that parses and names something deja never consults fails open
+	// exactly like a file that will not parse: the project the reader meant to
+	// withhold is in every answer, and the file on disk reads like a
+	// restriction. doctor listed these; nobody reads doctor while recall is
+	// answering, which is the reason the warning above exists (#2452).
+	if len(unknown) > 0 {
+		fmt.Fprintf(w, "deja: warning the trust policy at %s names %s, which deja does not consult — %s does nothing and every origin activates\n",
+			policy.Path(), quotedList(unknown, 3), pluralThat(len(unknown)))
+	}
+}
+
+// quotedList names at most n of the keys, and says how many more there are.
+func quotedList(keys []string, n int) string {
+	if len(keys) <= n {
+		out := make([]string, len(keys))
+		for i, k := range keys {
+			out[i] = fmt.Sprintf("%q", k)
+		}
+		return strings.Join(out, ", ")
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = fmt.Sprintf("%q", keys[i])
+	}
+	return fmt.Sprintf("%s and %d more", strings.Join(out, ", "), len(keys)-n)
+}
+
+func pluralThat(n int) string {
+	if n == 1 {
+		return "that rule"
+	}
+	return "those rules"
 }
 
 // policyFailureReason turns the load failure into a cause with something to do


### PR DESCRIPTION
`{"activations":{"search":{"work/secretclient":false}}}` parses, means nothing to deja — the keys are origins, not projects — and the project stays in every answer. The file on disk reads like a restriction.

`deja doctor` reported it and nothing else did, which is the argument #1088 already made for a policy file that will not parse: nobody reads doctor while recall is answering. Now:

    deja: warning the trust policy at ~/.config/deja/policy.json names
    "search.work/secretclient", which deja does not consult — that rule does
    nothing and every origin activates

Same path, same suppression list, and doctor still prints the file in full rather than being warned at.

Fixes #2452.