### PR TITLE
fix(show): say when a message was stored short of the transcript

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -516,8 +516,46 @@ func cmdShow(dir string, rest []string, sourceInstance string) error {
 		fmt.Fprintln(os.Stderr, note)
 	}
 	printSpawnEdges(os.Stderr, dir, s)
+	// A pasted log is one message, and the index keeps the head of it. The
+	// window note above says when messages were left out; nothing said when a
+	// message was, so a reader searching a log for the line that explains a
+	// failure searched one they believed was whole (#2467).
+	if line := clippedMessageNote(dir, s); line != "" {
+		fmt.Fprintln(os.Stderr, line)
+	}
 	search.PrintSession(os.Stdout, s)
 	return nil
+}
+
+// clippedMessageNote says that a message in this session was stored short of
+// what the transcript holds. The count is the store's, not this session's —
+// deja records it per file at ingest — so the line names the session's own
+// file and leaves the arithmetic to `deja doctor`.
+func clippedMessageNote(dir string, s model.Session) string {
+	if s.Path == "" {
+		return ""
+	}
+	files := index.IngestFilesReport(dir)
+	e, ok := files[s.Path]
+	if !ok || e.Clipped == 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja: %s stored short of what the transcript holds — the rest of %s is in the file itself",
+		pluralMessages(e.Clipped), pluralThem(e.Clipped))
+}
+
+func pluralMessages(n int) string {
+	if n == 1 {
+		return "one message was"
+	}
+	return fmt.Sprintf("%d messages were", n)
+}
+
+func pluralThem(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
 }
 
 // showWindowNote is what the terminal says about a slice: which messages it

--- a/cmd/deja/show_clipped_test.go
+++ b/cmd/deja/show_clipped_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A pasted log is one message, and the index stores the first 64 KB of it.
+// `deja show` printed that much and said nothing, so a reader looking for the
+// line that explains a failure searched a log they believed was whole — the
+// "showed part, read as whole" family, on the door where the whole point is to
+// read a session as it was (#2467).
+func TestShowSaysWhenAMessageWasClipped(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	// Longer than what the index keeps for one message.
+	huge := strings.Repeat("2026-08-28T10:00:00Z INFO orders.pipeline step finished with pool=8 retries=0\n", 1800)
+	line := `{"type":"user","sessionId":"huge","timestamp":"` + at + `","cwd":"/work/app",` +
+		`"message":{"role":"user","content":` + jsonString(huge) + `}}`
+	if err := os.WriteFile(filepath.Join(store, "huge.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut := captureBoth(t, "show", "huge")
+	whole := out + errOut
+	if len(out) >= len(huge) {
+		t.Fatalf("the fixture was not clipped at all: %d bytes shown", len(out))
+	}
+	if !strings.Contains(whole, "stored short of what the transcript holds") {
+		t.Errorf("show printed part of a message and said nothing:\n%.400s", tail(whole))
+	}
+}
+
+// tail is the end of the output, where a note about the message would sit.
+func tail(s string) string {
+	if len(s) <= 400 {
+		return s
+	}
+	return s[len(s)-400:]
+}


### PR DESCRIPTION
A session that is one pasted log — 165 KB in a single message — goes through every door bounded and fast: `last` 102 B, `share` 1.7 KB, `handoff` 3.9 KB, the page 17 KB, the session-start block 832 B, indexing 0.2 s. `show` prints 65 KB of it, which is what the index keeps, and said nothing about the other 100 KB.

`doctor --json` already knew: `ingest_health: {"claude": {"clipped_messages": 1}}`. Now `show` says it too:

    deja: one message was stored short of what the transcript holds — the rest of it is in the file itself

Same family as the session window note (#2296), blame, log, friction and the page: a surface that shows part of something has to say it is part.

Fixes #2467.