### PR TITLE
docs(hook-tool): record what the decision lines cost before a command

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -233,6 +233,15 @@ func commandHookLine(dir, cwd, cmd string) string {
 // sessions of the project — few, and bounded here — and asks each whether it
 // ran this command, which is the same question CommandHistory answers in
 // aggregate.
+//
+// What that costs, measured on a store the size of a working machine (1,500
+// sessions, the command run in 188 of them): this path and the ranking path
+// below add 3–5 ms to a hook that already cost ~19 ms, six session reads in the
+// worst case, three per path (#2522). In the common case the two read the same
+// sessions — one to ask whether a promoted note belongs to it, one to ask
+// whether it ran the command — and passing the session between them would halve
+// that. Not done: 5 ms is not worth the coupling, and this is where a reader
+// would look for the number.
 func promotedCommandDecision(dir, cwd, cmd string) string {
 	names := digest.ProjectNameCandidates(cwd)
 	if len(names) == 0 {


### PR DESCRIPTION
Comment only. Records the measurement in #2522 where the cost lives.

#2517 and #2521 both added session reads to the line before a Bash command, and neither was measured at the time. On a store the size of a working machine — 1,500 sessions, the command run in 188 of them:

    before #2517   19–20 ms
    after  #2521   21–25 ms
    with a promoted note in the project   22–24 ms

Six session reads in the worst case, three per path, both bounded by `toolHookDecisionScan`. Both binaries print the same sentence on the same input, so the change bought coverage — #2520 measured the old rule reaching no real command at all — without moving what it says where it already spoke.

The comment also names the redundancy it leaves: in the common case the two paths read the same sessions, and passing the session between them would halve the worst case. Not worth the coupling for 5 ms, but worth writing down next to the number.
