### PR TITLE
perf(rank): pay coverage only on words that identify something

### DIFF
--- a/internal/index/coverage_identifying_test.go
+++ b/internal/index/coverage_identifying_test.go
@@ -1,0 +1,42 @@
+package index
+
+import "testing"
+
+// Coverage multiplies a session's score by how much of the query it covers, and
+// it used to count every word the informative gate let through. That gate is
+// deliberately generous: it decides whether a term is worth speaking about at
+// all, and takes the more forgiving of its two readings of "rare" so a subject
+// word is never dismissed as filler. The two readings come apart on the shape a
+// real store is full of — a word sitting in one message of each of many long
+// sessions is ordinary counted in sessions and rare counted in messages.
+//
+// Paying for coverage on the forgiving reading pays a session for the words a
+// question happens to be phrased with. "Can you suggest a hotel for my trip" is
+// four such words and one that matters.
+func TestCoverageIsPaidOnTheWordsThatIdentify(t *testing.T) {
+	// Session 1 covers three ordinary words and nothing else; session 2 carries
+	// the one word that identifies.
+	all := map[uint32]int{1: 3, 2: 1}
+	identifying := map[uint32]int{2: 1}
+
+	got := coverageCounts(all, identifying, 1)
+	if got[1] != 0 {
+		t.Errorf("a session covering only ordinary words was still paid for "+
+			"covering %d of them", got[1])
+	}
+	if got[2] != 1 {
+		t.Errorf("the session carrying the identifying word lost its coverage: %d", got[2])
+	}
+}
+
+// A question made entirely of ordinary words has nothing to count strictly, and
+// counting them is all there is: dropping to zero coverage everywhere would
+// leave the ranking with one less signal exactly where it is thinnest.
+func TestCoverageKeepsTheGenerousCountWhenNothingIdentifies(t *testing.T) {
+	all := map[uint32]int{1: 3, 2: 2}
+	got := coverageCounts(all, map[uint32]int{}, 0)
+	if got[1] != 3 || got[2] != 2 {
+		t.Errorf("the generous count was dropped on a query with no identifying "+
+			"word: %v", got)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -507,6 +507,24 @@ func relevanceResult(ss []model.Session, matched int, idf map[string]float64) Se
 	}
 }
 
+// coverageCounts picks which count of matched terms coverage is paid on.
+//
+// When something in the query identifies on its own, coverage is counted over
+// those terms alone: the ordinary words a question is phrased with stop earning
+// a session credit for covering the query. When nothing does — a question made
+// entirely of ordinary words — counting them is all there is, and the generous
+// reading of the gate stands.
+//
+// Measured: LoCoMo 69.8% to 70.2% R@1 and MRR .768 to .770; on LongMemEval-S
+// the preference questions, which are ordinary words around one that matters,
+// go 33.3% to 36.7% hit@1 with the total unmoved.
+func coverageCounts(all, identifying map[uint32]int, identifyingTerms int) map[uint32]int {
+	if identifyingTerms == 0 {
+		return all
+	}
+	return identifying
+}
+
 // rankIDF is what a match is WORTH: documents counted in sessions, the unit
 // ranking has always used. Weighting by the gate's number instead lifts every
 // term a few long sessions happen to repeat, which reorders the top of the
@@ -826,6 +844,11 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	// kept and the better place of the two is used, at a price.
 	focus := map[uint32]float64{}
 	matchedTerms := map[uint32]int{}
+	// Coverage counted over the terms that identify something on their own,
+	// kept alongside so the choice between the two can be made once the whole
+	// query has been read rather than term by term.
+	identifyingTerms := 0
+	matchedIdentifying := map[uint32]int{}
 	strongTerms := map[uint32]int{}
 	anyTerms := map[uint32]int{}
 	// perMessage tracks how many distinct terms hit each message (record
@@ -1023,6 +1046,19 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			rank = 0.1
 		}
 		informative := idf >= dejaVuIDFFloor || minSess <= 2
+		// Identifying is the same bar read against the number the score itself
+		// uses: rare counted in whole sessions. gateIDF deliberately takes the
+		// more generous of its two verdicts so that a subject word is never
+		// called filler, which is what a term has to clear to be spoken about
+		// at all. Coverage is a different question — it multiplies a session's
+		// score by how much of the query it covers — and answering it
+		// generously pays a session for the ordinary words a question is
+		// phrased with. "Can you suggest a hotel for my trip" is four such
+		// words and one that matters.
+		identifying := rank >= dejaVuIDFFloor || minSess <= 2
+		if identifying {
+			identifyingTerms++
+		}
 		// Rare enough to identify something on its own: either well past the
 		// ordinary bar, or living in a single session of the whole corpus.
 		strong := idf >= dejaVuStrongIDFFloor || minSess <= 1
@@ -1055,11 +1091,15 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			if informative {
 				matchedTerms[ord]++
 			}
+			if identifying {
+				matchedIdentifying[ord]++
+			}
 			if strong {
 				strongTerms[ord]++
 			}
 		}
 	}
+	matchedTerms = coverageCounts(matchedTerms, matchedIdentifying, identifyingTerms)
 	ranked := make([]relevanceScored, 0, len(score))
 	for ord, sc := range score {
 		if sc <= 0 {


### PR DESCRIPTION
The informative gate answers two different questions with one number. Whether a term is worth speaking about at all takes the more generous of its two readings of "rare", so a subject word is never dismissed as filler. Coverage — the multiplier for how much of the query a session covers — was reading the same number, which pays a session for the ordinary words a question happens to be phrased with. "Can you suggest a hotel for my trip" is four of those and one that matters.

The two readings come apart on the shape a real store is full of: a word in one message of each of fifty long sessions is ordinary counted in sessions and rare counted in messages.

Now coverage is counted over the terms that identify on their own; when nothing in the query does, the generous count stands, since counting those words is all there is.

LoCoMo 69.8% to 70.2% R@1, MRR .768 to .770. LongMemEval-S preference questions 33.3% to 36.7% hit@1, total unmoved. bench prompt, recall and context unchanged.