### PR TITLE
fix(doctor): say which codex hook events an older install lacks

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -280,7 +280,28 @@ func doctorCodexHook(w io.Writer) {
 			status = "wired"
 		}
 	}
+	// Trusted is not the same as complete: the entry codex approved may be one
+	// written before the other events existed.
+	var missing []string
+	if status == "wired" {
+		var root map[string]any
+		if b, rerr := os.ReadFile(hooksPath); rerr == nil && json.Unmarshal(b, &root) == nil {
+			hooks, _ := root["hooks"].(map[string]any)
+			for _, h := range codexHookWiring {
+				if !hookEventWired(hooks, h.Event, h.Sub) {
+					missing = append(missing, h.Event)
+				}
+			}
+		}
+		if len(missing) > 0 {
+			status = "out of date"
+		}
+	}
 	line := fmt.Sprintf("  %-12s %-11s %s", "codex-hook", status, hooksPath)
+	if len(missing) > 0 {
+		line += fmt.Sprintf("\n               %d of %d events wired — no %s; run `deja install`",
+			len(codexHookWiring)-len(missing), len(codexHookWiring), strings.Join(missing, ", "))
+	}
 	if status == "untrusted" {
 		line += "  (codex has not been shown it — open codex once and approve it, or run /hooks; until then `codex exec` runs no hook at all)"
 	}

--- a/cmd/deja/doctor_codex_wiring_test.go
+++ b/cmd/deja/doctor_codex_wiring_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// codexHome writes a hooks.json holding the given events and the trust entry
+// codex needs before it runs any of them.
+func codexHome(t *testing.T, events ...string) {
+	t.Helper()
+	home := sources.CodexHome()
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sub := func(event string) string {
+		for _, h := range codexHookWiring {
+			if h.Event == event {
+				return h.Sub
+			}
+		}
+		return "hook-unknown"
+	}
+	var entries []string
+	for _, e := range events {
+		entries = append(entries, `"`+e+`":[{"matcher":"","hooks":[{"type":"command","command":"/usr/local/bin/deja `+
+			sub(e)+`"}]}]`)
+	}
+	if err := os.WriteFile(filepath.Join(home, "hooks.json"),
+		[]byte(`{"hooks":{`+strings.Join(entries, ",")+`}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "config.toml"),
+		[]byte("[hooks.json:session_start]\ntrusted_hash = \"sha256:abc\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Codex trusts a hooks.json by its hash, and the one it approved may be the one
+// an older deja wrote. Trusted said "wired" whatever was in it, so the events
+// added since ran nowhere and nothing said so.
+func TestDoctorNamesTheCodexEventsAnOlderInstallLacks(t *testing.T) {
+	withStatsStores(t)
+	codexHome(t, "SessionStart")
+
+	var out bytes.Buffer
+	doctorCodexHook(&out)
+	got := out.String()
+	if !strings.Contains(got, "out of date") {
+		t.Errorf("a one-of-three wiring was not called out:\n%s", got)
+	}
+	for _, want := range []string{"PreToolUse", "PostToolUse", "deja install"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the report does not name %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestDoctorIsQuietWhenCodexHasEveryEvent(t *testing.T) {
+	withStatsStores(t)
+	var all []string
+	for _, h := range codexHookWiring {
+		all = append(all, h.Event)
+	}
+	codexHome(t, all...)
+
+	var out bytes.Buffer
+	doctorCodexHook(&out)
+	if got := out.String(); strings.Contains(got, "out of date") {
+		t.Errorf("a complete wiring was reported as stale:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -558,7 +558,15 @@ func TestDoctorCodexHookStates(t *testing.T) {
 	if !strings.Contains(out.String(), "codex-hook   missing") {
 		t.Fatalf("missing state wrong:\n%s", out.String())
 	}
-	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"), []byte(`{"hooks":{"SessionStart":[]}}`), 0o644); err != nil {
+	// Every event deja installs, so what this measures is the trust state and
+	// not whether the wiring is complete.
+	var entries []string
+	for _, h := range codexHookWiring {
+		entries = append(entries, `"`+h.Event+`":[{"matcher":"","hooks":[{"type":"command","command":"/x/deja `+
+			h.Sub+`"}]}]`)
+	}
+	if err := os.WriteFile(filepath.Join(codexHome, "hooks.json"),
+		[]byte(`{"hooks":{`+strings.Join(entries, ",")+`}}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte("[hooks.state.\"/x/hooks.json:session_start:0:0\"]\ntrusted_hash = \"sha256:aa\"\nenabled = false\n"), 0o644); err != nil {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -16,6 +16,23 @@ import (
 // Claude Code, so the existing `deja hook-context` output works unchanged.
 // We merge one SessionStart entry into ~/.codex/hooks.json and leave
 // everything else in the file alone.
+// codexHookWiring is every event deja installs into Codex, in one place because
+// install writes from it and doctor reads it. A hooks.json written by an older
+// deja — SessionStart alone, where there are now three — was reported as wired
+// on the strength of the trust entry, and the two events added since reached
+// nobody.
+var codexHookWiring = []struct{ Event, Sub, Matcher string }{
+	// SessionStart carries the project digest.
+	{"SessionStart", "hook-context", "startup|resume"},
+	// PreToolUse carries the prior decision for the file or command about to
+	// change, scoped to the tools that run a command or change a file (codex
+	// edits via apply_patch) so the hook does not spawn on every read.
+	{"PreToolUse", "hook-tool", "Bash|apply_patch"},
+	// And the fix pair when a command fails, which is the moment an agent never
+	// thinks to ask for it.
+	{"PostToolUse", "hook-tool-after", "Bash"},
+}
+
 func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	// Use CodexHome() (honours CODEX_HOME / DEJA_CODEX_ROOT) rather than a raw
 	// ~/.codex join, so a sandboxed install stays sandboxed and a non-default
@@ -29,16 +46,9 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	// SessionStart carries the project digest; PreToolUse (hook-tool) carries
-	// the prior decision for the file or command about to change. Codex uses the
-	// same hooks.json shape as Claude Code, so both wire the same way.
-	updateCodexHook(root, "SessionStart", exe+" hook-context", "startup|resume", uninstall)
-	// Scoped to the tools that run a command or change a file (codex edits via
-	// apply_patch), so the hook does not spawn on every read.
-	updateCodexHook(root, "PreToolUse", exe+" hook-tool", "Bash|apply_patch", uninstall)
-	// And the fix pair when a command fails, which is the moment an agent never
-	// thinks to ask for it.
-	updateCodexHook(root, "PostToolUse", exe+" hook-tool-after", "Bash", uninstall)
+	for _, h := range codexHookWiring {
+		updateCodexHook(root, h.Event, exe+" "+h.Sub, h.Matcher, uninstall)
+	}
 	if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
 		delete(root, "hooks")
 	}


### PR DESCRIPTION
The same hole as #2553, in the harness next door. Codex trusts a hooks.json by its hash, and doctor read that trust as the answer — but the file codex approved may be the one an older deja wrote. On the machine this was found on it holds one event of three: SessionStart, and neither the recall before a command runs nor the fix pair after one fails.

The three events now live in one list that install writes from and doctor reads, and a trusted-but-incomplete file says so:

    codex-hook   out of date /Users/x/.codex/hooks.json
                 1 of 3 events wired — no PreToolUse, PostToolUse; run `deja install`

One existing test moved with it: it wrote `{"hooks":{"SessionStart":[]}}` to exercise the trust states, which now also reads as incomplete. It writes the full set, so what it measures is the trust state alone.