### PR TITLE
fix(recall): stop two sessions saying one thing from taking both slots

### DIFF
--- a/cmd/deja/fingerprint_lines_test.go
+++ b/cmd/deja/fingerprint_lines_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func said(id string, lines ...string) model.Session {
+	s := model.Session{ID: id, Harness: "claude", Project: "p"}
+	for i, l := range lines {
+		role := "assistant"
+		if i == 0 {
+			role = "user"
+		}
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: l})
+	}
+	return s
+}
+
+// Two sessions that settled the same thing say it in one sentence and differ in
+// everything around it. Hashing every line that held any word of the question
+// made the small talk part of what the session was saying, so the two came back
+// as different answers and the block spent both its slots on one.
+func TestTwoSessionsSayingOneThingFillOneSlot(t *testing.T) {
+	terms := []string{"queue", "throwing", "away"}
+	first := said("a",
+		"the watermark is what keeps the queue from throwing work away",
+		"noted, moving on to the invoice")
+	second := said("b",
+		"the watermark is what keeps the queue from throwing work away",
+		"right, and the queue for that runs nightly")
+	if !sameAnswerAs([]model.Session{first}, second, terms) {
+		t.Error("two sessions saying the same sentence took a slot each")
+	}
+}
+
+// The same rule must not merge two answers to one question. A session that
+// asked what everyone else asked is not a duplicate of them: what it settled is
+// its own, and here the two settled opposite numbers.
+func TestTwoAnswersToOneQuestionKeepTheirSlots(t *testing.T) {
+	terms := []string{"payment", "webhook", "retries"}
+	old := said("old",
+		"how many retries for the payment webhook",
+		"we set the payment webhook retries to 10")
+	recent := said("new",
+		"how many retries for the payment webhook",
+		"we cut the payment webhook retries to 3")
+	if sameAnswerAs([]model.Session{old}, recent, terms) {
+		t.Error("two different answers to the same question were merged into one")
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -448,12 +448,22 @@ func sameAnswerAs(chosen []model.Session, s model.Session, terms []string) bool 
 // matchedFingerprint is the session's matching lines, normalised, hashed. Empty
 // when nothing matched, which is not a duplicate of anything.
 func matchedFingerprint(s model.Session, terms []string) string {
+	// Lines that carry the question, not lines that brush it. A session says
+	// the thing once and talks around it for the rest, and the talk differs
+	// session to session — so hashing every line that held any query word gave
+	// two sessions that settled the same thing two fingerprints, and the block
+	// spent both its slots saying it twice. A line holding one ordinary word of
+	// the question is that talk.
 	var b strings.Builder
 	for _, m := range s.Messages {
+		line := strings.Join(strings.Fields(strings.ToLower(m.Text)), " ")
+		if search.TermHitsLowered(line, terms) < fingerprintTermsPerLine {
+			continue
+		}
 		if !search.SpeechCarriesAnyTerm(model.Session{Messages: []model.Message{m}}, terms) {
 			continue
 		}
-		b.WriteString(strings.Join(strings.Fields(strings.ToLower(m.Text)), " "))
+		b.WriteString(line)
 		b.WriteByte('\n')
 	}
 	if b.Len() == 0 {
@@ -461,6 +471,10 @@ func matchedFingerprint(s model.Session, terms []string) string {
 	}
 	return blockFingerprint(b.String())
 }
+
+// fingerprintTermsPerLine is how much of the question a line has to carry
+// before it counts toward what a session is saying.
+const fingerprintTermsPerLine = 2
 
 // leadTermsKept is how many of the question's identifying words a session may
 // be judged on. Three rather than one: the gate exists to reject a session


### PR DESCRIPTION
The block holds two sessions and dedupes them on what they matched, so it never says one thing twice. The fingerprint was every line holding any word of the question — which includes the small talk around the answer, and that differs session to session. Two sessions that settled the same thing came back as two answers and took a slot each.

Now a line counts toward what a session is saying only if it carries at least two of the question's words. What it settled is in the sentence that carries the question; a line holding one ordinary word of it is the talk around that.

The other side is pinned too: two sessions that asked the same question and answered it differently — "retries to 10" and "retries to 3" — share the question word for word and must keep their slots. That is the case #R12 exists for, and it stays green.

bench prompt: reworded-tied 4/6 to 6/6 correct, precision 1.00; real questions 13/13, negative controls 0 false fires of 12, reworded 15/20, all unchanged. Hook median on a 1696-session store 102ms to 90ms — fewer lines hashed per candidate.

Measured before this: widening the decision markers so the fingerprint could key on what was concluded instead. Rejected — on a real store of 207,320 assistant lines the shapes it needed appear 12, 10, 8 and 1 times, so it would have fitted the fixture and nothing else.