### PR TITLE
fix(install): do not count a brace inside a quoted path as structure

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1667,13 +1667,13 @@ func dropJSONCEntry(lines []string) (body, dropped []string) {
 			continue
 		}
 		dropped = append(dropped, lines[i])
-		depth := strings.Count(code, "{") - strings.Count(code, "}")
+		depth := jsoncBraceDelta(code)
 		for depth > 0 && i+1 < len(lines) {
 			i++
 			c, nb, _ := jsoncCodeOf(lines[i], inBlock)
 			inBlock = nb
 			dropped = append(dropped, lines[i])
-			depth += strings.Count(c, "{") - strings.Count(c, "}")
+			depth += jsoncBraceDelta(c)
 		}
 	}
 	return body, dropped
@@ -1736,6 +1736,35 @@ func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end
 	return strings.TrimSpace(b.String()), inBlock, end
 }
 
+// jsoncBraceDelta counts the braces of one line's code that a parser reads as
+// structure. Comments are already out — jsoncCodeOf strips them, and keeps
+// string contents because the `"deja"` match and the comma offset both need
+// them — so what is left to skip here is quoted text. A command path holding a
+// brace is ordinary (`${VENDOR}` left literal, `/opt/{a,b}/bin`, a Windows GUID
+// directory), and counting one as structure moved the end of the "mcp" block:
+// deja's entry landed outside it, or inside it without a comma, or the drop
+// loop swallowed the server underneath (#2475).
+func jsoncBraceDelta(code string) int {
+	depth := 0
+	inString, escaped := false, false
+	for i := 0; i < len(code); i++ {
+		switch c := code[i]; {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+		}
+	}
+	return depth
+}
+
 func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string, error) {
 	line := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
 	s := string(old)
@@ -1747,12 +1776,18 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 	}
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	start, end := -1, -1
+	inBlock := false
 	for i, l := range lines {
-		if strings.Contains(l, `"mcp"`) && strings.Contains(l, "{") {
+		code, next, _ := jsoncCodeOf(l, inBlock)
+		inBlock = next
+		if strings.Contains(code, `"mcp"`) && strings.Contains(code, "{") {
 			start = i
-			depth := strings.Count(l, "{") - strings.Count(l, "}")
+			depth := jsoncBraceDelta(code)
+			block := inBlock
 			for j := i + 1; j < len(lines); j++ {
-				depth += strings.Count(lines[j], "{") - strings.Count(lines[j], "}")
+				c, nb, _ := jsoncCodeOf(lines[j], block)
+				block = nb
+				depth += jsoncBraceDelta(c)
 				if depth <= 0 {
 					end = j
 					break

--- a/cmd/deja/install_jsonc_brace_test.go
+++ b/cmd/deja/install_jsonc_brace_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// jsoncValue reads a .jsonc file the way a config parser does: comments out,
+// trailing commas out, then JSON. A test that only looked at the text would
+// miss the case where deja's entry lands outside the "mcp" block — that file
+// parses, it just does not wire deja to anything.
+func jsoncValue(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	s := regexp.MustCompile(`(?m)//.*$`).ReplaceAllString(string(b), "")
+	s = regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(s, "")
+	s = regexp.MustCompile(`,(\s*[}\]])`).ReplaceAllString(s, "$1")
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("the config no longer parses (%v):\n%s", err, b)
+	}
+	return m
+}
+
+// The writer bounds the "mcp" block by counting braces as text, so a brace
+// inside a quoted command path counts as structure: an unmatched "{" puts
+// deja's entry outside the block, an unmatched "}" puts it in without a comma,
+// and one in deja's own entry makes the drop loop swallow the server under it
+// (#2475). Paths like ${VENDOR} or /opt/{a,b}/bin are ordinary.
+func TestABraceInAQuotedPathIsNotStructure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		old  string
+		keep string
+	}{
+		{
+			name: "an unmatched open brace",
+			old: `{
+  "mcp": {
+    "tools": {"type":"local","command":["/opt/shells/{/bin/tools"]},
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  },
+  "theme": "dark"
+}`,
+			keep: "tools",
+		},
+		{
+			name: "an unmatched closing brace",
+			old: `{
+  "mcp": {
+    "tools": {"type":"local","command":["/opt/shells/}/bin/tools"]},
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  },
+  "theme": "dark"
+}`,
+			keep: "tools",
+		},
+		{
+			name: "a brace in deja's own entry",
+			old: `{
+  "mcp": {
+    "deja": {"type":"local","command":["/opt/{/deja","mcp"]},
+    "mine": {"type":"local","command":["/usr/bin/mine"]}
+  }
+}`,
+			keep: "mine",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := updateOpencodeJSONC([]byte(tc.old), "/usr/local/bin/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := jsoncValue(t, out)
+			mcp, _ := got["mcp"].(map[string]any)
+			if mcp == nil {
+				t.Fatalf("the mcp block is gone:\n%s", out)
+			}
+			if _, ok := mcp["deja"]; !ok {
+				t.Errorf("deja is not in the mcp block:\n%s", out)
+			}
+			if _, ok := got["deja"]; ok {
+				t.Errorf("deja was written as a top-level key, where opencode will not look for it:\n%s", out)
+			}
+			if _, ok := mcp[tc.keep]; !ok {
+				t.Errorf("the %q server the reader already had is gone:\n%s", tc.keep, out)
+			}
+			if strings.Contains(string(out), `"/usr/local/bin/deja"`) == false {
+				t.Errorf("deja's own command is not in the file:\n%s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2475.

The `.jsonc` writer bounded the `mcp` block by counting braces as text, so a brace inside a quoted command path counted as structure. An unmatched `{` put deja's entry outside the block — the file parses, install says `updated`, and deja is wired to nothing; an unmatched `}` put it inside without a comma; one in deja's own entry made the drop loop swallow the server underneath. The last two leave a config that no longer parses, so opencode loses every server in it.

Braces are now counted outside quoted strings. Paths like `${VENDOR}` left literal or `/opt/{a,b}/bin` are ordinary; a balanced pair only survived by luck.
