### PR TITLE
fix(hook-tool): call a scanned line a decision only when it reads as one

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -391,8 +391,24 @@ func fileHookLine(dir, cwd, path string) string {
 	// it: a line that said "deja blame X has the history" drove no reuse, while
 	// the same moment carrying the prior decision did. So surface the decision
 	// here, and fall back to the pointer only when none can be extracted.
-	if d := fileDecisionLine(dir, inScope); d != "" {
+	// Named for what it is. A promoted note is the user's own decision; a line
+	// the conclusion scan found is the last thing a session said about the
+	// file, which is often "changed the renderer (5)". The line was built on a
+	// measurement — an agent follows a decision where it ignores a pointer —
+	// and calling filler a decision spends exactly that credibility (#2526).
+	// The command line has said the weaker "last time:" all along.
+	if d := promotedDecisionFor(inScope); d != "" {
 		return head + " — prior decision: " + d
+	}
+	if d := fileDecisionLine(dir, inScope); d != "" {
+		// A scanned line is called a decision only when it reads as one. The
+		// scan's own fallback is the newest session's closing sentence, which
+		// is as often "changed the renderer (5)" as it is a decision, and the
+		// same marker list the digest uses can tell them apart.
+		if digest.CarriesDecision(d) {
+			return head + " — prior decision: " + d
+		}
+		return head + " — last session on it ended: " + d
 	}
 	return fmt.Sprintf("%s — `deja blame %s` has the history.", head, name)
 }

--- a/cmd/deja/hook_tool_wording_test.go
+++ b/cmd/deja/hook_tool_wording_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func editStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	at := func(m int) string { return now.Add(-time.Duration(m) * time.Minute).Format(time.RFC3339) }
+	for k := 0; k < 6; k++ {
+		sid := fmt.Sprintf("f%d", k)
+		lines := []string{
+			`{"type":"user","sessionId":"` + sid + `","timestamp":"` + at(200-10*k) + `","cwd":"/work/app","message":{"role":"user","content":"work on the invoice renderer"}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(199-10*k) + `","cwd":"/work/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/work/app/render.go","old_string":"x","new_string":"y"}}]}}`,
+			`{"type":"assistant","sessionId":"` + sid + `","timestamp":"` + at(198-10*k) + `","cwd":"/work/app","message":{"role":"assistant","content":"changed the renderer (` + fmt.Sprint(k) + `)"}}`,
+		}
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The line was built on a measurement: an agent follows a decision where it
+// ignores a pointer. Calling the last sentence of the last session a "prior
+// decision" spends that credibility on filler — and the same surface already
+// says the honest weaker thing for commands (#2526).
+func TestAScannedConclusionIsNotCalledADecision(t *testing.T) {
+	dir := editStore(t)
+
+	line := fileHookLine(dir, "/work/app", "/work/app/render.go")
+	if line == "" {
+		t.Fatal("the fixture produced no line at all")
+	}
+	if strings.Contains(line, "prior decision") {
+		t.Errorf("a session's closing sentence is offered as a decision:\n  %s", line)
+	}
+	if !strings.Contains(line, "changed the renderer") {
+		t.Errorf("the line stopped carrying what the last session ended on:\n  %s", line)
+	}
+}
+
+// A promoted decision keeps the word, since that is what it is.
+func TestAPromotedDecisionKeepsTheWord(t *testing.T) {
+	dir := editStore(t)
+	if _, err := captureRunStderr(t, "promote", "f5", "--state", "accepted",
+		"--note", "the renderer never re-wraps a paragraph that already fits"); err != nil {
+		t.Fatal(err)
+	}
+
+	line := fileHookLine(dir, "/work/app", "/work/app/render.go")
+	if !strings.Contains(line, "prior decision: the renderer never re-wraps") {
+		t.Errorf("a promoted decision is no longer named as one:\n  %s", line)
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -580,6 +580,10 @@ func Short(s string) string {
 // sessions, where 95% of the transcript is status chatter around a few
 // sentences that actually explain what happened and why.
 var decisionMarkers = []string{
+	// "decision:" with the colon, which is how an agent labels one when it is
+	// writing for a reader rather than talking: the bare word is ordinary
+	// ("that decision is yours"), the labelled one is the line itself (#2526).
+	"decision:", "решение:",
 	"root cause", "because", "the fix", "fixed", "decided", "instead of",
 	"turned out", "the problem was", "solution", "so the answer", "conclusion",
 	"works now", "passes now", "merged", "released", "chose", "won't work",


### PR DESCRIPTION
Closes #2526.

Probing a decision that names no file and no command — "no new dependencies without an ADR" — showed that such a decision does reach the moment of action, through the file the promoted session touched:

    editing go.mod      … — prior decision: no new dependencies in this repo without an ADR
    running `go get …`  (silent — nobody has run it here)

and turned up the line beside it:

    editing render.go   … — prior decision: changed the renderer (5)

Nothing was ever promoted about `render.go`. The scan fell back to the newest session's closing sentence and the line called it a decision. That word was earned by a measurement — an agent follows a decision where it ignores a pointer — and spending it on filler teaches the opposite.

Now: a promoted note keeps "prior decision:", a scanned line keeps it when `digest.CarriesDecision` says it reads as one, and otherwise the line says what it actually is:

    editing render.go   … — last session on it ended: changed the renderer (5)

`decisionMarkers` also gains the labelled form, `decision:` and `решение:`, which it did not have — a line literally starting "Decision: config.go must load the sentinel" was not recognised as one, which is what the existing pin for that case turned up.
