### PR TITLE
fix(hook-tool): carry a decision that arrived by sync

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -365,10 +365,13 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 		return ""
 	}
 	want := make(map[string]bool, len(metas))
+	noteKeys := make(map[string]bool, len(metas))
 	for _, meta := range metas {
 		want[meta.Harness+":"+meta.ID] = true
+		noteKeys["deja-note-"+meta.Harness+"-"+meta.ID] = true
 		if meta.OrigID != "" {
 			want[meta.Harness+":"+meta.OrigID] = true
+			noteKeys["deja-note-"+meta.Harness+"-"+meta.OrigID] = true
 		}
 	}
 	// The note's own project as well as the session it came from. The metas
@@ -377,15 +380,49 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 	// and every other reader of these notes checks it (#2506).
 	pol := policy.Load()
 	var best sources.PromotedNote
-	for _, note := range sources.LoadPromotedNotes() {
-		if note.State != "accepted" || !want[note.Session] {
-			continue
+	keep := func(note sources.PromotedNote) {
+		if note.State != "accepted" {
+			return
 		}
 		if note.Project != "" && !pol.Allows(policy.ActivationAuto, note.Project) {
+			return
+		}
+		if best.At.IsZero() || note.At.After(best.At) {
+			best = note
+		}
+	}
+	for _, note := range sources.LoadPromotedNotes() {
+		if !want[note.Session] {
 			continue
 		}
-		if best.Session == "" || note.At.After(best.At) {
-			best = note
+		keep(note)
+	}
+	// And the decisions that arrived by sync. Those are not in this machine's
+	// notes file at all — a promotion crosses as a session of its own, carrying
+	// the state, which is how the view page reads them (#2421). It touched no
+	// file, so it is never among the sessions this file has; what ties it back
+	// is the id a note is built from, `deja-note-<harness>-<id>`, derived here
+	// from the session rather than parsed out of the note (harness names carry
+	// dashes, so the id does not invert). Without this a decision promoted on
+	// one machine was a decision in search on the other and filler prose at the
+	// moment of the edit (#2510).
+	for _, meta := range metas {
+		if meta.Lifecycle != "" {
+			keep(noteFromMeta(meta))
+		}
+	}
+	if len(noteKeys) > 0 {
+		for _, note := range index.PromotedNoteMetas(index.DefaultDir(), func(project string) bool {
+			return pol.Allows(policy.ActivationAuto, project)
+		}) {
+			id := note.OrigID
+			if id == "" {
+				id = note.ID
+			}
+			if !noteKeys[id] {
+				continue
+			}
+			keep(noteFromMeta(note))
 		}
 	}
 	text := strings.TrimSpace(best.Text)
@@ -396,6 +433,21 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 		return ""
 	}
 	return trimTrailingFragment(search.SafeText(clipDecision(text, toolHookDecisionBudget)))
+}
+
+// noteFromMeta reads the decision a session carries as a promoted note, so the
+// two sources — this machine's notes file and what arrived by sync — can be
+// weighed against each other by one rule.
+func noteFromMeta(meta index.SessionMeta) sources.PromotedNote {
+	when := meta.Updated
+	if t, err := time.Parse(time.RFC3339, meta.LifecycleAt); err == nil {
+		when = t
+	}
+	text := meta.LifecycleNote
+	if strings.TrimSpace(text) == "" {
+		text = meta.Title
+	}
+	return sources.PromotedNote{Project: meta.Project, State: meta.Lifecycle, Title: meta.Title, Text: text, At: when}
 }
 
 // clipDecision keeps a promoted note inside the same budget a scanned

--- a/cmd/deja/hook_tool_imported_decision_test.go
+++ b/cmd/deja/hook_tool_imported_decision_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A decision promoted on another machine arrives as a session carrying its
+// state, which is how #2421 taught the view page to read it. The line before an
+// edit read this machine's notes file alone, so on the receiving machine the
+// decision was a decision in search and filler prose at the moment it mattered
+// (#2510).
+func TestTheEditLineReadsADecisionThatArrivedBySync(t *testing.T) {
+	hermeticEnv(t)
+	now := time.Now().UTC()
+	metas := []index.SessionMeta{
+		{ID: "imported-9", Harness: "claude", Project: "imported:home/app", Updated: now.Add(-time.Hour),
+			Title: "should the retry budget go up to 10 for the payments client?",
+			// What sync carries for a promoted session.
+			Lifecycle:     "accepted",
+			LifecycleNote: "the retry budget stays at 5; the pool change is what fixed the timeouts",
+			LifecycleAt:   now.Add(-time.Hour).Format(time.RFC3339),
+		},
+		{ID: "b1", Harness: "claude", Project: "home/app", Updated: now},
+	}
+
+	got := promotedDecisionFor(metas)
+	if !strings.Contains(got, "retry budget stays at 5") {
+		t.Errorf("the imported decision is not what the line carries: %q", got)
+	}
+}
+
+// A state that is not "accepted" is not a standing decision, wherever it came
+// from: rejected, superseded and stale all mean someone took it back.
+func TestASupersededImportedDecisionIsNotCarried(t *testing.T) {
+	hermeticEnv(t)
+	now := time.Now().UTC()
+	metas := []index.SessionMeta{
+		{ID: "imported-9", Harness: "claude", Project: "imported:home/app", Updated: now,
+			Title: "the old plan", Lifecycle: "superseded", LifecycleNote: "we went back to five",
+			LifecycleAt: now.Format(time.RFC3339)},
+	}
+	if got := promotedDecisionFor(metas); got != "" {
+		t.Errorf("a decision that was taken back is still being served: %q", got)
+	}
+}
+
+// The trust rule reaches it too: an imported project the auto activation
+// withholds must not speak here.
+func TestAWithheldImportedDecisionStaysOut(t *testing.T) {
+	hermeticEnv(t)
+	writePolicy(t, `{"activations":{"auto":{"imported":false}}}`)
+	now := time.Now().UTC()
+	metas := []index.SessionMeta{
+		{ID: "imported-9", Harness: "claude", Project: "imported:home/app", Updated: now,
+			Title: "t", Lifecycle: "accepted", LifecycleNote: "the retry budget stays at 5",
+			LifecycleAt: now.Format(time.RFC3339)},
+	}
+	if got := promotedDecisionFor(metas); got != "" {
+		t.Errorf("an imported decision the rule withholds reached the line: %q", got)
+	}
+}

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -443,6 +443,33 @@ func hitFromRecords(recs []Record) []uint64 {
 	return out
 }
 
+// PromotedNoteMetas returns the sessions that carry a promoted note's state —
+// the shape a decision has after it crosses a machine boundary, where the local
+// notes file knows nothing about it. Manifest only, so a caller in a hook pays a
+// map walk rather than a read (#2510).
+//
+// allow gates a session's project the way TopFriction's does.
+func PromotedNoteMetas(dir string, allow func(project string) bool) []SessionMeta {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil
+	}
+	var out []SessionMeta
+	for _, meta := range m.Sessions {
+		if meta.Lifecycle == "" {
+			continue
+		}
+		if allow != nil && !allow(meta.Project) {
+			continue
+		}
+		out = append(out, meta)
+	}
+	return out
+}
+
 // FrictionSessions counts the sessions that hit one wall, by the signature a
 // FixPair carries. The manifest already holds every session's hashes and is
 // cached, so a caller in a hook pays a map walk rather than a read — which is

--- a/internal/index/promoted_metas_test.go
+++ b/internal/index/promoted_metas_test.go
@@ -1,0 +1,33 @@
+package index
+
+import (
+	"testing"
+)
+
+// The shape a decision has after it crosses a machine boundary: a session of
+// its own carrying the state, since the receiving machine's notes file knows
+// nothing about it (#2510).
+func TestPromotedNoteMetasFindsWhatArrivedBySync(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	m := Manifest{Sessions: map[string]SessionMeta{
+		"deja:imported-1": {ID: "imported-1", Harness: "deja", Project: "imported:home/app",
+			OrigID: "deja-note-claude-dec", Lifecycle: "accepted", LifecycleNote: "the retry budget stays at 5"},
+		"claude:imported-2": {ID: "imported-2", Harness: "claude", Project: "imported:home/app", OrigID: "dec"},
+		"claude:local":      {ID: "local", Harness: "claude", Project: "home/app"},
+	}}
+	if err := writeManifest(dir, m); err != nil {
+		t.Fatal(err)
+	}
+
+	got := PromotedNoteMetas(dir, nil)
+	if len(got) != 1 || got[0].OrigID != "deja-note-claude-dec" {
+		t.Fatalf("the note session is not what came back: %+v", got)
+	}
+	if n := PromotedNoteMetas(dir, func(p string) bool { return p == "home/app" }); len(n) != 0 {
+		t.Errorf("a project the caller withholds still came back: %+v", n)
+	}
+	if n := PromotedNoteMetas("", nil); len(n) != 1 {
+		t.Errorf("the default dir found %d, want 1", len(n))
+	}
+}


### PR DESCRIPTION
Closes #2510.

Two machines, end to end: A promotes a decision about `retry.go` and exports; B imports and starts editing the same file.

    B, search           [deja] imported:home/app · [accepted] the retry budget stays at 5; …
    B, before the edit  … — prior decision: looked at retry.go again (4)

On the receiving machine the decision was a decision when someone searched for it and filler prose at the moment this loop measured as the one that changes what an agent does (#2495).

A promotion crosses as a session of its own carrying the state — the shape #2421 taught the view page to read — and it touched no file, so it is never among the file's sessions. What ties it back is the id a note is built from: `deja-note-<harness>-<id>`, derived here from the session rather than parsed out of the note, since harness names carry dashes and the id does not invert. `index.PromotedNoteMetas` finds the note sessions from the manifest, policy-gated.

    after:  … — prior decision: the retry budget stays at 5; the pool change is what fixed the timeouts (from claude:dec, 2026-08-29)

A local-only rule keeps both surfaces silent, as before.

Named in the issue and left for its own iteration: the session-start block still has no standing-decisions line on the receiving machine. It computes them from project names before it holds any sessions, and an imported note's project is `imported:home/app` where the local one is `home/app` — a naming decision rather than a lookup.
