### PR TITLE
fix(policy): name a top-level key deja does not consult

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -214,6 +214,21 @@ func Diagnose() (exists bool, unknown []string, err error) {
 	if jerr := json.Unmarshal(b, &p); jerr != nil {
 		return true, nil, jerr
 	}
+	// The whole shape, before the keys inside it. A file written from memory or
+	// from another tool's config — `{"rules":[{"project":…,"auto":"deny"}]}` —
+	// parses into an empty policy, denies nothing, and read exactly like a rule
+	// that works, while the checks below only ever looked inside `activations`
+	// (#2504).
+	var top map[string]json.RawMessage
+	if json.Unmarshal(b, &top) == nil {
+		for key := range top {
+			switch key {
+			case "activations", "ignore":
+			default:
+				unknown = append(unknown, key)
+			}
+		}
+	}
 	// A file that parses but names an activation or origin deja never consults
 	// is silently doing nothing, which reads exactly like a rule that works.
 	for activation, rules := range p.Activations {

--- a/internal/policy/shape_test.go
+++ b/internal/policy/shape_test.go
@@ -1,0 +1,63 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func policyAt(t *testing.T, body string) {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "policy.json")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", p)
+}
+
+// Diagnose caught a typo inside a structure that was otherwise right, and said
+// nothing about a file whose whole shape is wrong — which is the one someone
+// writes from memory or from another tool's config. It parses, denies nothing,
+// and every surface stays silent (#2504).
+func TestDiagnoseNamesAKeyDejaDoesNotConsult(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "a shape from somewhere else",
+			body: `{"rules":[{"project":"work","auto":"deny"}]}`,
+			want: "rules",
+		},
+		{
+			name: "the right idea under the wrong name",
+			body: `{"activation":{"auto":{"local":false}}}`,
+			want: "activation",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			policyAt(t, tc.body)
+			exists, unknown, err := Diagnose()
+			if err != nil || !exists {
+				t.Fatalf("exists=%v err=%v", exists, err)
+			}
+			if !strings.Contains(strings.Join(unknown, " "), tc.want) {
+				t.Errorf("a file that denies nothing is reported as %v; want it to name %q", unknown, tc.want)
+			}
+		})
+	}
+}
+
+// The keys deja does consult stay quiet.
+func TestDiagnoseIsQuietOnAFileItUnderstands(t *testing.T) {
+	policyAt(t, `{"activations":{"auto":{"local":false}},"ignore":["/tmp/scratch"]}`)
+	_, unknown, err := Diagnose()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("a policy deja reads in full is reported as unknown: %v", unknown)
+	}
+}


### PR DESCRIPTION
Closes #2504.

`Diagnose` looked inside `activations` and caught a typo there — `auto.locals`, an activation spelled with a Cyrillic о — but never looked at the top level. A file whose whole shape is wrong parses into an empty policy, denies nothing, and warned nowhere:

    {"rules":[{"project":"work","auto":"deny"}]}   before: silence on search, silence in doctor
                                                   after:  warned on search, and doctor: ignored "rules"

That is the shape someone writes from memory or from another tool's config — I wrote exactly it in a test four iterations ago and only a failing assertion caught it.

`activations` and `ignore` are the two keys deja consults; anything else in that object is a rule that does nothing.
