### PR TITLE
fix(install): keep what the reader put on deja's MCP entry

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1074,9 +1074,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	if uninstall {
 		delete(m, "deja")
 	} else {
-		entry := mcpServerEntry(exe)
-		note = replacedEntryNote(m["deja"], entry)
-		m["deja"] = entry
+		m["deja"], note = mergeDejaEntry(m["deja"], mcpServerEntry(exe))
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1468,7 +1466,78 @@ func replacedEntryNote(prev, entry any) string {
 	if was == "" {
 		return "replaced the deja entry that was already here"
 	}
+	// The same command is not a replacement anyone would want told about. An
+	// entry an older deja wrote differs from this one by a field or two the
+	// format gained since, and saying "replaced … which ran /bin/deja" of
+	// /bin/deja is noise sitting where a real takeover should stand out
+	// (#2479).
+	if was == entryCommandName(entry) {
+		return ""
+	}
 	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
+}
+
+// entryRunsDeja reports whether an MCP entry runs the deja binary, wherever the
+// config keeps it: a command string, a command list, or the args behind a
+// wrapper like Windows' `cmd /c`.
+func entryRunsDeja(entry map[string]any) bool {
+	var words []string
+	switch c := entry["command"].(type) {
+	case string:
+		words = append(words, c)
+	case []any:
+		for _, v := range c {
+			if s, ok := v.(string); ok {
+				words = append(words, s)
+			}
+		}
+	}
+	if args, ok := entry["args"].([]any); ok {
+		for _, v := range args {
+			if s, ok := v.(string); ok {
+				words = append(words, s)
+			}
+		}
+	}
+	for _, w := range words {
+		if isDejaBinaryToken(w) {
+			return true
+		}
+	}
+	return false
+}
+
+// mergeDejaEntry writes deja's wiring onto the entry that was already there.
+// deja owns the command, the args and the type; an env pointing at a store on
+// another disk, a timeout, a `disabled` the reader set — those are theirs, and
+// replacing the whole entry threw them away on every reinstall (#2479).
+func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
+	note := replacedEntryNote(prev, entry)
+	old, ok := prev.(map[string]any)
+	// Only onto an entry that was deja's. Keeping the fields of somebody
+	// else's entry — a `url` of a remote server, an env built for another
+	// program — would leave a mixed shape whose client has to guess which half
+	// to believe.
+	if !ok || !entryRunsDeja(old) {
+		return entry, note
+	}
+	out := make(map[string]any, len(old)+len(entry))
+	for k, v := range old {
+		out[k] = v
+	}
+	for k, v := range entry {
+		out[k] = v
+	}
+	if disabled, _ := out["disabled"].(bool); disabled {
+		// Switching it back on silently would undo a decision deja was not
+		// asked to revisit; leaving it off without a word looks like a install
+		// that worked.
+		if note != "" {
+			note += "; "
+		}
+		note += "left the entry disabled, the way it was — deja will not answer until you turn it back on"
+	}
+	return out, note
 }
 
 // sameEntry compares an entry read out of a config with the one deja is about
@@ -1565,9 +1634,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 		delete(m, "deja")
 	} else {
 		command, args := mcpCommandArgs(exe)
-		entry := map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}}
-		note = replacedEntryNote(m["deja"], entry)
-		m["deja"] = entry
+		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1616,9 +1683,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 		delete(servers, "deja")
 	} else {
 		command, args := mcpCommandArgs(exe)
-		entry := map[string]any{"command": command, "args": args}
-		note = replacedEntryNote(servers["deja"], entry)
-		servers["deja"] = entry
+		servers["deja"], note = mergeDejaEntry(servers["deja"], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1660,9 +1725,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 		delete(m, "deja")
 	} else {
 		command, args := mcpCommandArgs(exe)
-		entry := map[string]any{"command": command, "args": args}
-		note = replacedEntryNote(m["deja"], entry)
-		m["deja"] = entry
+		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1719,9 +1782,7 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	if uninstall {
 		delete(m, "deja")
 	} else {
-		entry := map[string]any{"type": "local", "command": []string{exe, "mcp"}}
-		note = replacedEntryNote(m["deja"], entry)
-		m["deja"] = entry
+		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cmd/deja/install_entry_fields_test.go
+++ b/cmd/deja/install_entry_fields_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func dejaMCPEntry(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	entry, _ := servers["deja"].(map[string]any)
+	if entry == nil {
+		t.Fatalf("no deja entry left in %s:\n%s", path, b)
+	}
+	return entry
+}
+
+func writeClaudeMCP(t *testing.T, home string, entry map[string]any) string {
+	t.Helper()
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".claude.json")
+	b, err := json.MarshalIndent(map[string]any{"mcpServers": map[string]any{"deja": entry}}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// deja owns the command, the args and the type on its own entry. An env the
+// reader added, or a disabled flag they set, is theirs — replacing the whole
+// entry threw both away, and the note reported a replacement of the command by
+// itself while saying nothing about what actually went (#2479).
+func TestInstallKeepsWhatTheReaderPutOnDejasEntry(t *testing.T) {
+	home := filepath.Join(hermeticEnv(t), "home")
+	path := writeClaudeMCP(t, home, map[string]any{
+		"command":  "/old/bin/deja",
+		"args":     []string{"mcp"},
+		"env":      map[string]any{"DEJA_INDEX_DIR": "/data/index.db"},
+		"disabled": true,
+	})
+
+	res, err := installClaude("/new/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := dejaMCPEntry(t, path)
+	if entry["command"] != "/new/bin/deja" {
+		t.Errorf("the command was not repointed: %v", entry["command"])
+	}
+	env, _ := entry["env"].(map[string]any)
+	if env["DEJA_INDEX_DIR"] != "/data/index.db" {
+		t.Errorf("the reader's env is gone: %v", entry["env"])
+	}
+	if entry["disabled"] != true {
+		t.Errorf("install switched a disabled server back on: %v", entry["disabled"])
+	}
+	if res.Note == "" {
+		t.Errorf("the command really did change and the entry is disabled, and install said nothing")
+	}
+}
+
+// The same install run twice, and an entry an older deja wrote: the command is
+// the same either way, so there is nothing to report.
+func TestInstallIsQuietWhenTheCommandDidNotChange(t *testing.T) {
+	home := filepath.Join(hermeticEnv(t), "home")
+	writeClaudeMCP(t, home, map[string]any{"command": "/bin/deja", "args": []string{"mcp"}})
+
+	res, err := installClaude("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Note != "" {
+		t.Errorf("nothing the reader would call a replacement happened, but install says %q", res.Note)
+	}
+}
+
+// Only onto an entry that was deja's. A remote-server shape someone put under
+// the deja name is replaced whole: keeping its url beside deja's command would
+// leave the client two answers to choose between.
+func TestInstallDoesNotMergeIntoAnEntryThatIsNotDejas(t *testing.T) {
+	home := filepath.Join(hermeticEnv(t), "home")
+	path := writeClaudeMCP(t, home, map[string]any{"url": "https://example.invalid/mcp"})
+
+	if _, err := installClaude("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	entry := dejaMCPEntry(t, path)
+	if _, ok := entry["url"]; ok {
+		t.Errorf("the remote shape survived beside deja's own wiring: %v", entry)
+	}
+	if entry["command"] != "/bin/deja" {
+		t.Errorf("deja is not wired: %v", entry)
+	}
+}


### PR DESCRIPTION
Closes #2479.

The five MCP writers set `m["deja"] = entry`, so anything the reader added to deja's own entry went away on every reinstall: an `env` pointing the index at another disk, a `disabled` they had set. The note that reported it named only the command, which was usually the same command — it fired on an entry an older deja wrote and said nothing about what actually vanished.

deja now writes its wiring onto the entry that was there, when that entry ran deja; a shape that is not deja's (a remote `url`, somebody else's command) is still replaced whole. The note is silent when the command did not change, and an entry left disabled says so instead of being switched back on in silence.
