### PR TITLE
fix(hook-context): do not blame permissions where deja index rebuilds fine

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -214,6 +214,17 @@ func buildNotice(dir string) string {
 		if parent := filepath.Dir(dir); !dirExists(dir) && !dirExists(parent) {
 			return fmt.Sprintf("deja cannot find the index (%s) — the disk it lives on may have been unmounted; reconnect it, or point DEJA_INDEX_DIR somewhere local", parent)
 		}
+		// Which of the two states this is decides the sentence. A rebuild
+		// writes the new index beside the old directory and replaces it, so a
+		// read-only index directory inside a writable parent is rebuilt by
+		// `deja index` — measured: permissions come back and the search
+		// answers. What the hook cannot do there is start that rebuild itself,
+		// since the sentinel requestWarmup writes lives inside the read-only
+		// directory. Blaming permissions sent the reader to look at something
+		// that is not the problem (#2502).
+		if dirWritable(filepath.Dir(dir)) {
+			return "deja: the index cannot answer — recall is quiet until `deja index` rebuilds it"
+		}
 		return fmt.Sprintf("deja needs to rebuild the index and %s is not writable — `deja index` says what to change", unwritableIndexDir(dir))
 	}
 	if !warmupJustRequested(dir) {

--- a/cmd/deja/hook_readonly_indexdir_test.go
+++ b/cmd/deja/hook_readonly_indexdir_test.go
@@ -12,8 +12,14 @@ import (
 // #1048's line hangs on `indexDirWritable`, which probed the index directory's
 // parent. A read-only index directory inside a writable parent — a cache
 // directory owned by another user, a read-only subtree — was therefore read as
-// writable, and the session start went out silent in the one state deja never
-// recovers from on its own (#2499).
+// writable, and the session start went out silent (#2499).
+//
+// What it must say there is not what it says for an unwritable parent: `deja
+// index` rebuilds this one, because the build writes beside the directory and
+// replaces it. The hook itself cannot start that rebuild — the sentinel it
+// would write lives inside the read-only directory — so recall stays quiet
+// until the command runs, which is what the statusline says for the same state
+// (#2502).
 func TestHookNamesAReadOnlyIndexDirInsideAWritableParent(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("directory permissions do not deny writes on Windows")
@@ -56,10 +62,10 @@ func TestHookNamesAReadOnlyIndexDirInsideAWritableParent(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &resp); err != nil {
 		t.Fatalf("hook output is not JSON: %q", out)
 	}
-	if !strings.Contains(resp.SystemMessage, "is not writable") {
-		t.Errorf("the hook did not name the directory that cannot be written: %q", resp.SystemMessage)
+	if !strings.Contains(resp.SystemMessage, "recall is quiet until `deja index` rebuilds it") {
+		t.Errorf("the hook does not say what this state is: %q", resp.SystemMessage)
 	}
-	if !strings.Contains(resp.SystemMessage, dir) {
-		t.Errorf("the hook named a directory that is not the one at fault: %q", resp.SystemMessage)
+	if strings.Contains(resp.SystemMessage, "is not writable") {
+		t.Errorf("the hook blames permissions where `deja index` rebuilds fine: %q", resp.SystemMessage)
 	}
 }


### PR DESCRIPTION
Closes #2502. Corrects the sentence #2500 added yesterday.

Measured before changing anything else: with the index directory read-only and its parent writable, a rebuild runs. deja writes the new index beside the directory and replaces it, so `deja index` succeeds, the permissions come back as `drwx------`, and the search answers. Blaming permissions there sent the reader to look at something that is not the problem.

What is true in that state is that the hook cannot start the rebuild itself — the sentinel `requestWarmup` writes lives inside the read-only directory, which is why #1048 exists. So the two cases get their own sentences:

    parent unwritable          deja needs to rebuild the index and <dir> is not writable — `deja index` says what to change
    index directory read-only  deja: the index cannot answer — recall is quiet until `deja index` rebuilds it

The second is the statusline's wording for the same state.

Also verified in the same run and left alone: `deja doctor` saying "the next search rebuilds the index" for a damaged index in that directory is correct — the rebuild does happen. #2501 is closed as a measurement.
