### PR TITLE
fix(install): say that uninstall leaves gemini's hooks switch on

### DIFF
--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -24,15 +24,22 @@ const geminiExtensionName = "deja"
 func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 	dir := filepath.Join(sources.GeminiHome(), "extensions", geminiExtensionName)
 	if uninstall {
+		// hooksConfig stays: other extensions may rely on it, and turning it
+		// off would silently disable them. Said aloud, because the rest of
+		// this uninstall names what it keeps — "guidance kept …" — so silence
+		// here reads as "nothing of deja's is left in settings.json", and a
+		// switch deja turned on is (#2487).
+		note := ""
+		if geminiHooksEnabled() {
+			note = "left hooksConfig.enabled on in gemini's settings.json — other extensions may be running on it"
+		}
 		if _, err := os.Stat(dir); err != nil {
-			return installResult{Path: dir, Action: "unchanged"}, nil
+			return installResult{Path: dir, Action: "unchanged", Note: note}, nil
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			return installResult{}, err
 		}
-		// hooksConfig stays: other extensions may rely on it, and turning it
-		// off would silently disable them.
-		return installResult{Path: dir, Action: "removed"}, nil
+		return installResult{Path: dir, Action: "removed", Note: note}, nil
 	}
 	if err := os.MkdirAll(filepath.Join(dir, "hooks"), 0o755); err != nil {
 		return installResult{}, err
@@ -87,6 +94,23 @@ func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	return installResult{Path: dir, Action: a}, nil
+}
+
+// geminiHooksEnabled reports whether the master switch is on right now, which
+// is all an uninstall can honestly say about it: deja cannot tell its own flip
+// from one the reader made before ever installing.
+func geminiHooksEnabled() bool {
+	b, err := os.ReadFile(filepath.Join(sources.GeminiHome(), "settings.json"))
+	if err != nil {
+		return false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		return false
+	}
+	cfg, _ := root["hooksConfig"].(map[string]any)
+	enabled, _ := cfg["enabled"].(bool)
+	return enabled
 }
 
 // enableGeminiHooks flips the master switch. Without it the extension is

--- a/cmd/deja/install_gemini_hooksconfig_test.go
+++ b/cmd/deja/install_gemini_hooksconfig_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Installing for Gemini turns on hooksConfig.enabled, a switch that belongs to
+// the harness rather than to deja. Uninstall leaves it on for a good reason —
+// another extension may be running on it — and said nothing, while naming every
+// other thing it kept (#2487).
+func TestUninstallSaysItLeftGeminiHooksOn(t *testing.T) {
+	home := filepath.Join(hermeticEnv(t), "home")
+	path := filepath.Join(sources.GeminiHome(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"theme":"GitHub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = home
+
+	if _, err := installGeminiAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	res, err := installGeminiAuto("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ := root["hooksConfig"].(map[string]any)
+	if enabled, _ := cfg["enabled"].(bool); !enabled {
+		t.Fatalf("this test is about the switch staying on; it is off:\n%s", b)
+	}
+	if !strings.Contains(res.Note, "hooksConfig") {
+		t.Errorf("uninstall left a harness-wide switch on and its note does not mention it: %q", res.Note)
+	}
+}
+
+// Nothing to say when deja never turned it on.
+func TestUninstallIsQuietWhenGeminiHooksAreOff(t *testing.T) {
+	home := filepath.Join(hermeticEnv(t), "home")
+	_ = home
+	res, err := installGeminiAuto("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Note, "hooksConfig") {
+		t.Errorf("nothing was left on, but uninstall says %q", res.Note)
+	}
+}


### PR DESCRIPTION
Closes #2487.

Installing for Gemini turns on `hooksConfig.enabled`, since the extension's hooks never run without it. Uninstall leaves it on deliberately — another extension may be running on it — and said nothing, while naming everything else it keeps ("guidance kept …"). Reading that output, you would think nothing of deja's was left in settings.json.

Swept every target: install each, uninstall each, diff against the configs a reader would have had. This switch was the only thing not restored.

    gemini-auto: removed ~/.gemini/extensions/deja
                 left hooksConfig.enabled on in gemini's settings.json — other extensions may be running on it
