### PR TITLE
fix(view): the Notes tab leads with the decision, not the question

### DIFF
--- a/cmd/deja/view_note_headline_test.go
+++ b/cmd/deja/view_note_headline_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A promoted note's title is the session's own opening line — the question —
+// and the decision is what the person wrote. The Notes tab led each row with
+// the badge and the title, so the page read "accepted: should we move the
+// reports to a redis cache", which is the misread #2455 fixed for agents,
+// still on the page a person passes around (#2460).
+func TestTheNotesTabLeadsWithTheDecision(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	line := `{"type":"user","sessionId":"dec","timestamp":"` + at + `","cwd":"/work/app",` +
+		`"message":{"role":"user","content":"should we move the reports to a redis cache"}}`
+	if err := os.WriteFile(filepath.Join(store, "dec.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	rec := `{"ts":"` + time.Now().UTC().Format(time.RFC3339Nano) + `","project":"work/app","kind":"promoted",` +
+		`"session":"claude:dec","state":"accepted","title":"should we move the reports to a redis cache",` +
+		`"text":"no redis in front of the reports: they are materialised"}`
+	if err := os.WriteFile(notes, []byte(rec+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(tmp, "page.html")
+	if _, _, err := writeViewHTML(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	page := readFileString(t, out)
+	m := regexp.MustCompile(`(?s)const S=(.*?),R=(.*?),N=(.*?);\n`).FindStringSubmatch(page)
+	if m == nil {
+		t.Fatalf("the page's script no longer starts with the three arrays")
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(m[3]), &rows); err != nil {
+		t.Fatalf("the notes array does not decode: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want one note on the page, got %d", len(rows))
+	}
+	// Both halves reach the page: the decision and the question it answers.
+	title, _ := rows[0]["title"].(string)
+	text, _ := rows[0]["text"].(string)
+	if !strings.Contains(text, "no redis in front of the reports") {
+		t.Errorf("the decision is not on the page: %q / %q", title, text)
+	}
+	if !strings.Contains(title, "should we move the reports") {
+		t.Errorf("the question is not on the page: %q / %q", title, text)
+	}
+	// And the row is built decision-first. The page renders itself, so this is
+	// where a Go test can hold it: the headline takes the decision and falls
+	// back to the title only when a note has no text of its own.
+	row := regexp.MustCompile(`function rowN\(n\)\{([^\n]*)`).FindStringSubmatch(page)
+	if row == nil {
+		t.Fatalf("the page no longer builds its note rows in rowN")
+	}
+	if !strings.Contains(row[1], "n.text||n.title") {
+		t.Errorf("the note row does not lead with the decision:\n%s", row[1])
+	}
+	head := strings.Index(row[1], "class=\"t\"")
+	body := strings.Index(row[1], "<pre")
+	if head < 0 || body < 0 || head > body {
+		t.Errorf("the row no longer puts a headline above a body:\n%s", row[1])
+	}
+}

--- a/cmd/deja/view_template.go
+++ b/cmd/deja/view_template.go
@@ -78,7 +78,10 @@ const S={{.SessionsJSON}},R={{.RecallsJSON}},N={{.NotesJSON}};
 const esc=s=>(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 function rowS(s){return '<div class="row" onclick="this.classList.toggle(\'open\')"><span class="h">['+esc(s.harness)+']</span> <span class="t">'+esc(s.title||s.id)+'</span> <span class="m">'+esc(s.project)+' · '+esc(s.updated)+'</span>'+(s.preview?'<pre>'+esc(s.preview)+'</pre>':'')+'</div>'}
 function rowR(r){return '<div class="row" onclick="this.classList.toggle(\'open\')"><span class="h">['+esc(r.kind)+']</span> <span class="t">'+r.sessions+' sessions · '+r.bytes+' B</span> <span class="m">'+esc(r.time)+(r.policy?' · '+esc(r.policy):'')+(r.terms&&r.terms.length?' · via: '+esc(r.terms.join(', ')):'')+'</span><pre>'+esc(r.digest)+'</pre></div>'}
-function rowN(n){return '<div class="row"><span class="badge '+esc(n.state)+'">'+esc(n.state)+'</span> <span class="t">'+esc(n.title)+'</span> <span class="m">'+esc(n.project)+' · '+esc(n.at)+(n.tags&&n.tags.length?' · #'+esc(n.tags.join(' #')):'')+'</span><pre style="display:block">'+esc(n.text)+'</pre></div>'}
+// The decision heads the row. A note's title is the session's own opening line
+// — the question — so leading with it put an "accepted" badge on the question
+// (#2460). The title stays under it, as what the decision answers.
+function rowN(n){var head=n.text||n.title,under=(n.text&&n.title)?n.title:'';return '<div class="row"><span class="badge '+esc(n.state)+'">'+esc(n.state)+'</span> <span class="t">'+esc(head)+'</span> <span class="m">'+esc(n.project)+' · '+esc(n.at)+(n.tags&&n.tags.length?' · #'+esc(n.tags.join(' #')):'')+'</span>'+(under?'<pre style="display:block">'+esc(under)+'</pre>':'')+'</div>'}
 function draw(){const q=(document.getElementById('q').value||'').toLowerCase();
 const hit=S.filter(s=>!q||[s.title,s.project,s.harness,s.preview,s.id].join(' ').toLowerCase().includes(q));
 document.getElementById('list').innerHTML=hit.length?hit.map(rowS).join(''):'<div class="empty">nothing matches — try deja "'+esc(q)+'" for full-text search</div>'}


### PR DESCRIPTION
A promoted note has two halves: the title, which is the session's opening line, and the text, which is what was decided. The tab led with the title:

    [accepted] should we move the reports to a redis cache
               work/app · 2026-08-29
               no redis in front of the reports: they are materialised

an accepted question, with the answer in small type. #2455 fixed this for the block agents receive; this is the page people pass around.

Done in the template rather than in the fields: the Go side bounds a title with `SafeNoteTitle` and a body with `SafeText`, so swapping the values moves them out from under those rules — two existing tests caught that when I tried it the other way.

The other renderings of the same pair were swept and are right: session start, the search listing and `deja show` all lead with the decision.

Fixes #2459.