### PR TITLE
fix(hook-context): stand by a decision that arrived by sync

### DIFF
--- a/cmd/deja/hook_conventions.go
+++ b/cmd/deja/hook_conventions.go
@@ -58,6 +58,11 @@ func projectConventions(names []string, maxNotes, budget int) string {
 	b.WriteString("standing decisions in this project (promoted and still accepted — follow them unless the user overrides):\n")
 	head := b.Len()
 	shown := 0
+	// One decision, one line. A decision promoted here and synced to a peer
+	// comes back as their copy of it, so both are in hand — and two peers who
+	// both took it send two. The block is six lines and a reminder; saying the
+	// same thing twice spends one of them and reads as two agreements.
+	seen := map[string]bool{}
 	for _, note := range picked {
 		if shown >= maxNotes {
 			break
@@ -66,6 +71,11 @@ func projectConventions(names []string, maxNotes, budget int) string {
 		if line == "" {
 			continue
 		}
+		key := conventionKey(line)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		row := "  · " + search.SafeLine(line) + "\n"
 		if b.Len()+len(row) > budget {
 			break
@@ -110,6 +120,18 @@ func importedConventions(names []string) []sources.PromotedNote {
 		})
 	}
 	return out
+}
+
+// conventionKey is what makes two renderings of one decision the same. A copy
+// that arrived from a peer carries the provenance the promoting machine wrote
+// into it — "… (from claude:dec, 2026-08-29)" — so the tail is dropped before
+// comparing, and the rest is compared without case.
+func conventionKey(line string) string {
+	s := strings.TrimSpace(line)
+	if i := strings.LastIndex(s, "(from "); i > 0 && strings.HasSuffix(s, ")") {
+		s = strings.TrimSpace(s[:i])
+	}
+	return strings.ToLower(s)
 }
 
 // inAnyProject asks the shared question: is this session's project the one the

--- a/cmd/deja/hook_conventions.go
+++ b/cmd/deja/hook_conventions.go
@@ -3,7 +3,10 @@ package main
 import (
 	"sort"
 	"strings"
+	"time"
 
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -37,6 +40,14 @@ func projectConventions(names []string, maxNotes, budget int) string {
 		}
 		picked = append(picked, n)
 	}
+	// And the ones the team agreed on elsewhere. A promotion that arrived by
+	// sync is not in this machine's notes file — it is a session carrying its
+	// state, under the source machine's project name (#975), so neither half of
+	// the loop above can see it and the block quietly stopped naming the
+	// decisions syncing exists to share (#2512). Scoped by the rule every
+	// automatic surface shares (#2333) and by the auto activation, since this
+	// block is read unasked.
+	picked = append(picked, importedConventions(names)...)
 	if len(picked) == 0 {
 		return ""
 	}
@@ -66,6 +77,52 @@ func projectConventions(names []string, maxNotes, budget int) string {
 		return ""
 	}
 	return b.String()
+}
+
+// importedConventions reads the standing decisions that arrived by sync. The
+// manifest holds them, so this costs a map walk rather than a read; the same
+// shape the view page (#2421) and the line before an edit (#2511) read.
+func importedConventions(names []string) []sources.PromotedNote {
+	pol := policy.Load()
+	metas := index.PromotedNoteMetas(index.DefaultDir(), func(project string) bool {
+		return pol.Allows(policy.ActivationAuto, project)
+	})
+	var out []sources.PromotedNote
+	for _, meta := range metas {
+		if meta.Lifecycle != "accepted" {
+			continue
+		}
+		if !inAnyProject(meta.Project, names) {
+			continue
+		}
+		when := meta.Updated
+		if t, err := time.Parse(time.RFC3339, meta.LifecycleAt); err == nil {
+			when = t
+		} else if t, err := time.Parse("2006-01-02", meta.LifecycleAt); err == nil {
+			when = t
+		}
+		text := meta.LifecycleNote
+		if strings.TrimSpace(text) == "" {
+			text = meta.Title
+		}
+		out = append(out, sources.PromotedNote{
+			Project: meta.Project, State: meta.Lifecycle, Title: meta.Title, Text: text, At: when,
+		})
+	}
+	return out
+}
+
+// inAnyProject asks the shared question: is this session's project the one the
+// reader is standing in. It strips `imported:` and matches a peer's project by
+// suffix, which is what makes a decision from another machine belong to the
+// project it was made in rather than to a name that happens to match.
+func inAnyProject(project string, names []string) bool {
+	for _, n := range names {
+		if n != "" && index.ProjectInScope(project, n) {
+			return true
+		}
+	}
+	return false
 }
 
 // conventionLine is the one line to show for a promoted note: its title, or the

--- a/cmd/deja/hook_conventions_imported_test.go
+++ b/cmd/deja/hook_conventions_imported_test.go
@@ -69,3 +69,32 @@ func TestAWithheldImportedDecisionIsNotStanding(t *testing.T) {
 		t.Errorf("imported memory the auto rule withholds is standing anyway:\n%s", out)
 	}
 }
+
+// A decision promoted here and received back from a peer who imported it is one
+// decision. The block holds six lines at most and is a reminder, so saying it
+// twice costs one of them and reads as two separate agreements.
+func TestADecisionThatCameBackDoesNotStandTwice(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-home-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	rec := `{"type":"user","sessionId":"dec","timestamp":"` + at + `","cwd":"/home/app","message":{"role":"user","content":"should the retry budget go up to 10?"}}` + "\n" +
+		`{"type":"assistant","sessionId":"dec","timestamp":"` + at + `","cwd":"/home/app","message":{"role":"assistant","content":"no: the retry budget stays at 5"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "dec.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "dec", "--state", "accepted", "--note", "the retry budget stays at 5"); err != nil {
+		t.Fatal(err)
+	}
+	importDecision(t, "home/app", "the retry budget stays at 5")
+
+	out := projectConventions([]string{"home/app"}, 6, 800)
+	if n := strings.Count(out, "retry budget stays at 5"); n != 1 {
+		t.Errorf("one decision, %d lines:\n%s", n, out)
+	}
+}

--- a/cmd/deja/hook_conventions_imported_test.go
+++ b/cmd/deja/hook_conventions_imported_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// importDecision puts a promoted decision through the door it really arrives
+// by: a sync batch carrying the note session, whose text holds the state (the
+// other machine's notes.jsonl never travels — #975).
+func importDecision(t *testing.T, project, text string) {
+	t.Helper()
+	tmp := t.TempDir()
+	rec, err := json.Marshal(index.SyncRecord{
+		Harness: "deja", SessionID: "deja-note-claude-dec", Project: project,
+		Role: "user", Text: "[accepted] " + text + " (from claude:dec, 2026-08-29)",
+		Time: time.Now().UTC().Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "deja-sync-x.jsonl"), append(rec, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "sync", "import", tmp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The block that says "follow them unless the user overrides" stopped naming a
+// decision the moment it arrived by sync: it reads this machine's notes file,
+// and a synced promotion is a session under `imported:<project>` (#2512).
+func TestStandingDecisionsIncludeWhatArrivedBySync(t *testing.T) {
+	hermeticEnv(t)
+	importDecision(t, "home/app", "the retry budget stays at 5")
+
+	out := projectConventions([]string{"home/app"}, 6, 800)
+	if !strings.Contains(out, "retry budget stays at 5") {
+		t.Errorf("a decision the team agreed on elsewhere is not standing here:\n%s", out)
+	}
+}
+
+// Another project's decision does not become this one's.
+func TestAnImportedDecisionKeepsItsScope(t *testing.T) {
+	hermeticEnv(t)
+	importDecision(t, "clients/acme", "the acme retry budget stays at 5")
+
+	if out := projectConventions([]string{"home/app"}, 6, 800); strings.Contains(out, "acme retry budget") {
+		t.Errorf("another project's decision reached this project's block:\n%s", out)
+	}
+}
+
+// And a rule that withholds imported memory from the agent takes it back out.
+func TestAWithheldImportedDecisionIsNotStanding(t *testing.T) {
+	hermeticEnv(t)
+	importDecision(t, "home/app", "the retry budget stays at 5")
+	writePolicy(t, `{"activations":{"auto":{"imported":false}}}`)
+
+	if out := projectConventions([]string{"home/app"}, 6, 800); strings.Contains(out, "retry budget") {
+		t.Errorf("imported memory the auto rule withholds is standing anyway:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #2512. The other half of #2510.

After A promotes a decision and B imports it, B's session start had no standing-decisions line at all — the block that says "follow them unless the user overrides" stopped naming exactly the decisions syncing exists to share.

    before:  (no such line)
    after:   standing decisions in this project (promoted and still accepted — follow them unless the user overrides):
               · the retry budget stays at 5; the pool change is what fixed the timeouts (from claude:dec, 2026-08-29)

`projectConventions` reads this machine's `notes.jsonl` and matches on project name; a synced promotion is in neither half of that — it is a session carrying its state, under `imported:home/app` where the local candidate is `home/app`. It now also reads those sessions from the manifest, scoped by `index.ProjectInScope` (the rule every automatic surface shares) and by the auto activation.

A local-only rule keeps the block silent, as before, and another project's decision does not become this one's — both pinned.
