### PR TITLE
fix: three leftovers from this week's reviews

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -371,9 +371,17 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 			want[meta.Harness+":"+meta.OrigID] = true
 		}
 	}
+	// The note's own project as well as the session it came from. The metas
+	// are already scoped by the auto activation, so a note is reached only
+	// through an allowed session — but the note carries a project of its own,
+	// and every other reader of these notes checks it (#2506).
+	pol := policy.Load()
 	var best sources.PromotedNote
 	for _, note := range sources.LoadPromotedNotes() {
 		if note.State != "accepted" || !want[note.Session] {
+			continue
+		}
+		if note.Project != "" && !pol.Allows(policy.ActivationAuto, note.Project) {
 			continue
 		}
 		if best.Session == "" || note.At.After(best.At) {
@@ -405,7 +413,7 @@ func clipDecision(s string, budget int) string {
 	return s[:end]
 }
 
-// decisionUsable rejects a session whose decision should not be reused:// decisionUsable rejects a session whose decision should not be reused: one that
+// decisionUsable rejects a session whose decision should not be reused: one that
 // says in its own words it backed the approach out (GaveUp), and one a later
 // state marked rejected, superseded or stale. Surfacing either at the point of an
 // edit would push the agent to redo exactly what was undone.

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1403,6 +1403,21 @@ func (n *mcpNumber) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// rebuildRefusedForAgent is what an agent is told when this build cannot read
+// the index and cannot start a rebuild itself.
+//
+// Which of the two states it is decides the sentence, the way it does at
+// session start: a rebuild writes the new index beside the old directory and
+// replaces it, so a read-only index directory inside a writable parent is
+// rebuilt by `deja index` — measured in #2502. Saying it "cannot be rebuilt"
+// there denied in one half what the other half advised (#2506).
+func rebuildRefusedForAgent(dir string) string {
+	if dirWritable(filepath.Dir(dir)) {
+		return "deja's index was written by another version of deja and this session cannot rebuild it. Tell the user to run `deja index`; recall is quiet until they do."
+	}
+	return "deja's index was written by another version of deja and " + unwritableIndexDir(dir) + " is not writable, so it cannot be rebuilt. Tell the user to run `deja index`, which says what to change."
+}
+
 // buildingNowForAgent explains the one state an agent cannot ask a human about:
 // the index is not there yet because it is being built. Without this the tool
 // call failed with `manifest: open /…/manifest.gob: no such file or directory`
@@ -1436,7 +1451,7 @@ func buildingNowForAgent(dir string) string {
 		// one state that never repairs itself, and telling an agent to come
 		// back would loop it forever (the shape #1048 fixed at session start).
 		if !indexDirWritable(dir) {
-			return "deja's index was written by another version of deja and " + filepath.Dir(dir) + " is not writable, so it cannot be rebuilt. Tell the user to run `deja index`, which says what to change."
+			return rebuildRefusedForAgent(dir)
 		}
 		requestWarmup(dir)
 		return "deja is rebuilding its index for this version of deja. Recall comes online shortly; ask again then."

--- a/cmd/deja/review_leftovers_test.go
+++ b/cmd/deja/review_leftovers_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The MCP server told an agent the index "cannot be rebuilt" because a
+// directory is not writable, and in the same breath told it to have the user
+// run the command that does rebuild it. #2502 measured that: with the index
+// directory read-only and its parent writable, `deja index` replaces the
+// directory (#2506).
+func TestTheAgentIsNotToldARebuildIsImpossibleWhenItIsNot(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("directory permissions do not deny writes here")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "index.db")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	line := rebuildRefusedForAgent(dir)
+	if strings.Contains(line, "cannot be rebuilt") {
+		t.Errorf("the agent is told a rebuild is impossible where `deja index` does it: %q", line)
+	}
+	if !strings.Contains(line, "deja index") {
+		t.Errorf("the agent is not told what fixes this: %q", line)
+	}
+
+	// The parent locked too: nothing can rebuild it there, and moving the
+	// index is the only way out.
+	if err := os.Chmod(parent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+	line = rebuildRefusedForAgent(dir)
+	if !strings.Contains(line, "cannot be rebuilt") || !strings.Contains(line, dir) {
+		t.Errorf("the agent is not told that this one really cannot be rebuilt, or which directory is at fault: %q", line)
+	}
+}
+
+// The sessions reaching promotedDecisionFor are scoped by the auto activation,
+// but a note carries its own project and that was never re-checked — the check
+// every other note reader has (#2506).
+func TestAPromotedNoteIsCheckedAgainstThePolicyToo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	now := time.Now().UTC()
+	metas := []index.SessionMeta{{ID: "a", Harness: "claude", Project: "app", Updated: now}}
+	if err := sources.AppendPromoted("imported:box/app", "t", "the retry budget stays at 5",
+		"claude:a", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+	writePolicy(t, `{"activations":{"auto":{"imported":false}}}`)
+
+	if got := promotedDecisionFor(metas); got != "" {
+		t.Errorf("a note from a project the auto rule withholds reached the line before an edit: %q", got)
+	}
+
+	// The same note with the rule lifted still arrives: the check must not
+	// swallow what it was not written for.
+	writePolicy(t, `{}`)
+	if got := promotedDecisionFor(metas); !strings.Contains(got, "retry budget stays at 5") {
+		t.Errorf("the note is gone with no rule against it: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2506. Three findings reviewers sent after their own iterations had merged.

**The agent's line about an index it cannot read** said the index "cannot be rebuilt" because a directory is not writable, then told the user to run the command that rebuilds it. With only the index directory read-only, `deja index` does rebuild it (measured in #2502), so the two cases now say different things and the message names the directory at fault rather than its parent.

**A promoted note is checked against the policy.** The sessions reaching `promotedDecisionFor` are already scoped by the auto activation, so this needs a hand-edited notes file to matter — but every other reader of those notes checks the note's own project, and now this one does too.

**A duplicated comment head** left by #2496 at `hook_tool.go:408`. `TestDocCommentsNameWhatTheyDocument` missed it: the comment still begins with the name of the function below.
