### PR TITLE
fix(install): read the .jsonc block as a parser does when dropping deja's entry

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1651,18 +1651,29 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 // the rest of it in the block and the config stopped parsing (#2394), so the
 // entry is bounded by counting braces the way the block itself is.
 func dropJSONCEntry(lines []string) (body, dropped []string) {
+	// On the code a parser reads, not the raw line. A comment that only names
+	// deja — a parked entry someone commented out, a note saying who wrote the
+	// block — is not an entry to replace, and dropping its first line leaves a
+	// /* … */ closing on its own, which costs the reader every server in the
+	// file (#2473). The same reading keeps a brace inside a comment out of the
+	// depth count. jsoncLastCodeLine already reads the block this way to place
+	// its comma.
+	inBlock := false
 	for i := 0; i < len(lines); i++ {
-		l := lines[i]
-		if !strings.Contains(l, `"deja"`) {
-			body = append(body, l)
+		code, next, _ := jsoncCodeOf(lines[i], inBlock)
+		inBlock = next
+		if !strings.Contains(code, `"deja"`) {
+			body = append(body, lines[i])
 			continue
 		}
-		dropped = append(dropped, l)
-		depth := strings.Count(l, "{") - strings.Count(l, "}")
+		dropped = append(dropped, lines[i])
+		depth := strings.Count(code, "{") - strings.Count(code, "}")
 		for depth > 0 && i+1 < len(lines) {
 			i++
+			c, nb, _ := jsoncCodeOf(lines[i], inBlock)
+			inBlock = nb
 			dropped = append(dropped, lines[i])
-			depth += strings.Count(lines[i], "{") - strings.Count(lines[i], "}")
+			depth += strings.Count(c, "{") - strings.Count(c, "}")
 		}
 	}
 	return body, dropped

--- a/cmd/deja/install_jsonc_comment_test.go
+++ b/cmd/deja/install_jsonc_comment_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A .jsonc config that only mentions deja in a comment has no deja entry to
+// replace. The drop loop matched the word anywhere on the line, so it deleted
+// the comment — and with a block comment it deleted the opening line and left
+// the closing */ behind, which costs the reader every server in the file
+// (#2473).
+func TestACommentThatMentionsDejaSurvivesTheInstall(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		old  string
+		keep string
+	}{
+		{
+			name: "a line comment",
+			old: `{
+  "mcp": {
+    // "deja": {"type":"local","command":["/old/deja","mcp"]},
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  }
+}`,
+			keep: `// "deja"`,
+		},
+		{
+			name: "a block comment",
+			old: `{
+  "mcp": {
+    /* the "deja" server is installed by ` + "`deja install`" + `
+       do not edit this block by hand */
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  }
+}`,
+			keep: "/* the \"deja\" server",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, note, err := updateOpencodeJSONC([]byte(tc.old), "/usr/local/bin/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(out)
+			if !strings.Contains(got, tc.keep) {
+				t.Errorf("the comment is gone:\n%s", got)
+			}
+			if !strings.Contains(got, `"mine"`) {
+				t.Errorf("the server the comment sat above is gone:\n%s", got)
+			}
+			if !strings.Contains(got, `"deja": {"type":"local","command":["/usr/local/bin/deja","mcp"]}`) {
+				t.Errorf("deja was not added:\n%s", got)
+			}
+			if note != "" {
+				t.Errorf("nothing was replaced, but install says %q", note)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2473.

`dropJSONCEntry` looked for `"deja"` anywhere on a line. A config that only mentions deja in a comment lost that comment and `install` reported a replacement that never happened; with a `/* … */` comment it dropped the opening line and left the closing `*/` behind, so the config stopped parsing and opencode lost every server in it.

It now matches and counts braces on `jsoncCodeOf(line, inBlock)` — the code a parser reads — which is how `jsoncLastCodeLine` already reads the same block to place its comma.
