### PR TITLE
fix(sync): keep the counts behind an imported session's touched files

### DIFF
--- a/internal/index/import_touchhits_test.go
+++ b/internal/index/import_touchhits_test.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Touched is a ranking, and #1333 established that a ranking cannot be merged
+// without the numbers behind it — which is why SessionMeta.TouchHits exists and
+// why local ingest carries it. The import path derives Touched from the records
+// (counting as it goes) and then throws the counts away, so a peer's session
+// merges by rank alone: a file the second batch touched once leads one the first
+// batch touched throughout (#2558).
+func TestImportKeepsTheCountsBehindTouched(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	shared := filepath.Join(tmp, "shared")
+	if err := os.MkdirAll(shared, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC)
+	rec := func(role, text string, n int) string {
+		return `{"harness":"claude","session_id":"peer1","project":"svc","role":"` + role +
+			`","text":"` + text + `","time":"` + at.Add(time.Duration(n)*time.Minute).Format(time.RFC3339) + `"}` + "\n"
+	}
+	batch := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(shared, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Import(dir, shared); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(filepath.Join(shared, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The first batch passes over one file once.
+	batch("deja-sync-a.jsonl", rec("user", "a first look", 0)+rec("files", "/repo/tail.go", 1))
+
+	meta := importedPeerMeta(t, dir)
+	if len(meta.TouchHits) != len(meta.Touched) {
+		t.Errorf("Touched=%v carries %d counts", meta.Touched, len(meta.TouchHits))
+	}
+
+	// The second works on another file throughout.
+	second := rec("user", "working on the pool", 10)
+	for i := 0; i < 5; i++ {
+		second += rec("files", "/repo/pool.go", 11+i)
+	}
+	batch("deja-sync-b.jsonl", second)
+
+	meta = importedPeerMeta(t, dir)
+	if len(meta.Touched) < 2 {
+		t.Fatalf("Touched=%v, want both files", meta.Touched)
+	}
+	if meta.Touched[0] != "/repo/pool.go" {
+		t.Errorf("Touched=%v hits=%v — the file touched once leads the one touched throughout",
+			meta.Touched, meta.TouchHits)
+	}
+}
+
+func importedPeerMeta(t *testing.T, dir string) SessionMeta {
+	t.Helper()
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, meta := range metas {
+		if meta.OrigID == "peer1" {
+			return meta
+		}
+	}
+	t.Fatalf("imported session not found in %d metas", len(metas))
+	return SessionMeta{}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1647,7 +1647,11 @@ func topTouchedFiles(ms []model.Message) []string {
 // session as records rather than messages. Imported sessions used to carry no
 // Touched, so `deja blame` — which reads it — could not attribute a peer's
 // edits even though `search --role files` surfaced the same records.
-func touchedFromRecords(recs []Record) []string {
+// touchedFromRecords derives the touched-file ranking and the counts behind it.
+// The counts were computed here and thrown away, so an imported session carried
+// a ranking nothing could merge — the shape #1333 fixed for local ingest, still
+// standing for peers (#2558).
+func touchedFromRecords(recs []Record) ([]string, []int) {
 	count := map[string]int{}
 	for _, r := range recs {
 		if r.Role != roleFiles {
@@ -1655,7 +1659,7 @@ func touchedFromRecords(recs []Record) []string {
 		}
 		countTouchedPaths(count, r.Text)
 	}
-	return rankTouched(count)
+	return rankTouchedCounted(count)
 }
 
 // countTouchedPaths tallies the file paths in one `files` record's text, one

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -921,8 +921,8 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		// imported session carried no Touched, so `deja blame` — which reads
 		// Touched to find who edited a file — could not attribute a peer's edits
 		// even though `search --role files` surfaced the same records.
-		if t := touchedFromRecords(recsByKey[key]); len(t) > 0 {
-			meta.Touched = t
+		if t, hits := touchedFromRecords(recsByKey[key]); len(t) > 0 {
+			meta.Touched, meta.TouchHits = t, hits
 		}
 		// Same reason for the asked-twice signal: without meta.Asked an imported
 		// session can never contribute a repeat to the brief, so a question a
@@ -958,7 +958,7 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 			// on hardest (#1333). Six slots mean some earlier path does lose its
 			// place — to a path the session worked on more, which is what the field
 			// holds.
-			meta.Touched = mergeTouched(old.Touched, meta.Touched)
+			meta.Touched, meta.TouchHits = mergeTouchedCounted(old.Touched, old.TouchHits, meta.Touched, meta.TouchHits)
 			meta.Asked = mergeCappedU64(old.Asked, meta.Asked, askedQuestionCap)
 			meta.Hit = mergeCappedU64(old.Hit, meta.Hit, frictionSessionCap)
 			// Same reason: a reversal reported in an earlier batch is not in


### PR DESCRIPTION
Closes #2558.

`Touched` is a ranking and `TouchHits` is why it can be merged — #1333 added it after a file touched once in a tail outranked one touched throughout. Local ingest carries both. The import path counted the paths in `touchedFromRecords` and threw the numbers away, then merged later batches by rank alone, so a peer's session had the same defect with nothing able to repair it on the next sync.

Two batches for one peer session: the first passes over tail.go once, the second works on pool.go five times — tail.go led, with no counts stored.