### PR TITLE
fix(hook-tool): carry the promoted decision at the moment of the edit

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -326,6 +326,14 @@ func fileHookLine(dir, cwd, path string) string {
 // digest surfaces, but delivered at the moment the file is about to change.
 func fileDecisionLine(dir string, metas []index.SessionMeta) string {
 	sort.Slice(metas, func(i, j int) bool { return metas[i].Updated.After(metas[j].Updated) })
+	// A promoted note first. It is the user's own statement about this work,
+	// which is why the session-start block leads with it and calls it standing;
+	// scanning for a conclusion instead handed back whatever the newest session
+	// happened to end with — "looked at retry.go again (5)" in front of "the
+	// retry budget stays at 5" (#2495).
+	if line := promotedDecisionFor(metas); line != "" {
+		return line
+	}
 	states := sources.PromotedLifecycles()
 	for i, meta := range metas {
 		if i >= toolHookDecisionScan {
@@ -348,7 +356,56 @@ func fileDecisionLine(dir string, metas []index.SessionMeta) string {
 	return ""
 }
 
-// decisionUsable rejects a session whose decision should not be reused: one that
+// promotedDecisionFor returns the newest accepted promoted note belonging to one
+// of these sessions. Accepted only, for the reason projectConventions gives: a
+// decision later reversed carries a non-accepted state, and LoadPromotedNotes
+// keeps the latest state per source.
+func promotedDecisionFor(metas []index.SessionMeta) string {
+	if len(metas) == 0 {
+		return ""
+	}
+	want := make(map[string]bool, len(metas))
+	for _, meta := range metas {
+		want[meta.Harness+":"+meta.ID] = true
+		if meta.OrigID != "" {
+			want[meta.Harness+":"+meta.OrigID] = true
+		}
+	}
+	var best sources.PromotedNote
+	for _, note := range sources.LoadPromotedNotes() {
+		if note.State != "accepted" || !want[note.Session] {
+			continue
+		}
+		if best.Session == "" || note.At.After(best.At) {
+			best = note
+		}
+	}
+	text := strings.TrimSpace(best.Text)
+	if text == "" {
+		text = strings.TrimSpace(best.Title)
+	}
+	if text == "" {
+		return ""
+	}
+	return trimTrailingFragment(search.SafeText(clipDecision(text, toolHookDecisionBudget)))
+}
+
+// clipDecision keeps a promoted note inside the same budget a scanned
+// conclusion is held to, so one long note cannot take the line over.
+func clipDecision(s string, budget int) string {
+	if len(s) <= budget {
+		return s
+	}
+	// On a rune boundary: a note in Russian or Japanese cut mid-character puts
+	// invalid UTF-8 into the payload an agent is handed.
+	end := budget
+	for end > 0 && !utf8.ValidString(s[:end]) {
+		end--
+	}
+	return s[:end]
+}
+
+// decisionUsable rejects a session whose decision should not be reused:// decisionUsable rejects a session whose decision should not be reused: one that
 // says in its own words it backed the approach out (GaveUp), and one a later
 // state marked rejected, superseded or stale. Surfacing either at the point of an
 // edit would push the agent to redo exactly what was undone.

--- a/cmd/deja/hook_tool_promoted_test.go
+++ b/cmd/deja/hook_tool_promoted_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The line before an edit exists to carry the decision rather than point at it.
+// A promoted note is the user's own statement about the work — the session-start
+// block leads with it and calls it standing — and at the moment of the edit it
+// was thrown away for whatever the newest session happened to end with (#2495).
+func TestTheEditLineCarriesThePromotedDecision(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	write := func(sid string, minutes int, msgs [][2]any) {
+		var lines []string
+		for i, m := range msgs {
+			rec := map[string]any{"type": m[0], "sessionId": sid,
+				"timestamp": now.Add(-time.Duration(minutes-i) * time.Minute).Format(time.RFC3339),
+				"cwd":       "/work/app", "message": map[string]any{"role": m[0], "content": m[1]}}
+			b, err := json.Marshal(rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines = append(lines, string(b))
+		}
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	edit := func(old string) any {
+		return []any{map[string]any{"type": "tool_use", "name": "Edit",
+			"input": map[string]any{"file_path": "/work/app/retry.go", "old_string": old, "new_string": "y"}}}
+	}
+	write("dec", 200, [][2]any{
+		{"user", "should the retry budget go up to 10 for the payments client?"},
+		{"assistant", edit("return 3")},
+		{"assistant", "no: the pool change is what fixed the timeouts, the retry budget stays at 5"},
+	})
+	for k := 0; k < 6; k++ {
+		write(fmt.Sprintf("f%d", k), 150-10*k, [][2]any{
+			{"user", fmt.Sprintf("work on retry.go and the payments client (%d), the timeouts are back", k)},
+			{"assistant", edit(fmt.Sprintf("x%d", k))},
+			{"assistant", fmt.Sprintf("looked at retry.go again (%d)", k)},
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := sources.AppendPromoted("app", "should the retry budget go up to 10 for the payments client?",
+		"the retry budget stays at 5; the pool change is what fixed the timeouts",
+		"claude:dec", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+
+	line := fileHookLine(dir, "/work/app", "/work/app/retry.go")
+	if line == "" {
+		t.Fatal("the fixture produced no line at all")
+	}
+	if !strings.Contains(line, "retry budget stays at 5") {
+		t.Errorf("the promoted decision about this file is not in the line:\n  %s", line)
+	}
+}

--- a/cmd/deja/hook_tool_promoted_test.go
+++ b/cmd/deja/hook_tool_promoted_test.go
@@ -76,3 +76,52 @@ func TestTheEditLineCarriesThePromotedDecision(t *testing.T) {
 		t.Errorf("the promoted decision about this file is not in the line:\n  %s", line)
 	}
 }
+
+// The metas reaching fileDecisionLine are already scoped by the auto
+// activation, but LoadPromotedNotes reads every note on the machine. A rule
+// that withholds this memory has to take its promoted decision with it.
+func TestAWithheldPromotedDecisionStaysOut(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	for k := 0; k < 6; k++ {
+		var lines []string
+		for i, m := range [][2]any{
+			{"user", fmt.Sprintf("work on retry.go (%d)", k)},
+			{"assistant", []any{map[string]any{"type": "tool_use", "name": "Edit",
+				"input": map[string]any{"file_path": "/work/app/retry.go", "old_string": fmt.Sprintf("x%d", k), "new_string": "y"}}}},
+			{"assistant", "no: the retry budget stays at 5"},
+		} {
+			rec := map[string]any{"type": m[0], "sessionId": fmt.Sprintf("p%d", k),
+				"timestamp": now.Add(-time.Duration(100-i) * time.Minute).Format(time.RFC3339),
+				"cwd":       "/work/app", "message": map[string]any{"role": m[0], "content": m[1]}}
+			b, err := json.Marshal(rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines = append(lines, string(b))
+		}
+		if err := os.WriteFile(filepath.Join(store, fmt.Sprintf("p%d.jsonl", k)),
+			[]byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := sources.AppendPromoted("app", "retry", "the retry budget stays at 5",
+		"claude:p0", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+	writePolicy(t, `{"activations":{"auto":{"local":false}}}`)
+
+	if line := fileHookLine(dir, "/work/app", "/work/app/retry.go"); line != "" {
+		t.Errorf("memory the auto rule withholds still speaks before the edit:\n  %s", line)
+	}
+}


### PR DESCRIPTION
Closes #2495.

Read one promoted decision across every surface that names it: the search listing, the session-start block, MCP recall and recall_context all serve the note. The line before an edit — the one whose whole argument is that it carries the decision instead of pointing at it — served a filler sentence from a newer session:

    before: retry.go has been worked on in 7 sessions, last 2026-08-29 — prior decision: looked at retry.go again (5)
    after:  retry.go has been worked on in 7 sessions, last 2026-08-29 — prior decision: the retry budget stays at 5; the pool change is what fixed the timeouts

`fileDecisionLine` now prefers an accepted promoted note from the sessions already in scope, and falls back to the conclusion scan when there is none. Accepted only, on the same rule `projectConventions` uses.
