### PR TITLE
fix(hook-tool): ask whether the session ran the command, not whether its words are rare

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -288,19 +288,31 @@ func commandDecisionLine(dir, cwd, cmd string) string {
 	if len(terms) == 0 {
 		return ""
 	}
-	ranked, matched, _, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
+	ranked, _, _, _, err := index.ProjectRelevant(dir, digest.ProjectNameCandidates(cwd), terms, toolHookDecisionScan)
 	if err != nil {
 		return ""
 	}
 	pol := policy.Load()
 	states := sources.PromotedLifecycles()
-	for i, s := range ranked {
-		// Every term or nothing: a build command's words are common, and one
-		// of them matching finds a session about something else entirely.
-		if matched[i] < len(terms) {
+	for _, s := range ranked {
+		// The old rule wanted every one of the command's words to be rare.
+		// Measured on 1,696 sessions, none of the fifteen most-run commands
+		// clears that: a command's words are common by construction, which is
+		// what makes it one this machine runs. `go test ./...` reduces to the
+		// single term "test", and no bar built on rarity admits it (#2520).
+		//
+		// What the rule was after — is this session about this command — is a
+		// fact rather than a ranking: did the session run it. The words still
+		// choose the candidates; running the command earns the line. A session
+		// that merely says "apply" is not the history of `terraform apply`.
+		if !pol.Allows(policy.ActivationAuto, s.Project) || !decisionUsable(s, states) {
 			continue
 		}
-		if !pol.Allows(policy.ActivationAuto, s.Project) || !decisionUsable(s, states) {
+		// The ranked sessions are served without their command records, so the
+		// question is asked of the session as the index holds it. Bounded by
+		// the same scan the ranking is.
+		whole, ok, ferr := index.FindByIdentity(dir, s.Harness, s.ID)
+		if ferr != nil || !ok || !index.SessionRanCommand(whole, cmd) {
 			continue
 		}
 		if len(s.Messages) > toolHookMsgTail {

--- a/cmd/deja/hook_tool_common_command_test.go
+++ b/cmd/deja/hook_tool_common_command_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Measured on a real index: of the fifteen commands this machine runs most, not
+// one has every word clearing the idf floor — a command's words are common by
+// construction, which is what makes it a command that gets run. The line
+// therefore never reached a session at all (#2520).
+func TestTheCommandLineAnswersAboutAnOrdinaryCommand(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	at := func(m int) string { return now.Add(-time.Duration(m) * time.Minute).Format(time.RFC3339) }
+	write := func(sid string, lines []string) {
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bash := func(sid, when, cmd string) string {
+		return `{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + when + `","cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + cmd + `"}}]}}`
+	}
+	// A session that concluded something about the command, older than the runs
+	// below — the promoted-decision path (#2516) is what lifts this one; here
+	// it is only part of the corpus.
+	write("dec", []string{
+		`{"type":"user","sessionId":"dec","timestamp":"` + at(401) + `","cwd":"/work/app","message":{"role":"user","content":"the integration suite keeps failing on the shared fixture"}}`,
+		bash("dec", at(400), "go test ./..."),
+		`{"type":"assistant","sessionId":"dec","timestamp":"` + at(399) + `","cwd":"/work/app","message":{"role":"assistant","content":"the suite has to run with -p 1: the shared fixture cannot take parallel packages."}}`,
+	})
+	// Sessions that ran the same command, making its words ordinary — which is
+	// exactly what happens on a real machine.
+	for k := 0; k < 8; k++ {
+		sid := fmt.Sprintf("r%d", k)
+		write(sid, []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(300-10*k) + `","cwd":"/work/app","message":{"role":"user","content":"run the tests"}}`,
+			bash(sid, at(299-10*k), "go test ./..."),
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(298-10*k) + `","cwd":"/work/app","message":{"role":"assistant","content":"tests pass"}}`,
+		})
+	}
+	// And unrelated work, so the store is not one topic.
+	for i, top := range []string{"the sidebar layout", "the invoice renderer", "the webpack config",
+		"the login throttle", "the avatar uploader", "the cron scheduler", "the email templates"} {
+		sid := fmt.Sprintf("t%d", i)
+		write(sid, []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(900-10*i) + `","cwd":"/work/app","message":{"role":"user","content":"work on ` + top + `"}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(899-10*i) + `","cwd":"/work/app","message":{"role":"assistant","content":"changed ` + top + `"}}`,
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	line := commandHookLine(dir, "/work/app", "go test ./...")
+	if line == "" {
+		t.Fatal("the fixture produced no line at all")
+	}
+	// What the surface promises: what happened the last time this command ran.
+	if !strings.Contains(line, "last time:") {
+		t.Errorf("the line reached no session at all:\n  %s", line)
+	}
+	if !strings.Contains(line, "tests pass") {
+		t.Errorf("the line does not carry what the last run of this command concluded:\n  %s", line)
+	}
+}
+
+// The precision the old rule was after: a session that shares one ordinary word
+// with the command is not about it.
+func TestTheCommandLineIgnoresASessionSharingOneOrdinaryWord(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	at := func(m int) string { return now.Add(-time.Duration(m) * time.Minute).Format(time.RFC3339) }
+	write := func(sid string, lines []string) {
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Nobody ran `terraform apply` here; one session merely says "apply".
+	write("other", []string{
+		`{"type":"user","sessionId":"other","timestamp":"` + at(200) + `","cwd":"/work/app","message":{"role":"user","content":"apply the migration to the staging database"}}`,
+		`{"type":"assistant","sessionId":"other","timestamp":"` + at(199) + `","cwd":"/work/app","message":{"role":"assistant","content":"the staging database now matches production."}}`,
+	})
+	for i, top := range []string{"the sidebar layout", "the invoice renderer", "the webpack config"} {
+		sid := fmt.Sprintf("t%d", i)
+		write(sid, []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(900-10*i) + `","cwd":"/work/app","message":{"role":"user","content":"work on ` + top + `"}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(899-10*i) + `","cwd":"/work/app","message":{"role":"assistant","content":"changed ` + top + `"}}`,
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if line := commandDecisionLine(dir, "/work/app", "terraform apply"); line != "" {
+		t.Errorf("a session sharing one ordinary word became this command's history: %q", line)
+	}
+}


### PR DESCRIPTION
Closes #2520.

Measured on this machine's index (1,696 sessions, so `idf >= 2.0` admits a term living in at most 229 of them) — the fifteen commands run in the most sessions:

    $ rtk git status --short          rtk 1.19 (511 sessions)  git 1.32 (450)  status 1.19 (513)
    $ rtk go test ./...               rtk 1.19 (511)           test 0.78 (770)
    $ kubectl config current-context  kubectl 3.56 (47)        config 1.38 (425)  current-context 4.30 (22)

    commands whose every word clears the floor: 0 of 15

`commandDecisionLine` required exactly that before it would look at a session, so the decision half of the line never fired for any command a person actually runs. The reason is in the rule's own comment: a command's words are common *by construction* — that is what makes it a command this machine runs. `go test ./...` reduces to the single term `test`, and no bar built on rarity will admit it.

What the rule was after — is this session about this command — is a fact rather than a ranking: did the session run it. The words still choose the candidates; running the command earns the line. A session that merely says "apply" is not the history of `terraform apply`, and that is pinned.

The check is asked of the session as the index holds it, since the ranked sessions are served without their command records.
