### PR TITLE
fix(bench): clean up what a run leaves in the working directory

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/bench"
@@ -56,7 +57,7 @@ func runBenchRecall(jsonOutput bool, seed int64) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = os.RemoveAll(root) }()
+	defer func() { releaseBenchTempDir(root) }()
 	indexDir := filepath.Join(root, "index.db")
 	claudeRoot := filepath.Join(root, "claude")
 	if err := writeBenchCorpus(claudeRoot, corpus.Sessions); err != nil {
@@ -272,6 +273,12 @@ func isolateBenchEnv(root, claudeRoot, indexDir string) func() {
 	}
 }
 
+// benchStaleRun is how old a run tree has to be before a later run reclaims it.
+// A run that was interrupted leaves its corpus and index behind — megabytes of
+// it — and nothing else ever looks in that directory again. Bounded by age so a
+// run happening right now, in another shell, is not swept out from under it.
+const benchStaleRun = 24 * time.Hour
+
 func benchmarkTempDir() (string, error) {
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -281,7 +288,36 @@ func benchmarkTempDir() (string, error) {
 	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return "", err
 	}
+	sweepStaleBenchRuns(parent, time.Now())
 	return os.MkdirTemp(parent, "run-")
+}
+
+// sweepStaleBenchRuns removes what interrupted runs left behind.
+func sweepStaleBenchRuns(parent string, now time.Time) {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), "run-") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || now.Sub(info.ModTime()) < benchStaleRun {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(parent, e.Name()))
+	}
+}
+
+// releaseBenchTempDir drops this run's tree and, if it was the last thing in
+// there, the directory bench made in the user's working directory. `deja bench`
+// left an empty .deja-bench in whatever repo it was run from (#2560).
+func releaseBenchTempDir(dir string) {
+	_ = os.RemoveAll(dir)
+	// Remove, not RemoveAll: a parent still holding another run's tree fails
+	// here and stays, which is the point.
+	_ = os.Remove(filepath.Dir(dir))
 }
 
 func printBenchReport(w io.Writer, report benchReport) {

--- a/cmd/deja/bench_context.go
+++ b/cmd/deja/bench_context.go
@@ -89,7 +89,7 @@ func measureContext(seed int64) (contextReport, error) {
 	if err != nil {
 		return contextReport{}, err
 	}
-	defer func() { _ = os.RemoveAll(root) }()
+	defer func() { releaseBenchTempDir(root) }()
 	claudeRoot := filepath.Join(root, "claude")
 	indexDir := filepath.Join(root, "index.db")
 	var sessions []model.Session

--- a/cmd/deja/bench_leftovers_test.go
+++ b/cmd/deja/bench_leftovers_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// `deja bench` builds its corpus under .deja-bench/run-* in the working
+// directory — the user's repo — removes the run tree on success and never
+// touches the parent. So a ^C leaves megabytes there that nothing ever looks at
+// again, and a clean run still leaves an empty directory behind (#2560).
+func TestBenchSweepsWhatEarlierRunsLeft(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	work := t.TempDir()
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(work, ".deja-bench")
+	stale := filepath.Join(parent, "run-interrupted")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "corpus.jsonl"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+	// A run that started a minute ago is somebody else's, still going.
+	fresh := filepath.Join(parent, "run-live")
+	if err := os.MkdirAll(fresh, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := benchmarkTempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("the interrupted run's tree is still there: %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("a live run's tree was swept: %v", err)
+	}
+
+	// And the parent goes when this run's own tree is the last thing in it.
+	if err := os.RemoveAll(fresh); err != nil {
+		t.Fatal(err)
+	}
+	releaseBenchTempDir(dir)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("the run tree survived: %v", err)
+	}
+	if _, err := os.Stat(parent); !os.IsNotExist(err) {
+		t.Errorf(".deja-bench was left in the working directory: %v", err)
+	}
+}
+
+// A parent still holding another run's tree stays where it is.
+func TestBenchKeepsTheParentWhileAnotherRunIsInIt(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	work := t.TempDir()
+	if err := os.Chdir(work); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := benchmarkTempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(dir)
+	other := filepath.Join(parent, "run-other")
+	if err := os.MkdirAll(other, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	releaseBenchTempDir(dir)
+	if _, err := os.Stat(parent); err != nil {
+		t.Errorf("the parent was removed while another run was in it: %v", err)
+	}
+}

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -253,7 +253,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	if err != nil {
 		return promptReport{}, err
 	}
-	defer func() { _ = os.RemoveAll(root) }()
+	defer func() { releaseBenchTempDir(root) }()
 	claudeRoot := filepath.Join(root, "claude")
 	indexDir := filepath.Join(root, "index.db")
 	var sessions []model.Session


### PR DESCRIPTION
Closes #2560.

`deja bench` builds its corpus under `.deja-bench/run-*` in the current working directory — the user's repo — removes the run tree on success and never touches the parent. A `^C` leaves the corpus and index there, megabytes, and nothing in deja ever looks at that directory again; a clean run still leaves an empty `.deja-bench` behind. It is gitignored in this repo, not in anyone else's.

Runs older than a day are swept before a new one starts, and the parent goes when this run's tree was the last thing in it. Age-bounded so a run in another shell is not swept out from under it.