### PR TITLE
fix(hook-context): probe the index directory, not only its parent

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -147,14 +147,21 @@ func joinNotes(a, b string) string {
 // itself, which is why a store can rebuild fine while its own directory is
 // read-only.
 func indexDirWritable(dir string) bool {
-	parent := filepath.Dir(dir)
-	f, err := os.CreateTemp(parent, ".deja-probe-")
-	if err != nil {
+	// The directory the rebuild actually writes into. Probing the parent alone
+	// read a read-only index directory inside a writable parent as writable —
+	// a cache directory owned by another user, a read-only subtree — and the
+	// session start went silent again in the one state that never repairs
+	// itself (#2499). The parent is still the right probe when the index
+	// directory does not exist yet, since deja creates it.
+	// Both, when both exist: a build writes its files inside the index
+	// directory and its lock and temporaries beside it, so either one refusing
+	// is enough to stop it.
+	if !dirWritable(filepath.Dir(dir)) {
 		return false
 	}
-	name := f.Name()
-	_ = f.Close()
-	_ = os.Remove(name)
+	if dirExists(dir) {
+		return dirWritable(dir)
+	}
 	return true
 }
 
@@ -207,12 +214,22 @@ func buildNotice(dir string) string {
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
 			return fmt.Sprintf("deja cannot find the index (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
 		}
-		return fmt.Sprintf("deja needs to rebuild the index and %s is not writable — `deja index` says what to change", filepath.Dir(dir))
+		return fmt.Sprintf("deja needs to rebuild the index and %s is not writable — `deja index` says what to change", unwritableIndexDir(dir))
 	}
 	if !warmupJustRequested(dir) {
 		return ""
 	}
 	return "deja is indexing your history — recall comes online in a few seconds"
+}
+
+// unwritableIndexDir names the directory to fix: the index directory when that
+// is what cannot be written, its parent when the index directory does not
+// exist yet and the parent is what refuses to hold it.
+func unwritableIndexDir(dir string) string {
+	if dirExists(dir) {
+		return dir
+	}
+	return filepath.Dir(dir)
 }
 
 // indexNeedsRebuild reports that the index on disk cannot answer as it stands:

--- a/cmd/deja/hook_readonly_indexdir_test.go
+++ b/cmd/deja/hook_readonly_indexdir_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #1048's line hangs on `indexDirWritable`, which probed the index directory's
+// parent. A read-only index directory inside a writable parent — a cache
+// directory owned by another user, a read-only subtree — was therefore read as
+// writable, and the session start went out silent in the one state deja never
+// recovers from on its own (#2499).
+func TestHookNamesAReadOnlyIndexDirInsideAWritableParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not deny writes on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root writes into a read-only directory anyway")
+	}
+	hermeticEnv(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"zeppelin gasket"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	writeStaleFormatIndex(t, dir)
+
+	// The index directory alone. Its parent stays writable, which is the whole
+	// point: that is the shape the old probe could not see.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	out, err := captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("the session start said nothing at all on an index that cannot answer and cannot be rebuilt")
+	}
+	var resp struct {
+		SystemMessage string `json:"systemMessage"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not JSON: %q", out)
+	}
+	if !strings.Contains(resp.SystemMessage, "is not writable") {
+		t.Errorf("the hook did not name the directory that cannot be written: %q", resp.SystemMessage)
+	}
+	if !strings.Contains(resp.SystemMessage, dir) {
+		t.Errorf("the hook named a directory that is not the one at fault: %q", resp.SystemMessage)
+	}
+}


### PR DESCRIPTION
Closes #2499.

#1048 gave the session start a line for the one state deja never recovers from on its own: the index cannot answer and the directory cannot be written. The probe behind it tested the index directory's *parent*, so a read-only index directory inside a writable parent — a cache directory owned by another user, a read-only subtree — read as writable and every session started in silence again. The test for #1048 chmods both directories together, so it passed either way.

    before:  (nothing at all)
    after:   deja needs to rebuild the index and …/index.db is not writable — `deja index` says what to change

Both directories are probed now, since a build writes its files inside the index directory and its lock beside it, and the message names whichever one is at fault.

Left as it is and worth its own look: `deja doctor` still says "the next search rebuilds the index" for a damaged index in a directory where that cannot happen.
