### PR TITLE
fix(index): name a session that holds only harness plumbing

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1902,7 +1902,82 @@ func sessionTitleFrom(s model.Session) (title string, fromAgent bool) {
 	if t := earliestTitle(s.Messages, roleToolOutput); t != "" {
 		return toolOutputTitle(t), false
 	}
+	// Nothing here is worth a title on its own — every turn is harness
+	// plumbing, a CLI's own stdout or a notification the runtime spliced in.
+	// #1100 named the tool-only session so it would stop listing as an empty
+	// bracket; this is the same session one step further down. The surfaces
+	// that used to recover a title read .Messages, and they are all fed by
+	// Recent, which returns metadata alone, so the recovery never ran (#2548).
+	if t := earliestAnyText(s.Messages); t != "" {
+		return harnessOutputTitle(t), false
+	}
 	return "", false
+}
+
+// harnessOutputTitlePrefix marks a title borrowed from what the harness itself
+// wrote, the way toolOutputTitlePrefix marks one borrowed from tool output: it
+// rides in the text so every surface says the same thing.
+const harnessOutputTitlePrefix = "harness output: "
+
+// titlePlaceholder reports that a title is only standing in until the session
+// says something of its own. The incremental path fills a title in when it is
+// empty; a session that opens with a slash command would otherwise keep the
+// stand-in forever, with the reader's own first question one line below it.
+func titlePlaceholder(t string) bool {
+	return t == "" || strings.HasPrefix(t, harnessOutputTitlePrefix)
+}
+
+func harnessOutputTitle(t string) string {
+	return harnessOutputTitlePrefix + truncateTitle(stripPlumbingTag(t), 60-len([]rune(harnessOutputTitlePrefix)))
+}
+
+// stripPlumbingTag unwraps the element a harness wraps its own output in —
+// <local-command-stdout>…</local-command-stdout> and its neighbours — so the
+// row reads as the sentence rather than as markup.
+func stripPlumbingTag(t string) string {
+	t = strings.TrimSpace(t)
+	if !strings.HasPrefix(t, "<") {
+		return t
+	}
+	end := strings.Index(t, ">")
+	if end < 0 {
+		return t
+	}
+	name := t[1:end]
+	if i := strings.IndexAny(name, " \t"); i >= 0 {
+		name = name[:i]
+	}
+	rest := strings.TrimSpace(t[end+1:])
+	rest = strings.TrimSuffix(rest, "</"+name+">")
+	return strings.TrimSpace(rest)
+}
+
+// earliestAnyText is the first thing a session says, whoever said it, for the
+// last resort above.
+func earliestAnyText(ms []model.Message) string {
+	best := ""
+	var bestAt time.Time
+	for _, msg := range ms {
+		// Work records are not something anyone said — a file list, an
+		// invocation, a replaced span — and a session named after one reads as
+		// a sentence it never contained.
+		if msg.Role == roleFiles || msg.Role == roleCommand || msg.Role == roleEdit {
+			continue
+		}
+		t := strings.TrimSpace(msg.Text)
+		if t == "" {
+			continue
+		}
+		switch {
+		case best == "":
+		case bestAt.IsZero(), msg.Time.IsZero():
+			continue
+		case !msg.Time.Before(bestAt):
+			continue
+		}
+		best, bestAt = t, msg.Time
+	}
+	return best
 }
 
 // toolOutputTitlePrefix marks a title borrowed from tool output. It rides in
@@ -2849,7 +2924,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 			if s.Path != "" && owns {
 				meta.Path = s.Path
 			}
-			if meta.Title == "" {
+			if titlePlaceholder(meta.Title) {
 				// The incremental fallback redacted nothing at all before; keep
 				// sessionTitleFrom's correct fromAgent bit and redact before the
 				// cut, as the full rebuild does.

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -619,6 +619,15 @@ func Import(dir, inDir string) (int, error) {
 					titleAt[key] = sr.Time
 					titleRankOf[key] = rank
 				}
+			} else if meta.Title == "" && titleRank(sr.Role) > 0 {
+				// The same last resort ingest has: a session of nothing but
+				// harness plumbing arrives titleless and lists as a bare id
+				// here too. A real turn later in the stream replaces the
+				// stand-in, which is what the branch above does (#2548).
+				if t := strings.TrimSpace(text); t != "" {
+					meta.Title = harnessOutputTitle(t)
+					meta.AgentTitle = false
+				}
 			}
 			// A promoted note carries its state in the text: "[rejected] …".
 			// The states themselves live in the other machine's notes.jsonl,

--- a/internal/index/title_plumbing_test.go
+++ b/internal/index/title_plumbing_test.go
@@ -1,0 +1,38 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// #1100 named the tool-only session so it would stop listing as an empty
+// bracket. A session whose every turn is harness plumbing — a CLI's own
+// stdout, a task notification — fell off the end of the same chain and listed
+// as one: on this machine's index of 1,670, one row is a bracket and an id and
+// nothing else. The surfaces that try to fill it in call firstUserTitle, which
+// reads .Messages, and they are all fed by Recent, which returns metadata only
+// (#2548).
+func TestAPlumbingOnlySessionIsStillNamed(t *testing.T) {
+	at := time.Date(2026, 8, 11, 15, 48, 0, 0, time.UTC)
+	s := model.Session{ID: "plumbing", Harness: "claude", Project: "proj", Updated: at, Messages: []model.Message{
+		{Role: "user", Text: "<local-command-stdout>That session is still running as a background agent. Open `claude agents` to attach.</local-command-stdout>", Time: at},
+	}}
+	meta := metaForSession(s)
+	if meta.Title == "" {
+		t.Fatal("the session lists as a bare id")
+	}
+	if want := "harness output: That session is still running as a backgroun…"; meta.Title != want {
+		t.Errorf("title = %q, want %q", meta.Title, want)
+	}
+	// Not the reader's question and not the agent's words.
+	if meta.AgentTitle {
+		t.Error("harness plumbing was marked as the agent's own words")
+	}
+	// A session that has something better to say is unaffected.
+	s.Messages = append(s.Messages, model.Message{Role: "user", Text: "why does the pool run out under load?", Time: at.Add(time.Minute)})
+	if meta := metaForSession(s); meta.Title != "why does the pool run out under load?" {
+		t.Errorf("a real turn lost its title: %q", meta.Title)
+	}
+}

--- a/internal/index/title_plumbing_test.go
+++ b/internal/index/title_plumbing_test.go
@@ -1,6 +1,10 @@
 package index
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,5 +38,41 @@ func TestAPlumbingOnlySessionIsStillNamed(t *testing.T) {
 	s.Messages = append(s.Messages, model.Message{Role: "user", Text: "why does the pool run out under load?", Time: at.Add(time.Minute)})
 	if meta := metaForSession(s); meta.Title != "why does the pool run out under load?" {
 		t.Errorf("a real turn lost its title: %q", meta.Title)
+	}
+}
+
+// The receiving machine derives the title from the record stream alone, so the
+// two paths have to agree — the same pairing #1100 keeps for the tool-only
+// session.
+func TestImportNamesAPlumbingOnlySessionTheSameWay(t *testing.T) {
+	dir := t.TempDir()
+	exp := filepath.Join(dir, "export")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 11, 15, 48, 0, 0, time.UTC)
+	b, err := json.Marshal(SyncRecord{Harness: "claude", SessionID: "plumbing", Project: "proj",
+		Role: "user", Text: "<local-command-stdout>That session is still running as a background agent.</local-command-stdout>", Time: at})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), []byte(string(b)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(filepath.Join(dir, "index"), exp); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Recent(filepath.Join(dir, "index"), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("imported %d sessions, want 1", len(ss))
+	}
+	if !strings.HasPrefix(ss[0].Title, "harness output: That session is still running") {
+		t.Errorf("imported title = %q, want the name the local path gives", ss[0].Title)
+	}
+	if ss[0].AgentTitle {
+		t.Error("imported plumbing was marked as the agent's own words")
 	}
 }

--- a/internal/index/title_redaction_test.go
+++ b/internal/index/title_redaction_test.go
@@ -64,7 +64,10 @@ func TestIncrementalTitleFallbackRedacts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := m.Sessions["claude:s1"].Title; got != "" {
+	// The first pass has nothing but the slash command to go on, so the row
+	// carries the stand-in #2548 gave it rather than a bare id — and the real
+	// first turn, when it arrives, still replaces it.
+	if got := m.Sessions["claude:s1"].Title; !titlePlaceholder(got) {
 		t.Fatalf("precondition: the first pass already titled the session %q", got)
 	}
 	f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY, 0o644)
@@ -88,5 +91,8 @@ func TestIncrementalTitleFallbackRedacts(t *testing.T) {
 	}
 	if strings.Contains(title, "AKIAIOSFODNN7EXAMPLE") {
 		t.Fatalf("the incremental fallback stored an unredacted key: %q", title)
+	}
+	if titlePlaceholder(title) {
+		t.Fatalf("the stand-in outlived the turn that should have replaced it: %q", title)
 	}
 }


### PR DESCRIPTION
Closes #2548.

One session in this index of 1,670 listed as a bracket and an id and nothing else — every turn in it was `<local-command-stdout>…`, which `titleWorthy` rejects on purpose, and there was no fallback below the tool-output one (#1100). The surfaces that try to recover a title call `firstUserTitle`, which reads `.Messages`, and they are fed by `Recent`, which returns metadata only, so that recovery could never run.

Last resort: `harness output: <the text, unwrapped>`, work records skipped. It is a stand-in — a real turn arriving on a later append still replaces it, which is what the incremental fallback was built for.