### PR TITLE
fix(last): say what the ignore rule kept out of the listing

### DIFF
--- a/cmd/deja/last_ignored_note_test.go
+++ b/cmd/deja/last_ignored_note_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every rule in deja that withholds rows says how many: the trust policy prints
+// its own line, search says "showing 36 of 39", the brief counts what it filled
+// in for. The ignore rule says nothing — and since #2541 it takes rows out of
+// the listing too, so on this machine 253 of 400 disappeared with no line
+// anywhere connecting them to the rule (#2554).
+func TestLastSaysWhatTheIgnoreRuleWithheld(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	real := filepath.Join(claude, "projects", "-tmp-app")
+	jobs := filepath.Join(claude, ".claude", "jobs", "abc", "projects", "-tmp-app")
+	for _, d := range []string{real, jobs} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	write := func(dir, sid, text string, ago time.Duration) {
+		rec := claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/tmp/app",
+			"timestamp": time.Now().Add(-ago).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": text},
+		})
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(real, "keeper", "the pool starves under load", 2*time.Hour)
+	for i, sid := range []string{"scratch1", "scratch2", "scratch3"} {
+		write(jobs, sid, "one-shot question "+sid, time.Duration(i+1)*time.Hour)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "last") })
+	// The premise: the listing kept the real session and dropped the rest.
+	if !strings.Contains(out, "keeper") {
+		t.Fatalf("the real session is not listed, so this measures nothing:\n%s", out)
+	}
+	if strings.Contains(out, "scratch") {
+		t.Fatalf("an ignored session was listed:\n%s", out)
+	}
+	if !strings.Contains(stderr, "3") || !strings.Contains(stderr, "ignore") {
+		t.Errorf("the listing dropped three sessions and said %q", strings.TrimSpace(stderr))
+	}
+	// And it names the rule and where it lives, the way the trust policy's own
+	// line does — a person who wrote the pattern has to be able to find it.
+	if !strings.Contains(stderr, ".claude/jobs") || !strings.Contains(stderr, "policy.json") {
+		t.Errorf("the line does not say which rule or where: %q", strings.TrimSpace(stderr))
+	}
+
+	// Silence when the rule takes nothing: this is a state, not a decoration.
+	if err := os.RemoveAll(jobs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index", "--rebuild"); err != nil {
+		t.Fatal(err)
+	}
+	quiet := captureStderr(t, func() { _, _ = captureRun(t, "last") })
+	if strings.Contains(quiet, "ignore") {
+		t.Errorf("the line printed with nothing withheld: %q", strings.TrimSpace(quiet))
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -922,6 +922,12 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
 		fmt.Fprintln(os.Stderr, note)
 	}
+	// And the other rule that withholds rows here. It filters inside the index
+	// (#2541), so the count comes from the manifest rather than from what came
+	// back — the same walk the listing has just done, over metas already read.
+	if note := ignoredHiddenNote(index.IgnoredMatching(dir, o)); note != "" {
+		fmt.Fprint(os.Stderr, note)
+	}
 	if len(ss) == 0 {
 		if o.JSON {
 			return printRecentJSONWithheld(os.Stdout, nil, sourceInstance, policyHidden)

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
@@ -37,6 +38,19 @@ func policyHiddenNote(activation string, hidden int) string {
 	}
 	return fmt.Sprintf("deja: the trust policy hides %d matching session%s on this path (%s: %s) — see %s\n",
 		hidden, pluralS(hidden), activation, policy.Load().Describe(activation), policy.Path())
+}
+
+// ignoredHiddenNote is the same line for the ignore rule, which withholds by
+// path rather than by activation. It had no line at all: the rule is
+// user-editable, and a broad pattern took rows off every screen with nothing
+// anywhere connecting the two (#2554).
+func ignoredHiddenNote(hidden int) string {
+	if hidden <= 0 {
+		return ""
+	}
+	pats := policy.Load().IgnorePatterns()
+	return fmt.Sprintf("deja: the ignore rule keeps %d session%s out of this listing (%s) — see %s\n",
+		hidden, pluralS(hidden), strings.Join(pats, ", "), policy.Path())
 }
 
 // policyFilterBlame is policyFilterHits for blame results, which carry whole

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1466,6 +1466,32 @@ func ignoredByPolicy(ss []model.Session) []model.Session {
 	return out
 }
 
+// IgnoredMatching counts the sessions a listing would have shown if the ignore
+// rule did not cover them. Every other rule that withholds rows in deja says
+// how many; this one dropped 253 of 400 on a real store and said nothing
+// (#2554). Manifest only, so the listing pays a walk over metas it has just
+// read from the same cached manifest.
+func IgnoredMatching(dir string, o query.Options) int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return 0
+	}
+	pol := policy.Load()
+	n := 0
+	for _, meta := range m.Sessions {
+		if !sessionMetaMatches(meta, o) {
+			continue
+		}
+		if pol.Ignored(meta.Path, meta.Project) {
+			n++
+		}
+	}
+	return n
+}
+
 // metasNotIgnored is ignoredByPolicy one step earlier, on the metas a walk is
 // about to cut a window out of. sessionsForMetas filters what it loads, which
 // is right, but by then the window is chosen: three ignored sessions at the top


### PR DESCRIPTION
Closes #2554.

The ignore rule (`*/.claude/jobs/*` by default, or whatever someone writes in `ignore`) keeps sessions out of recall and, since #2541, out of the listing. It was the only withholding rule in deja that said nothing: the trust policy prints its own line, search says "showing 36 of 39", the brief counts what it filled in for.

    deja: the ignore rule keeps 305 sessions out of this listing (*/.claude/jobs/*) — see ~/.config/deja/policy.json

Silent when it takes nothing.