### PR TITLE
fix(install): a redirect ends deja's subcommand too

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1228,6 +1228,12 @@ func subcommandEndsAt(rest string) bool {
 	switch rest[0] {
 	case ' ', '\t', '\'', '"', ';', '&', '|', ')', '`', '\n':
 		return true
+	// A redirect glued to the word ends it the same way a pipe does, and no
+	// subcommand contains one. Left out at first, so `deja hook-context>>/tmp/x`
+	// read as somebody else's command and deja installed its hook beside it —
+	// two session starts, memory injected twice (#2493).
+	case '>', '<':
+		return true
 	}
 	return false
 }

--- a/cmd/deja/install_hook_redirect_test.go
+++ b/cmd/deja/install_hook_redirect_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+)
+
+// A redirect written without a space ends the command word as surely as a pipe
+// does. It was not in the set, so a line that already runs deja's hook was read
+// as somebody else's and deja installed a second one beside it — the session
+// start then injects memory twice (#2493).
+func TestARedirectEndsTheSubcommand(t *testing.T) {
+	const cmd = "/new/path/deja hook-context"
+	for _, was := range []string{
+		"/usr/local/bin/deja hook-context>>/tmp/deja.log",
+		"/usr/local/bin/deja hook-context>/tmp/deja.log",
+		"/usr/local/bin/deja hook-context</dev/null",
+		"/usr/local/bin/deja hook-context|tee /tmp/deja.log",
+	} {
+		got := sessionStartCommands(t, updateClaudeHook(hookRootWith(was), "SessionStart", cmd, "", false))
+		if len(got) != 1 || got[0] != was {
+			t.Errorf("install turned\n  %q\ninto\n  %q\nwant the reader's line alone", was, got)
+		}
+	}
+}
+
+// A subcommand that is the head of a longer word is still not ours.
+func TestALongerSubcommandIsNotOurs(t *testing.T) {
+	const cmd = "/new/path/deja hook-context"
+	was := "/usr/local/bin/deja hook-context-extra"
+	got := sessionStartCommands(t, updateClaudeHook(hookRootWith(was), "SessionStart", cmd, "", false))
+	if len(got) != 2 {
+		t.Errorf("a different subcommand was taken for ours: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2493.

The leftover rev447 named on #2477: `subcommandEndsAt` counted a space, a quote, `;`, `&`, `|`, `)`, a backtick and a newline as ending deja's subcommand, but not a redirect glued to the word. So `…/deja hook-context>>/tmp/deja.log` read as somebody else's command and deja installed its own hook beside it — two session-start hooks, memory injected twice, nothing said. The same line with a pipe was recognised and left alone.

Also checked: the retire path leaves the reader's wrapper alone on Claude, since PreCompact is not retired there.
