### PR TITLE
fix(handoff): end the block where the marker says it ends

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -267,6 +267,10 @@ func looksLikeDataDump(t string) bool {
 // it carries the paragraph break with it.
 const cutMarker = "…\n\n"
 
+// cutMark is the marker without its trailing blank line, for a caller checking
+// how a block ended.
+const cutMark = "…"
+
 // cutMarked trims a passage to n bytes and says that it was cut. A block handed
 // to a person or an agent that simply stops reads as a finished thought, and the
 // end of a message is where a session says it changed its mind — the same defect
@@ -460,6 +464,27 @@ func Handoff(s model.Session, budget int) string {
 	// Drop the share header line; the framing above replaces it.
 	if i := strings.Index(body, "\n"); i > 0 && strings.HasPrefix(body, "# deja share:") {
 		body = strings.TrimSpace(body[i:])
+	}
+	// The marker says the passage before it was cut and that the block ends
+	// there — that is the rule Share and the tail each keep on their own. The
+	// handoff composes them, and put a whole section, four messages and a
+	// closing paragraph after it, so the marker stopped meaning anything
+	// (#2464). Ending the body at the last thing said in full costs the
+	// fragment and keeps the promise; what the block loses, its closing
+	// sentence already says how to fetch.
+	if trimmed := strings.TrimRight(body, " \t\n"); strings.HasSuffix(trimmed, cutMark) {
+		// Back to the last thing said in full. Only a marker Share itself
+		// wrote is treated as one, and it is always the last thing in the
+		// body — searching for the character anywhere would cut the block at
+		// an ellipsis somebody typed.
+		body = strings.TrimRight(trimmed[:len(trimmed)-len(cutMark)], " \t\n")
+		if i := strings.LastIndex(body, "\n\n"); i >= 0 {
+			body = strings.TrimRight(body[:i], " \t\n")
+		}
+		// A section header with nothing left under it says less than nothing.
+		if i := strings.LastIndex(body, "\n\n## "); i >= 0 && !strings.Contains(body[i+4:], "\n\n") {
+			body = strings.TrimRight(body[:i], " \t\n")
+		}
 	}
 	b.WriteString(body)
 	if tail := tailSection(s, budget-b.Len()); tail != "" {

--- a/internal/digest/handoff_marker_test.go
+++ b/internal/digest/handoff_marker_test.go
@@ -1,0 +1,54 @@
+package digest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// "A marker in the middle of a block is worse than none: it says the passage it
+// follows was cut and lets the next one read as continuous. Once a chunk is
+// cut, the block ends." — TestNothingFollowsAMarkedCut, which holds that for
+// `Share` and for the tail on their own. The handoff composes both and put a
+// whole section, four messages and a closing paragraph after the marker (#2464).
+func TestAHandoffDoesNotContinuePastACutMarker(t *testing.T) {
+	now := time.Now()
+	s := model.Session{ID: "long", Harness: "claude", Project: "work/app", Updated: now}
+	add := func(role, text string, i int) {
+		s.Messages = append(s.Messages, model.Message{
+			Role: role, Text: text, Time: now.Add(-time.Duration(600-i) * time.Minute),
+		})
+	}
+	add("user", "we need to cut the p99 on the orders endpoint from 900ms to under 300ms", 0)
+	for i := 0; i < 96; i++ {
+		add("assistant", fmt.Sprintf("step %d: reading handler_%d.go and measuring the %dth span, weighing whether the pool or the retries explain it", i, i, i), 1+2*i)
+		add("user", fmt.Sprintf("go on (%d)", i), 2+2*i)
+	}
+	add("assistant", "the cause was the per-request pool checkout; a shared pool and a 200ms budget brought p99 to 240ms", 400)
+	add("user", "good — leave the retries alone for now", 401)
+	add("assistant", "stopping here: the pool change is merged, the retry work is untouched", 402)
+
+	for budget := 2000; budget <= 8000; budget += 500 {
+		block := Handoff(s, budget)
+		i := strings.Index(block, "…")
+		if i < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(block[i+len("…"):])
+		// The closing sentence is deja's own framing and always ends the block;
+		// what must not follow the marker is more of the session.
+		rest = strings.TrimSpace(strings.TrimPrefix(rest, closingLine(s)))
+		if rest != "" {
+			t.Fatalf("budget %d: the handoff continues past the marker with %.200q", budget, rest)
+		}
+	}
+}
+
+// closingLine is the sentence Handoff ends with, for the test above.
+func closingLine(s model.Session) string {
+	short := idSelector(Short(s.ID))
+	return fmt.Sprintf("This is a compact slice of session %s. If anything you need is missing — an exact error, a file, a decision — search the full history with `deja \"<term>\"` or `deja show %s`, or call the deja MCP tools recall / recall_context if available.", short, short)
+}


### PR DESCRIPTION
`TestNothingFollowsAMarkedCut` states the rule: the marker says the passage before it was cut and the block ends there. The handoff composes a `Share` body with a tail, and put a whole section, four messages and a closing paragraph after it — so an agent reading the marker as the end loses the most current state deja has.

The body is now taken back to the last thing said in full before the tail is appended: only a marker Share itself wrote counts (it is always last, so an ellipsis someone typed is left alone), the trailing fragment goes with it, and a section header left with nothing under it goes too.

Measured across budgets from 800 to 6144: problem statements, conclusions and "Where it stopped" all present, no empty headers, and a prose ellipsis in a user's own line survives.

Fixes #2463.