### PR TITLE
fix(digest): cut a lone conclusion rather than dropping it

### DIFF
--- a/internal/digest/conclusion_budget_test.go
+++ b/internal/digest/conclusion_budget_test.go
@@ -7,66 +7,46 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// Conclusions are what an agent reads instead of the session. Fitting the last
-// one by cutting it mid-sentence left a line that reads as a finished thought
-// while the part that fell off the end was the end of it — and the end is where
-// a session says it changed its mind.
-func TestConclusionsDoNotEndMidSentence(t *testing.T) {
-	long := "we moved the scheduler into its own process " + strings.Repeat("after weighing the options ", 12) + "and then reverted that."
+// Measured on a real index: of 120 sessions read at the tool hook's 200-byte
+// budget, 29 yielded no conclusion — and 16 of those had one, a sentence that
+// did not fit. The rule is "whole sentences or nothing" (#1336), and the trade
+// it made was silence where every other surface cuts and marks the cut (#2518).
+func TestASingleConclusionIsCutRatherThanDropped(t *testing.T) {
+	long := "DONE: restored the retry precedence so an exact-key failure retries once more, " +
+		"which is what the ticket asked for and what the earlier change had quietly reversed " +
+		"when it moved the check above the cache lookup instead of below it"
 	s := model.Session{Messages: []model.Message{
-		{Role: "assistant", Text: "we capped retries at three " + strings.Repeat("having weighed the options ", 12) + "and left it there."},
+		{Role: "user", Text: "what did we settle on?"},
 		{Role: "assistant", Text: long},
 	}}
-	for _, c := range Conclusions(s, 400, 2) {
-		// A sentence, or a cut this project marks as one. What must not happen
-		// is a line that simply stops.
-		c = strings.TrimSpace(c)
-		if !strings.HasSuffix(c, ".") && !strings.HasSuffix(c, "…") {
-			t.Errorf("conclusion ends mid-sentence with nothing to say so: %q", c)
-		}
+
+	got := Conclusions(s, 200, 1)
+	if len(got) == 0 {
+		t.Fatalf("a session whose conclusion is one long sentence answered with nothing")
+	}
+	if len(got[0]) > 200 {
+		t.Errorf("the line is %d bytes against a 200-byte budget: %q", len(got[0]), got[0])
+	}
+	if !strings.HasSuffix(got[0], "…") {
+		t.Errorf("the cut is not marked, so the line reads as a finished thought: %q", got[0])
+	}
+	if !strings.HasPrefix(got[0], "DONE: restored the retry precedence") {
+		t.Errorf("the line does not start where the conclusion does: %q", got[0])
 	}
 }
 
-// A conclusion that fits whole is still returned whole, and the budget still
-// bounds the total — otherwise a fix could pass the test above by dropping
-// every conclusion that needs the budget checked at all.
-func TestConclusionsStillFillTheBudget(t *testing.T) {
+// A caller asking for several keeps the old rule: there the cut marker would
+// have text after it, which is the one thing the digest's own invariant forbids.
+func TestSeveralConclusionsKeepWholeSentences(t *testing.T) {
+	long := strings.Repeat("this sentence is long enough to overflow a small budget on its own. ", 3)
 	s := model.Session{Messages: []model.Message{
-		{Role: "assistant", Text: "we capped retries at three. the write-up is in the ticket."},
-		{Role: "assistant", Text: "we moved the scheduler into its own process. it has run clean since."},
+		{Role: "user", Text: "and?"},
+		{Role: "assistant", Text: long},
+		{Role: "assistant", Text: "we kept the pool change."},
 	}}
-	got := Conclusions(s, 400, 2)
-	if len(got) != 2 {
-		t.Fatalf("got %d conclusions, want both: %q", len(got), got)
-	}
-	// A conclusion that fits keeps its second sentence: the budget shortens
-	// what does not fit, not everything.
-	for _, c := range got {
-		if strings.Count(c, ".") < 2 {
-			t.Errorf("conclusion lost its second sentence though it fit: %q", c)
+	for _, line := range Conclusions(s, 60, 3) {
+		if strings.HasSuffix(line, "…") {
+			t.Errorf("a multi-line request produced a marked cut: %q", line)
 		}
-	}
-	total := 0
-	for _, c := range got {
-		total += len(c)
-	}
-	if total > 400 {
-		t.Errorf("conclusions total %d bytes, over the 400 budget", total)
-	}
-}
-
-// When the line that does not fit has a first sentence that does, that sentence
-// is what gets kept — the budget shortens the conclusion instead of deleting it.
-func TestConclusionsFallBackToTheFirstSentence(t *testing.T) {
-	s := model.Session{Messages: []model.Message{
-		{Role: "assistant", Text: "we capped retries at three " + strings.Repeat("having weighed the options ", 12) + "and left it there."},
-		{Role: "assistant", Text: "we moved the scheduler out. " + strings.Repeat("the write-up is above ", 20) + "and nothing else changed."},
-	}}
-	got := Conclusions(s, 400, 2)
-	if len(got) != 2 {
-		t.Fatalf("got %d conclusions, want the shortened one kept: %q", len(got), got)
-	}
-	if !strings.HasPrefix(got[1], "we capped retries at three") {
-		t.Errorf("second conclusion is %q, not the first sentence of the one that did not fit", got[1])
 	}
 }

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -792,6 +792,19 @@ func Conclusions(s model.Session, budget int, max int) []string {
 			// options" arrived without the "and then reverted that" it ended on,
 			// which is the opposite of what the session concluded (#1336).
 			if line = firstSentences(line, 1); spent+len(line) > budget {
+				// Unless one line is the whole answer. Measured on this
+				// machine's index at the tool hook's budget: of 120 sessions,
+				// 29 yielded no conclusion and 16 of those had one — a sentence
+				// a few bytes too long, answered with silence (#2518). A caller
+				// asking for one line is the shape where nothing follows the
+				// cut, so it can be marked the way every other surface marks
+				// one; a caller asking for several keeps the old rule, since
+				// there text would follow the marker.
+				if max == 1 && len(out) == 0 {
+					if cut := markedCut(line, budget); cut != "" {
+						out = append(out, cut)
+					}
+				}
 				break
 			}
 		}
@@ -821,6 +834,21 @@ func isCJKSentenceEnd(r rune) bool {
 		return true
 	}
 	return false
+}
+
+// markedCut is a conclusion held to a budget it does not fit, ending in the
+// marker that says so. Rune-safe, and it gives back nothing when the budget
+// leaves no room for a readable line rather than a bare marker.
+func markedCut(line string, budget int) string {
+	const mark = "…"
+	if budget <= len(mark)+8 {
+		return ""
+	}
+	cut := strings.TrimRight(UTF8SafeCut(line, budget-len(mark)), " \t")
+	if cut == "" {
+		return ""
+	}
+	return cut + mark
 }
 
 // firstSentences keeps the opening n sentences of a message: a conclusion


### PR DESCRIPTION
Closes #2518.

Measured on this machine's index — 120 real sessions at the tool hook's 200-byte budget:

    before:  91 yielded a conclusion, 29 did not — 16 of those only because the line did not fit
    after:  108 yielded a conclusion, 12 did not

The 16 were not sessions without a conclusion. Their conclusion was a sentence a few bytes too long, and `Conclusions` answered with nothing:

    233B: VERDICT: PASS MISSING: - None SUMMARY: README and section docs cover onboarding, …
    414B: DONE: Restored `should_test()` precedence so exact-key FAILED retries are allowed …

"Whole sentences or nothing" was written so a cut conclusion could not read as a finished thought while the decisive half fell off (#1336). The trade it made was silence, which deja makes nowhere else — the environment block, the plan finding and the handoff all cut and mark the cut.

So: when the caller asked for one conclusion and nothing has been emitted, the candidate is cut to the budget and marked. Only for `max == 1`, the shape where the line is the whole answer and nothing follows it, so the marker cannot meet the "nothing follows a marked cut" invariant that governs `Share` and the handoff — both ask for several and are untouched.
