### PR TITLE
perf(notes): remember one parse of the notes file per process

### DIFF
--- a/internal/sources/lifecycle.go
+++ b/internal/sources/lifecycle.go
@@ -31,7 +31,28 @@ type Lifecycle struct {
 // Binding the state to the session rather than hoping the correction wins the
 // ranking is the difference between recording a lifecycle and using one.
 func PromotedLifecycles() map[string]Lifecycle {
-	return promotedLifecyclesFrom(NotesFile())
+	path := NotesFile()
+	size, mod, statOK := notesStamp(path)
+	notesMemo.Lock()
+	if notesFresh(path, size, mod, statOK) && notesMemo.states != nil {
+		out := notesMemo.states
+		notesMemo.Unlock()
+		return out
+	}
+	notesMemo.Unlock()
+
+	out := promotedLifecyclesFrom(path)
+	notesMemo.Lock()
+	if statOK {
+		if !notesFresh(path, size, mod, statOK) {
+			notesMemo.path, notesMemo.size, notesMemo.mod = path, size, mod
+			notesMemo.stamped, notesMemo.notes = true, nil
+		}
+		notesMemo.states = out
+	}
+	notesMemo.parses++
+	notesMemo.Unlock()
+	return out
 }
 
 func promotedLifecyclesFrom(path string) map[string]Lifecycle {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -580,7 +580,10 @@ func LoadPromotedNotes() []PromotedNote {
 	size, mod, statOK := notesStamp(path)
 	notesMemo.Lock()
 	if notesFresh(path, size, mod, statOK) && notesMemo.notes != nil {
-		out := notesMemo.notes
+		// A copy: the caller owns what it gets. The page appends its synced
+		// decisions to this slice and sorts the result, and handing back the
+		// memo's own array would let that reorder what the next caller reads.
+		out := append([]PromotedNote(nil), notesMemo.notes...)
 		notesMemo.Unlock()
 		return out
 	}
@@ -593,7 +596,9 @@ func LoadPromotedNotes() []PromotedNote {
 			notesMemo.path, notesMemo.size, notesMemo.mod = path, size, mod
 			notesMemo.stamped, notesMemo.states = true, nil
 		}
-		notesMemo.notes = out
+		// The memo keeps its own array for the same reason the read above
+		// hands out a copy.
+		notesMemo.notes = append([]PromotedNote(nil), out...)
 	}
 	notesMemo.parses++
 	notesMemo.Unlock()

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -523,11 +524,79 @@ type PromotedNote struct {
 	At      time.Time
 }
 
+// notesMemo remembers one parse of the notes file. The file only grows — every
+// promotion, every sync import, for the life of the machine — and it is read
+// twice by a single `hook-tool` run before an edit: once for the promoted
+// decision, once for the lifecycle states behind the conclusion scan (#2497).
+// Keyed on size and modification time, so a promotion made in one MCP call is
+// visible in the next; the manifest is remembered the same way.
+var notesMemo struct {
+	sync.Mutex
+	path    string
+	size    int64
+	mod     time.Time
+	notes   []PromotedNote
+	states  map[string]Lifecycle
+	parses  int
+	stamped bool
+}
+
+// notesParses counts the parses that actually read the file, for the test that
+// pins the memo.
+func notesParses() int {
+	notesMemo.Lock()
+	defer notesMemo.Unlock()
+	return notesMemo.parses
+}
+
+// notesStamp identifies the file a memo was built from. A file that cannot be
+// stat'd is never memoized: the read below answers with nothing and remembering
+// that would hide the file arriving a moment later.
+func notesStamp(path string) (int64, time.Time, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	return fi.Size(), fi.ModTime(), true
+}
+
+// notesFresh reports whether the memo still describes the file, and takes the
+// lock's word for it — callers hold the lock.
+func notesFresh(path string, size int64, mod time.Time, ok bool) bool {
+	return ok && notesMemo.stamped && notesMemo.path == path &&
+		notesMemo.size == size && notesMemo.mod.Equal(mod)
+}
+
 // LoadPromotedNotes returns the latest state per promoted source session.
 func LoadPromotedNotes() []PromotedNote {
+	path := NotesFile()
+	size, mod, statOK := notesStamp(path)
+	notesMemo.Lock()
+	if notesFresh(path, size, mod, statOK) && notesMemo.notes != nil {
+		out := notesMemo.notes
+		notesMemo.Unlock()
+		return out
+	}
+	notesMemo.Unlock()
+
+	out := loadPromotedNotesFrom(path)
+	notesMemo.Lock()
+	if statOK {
+		if !notesFresh(path, size, mod, statOK) {
+			notesMemo.path, notesMemo.size, notesMemo.mod = path, size, mod
+			notesMemo.stamped, notesMemo.states = true, nil
+		}
+		notesMemo.notes = out
+	}
+	notesMemo.parses++
+	notesMemo.Unlock()
+	return out
+}
+
+func loadPromotedNotesFrom(path string) []PromotedNote {
 	latest := map[string]*PromotedNote{}
 	var order []string
-	_ = scanJSONLFromOffset(NotesFile(), 0, func(m map[string]any) {
+	_ = scanJSONLFromOffset(path, 0, func(m map[string]any) {
 		kind, _ := m["kind"].(string)
 		if kind != "promoted" {
 			return

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -530,6 +530,13 @@ type PromotedNote struct {
 // decision, once for the lifecycle states behind the conclusion scan (#2497).
 // Keyed on size and modification time, so a promotion made in one MCP call is
 // visible in the next; the manifest is remembered the same way.
+//
+// What that key cannot see: a hand edit that changes no byte count — swapping
+// `accepted` for `rejected` is the same eight characters — on a filesystem
+// whose modification times are whole seconds, read again by the same
+// long-lived process inside that second. Every write deja makes is an append,
+// so this needs a person editing the file by hand at exactly that moment; the
+// next read after that second sees it.
 var notesMemo struct {
 	sync.Mutex
 	path    string

--- a/internal/sources/notes_memo_test.go
+++ b/internal/sources/notes_memo_test.go
@@ -52,3 +52,26 @@ func TestTheNotesFileIsParsedOncePerProcess(t *testing.T) {
 		t.Fatalf("a changed file was answered from the memo: %+v", got)
 	}
 }
+
+// The caller owns the slice it gets: the view page appends to it and sorts it.
+func TestAMemoisedReadCannotBeReorderedByItsCaller(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeNotesFile(t, path,
+		`{"kind":"promoted","session":"claude:a","project":"app","state":"accepted","title":"a","text":"first","ts":"`+now+`"}`+"\n"+
+			`{"kind":"promoted","session":"claude:b","project":"app","state":"accepted","title":"b","text":"second","ts":"`+now+`"}`+"\n")
+
+	first := LoadPromotedNotes()
+	if len(first) != 2 {
+		t.Fatalf("fixture: %d notes", len(first))
+	}
+	first[0], first[1] = first[1], first[0]
+	first[0].Text = "clobbered"
+
+	again := LoadPromotedNotes()
+	if again[0].Text != "first" || again[1].Text != "second" {
+		t.Errorf("one caller's edit reached the next read: %+v", again)
+	}
+}

--- a/internal/sources/notes_memo_test.go
+++ b/internal/sources/notes_memo_test.go
@@ -1,0 +1,54 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeNotesFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The notes file only grows, and a hook before every edit reads it twice — once
+// for the promoted decision, once for the lifecycle states. What one read found
+// answers for the next, the way the manifest is remembered (#2497).
+func TestTheNotesFileIsParsedOncePerProcess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeNotesFile(t, path, `{"kind":"promoted","session":"claude:a","project":"app","state":"accepted","title":"t","text":"keep the pool","ts":"`+now+`"}`+"\n")
+
+	before := notesParses()
+	if got := LoadPromotedNotes(); len(got) != 1 || got[0].Text != "keep the pool" {
+		t.Fatalf("first read is wrong: %+v", got)
+	}
+	if got := PromotedLifecycles(); got["claude:a"].State != "accepted" {
+		t.Fatalf("lifecycles are wrong: %+v", got)
+	}
+	// Two derivations of the same file — the notes and the lifecycle states —
+	// each parsed once. They keep different tie rules, so one cannot be built
+	// from the other; what the memo removes is the repeat.
+	if n := notesParses() - before; n != 2 {
+		t.Errorf("the first pair of reads parsed the file %d times, want 2", n)
+	}
+	for i := 0; i < 3; i++ {
+		LoadPromotedNotes()
+		PromotedLifecycles()
+	}
+	if n := notesParses() - before; n != 2 {
+		t.Errorf("repeat reads of an unchanged file parsed it again: %d parses in all", n)
+	}
+
+	// A file that changed is read again: the MCP server lives across many
+	// calls, and a promotion made in one of them has to be visible in the next.
+	writeNotesFile(t, path, `{"kind":"promoted","session":"claude:a","project":"app","state":"rejected","title":"t","text":"keep the pool","ts":"`+now+`"}`+"\n")
+	if got := LoadPromotedNotes(); len(got) != 1 || got[0].State != "rejected" {
+		t.Fatalf("a changed file was answered from the memo: %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #2497.

`LoadPromotedNotes` and `PromotedLifecycles` each opened, scanned and parsed the whole notes file every time, with 14 call sites between them. The file only grows — every promotion, every sync import — and since #2496 a `hook-tool` run before an edit reaches both.

Measured (seven sessions, varying only the notes file):

    201 promotions,     69 KB   hook-tool 16 ms
    20,001 promotions, 7.1 MB   hook-tool 90 ms

Honest about what this buys: a one-shot hook process still parses once per derivation, so its cost is unchanged. What the memo removes is the repeat — a long-lived process (the MCP server) re-reading a 7 MB file on every call. The two derivations keep different tie rules (file order vs timestamp), so one cannot be built from the other; each caches its own value against the same stamp.

Keyed on path, size and modification time. Every write deja makes is an append, so the case the key cannot see is a hand edit of identical length read back inside the same second on a coarse-grained filesystem — named in the comment.
