### PR TITLE
fix(hook-tool): show the rule as well as the exception

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -457,7 +457,7 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 	// through an allowed session — but the note carries a project of its own,
 	// and every other reader of these notes checks it (#2506).
 	pol := policy.Load()
-	var best sources.PromotedNote
+	var found []sources.PromotedNote
 	keep := func(note sources.PromotedNote) {
 		if note.State != "accepted" {
 			return
@@ -465,9 +465,7 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 		if note.Project != "" && !pol.Allows(policy.ActivationAuto, note.Project) {
 			return
 		}
-		if best.At.IsZero() || note.At.After(best.At) {
-			best = note
-		}
+		found = append(found, note)
 	}
 	for _, note := range sources.LoadPromotedNotes() {
 		if !want[note.Session] {
@@ -503,14 +501,50 @@ func promotedDecisionFor(metas []index.SessionMeta) string {
 			keep(noteFromMeta(note))
 		}
 	}
-	text := strings.TrimSpace(best.Text)
-	if text == "" {
-		text = strings.TrimSpace(best.Title)
+	return decisionLineOf(found, toolHookDecisionBudget)
+}
+
+// decisionLineOf words what this file or command has standing, newest first.
+//
+// Two, when they fit. A file often has a broad rule and a narrow exception, and
+// the exception is newer almost by definition — it is an exception to something
+// — so showing only the newest handed the agent the half that reverses the
+// rule, with nothing to say the rule existed (#2524). When the second does not
+// fit, the line says one was left out rather than leaving the narrower half
+// standing alone.
+func decisionLineOf(notes []sources.PromotedNote, budget int) string {
+	sort.SliceStable(notes, func(i, j int) bool { return notes[i].At.After(notes[j].At) })
+	var lines []string
+	seen := map[string]bool{}
+	for _, note := range notes {
+		text := strings.TrimSpace(note.Text)
+		if text == "" {
+			text = strings.TrimSpace(note.Title)
+		}
+		if text == "" {
+			continue
+		}
+		text = trimTrailingFragment(search.SafeText(clipDecision(text, budget)))
+		if text == "" || seen[strings.ToLower(text)] {
+			continue
+		}
+		seen[strings.ToLower(text)] = true
+		lines = append(lines, text)
 	}
-	if text == "" {
+	if len(lines) == 0 {
 		return ""
 	}
-	return trimTrailingFragment(search.SafeText(clipDecision(text, toolHookDecisionBudget)))
+	out := lines[0]
+	rest := len(lines) - 1
+	if rest > 0 {
+		if joined := out + "; also: " + lines[1]; len(joined) <= budget {
+			out, rest = joined, rest-1
+		}
+	}
+	if rest > 0 {
+		out += fmt.Sprintf(" (+%d more standing here)", rest)
+	}
+	return out
 }
 
 // noteFromMeta reads the decision a session carries as a promoted note, so the

--- a/cmd/deja/hook_tool_two_decisions_test.go
+++ b/cmd/deja/hook_tool_two_decisions_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A file with a broad rule and a narrow exception. The exception is newer
+// almost by definition — it is an exception to something — so "newest wins"
+// hands the agent the half that reverses the rule, with nothing to say the rule
+// exists (#2524).
+func TestTheEditLineCarriesBothDecisionsWhenTheyFit(t *testing.T) {
+	tmp := hermeticEnv(t)
+	_ = tmp
+	now := time.Now().UTC()
+	if err := sources.AppendPromoted("app", "the general rule",
+		"every retry path in retry.go goes through the shared budget",
+		"claude:broad", "accepted", now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sources.AppendPromoted("app", "the exception",
+		"the webhook replay is the one exception: it retries twice on its own",
+		"claude:narrow", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+	metas := []index.SessionMeta{
+		{ID: "narrow", Harness: "claude", Project: "app", Updated: now},
+		{ID: "broad", Harness: "claude", Project: "app", Updated: now.Add(-48 * time.Hour)},
+	}
+
+	got := promotedDecisionFor(metas)
+	if !strings.Contains(got, "webhook replay") {
+		t.Errorf("the newest decision is missing: %q", got)
+	}
+	if !strings.Contains(got, "shared budget") {
+		t.Errorf("the rule the exception qualifies is missing, so the line reverses it: %q", got)
+	}
+}
+
+// When the second does not fit, the line says one is missing rather than
+// leaving the reader with the narrower half alone.
+func TestTheEditLineSaysWhenADecisionDidNotFit(t *testing.T) {
+	hermeticEnv(t)
+	now := time.Now().UTC()
+	long := "every retry path in retry.go goes through the shared budget, which the pool owns, " +
+		"and nothing in this package may open its own client or set its own deadline for any reason"
+	if err := sources.AppendPromoted("app", "the general rule", long, "claude:broad", "accepted", now.Add(-48*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := sources.AppendPromoted("app", "the exception",
+		"the webhook replay is the one exception: it retries twice on its own",
+		"claude:narrow", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+	metas := []index.SessionMeta{
+		{ID: "narrow", Harness: "claude", Project: "app", Updated: now},
+		{ID: "broad", Harness: "claude", Project: "app", Updated: now.Add(-48 * time.Hour)},
+	}
+
+	got := promotedDecisionFor(metas)
+	if !strings.Contains(got, "webhook replay") {
+		t.Errorf("the newest decision is missing: %q", got)
+	}
+	if !strings.Contains(got, "1 more") {
+		t.Errorf("the line does not say that another standing decision was left out: %q", got)
+	}
+	if len(got) > toolHookDecisionBudget+40 {
+		t.Errorf("the line is %d bytes, well past its budget: %q", len(got), got)
+	}
+}
+
+// One decision reads exactly as it did.
+func TestTheEditLineWithOneDecisionIsUnchanged(t *testing.T) {
+	hermeticEnv(t)
+	now := time.Now().UTC()
+	if err := sources.AppendPromoted("app", "t", "the retry budget stays at 5", "claude:a", "accepted", now); err != nil {
+		t.Fatal(err)
+	}
+	metas := []index.SessionMeta{{ID: "a", Harness: "claude", Project: "app", Updated: now}}
+	if got := promotedDecisionFor(metas); got != "the retry budget stays at 5" {
+		t.Errorf("a single decision now reads as %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2524.

A file with two accepted decisions — a broad rule and a narrow exception:

    session start    · the webhook replay in retry.go is the one exception: it retries twice on its own
                     · every retry path in retry.go goes through the shared budget

    before the edit  … — prior decision: the webhook replay in retry.go is the one exception: it retries twice on its own

The session-start block has both. The line at the moment of the edit took the newest, and the newest is the exception — so the agent was told that retry.go retries on its own, which is the opposite of the rule the exception qualifies. An exception is newer than its rule almost by definition, which makes "newest wins" exactly the wrong tie-break when only one line is shown.

Both now go on the line when they fit the 200-byte decision budget, joined with "; also: ", and anything left out is counted: `(+N more standing here)`. A single decision reads exactly as before, which is pinned.
