### PR TITLE
fix(hook-tool): carry the decision about the command about to run

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -213,10 +213,67 @@ func commandHookLine(dir, cwd, cmd string) string {
 	// exists changes nothing. A command deserves the same: before `npm run
 	// build`, what matters is that it failed here last time and why, not that
 	// it has been run twice.
+	// A decision the user promoted about this very command comes first. The
+	// ranking below asks whether a session's words match the command's, which
+	// on a store where several sessions ran it makes those words too common to
+	// clear the idf floor — measured: every candidate at 0 informative terms,
+	// so the scan never ran and the count printed alone. Whether the promoted
+	// session ran the command is a fact rather than a ranking (#2516).
+	if d := promotedCommandDecision(dir, cwd, cmd); d != "" {
+		return head + " — last time: " + d
+	}
 	if d := commandDecisionLine(dir, cwd, cmd); d != "" {
 		return head + " — last time: " + d
 	}
 	return head + "."
+}
+
+// promotedCommandDecision is the decision this project promoted about the
+// command about to run, or "" when there is none. It reads the promoted
+// sessions of the project — few, and bounded here — and asks each whether it
+// ran this command, which is the same question CommandHistory answers in
+// aggregate.
+func promotedCommandDecision(dir, cwd, cmd string) string {
+	names := digest.ProjectNameCandidates(cwd)
+	if len(names) == 0 {
+		return ""
+	}
+	pol := policy.Load()
+	notes := importedConventions(names)
+	for _, n := range sources.LoadPromotedNotes() {
+		if n.State != "accepted" || !inAnyProject(n.Project, names) {
+			continue
+		}
+		if n.Project != "" && !pol.Allows(policy.ActivationAuto, n.Project) {
+			continue
+		}
+		notes = append(notes, n)
+	}
+	sort.Slice(notes, func(i, j int) bool { return notes[i].At.After(notes[j].At) })
+	read := 0
+	for _, note := range notes {
+		if read >= toolHookDecisionScan {
+			break
+		}
+		harness, id, ok := strings.Cut(note.Session, ":")
+		if !ok {
+			continue
+		}
+		read++
+		s, found, err := index.FindByIdentity(dir, harness, id)
+		if err != nil || !found || !index.SessionRanCommand(s, cmd) {
+			continue
+		}
+		text := strings.TrimSpace(note.Text)
+		if text == "" {
+			text = strings.TrimSpace(note.Title)
+		}
+		if text == "" {
+			continue
+		}
+		return trimTrailingFragment(search.SafeText(clipDecision(text, toolHookDecisionBudget)))
+	}
+	return ""
 }
 
 // commandDecisionLine returns what happened the last time this command ran, or

--- a/cmd/deja/hook_tool_command_decision_test.go
+++ b/cmd/deja/hook_tool_command_decision_test.go
@@ -1,79 +1,79 @@
 package main
 
 import (
-	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
 )
 
-// Before a command that failed here last time, the count is not the useful
-// part — the cause is. The file path already carries the prior decision for
-// exactly this reason; the command path said only how often it had been run.
-func TestToolHookCommandLineCarriesWhatHappenedLastTime(t *testing.T) {
+// The line before a command has the same shape as the line before an edit, and
+// #2496 taught only the second one to carry a promoted decision. Here the
+// decision is about that exact command and the line said only how often the
+// machine had run it (#2516).
+func TestTheCommandLineCarriesThePromotedDecision(t *testing.T) {
 	tmp := hermeticEnv(t)
-	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
-	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	// Two sessions ran it; the second says how it was resolved.
-	writeClaudeFixture(t, filepath.Join(root, "alpha", "run1.jsonl"), "run1", []string{
-		`{"type":"user","sessionId":"run1","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"build it"}}`,
-		`{"type":"assistant","sessionId":"run1","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
-	})
-	writeClaudeFixture(t, filepath.Join(root, "alpha", "run2.jsonl"), "run2", []string{
-		`{"type":"user","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"pnpm run bundle is failing again"}}`,
-		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
-		`{"type":"assistant","sessionId":"run2","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:07Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: pnpm run bundle needs the ARENAGUARD lockfile refreshed first."}]}}`,
-	})
-	if _, err := captureRun(t, "index"); err != nil {
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
-	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pnpm run bundle"},"session_id":"now","cwd":"/work/alpha"}`)
-	if out == "" {
-		t.Fatal("no line for a command with history")
+	now := time.Now().UTC()
+	at := func(m int) string { return now.Add(-time.Duration(m) * time.Minute).Format(time.RFC3339) }
+	write := func(sid string, lines []string) {
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
-	var resp sessionStartHookResponse
-	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+	bash := func(sid, when string) string {
+		return `{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + when + `","cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make migrate-orders"}}]}}`
+	}
+	write("dec", []string{
+		`{"type":"user","sessionId":"dec","timestamp":"` + at(401) + `","cwd":"/work/app","message":{"role":"user","content":"should we keep running the orders migration against production directly?"}}`,
+		bash("dec", at(400)),
+		`{"type":"assistant","sessionId":"dec","timestamp":"` + at(399) + `","cwd":"/work/app","message":{"role":"assistant","content":"no: run the orders migration against the replica first"}}`,
+	})
+	for k := 0; k < 5; k++ {
+		sid := fmt.Sprintf("f%d", k)
+		write(sid, []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(200-20*k) + `","cwd":"/work/app","message":{"role":"user","content":"run the orders migration again"}}`,
+			bash(sid, at(199-20*k)),
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(198-20*k) + `","cwd":"/work/app","message":{"role":"assistant","content":"ran the migration"}}`,
+		})
+	}
+	// Sessions about other work, so the command's words carry weight: in a
+	// store where every session says the same thing no term is informative and
+	// the ranking matches nothing — the lesson of 430 and 437.
+	topics := []string{"the sidebar layout", "the invoice pdf renderer", "the webpack config",
+		"the login throttle", "the avatar uploader", "the search autocomplete", "the cron scheduler",
+		"the email templates", "the feature flags", "the toast component", "the graphql schema",
+		"the docker base image", "the css variables", "the storybook snapshots", "the i18n strings"}
+	for i, top := range topics {
+		sid := fmt.Sprintf("t%d", i)
+		write(sid, []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(900-10*i) + `","cwd":"/work/app","message":{"role":"user","content":"work on ` + top + ` today"}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(899-10*i) + `","cwd":"/work/app","message":{"role":"assistant","content":"changed ` + top + ` and the tests pass"}}`,
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
 	}
-	ctx := resp.HookSpecificOutput.AdditionalContext
-	if !strings.Contains(ctx, "ARENAGUARD") {
-		t.Errorf("the line says the command has run before but not what happened:\n%s", ctx)
+	if _, err := captureRunStderr(t, "promote", "dec", "--state", "accepted",
+		"--note", "run the orders migration against the replica first; production needs the pool drained"); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(ctx, "last time:") {
-		t.Errorf("the outcome is not labelled as the prior one:\n%s", ctx)
-	}
-}
 
-// A command whose history holds no conclusion keeps the plain count rather
-// than borrowing a decision from a session about something else.
-func TestToolHookCommandLineStaysACountWithoutAConclusion(t *testing.T) {
-	tmp := hermeticEnv(t)
-	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
-	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	writeClaudeFixture(t, filepath.Join(root, "alpha", "quiet.jsonl"), "quiet", []string{
-		`{"type":"user","sessionId":"quiet","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run it"}}`,
-		`{"type":"assistant","sessionId":"quiet","cwd":"/work/alpha","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"pnpm run bundle"}}]}}`,
-	})
-	// A session that decided something unrelated, which must not be borrowed.
-	writeClaudeFixture(t, filepath.Join(root, "alpha", "other.jsonl"), "other", []string{
-		`{"type":"user","sessionId":"other","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"the avatar flashes on reload"}}`,
-		`{"type":"assistant","sessionId":"other","cwd":"/work/alpha","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"text","text":"Decision: the ARENAGUARD image needs an explicit width."}]}}`,
-	})
-	if _, err := captureRun(t, "index"); err != nil {
-		t.Fatal(err)
+	line := commandHookLine(dir, "/work/app", "make migrate-orders")
+	if line == "" {
+		t.Fatal("the fixture produced no line at all")
 	}
-	t.Setenv("CLAUDE_PROJECT_DIR", "/work/alpha")
-	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pnpm run bundle"},"session_id":"now","cwd":"/work/alpha"}`)
-	if out == "" {
-		return // saying nothing is also acceptable here
-	}
-	var resp sessionStartHookResponse
-	if err := json.Unmarshal([]byte(out), &resp); err != nil {
-		t.Fatal(err)
-	}
-	if ctx := resp.HookSpecificOutput.AdditionalContext; strings.Contains(ctx, "ARENAGUARD") {
-		t.Errorf("a decision about something else was attached to the command:\n%s", ctx)
+	if !strings.Contains(line, "replica first") {
+		t.Errorf("the decision about this command is not in the line:\n  %s", line)
 	}
 }

--- a/internal/index/command_ran_test.go
+++ b/internal/index/command_ran_test.go
@@ -1,0 +1,42 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The question the tool hook asks of a promoted session: did it run this
+// command. Compared the way CommandHistory compares (#2516).
+func TestSessionRanCommand(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "run the orders migration"},
+		{Role: roleCommand, Text: "$ Make Migrate-Orders"},
+		{Role: roleCommand, Text: "git status --short"},
+		// An assistant sentence that names the command is not a run of it.
+		{Role: "assistant", Text: "make something-else"},
+	}}
+	for _, tc := range []struct {
+		cmd  string
+		want bool
+	}{
+		{cmd: "make migrate-orders", want: true},
+		{cmd: "  make migrate-orders  ", want: true},
+		{cmd: "git status --short", want: true},
+		{cmd: "make migrate", want: false},
+		{cmd: "make something-else", want: false},
+		{cmd: "", want: false},
+		// A multi-line command is never the stored single-line one, for the
+		// reason CommandHistory gives: the harmless first line would carry the
+		// rest.
+		{cmd: "make migrate-orders\nrm -rf /", want: false},
+	} {
+		if got := SessionRanCommand(s, tc.cmd); got != tc.want {
+			t.Errorf("SessionRanCommand(%q) = %v, want %v", tc.cmd, got, tc.want)
+		}
+	}
+	if SessionRanCommand(model.Session{Updated: time.Now()}, "make migrate-orders") {
+		t.Error("a session with no records ran nothing")
+	}
+}

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -297,6 +297,26 @@ func CommandHistory(dir, cmd string) (CommandUse, bool) {
 	return CommandUse{}, false
 }
 
+// SessionRanCommand reports whether this session ran the command, comparing the
+// way CommandHistory does. It is how a caller with a session in hand — the tool
+// hook, holding the promoted decisions of a project — can ask whether the
+// decision is about the command about to run (#2516).
+func SessionRanCommand(s model.Session, cmd string) bool {
+	want := normalizeCommand(cmd)
+	if want == "" || hasSecondLine(cmd) {
+		return false
+	}
+	for _, m := range s.Messages {
+		if m.Role != roleCommand {
+			continue
+		}
+		if normalizeCommand(m.Text) == want {
+			return true
+		}
+	}
+	return false
+}
+
 // CrossBase is filepath.Base that splits on both separators regardless of the
 // host OS. A store synced from Windows holds paths like C:\src\main.go; on a
 // Unix host filepath.Base leaves them whole, so a same-file lookup missed and


### PR DESCRIPTION
Closes #2516.

#2496 taught the line before a file edit to carry a promoted decision instead of scanning for whatever conclusion a session happened to end with. The line before a *command* never learned it:

    session start        standing decisions in this project …
                           · run the orders migration against the replica first; production needs the pool drained
    before the command   This machine has run that command in 6 sessions, last 2026-08-29.

Measured while fixing it: the ranking behind that line was not merely walking past the decision, it was producing nothing at all. It requires every one of the command's words to clear the idf floor, and once several sessions have run the same command those words stop being rare — every candidate came back with 0 informative terms.

So the decision is found by a fact rather than a ranking: take the project's accepted promoted notes, newest first, and ask whether that session ran this exact command — the same question `CommandHistory` answers in aggregate. Bounded to `toolHookDecisionScan` session reads, and only when the project has promoted notes at all. The old scan stays as the fallback.

    after: This machine has run that command in 6 sessions, last 2026-08-29 — last time: run the orders migration against the replica first; production needs the pool drained
