### PR TITLE
feat(recall): reach a rephrased question's answer through the project's own words

### DIFF
--- a/internal/index/bridged_retry_test.go
+++ b/internal/index/bridged_retry_test.go
@@ -1,0 +1,92 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// bridgedStore holds the three things a rephrased question needs to be
+// answerable: the session that settled it in the project's own word, a session
+// that explains that word in ordinary ones, and enough other sessions that the
+// ordinary words are not rare by accident.
+func bridgedStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	for i := 0; i < 80; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("filler%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user", Text: "notes on the weekly planning meeting and the invoice"}},
+		})
+	}
+	// Said in three sessions, which is the evidence the co-occurrence map asks
+	// for before it records a pairing.
+	for i := 0; i < 3; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("explains%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: "the debounce is how long we wait before sending what someone typed"}},
+		})
+	}
+	sessions = append(sessions, model.Session{
+		ID: "answer", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "we set the debounce on the search box to 250ms"}},
+	})
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A question asked in words the project does not use reaches the session that
+// settled it, through the sentence that ties the two vocabularies.
+//
+// The rescue rung in cooccur.go cannot: it intersects postings, so the best it
+// can reach is the record holding both vocabularies — the sentence that
+// explains the word, never the session that used it and settled something.
+func TestARephrasedQuestionReachesTheAnswer(t *testing.T) {
+	dir := bridgedStore(t)
+	terms := []string{"long", "wait", "sending", "typed"}
+	ranked, _, _, _, err := ProjectRelevant(dir, []string{"p"}, terms, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	got := make([]string, 0, len(ranked))
+	for _, s := range ranked {
+		got = append(got, s.ID)
+		if s.ID == "answer" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the session that settled it was never reached: %v", got)
+	}
+}
+
+// The same machinery must not answer a question whose subject the project never
+// held. Its words are ordinary, and the corpus's neighbours for ordinary words
+// are every subject it has — which is how a bridge becomes a machine for
+// confident wrong answers.
+func TestAnAbsentSubjectIsNotBridgedTo(t *testing.T) {
+	dir := bridgedStore(t)
+	ranked, _, strong, _, err := ProjectRelevant(dir, []string{"p"}, []string{"open", "file", "read"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, s := range ranked {
+		if s.ID == "answer" && strong[i] > 0 {
+			t.Errorf("a question about something the project never held was "+
+				"answered with %q", s.ID)
+		}
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -587,6 +587,9 @@ func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip m
 		// stays quiet on an error.
 		return nil, nil, nil, nil, rerr
 	}
+	if bm, bmatched, bstrong, bidf, ok := bridgedRetry(dir, m, projects, terms, n, skip, strong, idf); ok {
+		metas, matched, strong, idf = bm, bmatched, bstrong, bidf
+	}
 	if len(metas) == 0 {
 		return nil, nil, nil, nil, nil
 	}
@@ -595,6 +598,124 @@ func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip m
 		return nil, nil, nil, nil, err
 	}
 	return out, matched, strong, idf, nil
+}
+
+const bridgeTerms = 4
+
+// bridgedRetry answers a question asked in words the project does not use.
+//
+// The ranking has just read every term and nothing it found identifies
+// anything: no session holds a word of this question rare enough to be worth an
+// unprompted recall. That is what a rephrasing looks like from inside — the
+// answer is there in the words the project actually uses, and the question
+// shares none of them.
+//
+// The corpus knows the pairing: a session that says "the debounce is how long
+// we wait before sending" puts both vocabularies in one message, and the
+// co-occurrence map records it. But that map is built over the whole store,
+// and a question about something this project never held is made of ordinary
+// words whose neighbours are every subject any project ever had — so the map
+// alone answers both kinds of question with equal confidence. Measured on the
+// bench's negative controls, bridging on the map alone fired on three of
+// twelve questions with no answer to find.
+//
+// So the tie has to be the project's own. A candidate is kept only when some
+// record in this project says it in the same breath as the question's word,
+// which is the sentence that explains the term — the thing a rephrasing has
+// and an absent subject does not.
+func bridgedRetry(dir string, m Manifest, projects, terms []string, n int, skip map[string]bool,
+	strong []int, idfOf map[string]float64) ([]SessionMeta, []int, []int, map[string]float64, bool) {
+	was := 0
+	for _, v := range strong {
+		if v > was {
+			was = v
+		}
+	}
+	neighbours := readCooccur(dir)
+	if neighbours == nil {
+		return nil, nil, nil, nil, false
+	}
+	inProject := map[uint32]bool{}
+	for key, meta := range m.Sessions {
+		_ = key
+		for _, want := range projects {
+			if projectInScope(meta.Project, want) {
+				inProject[meta.Ord] = true
+				break
+			}
+		}
+	}
+	have := make(map[string]bool, len(terms))
+	for _, t := range terms {
+		have[t] = true
+	}
+	added := make([]string, 0, bridgeTerms)
+	for _, t := range terms {
+		// Bridge from a word that means something. "open the file and read it"
+		// is three ordinary words, and the corpus's neighbours for ordinary
+		// words are its subjects — that sentence was the one negative control
+		// this fired on.
+		if idfOf[t] < dejaVuStrongIDFFloor {
+			continue
+		}
+		tPosts, terr := postingsFor(dir, "t"+t)
+		if terr != nil || len(tPosts) == 0 {
+			continue
+		}
+		at := make(map[int64]bool, len(tPosts))
+		for _, pp := range tPosts {
+			if inProject[pp.Sid] {
+				at[pp.Off] = true
+			}
+		}
+		if len(at) == 0 {
+			continue
+		}
+		for _, cand := range neighbours[t] {
+			if have[cand] || query.IsStopWord(cand) {
+				continue
+			}
+			cPosts, cerr := postingsFor(dir, "t"+cand)
+			if cerr != nil || len(cPosts) == 0 {
+				continue
+			}
+			tied := false
+			for _, pp := range cPosts {
+				if inProject[pp.Sid] && at[pp.Off] {
+					tied = true
+					break
+				}
+			}
+			if !tied {
+				continue
+			}
+			have[cand] = true
+			added = append(added, cand)
+			if len(added) == bridgeTerms {
+				break
+			}
+		}
+		if len(added) == bridgeTerms {
+			break
+		}
+	}
+	if len(added) == 0 {
+		return nil, nil, nil, nil, false
+	}
+	metas, matched, bstrong, idf, err := relevantMetasMatched(dir, m, projects,
+		append(append([]string{}, terms...), added...), n, skip)
+	if err != nil || len(metas) == 0 {
+		return nil, nil, nil, nil, false
+	}
+	// Taken only when the bridge found something more identifying than the
+	// question's own words did. Otherwise the project has no better answer and
+	// the first ranking stands.
+	for _, v := range bstrong {
+		if v > was {
+			return metas, matched, bstrong, idf, true
+		}
+	}
+	return nil, nil, nil, nil, false
 }
 
 func relevantMetasMatched(dir string, m Manifest, projects, terms []string, n int, skip map[string]bool) ([]SessionMeta, []int, []int, map[string]float64, error) {


### PR DESCRIPTION
A question asked a month later is asked in different words. The ranking reads every one of them and finds nothing that identifies anything, because the answer is written in the word the project actually uses and the question shares none of it.

The corpus already knows the pairing — some session says "the debounce is how long we wait before sending" and the co-occurrence map records it. The rescue rung in cooccur.go cannot use that to answer: it intersects postings, so the furthest it reaches is the record holding both vocabularies, which is the sentence explaining the word, never the session that settled something with it. Measured on the corpus the tied arm is built from, it returned nothing at all for five of its six chains, and it is only consulted when every other rung came back empty — which for these questions never happens.

So the lookup happens in the ranking instead, and twice guarded, because the map alone cannot tell a rephrasing from a question about something the project never held: both are ordinary words, and the neighbours of ordinary words are every subject the store has. The tie has to be the project's own — some record here says the candidate in the same breath as the question's word — and the bridge starts only from a word rare enough to justify a recall on its own. Without the second guard it fired on "open the file and read it".

Taken only when it finds something more identifying than the question's own words did, so a project with no answer stays quiet.

bench prompt: reworded-tied 1/6 to 4/6 correct, negative controls still 0 false fires of 12, real questions 13/13, reworded 15/20, all unchanged. LoCoMo and LongMemEval-S unmoved (they do not use this path). Hook latency on a 1696-session store: median 74ms to 85ms, p90 353ms to 370ms.