### PR TITLE
fix(hook-context): retire the cached block when the notes file changes

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
 
@@ -604,7 +605,25 @@ func hookGate() string {
 	// The shape of the entry is part of what it was built under: one written
 	// before the digest recorded its projects would be served for its whole
 	// TTL and logged as a digest that came from nowhere (#2349).
-	return "v2|" + mode + "|" + policy.Load().Describe(policy.ActivationAuto)
+	//
+	// And the notes file, because the block leads with the decisions promoted
+	// in this project. Without it a decision the reader had just removed with
+	// `deja forget` kept being handed to every session start until the TTL ran
+	// out — search agreed it was gone and the block went on quoting it, which
+	// is the one thing the privacy command must not do (#2537). A promotion
+	// made a moment ago has the same problem in reverse. Stat, not read.
+	return "v3|" + mode + "|" + policy.Load().Describe(policy.ActivationAuto) + "|" + notesStamp()
+}
+
+// notesStamp identifies the notes file as it is now. A file that cannot be
+// stat'd stamps as absent, which is itself a state worth telling apart from a
+// file with content in it.
+func notesStamp() string {
+	fi, err := os.Stat(sources.NotesFile())
+	if err != nil {
+		return "none"
+	}
+	return strconv.FormatInt(fi.Size(), 10) + "@" + strconv.FormatInt(fi.ModTime().UnixNano(), 10)
 }
 
 // hookCWD is where the hook is standing: what the payload says, else the

--- a/cmd/deja/hook_context_notes_gate_test.go
+++ b/cmd/deja/hook_context_notes_gate_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// sessionStartBlock runs the session-start hook the way a harness does and
+// returns what it injected.
+func sessionStartBlock(t *testing.T, cwd string) string {
+	t.Helper()
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	err = runHookContext(index.DefaultDir(), true)
+	_ = w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if _, cerr := io.Copy(&out, r); cerr != nil {
+		t.Fatal(cerr)
+	}
+	return out.String()
+}
+
+// The standing-decisions block is folded into the cached session-start digest,
+// whose gate is the recall mode and the trust policy. A decision the reader has
+// just removed with `deja forget` was therefore handed to every session start
+// for the rest of the TTL — the one thing the privacy command must not do
+// (#2537).
+func TestForgettingANoteRetiresTheCachedBlock(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	rec := `{"type":"user","sessionId":"dec","timestamp":"` + at + `","cwd":"/work/app","message":{"role":"user","content":"should the retry budget go up to 10?"}}` + "\n" +
+		`{"type":"assistant","sessionId":"dec","timestamp":"` + at + `","cwd":"/work/app","message":{"role":"assistant","content":"no: the retry budget stays at 5"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "dec.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := sources.AppendPromoted("app", "t", "the retry budget stays at 5",
+		"claude:dec", "accepted", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Served once, which is what puts it in the cache.
+	if got := sessionStartBlock(t, "/work/app"); !strings.Contains(got, "standing decisions in this project") {
+		t.Fatalf("the fixture never served the decision:\n%s", got)
+	}
+
+	// Removed the way deja's own message tells the reader to remove it.
+	if err := os.WriteFile(sources.NotesFile(), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sessionStartBlock(t, "/work/app"); strings.Contains(got, "standing decisions in this project") {
+		t.Errorf("a decision the reader removed is still being served as standing:\n%s", got)
+	}
+}
+
+// A promotion made a moment ago is the same question the other way round: the
+// block has to notice the file growing, not only shrinking.
+func TestANewNoteReachesTheNextSessionStart(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	store := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	rec := `{"type":"user","sessionId":"dec","timestamp":"` + at + `","cwd":"/work/app","message":{"role":"user","content":"the retry budget question"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "dec.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_ = sessionStartBlock(t, "/work/app")
+
+	if err := sources.AppendPromoted("app", "t", "the retry budget stays at 5",
+		"claude:dec", "accepted", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if got := sessionStartBlock(t, "/work/app"); !strings.Contains(got, "standing decisions in this project") {
+		t.Errorf("a decision promoted a moment ago did not reach the next session start:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #2537.

Walking `[a-promoted-note-with-no-session-left]` from the queue: forgetting the *transcript* a decision came from behaves well — `forget` says the note is kept and where, the decision stays standing, and the file line stops carrying it because the session was the only evidence tying it to that file. Nothing to fix there.

Forgetting the *note* is where it breaks. The note goes from `notes.jsonl` and from search, and the session-start block keeps handing it to agents:

    notes after:  0 records
    deja "retry budget"   no matches in 5 indexed sessions …
    session start         standing decisions in this project (promoted and still accepted — follow them unless the user overrides):
                            · the retry budget stays at 5; …

The block is folded into the cached session-start digest, and the gate is the recall mode plus the trust policy — nothing about the notes file. So a removal is invisible for the rest of the 60-second TTL, and so is a promotion: a decision written a moment ago reaches no session start until the cache turns over. Both are pinned.

The gate now carries the notes file's size and mtime, and the version moves v2 → v3. Stat, not read.
