### PR TITLE
test(index): catch a comment line that repeats its own head

### DIFF
--- a/internal/index/doccomment_test.go
+++ b/internal/index/doccomment_test.go
@@ -126,3 +126,93 @@ func declaredIn(f *ast.File, name string) bool {
 	})
 	return found
 }
+
+// doubledCommentHead reports the text a comment line repeats after a second
+// `//` on the same line. That is what a patch leaves when it inserts at the
+// head of an existing block: the guard above is satisfied — the block still
+// begins with the right name — and the eye reads the first half and stops
+// (#2508).
+//
+// Narrow on purpose. A second marker alone is ordinary: comments quote one
+// ("// Event kinds."), and paths contain one (github.com/x/y//issues). Only a
+// tail that begins with its own head counts, and only when that head is more
+// than a word long.
+func doubledCommentHead(line string) (string, bool) {
+	body := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "//"))
+	for i := strings.Index(body, "//"); i > 0; {
+		head := strings.TrimSpace(body[:i])
+		tail := strings.TrimSpace(body[i+2:])
+		if len(head) >= 20 && strings.HasPrefix(tail, head) {
+			return head, true
+		}
+		next := strings.Index(body[i+2:], "//")
+		if next < 0 {
+			break
+		}
+		i += next + 2
+	}
+	return "", false
+}
+
+// TestNoDocCommentRepeatsItsOwnHead walks every comment in the tree, not only
+// doc blocks: a doubled head is a patch artifact and lands wherever the patch
+// did.
+func TestNoDocCommentRepeatsItsOwnHead(t *testing.T) {
+	roots := []string{"..", filepath.Join("..", "..", "cmd")}
+	seen := 0
+	for _, root := range roots {
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil //nolint:nilerr // a file that disappeared mid-walk is not this test's business
+			}
+			if info.IsDir() {
+				if strings.HasPrefix(info.Name(), ".") && info.Name() != "." && info.Name() != ".." {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			fset := token.NewFileSet()
+			f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if perr != nil {
+				return nil
+			}
+			for _, group := range f.Comments {
+				for _, c := range group.List {
+					seen++
+					if head, ok := doubledCommentHead(c.Text); ok {
+						t.Errorf("%s: this comment line repeats itself — %q appears twice, which is what a patch applied at the head leaves behind",
+							fset.Position(c.Pos()), head)
+					}
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if seen == 0 {
+		t.Fatal("walked no comments at all; the check is not looking at anything")
+	}
+}
+
+func TestDoubledCommentHead(t *testing.T) {
+	for _, tc := range []struct {
+		line string
+		want bool
+	}{
+		{line: "// decisionUsable rejects a session whose decision should not be reused:// decisionUsable rejects a session whose decision should not be reused: one that", want: true},
+		{line: "// member: \"// Event kinds.\" above a const block of six is correct and", want: false},
+		{line: "// reading github.com/x/y//issues\"). So reject a line that BEGINS like code,", want: false},
+		{line: "// A // inside a string is part of the value, not a comment.", want: false},
+		{line: "// short//short", want: false},
+		{line: "// plain prose with no marker at all", want: false},
+	} {
+		if _, got := doubledCommentHead(tc.line); got != tc.want {
+			t.Errorf("doubledCommentHead(%q) = %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2508. Test only.

`TestDocCommentsNameWhatTheyDocument` passed this for two days:

    // decisionUsable rejects a session whose decision should not be reused:// decisionUsable rejects a session whose decision should not be reused: one that

The block still begins with the right name, so the guard is satisfied; what went wrong is one character further on, where a patch inserted at the anchor and the head repeated itself. This tree has produced that shape twice, and both times a reader of the diff missed it.

The new check is narrow: within one comment line, the text before a second `//` and the text after it, flagged only when the second begins with the first and the first is more than a word long. Every comment line in this tree that carries a second marker quotes one inside a sentence or a path, and none repeats itself. Verified by reintroducing the real artifact — it is caught, with the file and line.
