### PR TITLE
fix(index): keep ignored sessions out of the recent listing

### DIFF
--- a/internal/index/recent_ignored_test.go
+++ b/internal/index/recent_ignored_test.go
@@ -1,0 +1,102 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #2070 put the ignore rule where metas turn into servable sessions so it would
+// hold on every surface. The manifest walk was not one of them: `Recent` and the
+// per-project variants build their result straight from the manifest, so
+// `deja last` led with 253 rows out of 400 from the tree deja says it does not
+// recall from, and the same helpers feed the session-start block, the brief,
+// handoff, the page and the MCP resource list (#2541).
+func TestTheRecentListingSkipsIgnoredSessions(t *testing.T) {
+	tmp := t.TempDir()
+	jobs := filepath.Join(tmp, "home", ".claude", "jobs", "abc", "projects", "-w-app")
+	real := filepath.Join(tmp, "home", "projects", "-w-app")
+	for _, d := range []string{jobs, real} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	line := func(sid, role, text string) string {
+		return `{"type":"` + role + `","sessionId":"` + sid + `","cwd":"/w/app",` +
+			`"timestamp":"2026-01-02T03:04:05Z","message":{"role":"` + role +
+			`","content":"` + text + `"}}`
+	}
+	write := func(dir, sid, text string) {
+		body := strings.Join([]string{
+			line(sid, "user", text),
+			line(sid, "assistant", "Decision: we pinned the frobnicator to one shard."),
+		}, "\n") + "\n"
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(jobs, "scratch", "the frobnicator keeps dropping its widgets under load")
+	write(real, "keeper", "the frobnicator keeps dropping its widgets under load")
+
+	// Both roots are read: the ignored one is a subtree of the store, which is
+	// how it looks on a real machine.
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "home"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	recent, err := Recent(dir, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the session that is not ignored is listed at all.
+	found := false
+	for _, s := range recent {
+		if s.ID == "keeper" {
+			found = true
+		}
+		if s.ID == "scratch" {
+			t.Errorf("the listing served an ignored session: %s (%s)", s.ID, s.Path)
+		}
+	}
+	if !found {
+		t.Fatalf("the real session is not in the listing of %d, so this measures nothing", len(recent))
+	}
+
+	inProject, err := RecentInProject(dir, "w/app", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range inProject {
+		if s.ID == "scratch" {
+			t.Errorf("RecentInProject served an ignored session: %s", s.Path)
+		}
+	}
+	byName, err := RecentProject(dir, "app", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range byName {
+		if s.ID == "scratch" {
+			t.Errorf("RecentProject served an ignored session: %s", s.Path)
+		}
+	}
+	many, err := RecentProjects(dir, []string{"w/app", "app"}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range many {
+		if s.ID == "scratch" {
+			t.Errorf("RecentProjects served an ignored session: %s", s.Path)
+		}
+	}
+
+	// Named directly, it still answers: a person asking for a session by id is
+	// asking for it.
+	if _, ok, err := FindByIdentity(dir, "claude", "scratch"); err != nil || !ok {
+		t.Errorf("an ignored session named by id did not answer: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1264,6 +1264,11 @@ func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error)
 		}
 		out = append(out, sessionFromMeta(meta))
 	}
+	// This walk serves sessions without going through sessionsForMetas, so it
+	// is the one path #2070's rule never reached: `deja last` led with the
+	// background agents' own temp tree, 253 rows of 400 on a real store, while
+	// every ranked surface filtered it out (#2541).
+	out = ignoredByPolicy(out)
 	sort.Slice(out, func(i, j int) bool { return newestFirstSession(out[i], out[j]) })
 	if n > 0 && len(out) > n {
 		out = out[:n]
@@ -1308,6 +1313,7 @@ func RecentInProject(dir, project string, n int) ([]model.Session, error) {
 			metas = append(metas, meta)
 		}
 	}
+	metas = metasNotIgnored(metas)
 	sort.Slice(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
 	if n > 0 && len(metas) > n {
 		metas = metas[:n]
@@ -1342,6 +1348,7 @@ func RecentProject(dir, project string, n int) ([]model.Session, error) {
 			metas = append(metas, meta)
 		}
 	}
+	metas = metasNotIgnored(metas)
 	sort.Slice(metas, func(i, j int) bool { return newestFirstMeta(metas[i], metas[j]) })
 	if n > 0 && len(metas) > n {
 		metas = metas[:n]
@@ -1426,6 +1433,23 @@ func ignoredByPolicy(ss []model.Session) []model.Session {
 	return out
 }
 
+// metasNotIgnored is ignoredByPolicy one step earlier, on the metas a walk is
+// about to cut a window out of. sessionsForMetas filters what it loads, which
+// is right, but by then the window is chosen: three ignored sessions at the top
+// of a project left `handoff` and the session-start block with nothing while
+// three real ones sat below the cut (#2541).
+func metasNotIgnored(metas []SessionMeta) []SessionMeta {
+	pol := policy.Load()
+	out := metas[:0:0]
+	for _, meta := range metas {
+		if pol.Ignored(meta.Path, meta.Project) {
+			continue
+		}
+		out = append(out, meta)
+	}
+	return out
+}
+
 // sessionsForMetas loads full sessions for the given metas in ONE pass over
 // records.bin. The per-session variant re-scanned the whole log for every
 // session, which turned a session-start hook into hundreds of milliseconds.
@@ -1488,6 +1512,7 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 				mine = append(mine, meta)
 			}
 		}
+		mine = metasNotIgnored(mine)
 		sort.Slice(mine, func(i, j int) bool { return newestFirstMeta(mine[i], mine[j]) })
 		if perName > 0 && len(mine) > perName {
 			mine = mine[:perName]


### PR DESCRIPTION
Closes #2541.

`policy.Ignored` defaults to `*/.claude/jobs/*`, and #2070 put that filter where metas become servable sessions so it would hold everywhere. The manifest walk never got it: on this machine's index `deja last 400` came back with 253 rows from that tree, while search and the ranked paths filtered it out. The project walks also cut their window before the filter ran, so an ignored session could spend a slot and shorten the answer.

RecentMatching filters before the sort; the three project walks filter their metas before the cut. A session named by id still answers.