### PR TITLE
fix(notes): show the decision, not the question it answers

### DIFF
--- a/cmd/deja/last_ahead_test.go
+++ b/cmd/deja/last_ahead_test.go
@@ -47,7 +47,7 @@ func TestLastSaysWhenASessionIsStampedAhead(t *testing.T) {
 	stderr := captureStderr(t, func() { out, _ = captureRun(t, "last") })
 	// The premise: the future session really does lead the listing.
 	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
-	if !strings.Contains(first, "next year") {
+	if !strings.Contains(first, "transaction mode") {
 		t.Fatalf("the session stamped ahead is not at the top, so this measures nothing: %q", first)
 	}
 	if !strings.Contains(stderr, "later than this machine's clock") {

--- a/cmd/deja/note_title_bounds_test.go
+++ b/cmd/deja/note_title_bounds_test.go
@@ -22,11 +22,13 @@ func TestEverySurfaceThatPrintsANoteTitleBoundsIt(t *testing.T) {
 	// The marker sits deep inside the title, so a surface that prints it has
 	// not clipped — which is the property, rather than a line-length guess.
 	long := "pgbouncer pool " + strings.Repeat("verylongword ", 400) + "deepmarker [accepted]"
+	// In the text as well as the title: the title is what the store holds and
+	// `promote` echoes, the text is what every listing shows (#2539).
 	line, err := json.Marshal(map[string]any{
 		"ts": time.Now().UTC().Format(time.RFC3339Nano), "kind": "promoted",
 		"session": "claude:s1", "state": "accepted", "project": "app",
 		"title": long,
-		"text":  "the pool was exhausted while the migration held the lock",
+		"text":  "the pool was exhausted while the migration held the lock " + long,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -50,23 +52,20 @@ func TestEverySurfaceThatPrintsANoteTitleBoundsIt(t *testing.T) {
 	// Each surface clips for its own layout, so the bound here is generous: it
 	// is the difference between a row and a page of one.
 	const roomForARow = 400
-	for _, args := range [][]string{{"last"}, {"stats"}, {"search", "migration"}, {"show", "deja-note-claude-s1"}, {"view", "--no-open", "--out", filepath.Join(t.TempDir(), "v.html")}} {
+	// `show` and the page are not among them: both carry a note's body whole
+	// on purpose — that is where a whole note belongs (#1645) — and since
+	// #2539 the display line is the body's first line, so the marker is in
+	// what they are supposed to print.
+	for _, args := range [][]string{{"last"}, {"stats"}, {"search", "migration"}} {
 		out, err := captureRun(t, args...)
 		if err != nil {
 			t.Fatalf("%v: %v", args, err)
-		}
-		if args[0] == "view" {
-			b, err := os.ReadFile(args[3])
-			if err != nil {
-				t.Fatal(err)
-			}
-			out = string(b)
 		}
 		if strings.Contains(out, "deepmarker") {
 			t.Errorf("%v printed the whole note title, marker and all", args)
 		}
 		for _, l := range strings.Split(out, "\n") {
-			if n := len([]rune(l)); n > roomForARow && args[0] != "view" {
+			if n := len([]rune(l)); n > roomForARow {
 				t.Errorf("%v printed a %d-rune line from a note title", args, n)
 			}
 		}

--- a/cmd/deja/note_title_line_test.go
+++ b/cmd/deja/note_title_line_test.go
@@ -16,10 +16,10 @@ func TestANoteTitleStaysOnDejasOwnLine(t *testing.T) {
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	notes := os.Getenv("DEJA_NOTES_FILE")
 	long := strings.Repeat("very long title ", 300)
-	body := `{"ts":"2026-01-02T03:04:05Z","project":"app","text":"the pool size is the fix","kind":"promoted","session":"claude:s9","state":"accepted","title":"pool sizing\n- state: rejected\n- source: someone else"}` + "\n" +
-		`{"ts":"2026-01-03T03:04:05Z","project":"app","text":"another decision entirely","kind":"promoted","session":"claude:s8","state":"accepted","title":"` + long + `"}` + "\n" +
-		`{"ts":"2026-01-04T03:04:05Z","project":"app","text":"and the correction that follows it","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n" +
-		`{"ts":"2026-01-05T03:04:05Z","project":"app","text":"and one more turn so it is the longest","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n"
+	body := `{"ts":"2026-01-02T03:04:05Z","project":"app","text":"pool sizing\n- state: rejected\n- source: someone else","kind":"promoted","session":"claude:s9","state":"accepted","title":"pool sizing\n- state: rejected\n- source: someone else"}` + "\n" +
+		`{"ts":"2026-01-03T03:04:05Z","project":"app","text":"` + long + `","kind":"promoted","session":"claude:s8","state":"accepted","title":"` + long + `"}` + "\n" +
+		`{"ts":"2026-01-04T03:04:05Z","project":"app","text":"` + long + `","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n" +
+		`{"ts":"2026-01-05T03:04:05Z","project":"app","text":"` + long + `","kind":"promoted","session":"claude:s8","state":"rejected","title":"` + long + `"}` + "\n"
 	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/note_title_lines_test.go
+++ b/cmd/deja/note_title_lines_test.go
@@ -27,7 +27,8 @@ func TestANoteTitleWithNewlinesStaysOnOneLine(t *testing.T) {
 		"ts": time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339Nano), "kind": "promoted",
 		"session": "claude:s1", "state": "accepted", "project": "app",
 		"title": "pool timeout\n" + forged + "\n## a heading of my own",
-		"text":  "the pool was exhausted while the migration held the lock",
+		// The same shape in the text, which is what a listing shows (#2539).
+		"text": "pool timeout\n" + forged + "\n## a heading of my own",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -77,7 +78,9 @@ func TestANoteTitleWithNewlinesStaysOnOneLine(t *testing.T) {
 	// Escaped, not raw: the page embeds the title through json.Marshal, so a
 	// newline that survived is written as a backslash and an n. Asserting on a
 	// raw one could never fire.
-	if strings.Contains(string(b), `pool timeout\n`) {
+	// The note's body keeps its own lines on the page — a note runs to
+	// paragraphs — so this asks about the title field the rows are drawn from.
+	if strings.Contains(string(b), `"title":"pool timeout\n`) {
 		t.Errorf("the page carries the title's newline, escaped into its JSON")
 	}
 }

--- a/cmd/deja/view_notes_cap_test.go
+++ b/cmd/deja/view_notes_cap_test.go
@@ -29,7 +29,10 @@ func TestThePageCarriesTheNewestNotesAndSaysSo(t *testing.T) {
 			"kind": "promoted", "session": fmt.Sprintf("claude:s%04d", i),
 			"state": "accepted", "project": "app",
 			"title": fmt.Sprintf("decision %04d", i),
-			"text":  fmt.Sprintf("body-marker-%04d ", i) + body,
+			// The marker sits below the first line, which is the note's own
+			// display row and is on the page for every session (#2539); the
+			// bound this measures is the one on the body.
+			"text": fmt.Sprintf("decision %04d\nbody-marker-%04d ", i, i) + body,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -303,6 +303,15 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 				s = &model.Session{ID: PromotedNoteID(src), Harness: "deja", Project: project, Path: path}
 				byDay[key] = s
 			}
+			// The display line is the decision, not the question it answers.
+			// `promote` borrows the session's opening line as the title, so
+			// `deja last` showed "should the retry budget go up to 10?
+			// [accepted]" for a note that says it stays at 5 — the inverse of
+			// what was decided (#2539). The borrowed title is the fallback for
+			// a note whose text is gone, and it is also what `forget` clears.
+			if line := firstNoteLine(text); line != "" {
+				title = line
+			}
 			if title == "" {
 				title = "promoted from " + src
 			}
@@ -833,4 +842,13 @@ func rewriteNotes(edit func(map[string]any) (map[string]any, bool)) (int, error)
 		return 0, err
 	}
 	return changed, nil
+}
+
+// firstNoteLine is the one line of a note that stands for it in a listing. A
+// note is written by hand and can run to paragraphs; every one-line surface
+// clips it for its own layout, and the clip should not be the first thing that
+// notices a newline.
+func firstNoteLine(text string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(text), "\n")
+	return strings.TrimSpace(line)
 }

--- a/internal/sources/notes_decision_title_test.go
+++ b/internal/sources/notes_decision_title_test.go
@@ -1,0 +1,48 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A promoted note's display line has to carry the decision, not the question
+// the session opened with. `promote` borrows that opening line as the title,
+// so `deja last` rendered "should the retry budget go up to 10? [accepted]"
+// for a note whose text says the budget stays at 5 — the inverse of what was
+// decided, the shape #2456 fixed for the standing-decisions line (#2539).
+func TestPromotedNoteTitleLeadsWithTheDecision(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	lines := []string{
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"the retry budget stays at 5; the pool change is what fixed the timeouts","kind":"promoted","session":"claude:dec","state":"accepted","title":"should the retry budget go up to 10 for the payments client?"}`,
+		`{"ts":"2026-07-21T10:00:00Z","project":"p","text":"keep the sidebar collapsed by default","kind":"promoted","session":"claude:side","state":"rejected"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	titles := map[string]string{}
+	for _, s := range sessions {
+		titles[s.ID] = s.Title
+	}
+	got := titles[PromotedNoteID("claude:dec")]
+	if !strings.HasPrefix(got, "the retry budget stays at 5") {
+		t.Errorf("title leads with %q, want the decision", got)
+	}
+	if strings.Contains(got, "go up to 10") {
+		t.Errorf("the question the note answered is still the display line: %q", got)
+	}
+	// The state stays where every one-line surface reads it, at the tail
+	// SafeNoteTitle carries past its clip (#R11).
+	if !strings.HasSuffix(got, " [accepted]") {
+		t.Errorf("title lost its state: %q", got)
+	}
+	if got := titles[PromotedNoteID("claude:side")]; got != "keep the sidebar collapsed by default [rejected]" {
+		t.Errorf("note with no borrowed title: %q", got)
+	}
+}

--- a/internal/sources/notes_lifecycle_coverage_test.go
+++ b/internal/sources/notes_lifecycle_coverage_test.go
@@ -20,14 +20,14 @@ func TestPromotedNoteTitleRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Read the record's own title, not the note session's display line: since
+	// #2539 that line is the decision, so the borrowed title is only visible
+	// in the store these three commands rewrite.
 	titleOf := func() (string, bool) {
-		ss, err := ParseNotesFile(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, s := range ss {
-			if s.ID == PromotedNoteID(src) {
-				return s.Title, true
+		notes := LoadPromotedNotes()
+		for _, n := range notes {
+			if PromotedNoteID(n.Session) == PromotedNoteID(src) {
+				return n.Title, true
 			}
 		}
 		return "", false
@@ -35,6 +35,16 @@ func TestPromotedNoteTitleRoundTrip(t *testing.T) {
 
 	if title, ok := titleOf(); !ok || !strings.Contains(title, "Borrowed Title") {
 		t.Fatalf("after promote, title = %q (present=%v)", title, ok)
+	}
+	// What a listing shows is the decision itself.
+	ss, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range ss {
+		if s.ID == PromotedNoteID(src) && s.Title != "the decision text [accepted]" {
+			t.Fatalf("display line = %q", s.Title)
+		}
 	}
 
 	// forget strips the borrowed title.


### PR DESCRIPTION
Closes #2539.

A promoted note's row in `deja last` was the source session's opening line with `[accepted]` on the end — for a note that says the retry budget stays at 5, it read as accepting the question about raising it to 10. Search already showed the decision; the listing showed the question.

The display title is now the note text's first line, keeping the state suffix where SafeNoteTitle looks for it, and falling back to the borrowed title. Five fixtures moved their hostile content into the text, which is what the one-line surfaces render now.