### PR TITLE
fix(hook): a standing decision is the decision, not the problem

### DIFF
--- a/cmd/deja/agent_text_cuts_test.go
+++ b/cmd/deja/agent_text_cuts_test.go
@@ -34,13 +34,18 @@ func TestAgentFacingTextIsCutOnRuneBoundaries(t *testing.T) {
 	}
 }
 
-// A note that fits keeps its whole text, and a title still wins over the body.
+// A note that fits keeps its whole text, and the decision is what the line
+// carries — the title is the session's own opening line, which is the problem
+// rather than what was decided about it (#2456).
 func TestAShortConventionKeepsItsText(t *testing.T) {
 	if got := conventionLine(sources.PromotedNote{Text: "queue retries with full jitter"}); got != "queue retries with full jitter" {
 		t.Errorf("a short note was changed: %q", got)
 	}
-	if got := conventionLine(sources.PromotedNote{Title: "retry policy", Text: "long body"}); got != "retry policy" {
-		t.Errorf("the title should name the note: %q", got)
+	if got := conventionLine(sources.PromotedNote{Title: "retry policy", Text: "queue retries with full jitter"}); got != "queue retries with full jitter" {
+		t.Errorf("the decision should be the line, not the title: %q", got)
+	}
+	if got := conventionLine(sources.PromotedNote{Title: "retry policy"}); got != "retry policy" {
+		t.Errorf("a note with only a title should still say it: %q", got)
 	}
 	// The first sentence, when there is one.
 	if got := conventionLine(sources.PromotedNote{Text: "Retry three times. Then give up."}); got != "Retry three times." {

--- a/cmd/deja/hook_conventions.go
+++ b/cmd/deja/hook_conventions.go
@@ -72,12 +72,15 @@ func projectConventions(names []string, maxNotes, budget int) string {
 // first sentence of its body when it has no title. Kept short — the block is a
 // reminder of what was decided, not the reasoning, which recall_context carries.
 func conventionLine(n sources.PromotedNote) string {
-	if t := strings.TrimSpace(n.Title); t != "" {
-		return t
-	}
+	// The decision first. A note's title is the session's own opening line —
+	// usually the problem someone brought — and the decision is what they
+	// wrote with `--note`, so leading with the title told an agent to follow
+	// "the migration keeps failing on retry" (#2456). The title is the
+	// fallback for a note that has nothing else, which is what `deja promote`
+	// writes without `--note`.
 	text := strings.TrimSpace(strings.ReplaceAll(n.Text, "\n", " "))
 	if text == "" {
-		return ""
+		return strings.TrimSpace(n.Title)
 	}
 	for i, r := range text {
 		if (r == '.' || r == '!' || r == '?') && (i+1 >= len(text) || text[i+1] == ' ') {

--- a/cmd/deja/hook_conventions_decision_test.go
+++ b/cmd/deja/hook_conventions_decision_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The block tells an agent to follow these lines. A promoted note's title is
+// the session's own first line — usually the problem — while what was decided
+// is the note the person wrote with `--note`. Printing the title handed the
+// agent the question as the answer: "follow: the migration keeps failing on
+// retry" (#2456).
+func TestAStandingDecisionIsTheDecisionNotTheProblem(t *testing.T) {
+	note := sources.PromotedNote{
+		Project: "work/app",
+		State:   "accepted",
+		Title:   "the migration keeps failing on retry",
+		Text:    "retry budget stays at 5 after the pool change",
+		At:      time.Now(),
+	}
+	line := conventionLine(note)
+	if !strings.Contains(line, "retry budget stays at 5") {
+		t.Errorf("the line an agent is told to follow does not carry the decision: %q", line)
+	}
+	if strings.HasPrefix(line, "the migration keeps failing") {
+		t.Errorf("the line leads with the problem: %q", line)
+	}
+
+	// A note with nothing but a title still says what it has.
+	titleOnly := sources.PromotedNote{Project: "work/app", State: "accepted",
+		Title: "keep the pool at 8", At: time.Now()}
+	if got := conventionLine(titleOnly); !strings.Contains(got, "keep the pool at 8") {
+		t.Errorf("a note that is only a title said %q", got)
+	}
+
+	// And one with neither says nothing rather than an empty bullet.
+	if got := conventionLine(sources.PromotedNote{Project: "work/app", State: "accepted"}); got != "" {
+		t.Errorf("an empty note produced %q", got)
+	}
+}


### PR DESCRIPTION
Session start opens with the lines an agent is told to obey:

    standing decisions in this project (promoted and still accepted — follow them unless the user overrides):
      · the migration keeps failing on retry

That is the note's title — the session's own first user line — while the decision (`--note "retry budget stays at 5"`) appeared nowhere. `conventionLine` preferred the title and fell back to the text.

Now the text is the line, with the title as the fallback for a note promoted without one:

      · retry budget stays at 5

`TestAShortConventionKeepsItsText` pinned the old preference ("a title still wins over the body") and now pins this, plus the title-only case.

Fixes #2455.