### PR TITLE
fix(handoff): keep room for what the session concluded

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -33,6 +33,32 @@ func Share(s model.Session, budget int) string {
 	fmt.Fprintf(&b, "- Project: %s\n", oneLine(s.Project))
 	fmt.Fprintf(&b, "- Harness: %s\n", s.Harness)
 	fmt.Fprintf(&b, "- Date: %s\n\n", date)
+	// appendSectionWithin is appendSection held to a smaller ceiling, so a
+	// section that could fill the block leaves room for the one after it.
+	appendSectionWithin := func(title string, messages []model.Message, ceiling int) {
+		if len(messages) == 0 || b.Len() >= ceiling {
+			return
+		}
+		fmt.Fprintf(&b, "## %s\n\n", title)
+		for _, m := range messages {
+			if b.Len() >= ceiling {
+				break
+			}
+			text := MessageText(m.Text)
+			if text == "" {
+				continue
+			}
+			chunk := fmt.Sprintf("%s\n\n", text)
+			// At a message boundary, with no cut marker: the marker promises
+			// that nothing follows it, and something does — the section this
+			// ceiling exists to leave room for. The block's closing sentence
+			// already tells the reader it is a compact slice.
+			if b.Len()+len(chunk) > ceiling {
+				break
+			}
+			b.WriteString(chunk)
+		}
+	}
 	appendSection := func(title string, messages []model.Message) {
 		if len(messages) == 0 || b.Len() >= budget {
 			return
@@ -72,8 +98,23 @@ func Share(s model.Session, budget int) string {
 			assistants = append(assistants, m)
 		}
 	}
-	appendSection("User problem statement(s)", dedupeStatus(users))
-	appendSection("Key assistant conclusions / code blocks", dedupeStatus(selectConclusions(assistants)))
+	// Half the budget for the question, half for the answer. The sections were
+	// written in order until the budget ran out, so a long session — where the
+	// user side is mostly "go on" — spent the whole block on problem
+	// statements and handed over no conclusions at all, which is the half a
+	// receiving agent cannot re-derive (#2462). A short session is unaffected:
+	// the reserve only binds when the first section would have eaten it.
+	conclusions := dedupeStatus(selectConclusions(assistants))
+	if len(conclusions) > 0 {
+		if reserved := budget / 2; reserved > 0 {
+			appendSectionWithin("User problem statement(s)", dedupeStatus(users), budget-reserved)
+		} else {
+			appendSection("User problem statement(s)", dedupeStatus(users))
+		}
+	} else {
+		appendSection("User problem statement(s)", dedupeStatus(users))
+	}
+	appendSection("Key assistant conclusions / code blocks", conclusions)
 	return strings.TrimSpace(b.String()) + "\n"
 }
 

--- a/internal/digest/handoff_budget_test.go
+++ b/internal/digest/handoff_budget_test.go
@@ -1,0 +1,46 @@
+package digest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A handoff is meant to carry the problem, what was concluded, and where it
+// stopped. Sections are written in order until the budget runs out, so a long
+// session — where the user side is mostly "go on" — spent the whole block on
+// problem statements and the conclusions never got a line, which is the half
+// the receiving agent cannot re-derive (#2462).
+func TestALongSessionStillHandsOverItsConclusions(t *testing.T) {
+	now := time.Now()
+	s := model.Session{ID: "long", Harness: "claude", Project: "work/app", Updated: now}
+	add := func(role, text string, i int) {
+		s.Messages = append(s.Messages, model.Message{
+			Role: role, Text: text, Time: now.Add(-time.Duration(600-i) * time.Minute),
+		})
+	}
+	add("user", "we need to cut the p99 on the orders endpoint from 900ms to under 300ms", 0)
+	for i := 0; i < 96; i++ {
+		add("assistant", fmt.Sprintf("step %d: reading handler_%d.go and measuring that span; nothing conclusive yet", i, i), 1+2*i)
+		add("user", fmt.Sprintf("go on (%d)", i), 2+2*i)
+	}
+	add("assistant", "the cause was the per-request pool checkout; a shared pool and a 200ms budget brought p99 to 240ms", 400)
+	add("user", "good — leave the retries alone for now", 401)
+
+	block := Handoff(s, 4000)
+	if !strings.Contains(block, "cut the p99 on the orders endpoint") {
+		t.Errorf("the problem statement is missing:\n%s", block)
+	}
+	if !strings.Contains(block, "Key assistant conclusions") {
+		t.Errorf("a long session handed over no conclusions section at all:\n%.400s", block)
+	}
+	if !strings.Contains(block, "per-request pool checkout") {
+		t.Errorf("what the session concluded did not survive the budget:\n%.400s", block)
+	}
+	if len(block) > 4000+200 {
+		t.Errorf("the block ran past its budget: %d bytes", len(block))
+	}
+}


### PR DESCRIPTION
Sections are written in order until the budget runs out. On a 196-message session the user side is mostly "go on (N)", so 5.4 KB of block went to problem statements and the conclusions section never appeared — losing "the cause was the per-request pool checkout; a shared pool and a 200ms budget brought p99 to 240ms", which is the half a receiving agent cannot re-derive.

The first section is now held to half the budget when there are conclusions to write, and it stops at a message boundary rather than with the cut marker: `TestNothingFollowsAMarkedCut` holds that nothing may follow that marker, and the conclusions section would.

After: problem, conclusions and "Where it stopped" all present at both the 4 KB and 6 KB budgets.

Fixes #2461.