### PR TITLE
fix(hook-tool-after): say how often the error came up, not just that it did

### DIFF
--- a/cmd/deja/hook_after_scope_wording_test.go
+++ b/cmd/deja/hook_after_scope_wording_test.go
@@ -17,7 +17,7 @@ func TestTheAfterErrorLineSaysWhoseCommandItIs(t *testing.T) {
 	other := fixLine(index.FixPair{
 		Error: "panic: quaxbolt overflow", Command: "make acme-widen-cast",
 		Key: "claude:acme0", When: when, Project: "clients/acme/api",
-	})
+	}, 1)
 	if other == "" {
 		t.Fatal("no line for a usable pair, so this measures nothing")
 	}
@@ -36,7 +36,7 @@ func TestTheAfterErrorLineSaysWhoseCommandItIs(t *testing.T) {
 	old := fixLine(index.FixPair{
 		Error: "panic: quaxbolt overflow", Command: "make widen-cast",
 		Key: "claude:s0", When: when,
-	})
+	}, 1)
 	if old == "" || !strings.Contains(old, "make widen-cast") {
 		t.Errorf("a pair without a project lost its line: %q", old)
 	}

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -276,14 +276,28 @@ func fixPairLine(dir, output string) string {
 		return pol.Allows(policy.ActivationAuto, project)
 	})
 	for _, p := range pairs {
-		if line := fixLine(p); line != "" {
+		if line := fixLine(p, frictionCount(dir, p, pol)); line != "" {
 			return line
 		}
 	}
 	return ""
 }
 
-func fixLine(p index.FixPair) string {
+// frictionCount is how many sessions hit this error, scoped the way the line
+// that reports it is scoped: the pair names a project, so the count is that
+// project's, and a machine-wide pair counts machine-wide. Same trust rule as
+// the pair itself.
+func frictionCount(dir string, p index.FixPair, pol policy.Policy) int {
+	project := strings.TrimSpace(p.Project)
+	return index.FrictionSessions(dir, p.Sig, func(proj string) bool {
+		if !pol.Allows(policy.ActivationAuto, proj) {
+			return false
+		}
+		return project == "" || proj == project
+	})
+}
+
+func fixLine(p index.FixPair, sessions int) string {
 	// Some harnesses store the command with the prompt they printed it after;
 	// the line reads as an instruction, so it should not start with a shell
 	// prompt the reader would have to mentally strip.
@@ -307,7 +321,16 @@ func fixLine(p index.FixPair) string {
 	if project := strings.TrimSpace(search.SafeLine(p.Project)); project != "" {
 		where = "in " + project
 	}
-	return "deja: this error came up " + where + " before" + when + " — what followed it: " + cmd
+	// How often, not just that it happened: "came up before" reads as a
+	// coincidence where "came up in 12 sessions" reads as a property of this
+	// machine. friction, the environment block and the plan finding all lead
+	// with the count; this line, the one that arrives at the moment of the
+	// failure, said only "before" (#2491).
+	how := ""
+	if sessions > 1 {
+		how = " in " + toolSessionCount(sessions)
+	}
+	return "deja: this error came up" + how + " " + where + " before" + when + " — what followed it: " + cmd
 }
 
 // exitMarker is the shape a source appends when it knows what a command

--- a/cmd/deja/hook_tool_after_count_test.go
+++ b/cmd/deja/hook_tool_after_count_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The count is what turns a remedy into a decision: "came up before" reads as a
+// coincidence, "came up in 12 sessions" reads as a property of this machine.
+// friction, the environment block and the plan finding all lead with it; the
+// line that arrives at the moment of the failure did not (#2491).
+func TestTheAfterHookSaysHowOftenTheErrorCameUp(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wall := "psql: error: connection to the orders migration database failed: Connection refused"
+	now := time.Now().UTC()
+	for k := 0; k < 12; k++ {
+		at := now.Add(-time.Duration(600-20*k) * time.Minute).Format(time.RFC3339)
+		var lines []string
+		add := func(role string, content any) {
+			b, err := json.Marshal(map[string]any{"type": role, "sessionId": fmt.Sprintf("m%d", k),
+				"timestamp": at, "cwd": "/work/app", "message": map[string]any{"role": role, "content": content}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines = append(lines, string(b))
+		}
+		add("user", fmt.Sprintf("run the orders migration (%d) against the production database", k))
+		add("assistant", []any{map[string]any{"type": "tool_use", "name": "Bash",
+			"input": map[string]any{"command": "make migrate-orders"}}})
+		add("user", []any{map[string]any{"type": "tool_result", "is_error": true, "content": wall}})
+		add("assistant", []any{map[string]any{"type": "tool_use", "name": "Bash",
+			"input": map[string]any{"command": "docker compose up -d db"}}})
+		add("user", []any{map[string]any{"type": "tool_result", "content": "db started"}})
+		if err := os.WriteFile(filepath.Join(store, fmt.Sprintf("m%d.jsonl", k)),
+			[]byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	line := fixPairLine(dir, wall)
+	if line == "" {
+		t.Fatalf("the fixture found no fix pair for the wall")
+	}
+	if !strings.Contains(line, "docker compose up -d db") {
+		t.Errorf("the remedy is missing: %s", line)
+	}
+	if !strings.Contains(line, "12 sessions") {
+		t.Errorf("twelve sessions hit this error and the line does not say so:\n  %s", line)
+	}
+}

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -443,6 +443,36 @@ func hitFromRecords(recs []Record) []uint64 {
 	return out
 }
 
+// FrictionSessions counts the sessions that hit one wall, by the signature a
+// FixPair carries. The manifest already holds every session's hashes and is
+// cached, so a caller in a hook pays a map walk rather than a read — which is
+// what lets the line that arrives at the moment of a failure say how often this
+// machine has been here (#2491).
+//
+// allow gates a session's project the way TopFriction's does.
+func FrictionSessions(dir string, sig uint64, allow func(project string) bool) int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, meta := range m.Sessions {
+		if allow != nil && !allow(meta.Project) {
+			continue
+		}
+		for _, h := range meta.Hit {
+			if h == sig {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
 // FindFriction picks the wall worth showing on a screen with room for one. See
 // TopFriction for allow.
 func FindFriction(dir string, allow func(project string) bool) (Friction, bool) {

--- a/internal/index/friction_sessions_test.go
+++ b/internal/index/friction_sessions_test.go
@@ -1,0 +1,43 @@
+package index
+
+import (
+	"testing"
+)
+
+// The count behind the after-tool hook's line (#2491): sessions carrying one
+// wall's signature, gated by the caller's activation the way TopFriction is.
+func TestFrictionSessionsCountsAndScopes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if n := FrictionSessions(dir, 1, nil); n != 0 {
+		t.Errorf("an index that does not exist counted %d sessions", n)
+	}
+
+	m := Manifest{Sessions: map[string]SessionMeta{
+		"claude:a": {ID: "a", Harness: "claude", Project: "app", Hit: []uint64{7, 9}},
+		"claude:b": {ID: "b", Harness: "claude", Project: "app", Hit: []uint64{7}},
+		"claude:c": {ID: "c", Harness: "claude", Project: "other", Hit: []uint64{7}},
+		"claude:d": {ID: "d", Harness: "claude", Project: "app", Hit: []uint64{9}},
+		// One session hitting the same wall twice is still one session.
+		"claude:e": {ID: "e", Harness: "claude", Project: "app", Hit: []uint64{7, 7}},
+	}}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	if n := FrictionSessions(dir, 7, nil); n != 4 {
+		t.Errorf("counted %d sessions for the wall, want 4", n)
+	}
+	if n := FrictionSessions(dir, 7, func(p string) bool { return p == "app" }); n != 3 {
+		t.Errorf("counted %d in app, want 3", n)
+	}
+	if n := FrictionSessions(dir, 42, nil); n != 0 {
+		t.Errorf("counted %d for a wall nobody hit", n)
+	}
+
+	// An empty dir falls back to the default, which the env var above points
+	// at the same place.
+	if n := FrictionSessions("", 7, nil); n != 4 {
+		t.Errorf("the default dir counted %d, want 4", n)
+	}
+}


### PR DESCRIPTION
Closes #2491.

Twelve sessions ran the same command, hit the same wall, and then ran the same fix. `deja friction` says "12 sessions"; the plan finding says "wall hit in 4 sessions"; the line that arrives at the moment of the failure said "this error came up in home/work before". The count is what turns a remedy into a decision — "before" reads as a coincidence.

    deja: this error came up in 12 sessions in home/work before (2026-08-29) — what followed it: docker compose up -d db

`index.FrictionSessions` counts sessions carrying the pair's signature out of the cached manifest, scoped to the pair's project and to the auto activation, so the count and the sentence around it agree.

Left for the queue: the pre-tool hook, which before running that same command says only that the machine has run it, while every one of those runs ended at this wall.
