### PR TITLE
fix(install): tell deja's hook line apart from one the reader wrapped it in

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1146,20 +1146,92 @@ func hookStatusMessage(event string) string {
 	return ""
 }
 
-// isDejaHookCommand reports whether an existing hook entry is one of ours for
-// the same subcommand. Matching on the trailing subcommand rather than the
-// whole string means moving the binary replaces the old entry instead of
-// leaving a duplicate that fires alongside the new one.
-func isDejaHookCommand(existing any, cmd string) bool {
+// hookCommandKind says whose a hook command is. The word "deja" anywhere in the
+// line is not the test: a tool living under /home/deja is somebody else's, and
+// a line the reader wrote around deja's own invocation is theirs even though it
+// runs ours (#2477). What decides it is the token in front of the subcommand.
+type hookCommandKind int
+
+const (
+	// hookNotDejas: deja did not write this and does not run in it.
+	hookNotDejas hookCommandKind = iota
+	// hookDejas: the line deja writes — the binary and the subcommand, nothing
+	// else. Install repoints it at the current path; uninstall takes it out.
+	hookDejas
+	// hookWrapsDejas: the reader's own line, which runs deja's hook as part of
+	// something larger. It is already installed, so adding deja's line beside
+	// it would run the hook twice at every session start; and it is not deja's
+	// to rewrite or to delete.
+	hookWrapsDejas
+)
+
+func hookCommandKindOf(existing any, cmd string) hookCommandKind {
 	s, ok := existing.(string)
-	if !ok {
-		return false
+	if !ok || s == "" {
+		return hookNotDejas
 	}
 	if s == cmd {
-		return true
+		return hookDejas
 	}
 	sub := cmd[strings.LastIndex(cmd, " ")+1:]
-	return strings.HasSuffix(s, " "+sub) && strings.Contains(s, "deja")
+	for i := 0; i < len(s); {
+		j := strings.Index(s[i:], " "+sub)
+		if j < 0 {
+			return hookNotDejas
+		}
+		at := i + j
+		end := at + 1 + len(sub)
+		if isDejaBinaryToken(lastShellToken(s[:at])) && subcommandEndsAt(s[end:]) {
+			if strings.TrimSpace(s) == strings.TrimSpace(lastShellToken(s[:at])+" "+sub) {
+				return hookDejas
+			}
+			return hookWrapsDejas
+		}
+		i = end
+	}
+	return hookNotDejas
+}
+
+// isDejaHookCommand reports whether deja's hook runs in this command at all,
+// whether as the line deja wrote or inside one the reader did. Callers that go
+// on to rewrite the command ask for hookDejas instead.
+func isDejaHookCommand(existing any, cmd string) bool {
+	return hookCommandKindOf(existing, cmd) != hookNotDejas
+}
+
+// lastShellToken is the word a command name would occupy: the last run of
+// non-space characters before the subcommand.
+func lastShellToken(s string) string {
+	f := strings.Fields(s)
+	if len(f) == 0 {
+		return ""
+	}
+	return f[len(f)-1]
+}
+
+// isDejaBinaryToken reports whether a token names the deja binary, quoted or
+// not, under any directory, on either platform's separator.
+func isDejaBinaryToken(tok string) bool {
+	tok = strings.Trim(tok, `"'`)
+	if i := strings.LastIndexAny(tok, `/\`); i >= 0 {
+		tok = tok[i+1:]
+	}
+	return tok == "deja" || tok == "deja.exe"
+}
+
+// subcommandEndsAt reports whether the subcommand really ended where it was
+// found, rather than being the head of a longer word: "hook-prompt" must not
+// match inside "hook-prompt-extra". A quote, a shell separator or the end of
+// the line all end it.
+func subcommandEndsAt(rest string) bool {
+	if rest == "" {
+		return true
+	}
+	switch rest[0] {
+	case ' ', '\t', '\'', '"', ';', '&', '|', ')', '`', '\n':
+		return true
+	}
+	return false
 }
 
 func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall bool) map[string]any {
@@ -1188,7 +1260,20 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 		removed := false
 		for _, hAny := range hs {
 			h, _ := hAny.(map[string]any)
-			if h != nil && h["type"] == "command" && isDejaHookCommand(h["command"], cmd) {
+			kind := hookNotDejas
+			if h != nil && h["type"] == "command" {
+				kind = hookCommandKindOf(h["command"], cmd)
+			}
+			if kind == hookWrapsDejas {
+				// This hook is already installed, inside a line deja did not
+				// write. Leaving it alone is the whole of what to do: a second
+				// entry would inject memory twice, and rewriting it would throw
+				// away whatever else the reader put on that line.
+				found = true
+				kept = append(kept, hAny)
+				continue
+			}
+			if kind == hookDejas {
 				if uninstall {
 					removed = true
 					continue

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -101,7 +101,10 @@ func adoptCodexHookEntry(entry map[string]any, cmd, event string) {
 	hs, _ := entry["hooks"].([]any)
 	for _, hAny := range hs {
 		h, _ := hAny.(map[string]any)
-		if h == nil || h["type"] != "command" || !isDejaHookCommand(h["command"], cmd) {
+		// hookDejas, not "deja runs in here somewhere": a line the reader
+		// wrote around our hook is theirs, and rewriting it throws away the
+		// rest of what it does (#2477).
+		if h == nil || h["type"] != "command" || hookCommandKindOf(h["command"], cmd) != hookDejas {
 			continue
 		}
 		h["command"] = cmd

--- a/cmd/deja/install_hook_wrapper_test.go
+++ b/cmd/deja/install_hook_wrapper_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func sessionStartCommands(t *testing.T, root map[string]any) []string {
+	t.Helper()
+	hooks, _ := root["hooks"].(map[string]any)
+	entries, _ := hooks["SessionStart"].([]any)
+	var out []string
+	for _, e := range entries {
+		entry, _ := e.(map[string]any)
+		hs, _ := entry["hooks"].([]any)
+		for _, h := range hs {
+			cmd, _ := h.(map[string]any)["command"].(string)
+			out = append(out, cmd)
+		}
+	}
+	return out
+}
+
+func hookRootWith(cmd string) map[string]any {
+	return map[string]any{"hooks": map[string]any{"SessionStart": []any{
+		map[string]any{"hooks": []any{map[string]any{"type": "command", "command": cmd}}},
+	}}}
+}
+
+// The reader's own line that runs deja's hook is deja's hook: adding a second
+// entry runs it twice at every session start, and rewriting the line throws
+// away whatever else it did. Somebody else's tool that merely lives under a
+// path containing the word is not deja's (#2477).
+func TestAHookWrapperIsNeitherDuplicatedNorRewritten(t *testing.T) {
+	const cmd = "/new/path/deja hook-context"
+	for _, tc := range []struct {
+		name    string
+		was     string
+		want    []string
+		wantSub string
+	}{
+		{
+			name: "a wrapper around deja's own hook",
+			was:  `sh -c 'caffeinate -i /usr/local/bin/deja hook-context'`,
+			want: []string{`sh -c 'caffeinate -i /usr/local/bin/deja hook-context'`},
+		},
+		{
+			name: "a wrapper that runs something first",
+			was:  "/usr/local/bin/mylog && /usr/local/bin/deja hook-context",
+			want: []string{"/usr/local/bin/mylog && /usr/local/bin/deja hook-context"},
+		},
+		{
+			name: "somebody else's tool under a path with the word in it",
+			was:  "/home/deja/bin/mytool hook-context",
+			want: []string{"/home/deja/bin/mytool hook-context", cmd},
+		},
+		{
+			name: "deja's own hook at an older path",
+			was:  "/old/path/deja hook-context",
+			want: []string{cmd},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sessionStartCommands(t, updateClaudeHook(hookRootWith(tc.was), "SessionStart", cmd, "", false))
+			if strings.Join(got, "\n") != strings.Join(tc.want, "\n") {
+				t.Errorf("install left\n  %s\nwant\n  %s", strings.Join(got, "\n  "), strings.Join(tc.want, "\n  "))
+			}
+		})
+	}
+}
+
+// Uninstall takes deja's own line out and leaves the reader's alone: a wrapper
+// is their command, and somebody else's tool was never deja's to remove.
+func TestUninstallLeavesLinesThatAreNotDejasOwn(t *testing.T) {
+	const cmd = "/new/path/deja hook-context"
+	for _, tc := range []struct {
+		was  string
+		want []string
+	}{
+		{was: "/old/path/deja hook-context", want: nil},
+		{was: "/home/deja/bin/mytool hook-context", want: []string{"/home/deja/bin/mytool hook-context"}},
+		{was: "/usr/local/bin/mylog && /usr/local/bin/deja hook-context", want: []string{"/usr/local/bin/mylog && /usr/local/bin/deja hook-context"}},
+	} {
+		got := sessionStartCommands(t, updateClaudeHook(hookRootWith(tc.was), "SessionStart", cmd, "", true))
+		if strings.Join(got, "\n") != strings.Join(tc.want, "\n") {
+			t.Errorf("uninstall of %q left %q, want %q", tc.was, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2477.

`isDejaHookCommand` asked whether a hook command ended with deja's subcommand and mentioned `deja` anywhere. A line like `sh -c '… /usr/local/bin/deja hook-context'` ends in a quote, so it was not recognised and deja installed a second hook beside it — memory injected twice at every session start. A line like `mylog && /usr/local/bin/deja hook-context` was recognised and silently rewritten to deja's own command, and uninstall then deleted it. A tool under `/home/deja/bin` was treated as ours in both directions.

What decides it now is the token immediately before the subcommand: `…/deja hook-context` is deja's line and gets repointed or removed; the same invocation inside a larger line is the reader's — already installed, so no second entry, and not deja's to rewrite or delete.
