### PR TITLE
fix(hook-prompt): let a spawned agent past the project cooldown

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -184,7 +184,19 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if cands := digest.ProjectNameCandidates(cwd); len(cands) > 0 {
 		projectKey = cands[0]
 	}
-	inProject := recentlyInjectedInProject(dir, projectKey, injectionCooldown)
+	// Except for a spawned agent. The cooldown above counts servings across
+	// agent sessions, which is right for a reader working through a run of
+	// messages — #2038 measured 92% repeats and one marathon served 110 times.
+	// A fleet is the other shape: ten agents spawned together are ten readers,
+	// each seeing a session once, and the answer they all need is the one the
+	// cooldown has just spent. Measured: of three agents spawned on the same
+	// work, the first was given it and the other two were sent out with
+	// nothing (#2534). Their own per-reader key and the block fingerprint still
+	// stop the same agent being handed the same thing twice.
+	var inProject map[string]bool
+	if !isSpawnedReader(input.SessionID) {
+		inProject = recentlyInjectedInProject(dir, projectKey, injectionCooldown)
+	}
 	skip := make(map[string]bool, len(recent)+len(inProject)+1)
 	for id := range recent {
 		skip[id] = true
@@ -648,6 +660,11 @@ func blockFingerprint(body string) string {
 	sum := sha256.Sum256([]byte(strings.Join(strings.Fields(body), " ")))
 	return hex.EncodeToString(sum[:8])
 }
+
+// isSpawnedReader reports whether this recall is for an agent the parent just
+// spawned rather than for someone typing. spawnRecall builds the id, and the
+// prefix is the only thing that separates the two readers here.
+func isSpawnedReader(sid string) bool { return strings.HasPrefix(sid, "task:") }
 
 // injectionCooldown is how many later injections a session sits out after
 // being shown. Counted in injections rather than minutes because that is what

--- a/cmd/deja/hook_spawn_cooldown_test.go
+++ b/cmd/deja/hook_spawn_cooldown_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The project cooldown (#2038) counts servings across agent sessions, which is
+// right for a reader working through a run of messages and wrong for a fleet:
+// ten agents spawned together are ten readers, each seeing the session once,
+// and the one they all need is the one the cooldown has just spent (#2534).
+func TestAFleetIsNotSilencedByTheProjectCooldown(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// One session holds the answer, which is the ordinary shape of a decision
+	// made once.
+	writeClaudeFixture(t, filepath.Join(root, "app", "kafka.jsonl"), "kafka", []string{
+		`{"type":"user","sessionId":"kafka","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the kafka consumer rebalance keeps flapping on the orders topic"}}`,
+		`{"type":"assistant","sessionId":"kafka","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":"The fix was to raise session.timeout.ms above the poll interval; nothing else held."}}`,
+	})
+	for i, top := range []string{"the sidebar layout", "the invoice renderer", "the webpack config",
+		"the login throttle", "the avatar uploader", "the cron scheduler"} {
+		id := fmt.Sprintf("t%d", i)
+		writeClaudeFixture(t, filepath.Join(root, "app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-01T0` + fmt.Sprint(i) + `:00:00Z","message":{"role":"user","content":"work on ` + top + ` today"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-01T0` + fmt.Sprint(i) + `:00:01Z","message":{"role":"assistant","content":"changed ` + top + `"}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "src", "app")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	spawn := func(prompt string) string {
+		t.Helper()
+		b, err := json.Marshal(prompt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Task","tool_input":`+
+			`{"prompt":`+string(b)+`,"subagent_type":"general-purpose"},"session_id":"parent"}`)
+		if strings.TrimSpace(out) == "" {
+			return ""
+		}
+		var resp struct {
+			HookSpecificOutput struct {
+				UpdatedInput map[string]json.RawMessage `json:"updatedInput"`
+			} `json:"hookSpecificOutput"`
+		}
+		if err := json.Unmarshal([]byte(out), &resp); err != nil {
+			t.Fatalf("the spawn reply is not JSON: %q", out)
+		}
+		var extended string
+		_ = json.Unmarshal(resp.HookSpecificOutput.UpdatedInput["prompt"], &extended)
+		return extended
+	}
+
+	first := spawn("Investigate why the kafka consumer rebalance keeps flapping on the orders topic.")
+	if !strings.Contains(first, "session.timeout.ms") {
+		t.Fatalf("the first agent of the fleet got no memory: %q", first)
+	}
+	for i, prompt := range []string{
+		"Look into the kafka consumer rebalance flapping on the orders topic.",
+		"Find out what makes the kafka consumer rebalance flap on the orders topic.",
+	} {
+		if got := spawn(prompt); !strings.Contains(got, "session.timeout.ms") {
+			t.Errorf("agent %d of the fleet was sent out without the answer the first one got: %q", i+2, got)
+		}
+	}
+}
+
+// The reader the cooldown was written for keeps it: a person asking twice in a
+// row is the repetition #2038 measured.
+func TestAnOrdinaryPromptStillSitsOutTheCooldown(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "app", "kafka.jsonl"), "kafka", []string{
+		`{"type":"user","sessionId":"kafka","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the kafka consumer rebalance keeps flapping on the orders topic"}}`,
+		`{"type":"assistant","sessionId":"kafka","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":"The fix was to raise session.timeout.ms above the poll interval; nothing else held."}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "src", "app")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	ask := func(sid, prompt string) string {
+		t.Helper()
+		b, err := json.Marshal(prompt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out bytes.Buffer
+		payload := `{"prompt":` + string(b) + `,"session_id":"` + sid + `","cwd":"` + cwd + `"}`
+		if err := runHookPrompt(index.DefaultDir(), strings.NewReader(payload), &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+	if got := ask("one", "why does the kafka consumer rebalance keep flapping on the orders topic"); !strings.Contains(got, "session.timeout.ms") {
+		t.Fatalf("the first ask got nothing: %q", got)
+	}
+	if got := ask("two", "and why does the kafka rebalance keep flapping on the orders topic"); strings.Contains(got, "session.timeout.ms") {
+		t.Errorf("the session just served was served again to the next reader: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #2534.

`spawnRecall` gives each spawned agent its own key, with the reason written down: "a fleet of ten agents spawned together all count as one reader" is what it is avoiding. The per-reader key does that for the fingerprint dedupe and does not reach the *project* cooldown (#2038), which counts servings across agent sessions.

Three agents spawned on the same work, in a project whose answer lives in one session:

    before:  agent 1 — This was asked here before … session.timeout.ms above the poll interval
             agent 2 — (no memory added)
             agent 3 — (no memory added)

    after:   all three carry it

#2038 was measured and stays for the reader it was written for: 937 injections from 74 sessions, 92% repeats, one marathon served 110 times. That is a person working through a run of messages, and a second ask in the next agent session is still met with silence — pinned. A fleet is the other shape: ten readers, each seeing the session once, and the answer they all need is the one the cooldown has just spent.

Their own per-reader key and the block fingerprint still stop the same agent being handed the same thing twice.
