### PR TITLE
fix(bench): stop the cross-paired arm asking where the answer lives

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -223,6 +223,26 @@ type promptReport struct {
 	CrossPaired promptArmReport `json:"cross_paired"`
 }
 
+// awayFor picks where a chain's question is asked: forward to the first chain
+// of another project, not merely the next one. Several chains share a project —
+// the Russian ones do — so a single step lands back at home, and the two
+// projects built to hold everything are no better. The haystack keeps one
+// session that mentions every subject in the corpus and the bucket is the
+// catch-all scope; asking either is not asking somewhere the answer cannot be.
+// Measured: pairing without this counted eleven false fires where six were.
+func awayFor(crossed []PromptChainRef, i int) (PromptChainRef, bool) {
+	c := crossed[i]
+	for step := 1; step < len(crossed); step++ {
+		cand := crossed[(i+step)%len(crossed)]
+		if cand.Project == c.Project || cand.Project == bench.PromptHaystackProject ||
+			cand.Project == bench.PromptBucketProject {
+			continue
+		}
+		return cand, true
+	}
+	return PromptChainRef{}, false
+}
+
 // PromptChainRef is a chain reduced to what cross-pairing needs.
 type PromptChainRef struct {
 	Question string
@@ -530,9 +550,9 @@ func measurePrompt(seed int64) (promptReport, error) {
 	}
 	sort.Slice(crossed, func(i, j int) bool { return crossed[i].ID < crossed[j].ID })
 	for i, c := range crossed {
-		away := crossed[(i+1)%len(crossed)]
-		if away.Project == c.Project {
-			away = crossed[(i+2)%len(crossed)]
+		away, found := awayFor(crossed, i)
+		if !found {
+			continue
 		}
 		report.CrossPaired.Cases++
 		if fired, _ := promptBenchProbe(indexDir, away.Project, away.ID, prompt.Terms(c.Question)); fired {

--- a/cmd/deja/crosspaired_bench_test.go
+++ b/cmd/deja/crosspaired_bench_test.go
@@ -1,24 +1,49 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-// The cross-paired arm is only worth reading if no question is ever asked in
-// the project that holds its answer. Pairing by position makes that easy to get
-// wrong the day two neighbouring chains share a project.
+	"github.com/vshulcz/deja-vu/internal/bench"
+)
+
+// The arm is only worth reading if no question is ever asked where its answer
+// lives. Three chains of one project sit next to each other in the corpus, so
+// stepping once lands back at home — measured, that counted five sessions
+// holding the answer as false fires, of eleven.
 func TestCrossPairingNeverAsksAtHome(t *testing.T) {
 	crossed := []PromptChainRef{
 		{"a", "one", "a"},
 		{"b", "one", "b"},
-		{"c", "two", "c"},
-		{"d", "three", "d"},
+		{"c", "one", "c"},
+		{"d", "two", "d"},
 	}
 	for i, c := range crossed {
-		away := crossed[(i+1)%len(crossed)]
-		if away.Project == c.Project {
-			away = crossed[(i+2)%len(crossed)]
+		away, ok := awayFor(crossed, i)
+		if !ok {
+			t.Errorf("%q found nowhere to be asked", c.ID)
+			continue
 		}
 		if away.Project == c.Project {
 			t.Errorf("%q was asked in its own project %q", c.ID, c.Project)
 		}
+	}
+}
+
+// The haystack holds one session that mentions every subject in the corpus, and
+// the bucket is the catch-all scope. Asking either about anything is not asking
+// somewhere the answer cannot be.
+func TestCrossPairingSkipsTheProjectsThatHoldEverything(t *testing.T) {
+	crossed := []PromptChainRef{
+		{"a", "one", "a"},
+		{"b", bench.PromptHaystackProject, "b"},
+		{"c", bench.PromptBucketProject, "c"},
+		{"d", "two", "d"},
+	}
+	away, ok := awayFor(crossed, 0)
+	if !ok {
+		t.Fatal("nowhere to ask")
+	}
+	if away.Project != "two" {
+		t.Errorf("asked in %q, which holds every subject by construction", away.Project)
 	}
 }


### PR DESCRIPTION
The arm I added yesterday paired each question with the next chain and stepped once more when that chain shared its project. One step is not enough: three Russian chains sit next to each other in the same project, so the question came back home and a session that holds the answer was counted as a false fire. The haystack project is worse — it keeps one session that mentions every subject in the corpus, which is what it is for, so asking it about any of them is not asking somewhere the answer cannot be.

Now it walks forward to the first chain of another project and skips the two projects built to hold everything.

The arm reads 6 false fires of 47, not 11. Five of the eleven were the arm's own fault. Nothing else in the bench moves; the pairing rule now lives beside the arm and is pinned by tests on both halves — never at home, never in the projects that hold everything.