### PR TITLE
fix(doctor): say which hook events an older install lacks

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -198,12 +198,26 @@ func doctorHooks(w io.Writer) {
 		return
 	}
 	hooks, _ := root["hooks"].(map[string]any)
-	precompact := hookEventWired(hooks, "PreCompact", "hook-precompact")
-	status := "missing"
-	if precompact {
-		status = "wired"
+	var missing []string
+	for _, h := range claudeHookWiring {
+		if !hookEventWired(hooks, h.Event, h.Sub) {
+			missing = append(missing, h.Event)
+		}
 	}
-	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, path)
+	status := "wired"
+	if len(missing) == len(claudeHookWiring) {
+		status = "missing"
+	} else if len(missing) > 0 {
+		status = "out of date"
+	}
+	fmt.Fprintf(w, "  %-12s %-11s %s\n", "claude-code", status, path)
+	if len(missing) > 0 && len(missing) < len(claudeHookWiring) {
+		// Named, because the difference is what the machine is missing out on:
+		// a settings.json written by an older deja keeps working and quietly
+		// lacks everything added since.
+		fmt.Fprintf(w, "               %d of %d events wired — no %s; run `deja install`\n",
+			len(claudeHookWiring)-len(missing), len(claudeHookWiring), strings.Join(missing, ", "))
+	}
 }
 
 // doctorWiringExe reports configs that name a binary which is no longer there.

--- a/cmd/deja/doctor_hook_wiring_test.go
+++ b/cmd/deja/doctor_hook_wiring_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func writeClaudeSettings(t *testing.T, events ...string) {
+	t.Helper()
+	var entries []string
+	for _, e := range events {
+		entries = append(entries, `"`+e+`":[{"matcher":"","hooks":[{"type":"command","command":"/usr/local/bin/deja `+
+			subFor(e)+`"}]}]`)
+	}
+	body := `{"hooks":{` + strings.Join(entries, ",") + `}}`
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func subFor(event string) string {
+	for _, h := range claudeHookWiring {
+		if h.Event == event {
+			return h.Sub
+		}
+	}
+	return "hook-unknown"
+}
+
+// A settings.json written by an older deja keeps working and quietly lacks
+// everything added since. It was reported as "wired" on the strength of one
+// event out of five, so the features that arrived with the others reached
+// nobody until they happened to reinstall.
+func TestDoctorNamesTheHookEventsAnOlderInstallLacks(t *testing.T) {
+	withStatsStores(t)
+	writeClaudeSettings(t, "SessionStart", "PreCompact", "UserPromptSubmit")
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	got := out.String()
+	if !strings.Contains(got, "out of date") {
+		t.Errorf("a three-of-five wiring was not called out:\n%s", got)
+	}
+	for _, want := range []string{"PreToolUse", "PostToolUse", "deja install"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the report does not name %q:\n%s", want, got)
+		}
+	}
+}
+
+// Everything the installer writes is there: no complaint, and no advice to run
+// a command that would change nothing.
+func TestDoctorIsQuietWhenEveryHookIsWired(t *testing.T) {
+	withStatsStores(t)
+	var all []string
+	for _, h := range claudeHookWiring {
+		all = append(all, h.Event)
+	}
+	writeClaudeSettings(t, all...)
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	got := out.String()
+	if strings.Contains(got, "out of date") || strings.Contains(got, "deja install") {
+		t.Errorf("a complete wiring was reported as stale:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -58,7 +58,7 @@ func TestDoctorFullReport(t *testing.T) {
 	}
 	got := out.String()
 	for _, want := range []string{
-		"Harness stores:", "Tools:", "MCP wiring:", "Hooks:", "precompact", "Index:", "Version:",
+		"Harness stores:", "Tools:", "MCP wiring:", "Hooks:", "claude-code", "Index:", "Version:",
 		"claude", "opencode", "aider", "gemini", "cursor", "antigravity", "grok", "hermes",
 		"1 file", mcpLine("claude-code", "wired"), "config missing",
 		"not built", "current  1.0.0", "latest   v9.9.9", "update available",
@@ -530,13 +530,19 @@ func TestDoctorHooksMatchAbsolutePathCommands(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Real installs write the absolute binary path, not the bare subcommand.
-	if err := os.WriteFile(settings, []byte(`{"hooks":{"PreCompact":[{"matcher":"manual|auto","hooks":[{"type":"command","command":"/Users/x/.local/bin/deja hook-precompact"}]}]}}`), 0o644); err != nil {
+	var entries []string
+	for _, h := range claudeHookWiring {
+		entries = append(entries, `"`+h.Event+`":[{"matcher":"`+h.Matcher+
+			`","hooks":[{"type":"command","command":"/Users/x/.local/bin/deja `+h.Sub+`"}]}]`)
+	}
+	body := `{"hooks":{` + strings.Join(entries, ",") + `}}`
+	if err := os.WriteFile(settings, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	var out bytes.Buffer
 	doctorHooks(&out)
-	if !strings.Contains(out.String(), "precompact   wired") {
-		t.Fatalf("absolute-path hook must count as wired:\n%s", out.String())
+	if !strings.Contains(out.String(), "claude-code  wired") {
+		t.Fatalf("absolute-path hooks must count as wired:\n%s", out.String())
 	}
 }
 

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -977,6 +977,32 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a}, err
 }
 
+// claudeHookWiring is every event deja installs into Claude Code, in one place
+// because two commands read it: install writes them, and doctor says which of
+// them the machine actually has. They used to be a list of calls here and a
+// single check over there, so a settings.json written by an older deja — three
+// events where there are now five — was reported as "wired" and the features
+// added since reached nobody until they happened to reinstall.
+var claudeHookWiring = []struct{ Event, Sub, Matcher string }{
+	{"SessionStart", "hook-context", ""},
+	{"PreCompact", "hook-precompact", "manual|auto"},
+	{"UserPromptSubmit", "hook-prompt", ""},
+	// Recall at the moment of the action: before an edit or a command,
+	// hook-tool names the file's or command's prior decision. Scoped to the
+	// tools that change something so it never fires on a Read or a Glob.
+	//
+	// Task and Agent are the same event under two names: the parent spawning a
+	// subagent. That agent gets no session start and sends no user prompt, so
+	// its instructions are the only place memory can reach it, and hook-tool
+	// answers this one by rewriting them rather than by speaking to the parent.
+	{"PreToolUse", "hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent"},
+	// The other half of the point of action: the pre-tool line speaks before a
+	// command runs, this one speaks when it failed and the store knows what
+	// followed that error before. Bash only — a failed edit does not carry a
+	// shell error signature.
+	{"PostToolUse", "hook-tool-after", "Bash"},
+}
+
 func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
 	old, _ := os.ReadFile(path)
@@ -986,22 +1012,10 @@ func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	nextRoot := updateClaudeSessionStartHook(root, exe, uninstall)
-	nextRoot = updateClaudeHook(nextRoot, "PreCompact", exe+" hook-precompact", "manual|auto", uninstall)
-	nextRoot = updateClaudeHook(nextRoot, "UserPromptSubmit", exe+" hook-prompt", "", uninstall)
-	// Recall at the moment of the action: before an edit or a command, hook-tool
-	// names the file's or command's prior decision. Scoped to the tools that
-	// change something so it never fires on a Read or a Glob.
-	// Task and Agent are the same event under two names: the parent spawning a
-	// subagent. That agent gets no session start and sends no user prompt, so
-	// its instructions are the only place memory can reach it, and hook-tool
-	// answers this one by rewriting them rather than by speaking to the parent.
-	nextRoot = updateClaudeHook(nextRoot, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", uninstall)
-	// The other half of the point of action: the pre-tool line speaks before a
-	// command runs, this one speaks when it failed and the store knows what
-	// followed that error before. Bash only — a failed edit does not carry a
-	// shell error signature.
-	nextRoot = updateClaudeHook(nextRoot, "PostToolUse", exe+" hook-tool-after", "Bash", uninstall)
+	nextRoot := root
+	for _, h := range claudeHookWiring {
+		nextRoot = updateClaudeHook(nextRoot, h.Event, exe+" "+h.Sub, h.Matcher, uninstall)
+	}
 	next, err := json.MarshalIndent(nextRoot, "", "  ")
 	if err != nil {
 		return installResult{}, err

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -74,6 +74,6 @@ A="$(mktemp -d)"
 mkdir -p "$A/.claude"
 printf '{}\n' > "$A/.claude/settings.json"
 HOME="$A" USERPROFILE="$A" $D install --auto >/dev/null 2>&1 || fail "install --auto"
-HOME="$A" USERPROFILE="$A" $D doctor | grep -q "precompact   wired" || fail "doctor disagrees with install --auto"
+HOME="$A" USERPROFILE="$A" $D doctor | grep -q "claude-code  wired" || fail "doctor disagrees with install --auto"
 
 echo "e2e OK"


### PR DESCRIPTION
deja wires five events into Claude Code. doctor checked one of them and printed "wired", so a settings.json written before PreToolUse and PostToolUse existed looked healthy while the features that arrived with those events reached nobody. On the machine this was found on: three of five, and the two missing ones are recall at the moment of an edit or a command, and the memory a spawned subagent gets.

The list of events now lives in one place that install writes from and doctor reads, so the next event added cannot drift out of the check. When something is missing the row says which:

    claude-code  out of date /Users/x/.claude/settings.json
                 3 of 5 events wired — no PreToolUse, PostToolUse; run `deja install`

Two existing tests moved with it: one named the row "precompact", which is no longer what the row is about, and one wrote a single event to prove absolute paths count as wired — it now writes all five, so the thing it asserts is the thing it measures.