### PR TITLE
fix(recall): ask the store whether a word identifies, not just its shape

### DIFF
--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -46,6 +46,18 @@ func RecallWorthShowing(terms []string, matched, strong int, known map[string]fl
 // checked against the store.
 const identifierKnownFrom = 3
 
+// identifierIDFFloor is how rare a word has to be in this store before its
+// shape may carry a match on its own. Shape alone admits any word of three
+// letters that is not on the working-word list, and that list is written by
+// hand — "passed", "rows", "delay" are not on it and name nothing.
+//
+// Asking the store instead of the list: measured by cross-pairing 400 real
+// prompts against a project that cannot hold their answer, where every fire is
+// a false one, this takes them from 129 to 89 while the same questions asked at
+// home still fire 398 times out of 400. Higher costs the home rate — at 5.5 it
+// is 396 — and buys nothing: 91.
+const identifierIDFFloor = 4.0
+
 // HasIdentifierTermKnown is HasIdentifierTerm over the words the corpus
 // actually holds.
 //
@@ -70,7 +82,7 @@ func HasIdentifierTermKnown(terms []string, known map[string]float64) bool {
 	}
 	kept := make([]string, 0, len(terms))
 	for _, t := range terms {
-		if _, ok := known[t]; ok {
+		if v, ok := known[t]; ok && v >= identifierIDFFloor {
 			kept = append(kept, t)
 		}
 	}

--- a/internal/search/worth_known_test.go
+++ b/internal/search/worth_known_test.go
@@ -19,12 +19,17 @@ func TestASubjectTheStoreNeverSawCarriesNothing(t *testing.T) {
 	if !RecallWorthShowing(terms, 2, 1, known) {
 		t.Error("the two-word rule was lost")
 	}
-	// Whether anything else in the question carries on its own stays the shape
-	// rule's business. "passed" is not on the working-word list and is long
-	// enough to pass it, so a question holding it still fires — which is why
-	// this removes one of the benchmark's three false fires and not all three.
-	if !RecallWorthShowing(terms, 1, 1, map[string]float64{"branch": 2.4, "suite": 2.1, "passed": 2.0}) {
-		t.Error("a known word of identifier shape stopped carrying")
+	// Known is not enough on its own: the word also has to be rare here. The
+	// working-word list is written by hand and "passed" is not on it, so shape
+	// alone let it carry a match; the store says it is ordinary.
+	ordinary := map[string]float64{"branch": 2.4, "suite": 2.1, "passed": 2.0}
+	if RecallWorthShowing(terms, 1, 1, ordinary) {
+		t.Error("a word the store calls ordinary carried a match on its shape")
+	}
+	// Rare here, and it carries — which is the rule this must not weaken.
+	rare := map[string]float64{"branch": 2.4, "suite": 2.1, "passed": 5.1}
+	if !RecallWorthShowing(terms, 1, 1, rare) {
+		t.Error("a rare word the store holds stopped carrying a match")
 	}
 }
 


### PR DESCRIPTION
A single word may carry a match on its own when it reads like a term of art, and "reads like" is shape plus a hand-written list of ordinary words. The list cannot keep up: "passed", "rows", "delay" are not on it, name nothing, and are three letters or more.

The store already knows. The ranking returns the idf of every term the corpus holds, so a word now has to be rare here before its shape is allowed to speak for it.

Measured by cross-pairing 400 real prompts from a 1696-session store against a project that cannot hold their answer, where every fire is a false one: 129 before, 89 after. The same questions asked in their own project still fire 398 times out of 400 — the rule takes nothing at home. A higher bar costs that: at 5.5 home drops to 396 and the wrong-project fires go back up to 91.

bench prompt unchanged on every arm, LongMemEval-S unmoved at 84.8%.