### PR TITLE
fix(search): count the ignore rule where it withholds an answer

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1250,6 +1250,12 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 			fmt.Fprintf(os.Stderr, "deja: showing %d of %d — add --all to see the rest\n", len(hits), o.Total)
 		}
 	}
+	// The answer can also be short for a reason no flag lifts. Counted over the
+	// sessions holding every term, so an ordinary search in a store with a big
+	// ignored tree stays quiet (#2562).
+	if note := ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(o.Query))); note != "" {
+		fmt.Fprint(os.Stderr, note)
+	}
 	// The window this is being printed into, so the lines can be budgeted
 	// rather than assumed 80 wide. Only for a terminal: a pipe gets the whole
 	// line, since a script reading deja wants the text and not the layout
@@ -1482,6 +1488,12 @@ func printNoMatches(w io.Writer, dir, q string, regex bool) {
 		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", n, pluralS(n), q)
 	} else {
 		fmt.Fprintf(w, "deja: no matches — try fewer words or --re (query %q)\n", q)
+	}
+	// Before advising fewer words: the sessions that hold every one of them may
+	// exist and be covered by the ignore rule, in which case rewording is the
+	// wrong advice and the count is the answer (#2562).
+	if note := ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(q))); note != "" {
+		fmt.Fprint(w, note)
 	}
 	// Which word to drop is the reader's next question, and deja read the
 	// per-term counts to decide there was no intersection (#826).

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -45,12 +45,19 @@ func policyHiddenNote(activation string, hidden int) string {
 // user-editable, and a broad pattern took rows off every screen with nothing
 // anywhere connecting the two (#2554).
 func ignoredHiddenNote(hidden int) string {
+	return ignoredHiddenNoteFor("listing", hidden)
+}
+
+// ignoredHiddenNoteWhere names the surface, because the same rule takes rows
+// out of an answer as well as out of a listing and the reader is looking at one
+// of them, not at both (#2562).
+func ignoredHiddenNoteFor(where string, hidden int) string {
 	if hidden <= 0 {
 		return ""
 	}
 	pats := policy.Load().IgnorePatterns()
-	return fmt.Sprintf("deja: the ignore rule keeps %d session%s out of this listing (%s) — see %s\n",
-		hidden, pluralS(hidden), strings.Join(pats, ", "), policy.Path())
+	return fmt.Sprintf("deja: the ignore rule keeps %d session%s out of this %s (%s) — see %s\n",
+		hidden, pluralS(hidden), where, strings.Join(pats, ", "), policy.Path())
 }
 
 // policyFilterBlame is policyFilterHits for blame results, which carry whole

--- a/cmd/deja/search_ignored_note_test.go
+++ b/cmd/deja/search_ignored_note_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #2554 gave the listing a line for what the ignore rule withheld. Search filters
+// on the same rule inside the index and says nothing: the sessions that asked the
+// question are covered by it, so the answer comes back short — or empty — with
+// only the tier's own notes on screen (#2562).
+func TestSearchSaysWhatTheIgnoreRuleWithheld(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	real := filepath.Join(claude, "projects", "-tmp-app")
+	jobs := filepath.Join(claude, ".claude", "jobs", "abc", "projects", "-tmp-app")
+	for _, d := range []string{real, jobs} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	write := func(dir, sid, text string, ago time.Duration) {
+		rec := claudeRecord(t, map[string]any{
+			"type": "user", "sessionId": sid, "cwd": "/tmp/app",
+			"timestamp": time.Now().Add(-ago).UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": "user", "content": text},
+		})
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(rec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(real, "keeper", "the invoice renderer lost its footer", 2*time.Hour)
+	for i, sid := range []string{"scratch1", "scratch2"} {
+		write(jobs, sid, "why did the quokka telemetry sharding keep failing", time.Duration(i+1)*time.Hour)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out string
+	stderr := captureStderr(t, func() { out, _ = captureRun(t, "quokka telemetry sharding") })
+	if strings.Contains(out, "scratch") {
+		t.Fatalf("an ignored session was served:\n%s", out)
+	}
+	if !strings.Contains(stderr, "ignore rule") || !strings.Contains(stderr, "2") {
+		t.Errorf("two matching sessions were withheld and search said %q", strings.TrimSpace(stderr))
+	}
+
+	// Silence when the rule took nothing from this answer.
+	quiet := captureStderr(t, func() { _, _ = captureRun(t, "invoice renderer footer") })
+	if strings.Contains(quiet, "ignore rule") {
+		t.Errorf("the line printed for an answer the rule did not touch: %q", strings.TrimSpace(quiet))
+	}
+}

--- a/internal/index/ignored_counts_test.go
+++ b/internal/index/ignored_counts_test.go
@@ -1,0 +1,81 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The per-term counts and the withheld count are both read off the postings,
+// which hold every session — including the ones the ignore rule keeps out of
+// every answer (#2562).
+func TestTermCountsAndWithheldCountFollowTheIgnoreRule(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(home, "claude")
+	jobs := filepath.Join(root, ".claude", "jobs", "abc", "-w-app")
+	real := filepath.Join(root, "-w-app")
+	for _, d := range []string{jobs, real} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(dir, sid, text string) {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/app","timestamp":"2026-01-02T03:04:05Z",` +
+			`"message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(jobs, "scratch1", "why did the quokka telemetry sharding keep failing")
+	write(jobs, "scratch2", "the quokka telemetry sharding again")
+	write(real, "keeper", "the invoice renderer lost its footer")
+
+	setHome(t, home)
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	terms := []string{"quokka", "telemetry", "sharding"}
+	counts := TermSessionCounts(dir, terms)
+	for _, term := range terms {
+		if counts[term] != 0 {
+			t.Errorf("%q counted in %d sessions search cannot serve", term, counts[term])
+		}
+	}
+	// The words of a session that is served are still counted.
+	if got := TermSessionCounts(dir, []string{"invoice"}); got["invoice"] != 1 {
+		t.Errorf("invoice counted %d times, want 1", got["invoice"])
+	}
+	if n := IgnoredWithAllTerms(dir, terms); n != 2 {
+		t.Errorf("withheld = %d, want the two sessions that hold every term", n)
+	}
+	// Nothing withheld for a query the rule does not touch, and nothing for a
+	// query the store has never seen.
+	if n := IgnoredWithAllTerms(dir, []string{"invoice", "renderer"}); n != 0 {
+		t.Errorf("withheld = %d for a served answer", n)
+	}
+	if n := IgnoredWithAllTerms(dir, []string{"zzzqqq"}); n != 0 {
+		t.Errorf("withheld = %d for a word nobody wrote", n)
+	}
+	if n := IgnoredWithAllTerms(dir, nil); n != 0 {
+		t.Errorf("withheld = %d for no terms at all", n)
+	}
+	// An unreadable store answers "nothing withheld" rather than failing the
+	// command it decorates.
+	if n := IgnoredWithAllTerms(filepath.Join(tmp, "nowhere"), terms); n != 0 {
+		t.Errorf("withheld = %d with no index", n)
+	}
+	if got := servableSids(filepath.Join(tmp, "nowhere")); got != nil {
+		t.Errorf("servableSids on a missing index = %v, want nil so counts stand", got)
+	}
+	if strings.TrimSpace(dir) == "" {
+		t.Fatal("unreachable")
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2389,6 +2389,11 @@ func TermSessionCounts(dir string, terms []string) map[string]int {
 	if dir == "" {
 		dir = DefaultDir()
 	}
+	// Counted over what search would serve. Postings hold every session, the
+	// answer holds none the ignore rule covers, and counting the two
+	// differently had deja say "no session has them together" about a phrase
+	// two withheld sessions carry word for word (#2562).
+	servable := servableSids(dir)
 	out := make(map[string]int, len(terms))
 	for _, t := range terms {
 		key := "t" + t
@@ -2403,11 +2408,65 @@ func TermSessionCounts(dir string, terms []string) map[string]int {
 		}
 		seen := map[uint32]bool{}
 		for _, p := range posts {
+			if servable != nil && !servable[p.Sid] {
+				continue
+			}
 			seen[p.Sid] = true
 		}
 		out[t] = len(seen)
 	}
 	return out
+}
+
+// servableSids is the set of session ordinals the ignore rule leaves in reach.
+// nil when the manifest cannot be read, which the callers treat as "count
+// everything" rather than "count nothing".
+func servableSids(dir string) map[uint32]bool {
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return nil
+	}
+	pol := policy.Load()
+	out := make(map[uint32]bool, len(m.Sessions))
+	for _, meta := range m.Sessions {
+		if !pol.Ignored(meta.Path, meta.Project) {
+			out[meta.Ord] = true
+		}
+	}
+	return out
+}
+
+// IgnoredWithAllTerms counts the sessions that hold every one of these terms
+// and that the ignore rule keeps out of the answer. The listing says what the
+// rule withheld from it (#2554); a search that comes back short or empty owes
+// the reader the same sentence (#2562).
+func IgnoredWithAllTerms(dir string, terms []string) int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	if len(terms) == 0 {
+		return 0
+	}
+	keys := make([]string, 0, len(terms))
+	for _, t := range terms {
+		keys = append(keys, "t"+t)
+	}
+	posts, err := intersectPostings(dir, keys)
+	if err != nil || len(posts) == 0 {
+		return 0
+	}
+	servable := servableSids(dir)
+	if servable == nil {
+		return 0
+	}
+	seen := map[uint32]bool{}
+	for _, p := range posts {
+		if servable[p.Sid] || seen[p.Sid] {
+			continue
+		}
+		seen[p.Sid] = true
+	}
+	return len(seen)
 }
 
 func intersectPostings(dir string, keys []string) ([]posting, error) {


### PR DESCRIPTION
Closes #2562.

Two sessions under `.claude/jobs` hold a phrase word for word; the answer holds neither, and the advice line counted them anyway:

    deja: no matches in 3 indexed sessions — try fewer words or --re
    deja: on their own: "quokka" in 2, "telemetry" in 2, "sharding" in 2 — no session has them together

The per-term counts now run over what search can serve, and the sentence the listing already prints (#2554) is printed for an answer too, counted over sessions holding every query term so an ordinary search stays quiet. On the real store:

    deja: showing 47 of 229 — add --all to see the rest
    deja: the ignore rule keeps 3 sessions out of this answer (*/.claude/jobs/*) — see ~/.config/deja/policy.json