### PR TITLE
fix(usage): record the reader's own search in the log

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1249,7 +1249,16 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 	// line, since a script reading deja wants the text and not the layout
 	// (#604).
 	o.Width = printableWidth(os.Stdout)
-	search.Print(os.Stdout, hits, o)
+	// Through a counter, so the log records what actually went out rather than
+	// a guess at it. `deja log` is the audit of what deja did, and the search
+	// kind has been named in the docs, in the comment over the kind constants
+	// and in the empty-log line since #47 while nothing ever wrote one (#2471).
+	// It stays out of every count: servedKind and injectedKind both exclude it,
+	// so the statusline and the impact screen still speak only for memory that
+	// reached an agent.
+	counted := &countingWriter{w: os.Stdout}
+	search.Print(counted, hits, o)
+	usage.RecordResult(dir, usage.KindSearch, counted.n, len(hits), len(hits) == 0)
 	// A wrong guess at a command name falls through to search, and the hint
 	// that names it ran only on an empty result — so a typo whose word happens
 	// to be in the history got a conversation back and nothing about the

--- a/cmd/deja/search_logged_test.go
+++ b/cmd/deja/search_logged_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// deja log is the audit of what deja did, and three places say a search shows
+// up in it: the docs ("`search` and `handoff` are the reader's own commands"),
+// the comment over the kind constants, and the empty-log line itself. No path
+// has ever written one (#2471).
+func TestASearchLandsInTheLog(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	body := strings.Repeat("the pool checkout dominated the p99 of the orders pipeline ", 20)
+	lines := []string{
+		`{"type":"user","sessionId":"p1","timestamp":"` + at + `","cwd":"/work/app","message":{"role":"user","content":"why is the p99 high? ` + body + `"}}`,
+		`{"type":"assistant","sessionId":"p1","timestamp":"` + at + `","cwd":"/work/app","message":{"role":"assistant","content":"the shared pool is the p99 ` + body + `"}}`,
+	}
+	if err := os.WriteFile(filepath.Join(store, "p1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runSearch(dir, []string{"pool", "p99"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSearch(dir, []string{"zzzznothinghere"}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var found, empty int
+	for _, e := range eventsOf(dir) {
+		if e.Kind != usage.KindSearch {
+			continue
+		}
+		if e.Empty {
+			empty++
+			continue
+		}
+		found++
+		if e.Sessions == 0 || e.Bytes == 0 {
+			t.Errorf("a search that matched recorded nothing about it: %#v", e)
+		}
+	}
+	if found != 1 || empty != 1 {
+		t.Errorf("two searches, one with hits and one without, left %d matched and %d empty events in the log", found, empty)
+	}
+}
+
+func eventsOf(dir string) []usage.Event {
+	events, _ := usage.EventsCounted(dir, 50)
+	return events
+}


### PR DESCRIPTION
Closes #2471.

`KindSearch` has been declared since #47 and no path ever wrote one, while the docs, the comment over the kind constants and the empty-log line all tell the reader a search shows up in `deja log`. The CLI search now records one event with the bytes actually printed and the sessions shown.

Nothing on the counting screens moves: `servedKind` and `injectedKind` both exclude `search`, and `TestWritingKindsAreNotServings` already pins that. Checked by hand on a six-session store — three hook starts and two searches — the impact arithmetic before and after is the same 2994 B served / 9753 B raw / 3×.
