### PR TITLE
fix(recall): stop a subject the store never saw from carrying a match

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -540,13 +540,13 @@ func measurePrompt(seed int64) (promptReport, error) {
 // opening line came from the top of a long transcript does not, and that line
 // is the whole frame an agent reads before deciding to ignore the rest.
 func shownLineCarriesATerm(dir, project string, terms []string) bool {
-	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		keep = append(keep, s)
@@ -587,7 +587,7 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -616,7 +616,7 @@ func blockCarries(dir, project string, terms []string, fact, topic string) bool 
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -662,14 +662,14 @@ func promptBenchProbeBlock(dir, project, chainID string, terms []string) (fired,
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}
 	shown := 0
 	var chosen []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {
@@ -703,7 +703,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false, false
 	}
@@ -711,7 +711,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 		// The same bar the hook applies, from the same function — kept in one
 		// place because the two drifted: this one asked whether the query held
 		// an identifier, the hook asked whether the session did.
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {
@@ -743,13 +743,13 @@ func finishPromptArm(arm *promptArmReport, terms []int) {
 // blockOpensOnEcho reports whether the first line the agent would read is the
 // question it just asked, handed back.
 func blockOpensOnEcho(dir, project string, terms []string, question string) bool {
-	ranked, matched, strong, _, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		keep = append(keep, s)

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -246,7 +246,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// hook pays its cost on every message the user sends. Measured on
 		// cross-paired prompts whose answer is absent, the old bar injected on
 		// 94% of them; half of those rested on one ordinary word.
-		if !search.RecallWorthShowing(terms, matched[i], strong[i]) {
+		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
 			continue
 		}
 		// A word rare enough to identify something is a real match on its own —

--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -26,7 +26,7 @@ import "unicode/utf8"
 // fires on the benchmark's negative controls. Threading it changes nothing
 // today; using it is the next rule's decision, and it will now land in every
 // instrument at once.
-func RecallWorthShowing(terms []string, matched, strong int) bool {
+func RecallWorthShowing(terms []string, matched, strong int, known map[string]float64) bool {
 	_ = strong // see the note above: taken so the instruments cannot drift
 	if matched < 1 {
 		return false
@@ -36,10 +36,45 @@ func RecallWorthShowing(terms []string, matched, strong int) bool {
 	// applying all along while the hook applied only the first — measured on
 	// the corpus, the pair answers 11 of 12 real questions with no false fire,
 	// where the session-only rule answers 7 and fires on 2 controls.
-	if HasIdentifierTerm(terms) {
+	if HasIdentifierTermKnown(terms, known) {
 		return true
 	}
 	return matched >= 2
+}
+
+// identifierKnownFrom is how many words a question needs before its subject is
+// checked against the store.
+const identifierKnownFrom = 3
+
+// HasIdentifierTermKnown is HasIdentifierTerm over the words the corpus
+// actually holds.
+//
+// A word is judged a term of art by its shape, which says nothing about whether
+// this store has ever seen it. So a question naming something that lives in
+// another project entirely — "which branch was the oauth rotation on when the
+// suite passed" — cleared the bar on "oauth", and then a single match on
+// "branch" was enough to answer it. The subject contributed nothing: what
+// matched was the vocabulary every working session is made of, and the session
+// that says those words most often is whichever session is longest.
+//
+// known is the idf of each term the corpus contains; a term missing from it
+// appears nowhere in the store. Nil means the caller has no such map and every
+// term is taken as known, which is the behaviour this had before.
+func HasIdentifierTermKnown(terms []string, known map[string]float64) bool {
+	// A short question is all subject: "как там pr, смержился?" names the thing
+	// and one working verb, and there is nothing else in it for a candidate to
+	// have matched instead. The vocabulary a session is carried by only exists
+	// in a question long enough to hold it.
+	if known == nil || len(terms) <= identifierKnownFrom {
+		return HasIdentifierTerm(terms)
+	}
+	kept := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if _, ok := known[t]; ok {
+			kept = append(kept, t)
+		}
+	}
+	return HasIdentifierTerm(kept)
 }
 
 // HasIdentifierTerm reports whether the question contains a word specific

--- a/internal/search/worth_known_test.go
+++ b/internal/search/worth_known_test.go
@@ -1,0 +1,49 @@
+package search
+
+import "testing"
+
+// A question can name something specific this store has never seen — work from
+// another project, another machine, another life. The word still reads as a
+// term of art, and that was enough: a single match on one of the ordinary words
+// around it answered with whatever session says those words most often, which
+// is whichever session is longest. The subject contributed nothing.
+func TestASubjectTheStoreNeverSawCarriesNothing(t *testing.T) {
+	terms := []string{"oauth", "rotation", "branch", "suite", "passed"}
+	// The working vocabulary is here; the subject is not.
+	known := map[string]float64{"branch": 2.4, "suite": 2.1}
+	if RecallWorthShowing(terms, 1, 1, known) {
+		t.Error("a question about something absent was answered on one match")
+	}
+	// Two ordinary words that met in one message is a different rule, and this
+	// one leaves it alone.
+	if !RecallWorthShowing(terms, 2, 1, known) {
+		t.Error("the two-word rule was lost")
+	}
+	// Whether anything else in the question carries on its own stays the shape
+	// rule's business. "passed" is not on the working-word list and is long
+	// enough to pass it, so a question holding it still fires — which is why
+	// this removes one of the benchmark's three false fires and not all three.
+	if !RecallWorthShowing(terms, 1, 1, map[string]float64{"branch": 2.4, "suite": 2.1, "passed": 2.0}) {
+		t.Error("a known word of identifier shape stopped carrying")
+	}
+}
+
+// The subject is present: one match on it is an answer, and that is the rule
+// this must not weaken.
+func TestAKnownSubjectStillCarriesOnItsOwn(t *testing.T) {
+	terms := []string{"pgbouncer", "here"}
+	known := map[string]float64{"pgbouncer": 4.2, "here": 1.0}
+	if !RecallWorthShowing(terms, 1, 1, known) {
+		t.Error("a rare word the store holds stopped carrying a match")
+	}
+}
+
+// A short question is all subject. "как там pr, смержился?" names the thing and
+// one working verb: there is nothing else in it a candidate could have matched
+// instead, so it is judged on shape as before and the store is never asked.
+func TestAShortQuestionIsJudgedOnShapeAlone(t *testing.T) {
+	terms := []string{"смержился", "pr"}
+	if !RecallWorthShowing(terms, 1, 1, map[string]float64{"pr": 3.0}) {
+		t.Error("a short question naming its subject fell silent")
+	}
+}

--- a/internal/search/worth_test.go
+++ b/internal/search/worth_test.go
@@ -3,16 +3,16 @@ package search
 import "testing"
 
 func TestRecallWorthShowing(t *testing.T) {
-	if RecallWorthShowing([]string{"pgbouncer"}, 0, -1) {
+	if RecallWorthShowing([]string{"pgbouncer"}, 0, -1, nil) {
 		t.Error("nothing matched, so there is nothing to show")
 	}
-	if !RecallWorthShowing([]string{"pgbouncer"}, 1, -1) {
+	if !RecallWorthShowing([]string{"pgbouncer"}, 1, -1, nil) {
 		t.Error("a word that identifies something stands on one match")
 	}
-	if RecallWorthShowing([]string{"build"}, 1, -1) {
+	if RecallWorthShowing([]string{"build"}, 1, -1, nil) {
 		t.Error("one ordinary word is not a subject on its own")
 	}
-	if !RecallWorthShowing([]string{"build", "retry"}, 2, -1) {
+	if !RecallWorthShowing([]string{"build", "retry"}, 2, -1, nil) {
 		t.Error("two ordinary words that both matched earn the block")
 	}
 }

--- a/scripts/longmemeval/main.go
+++ b/scripts/longmemeval/main.go
@@ -639,7 +639,7 @@ func passHookGates(ranked []model.Session, matched, strong []int, terms []string
 		if i < len(strong) {
 			st = strong[i]
 		}
-		if i < len(matched) && !search.RecallWorthShowing(terms, matched[i], st) {
+		if i < len(matched) && !search.RecallWorthShowing(terms, matched[i], st, nil) {
 			continue
 		}
 		if !search.SpeechCarriesAnyTerm(s, terms) {
@@ -810,7 +810,7 @@ func runHookPrecision(questions []lmeQuestion, limit int) {
 		about := 0
 		// One match, and no claim about how rare it was: -1 keeps the
 		// question-side reading this arm has always used.
-		if len(ranked) > 0 && search.RecallWorthShowing(terms, 1, -1) {
+		if len(ranked) > 0 && search.RecallWorthShowing(terms, 1, -1, nil) {
 			about = 1
 		}
 		switch {


### PR DESCRIPTION
A single rare word is allowed to carry a match on its own, and a word is judged rare enough by its shape — long, or shaped like a symbol. Shape says nothing about whether this store has ever held the word. So a question naming something that lives in another project entirely — "which branch was the oauth rotation on when the suite passed" — cleared the bar on "oauth", and one match on "branch" was then enough to answer it. The subject contributed nothing: what matched was the vocabulary every working session is made of, and the session saying those words most often is whichever session is longest.

The ranking already knows which of the question's words the corpus contains — it returns their idf — so the gate now judges shape over those words alone. A short question is exempt: "как там pr, смержился?" names the thing and one working verb, and there is nothing else in it a candidate could have matched instead.

Threaded through every caller rather than added beside the old one, for the reason the file already gives: the hook and the benchmark applied two slightly different rules once, and the benchmark measured a gate the product did not have.

bench prompt: absent-subject 3 false fires to 2, every other arm unchanged (real questions 13/13, negative controls 0 of 12, reworded 15/20, reworded-tied 6/6). LongMemEval-S unmoved at 84.8%.

The remaining two fire through the shape rule on "passed", which is not on the working-word list and is long enough to pass it. That is the next thing to measure, and it is a different rule from this one.