### PR TITLE
fix(check): say why the answer is empty

### DIFF
--- a/cmd/deja/check.go
+++ b/cmd/deja/check.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 )
 
 // runCheck is the human-facing form of the plan hook. It deliberately calls
@@ -11,6 +12,16 @@ import (
 // when a finding is delivered twice in one session, not whether it matches,
 // and a measurement run has to see every match.
 func runCheck(dir string, args []string, stdin io.Reader, stdout io.Writer) error {
+	return runCheckTo(dir, args, stdin, stdout, os.Stderr)
+}
+
+// runCheckTo is runCheck with somewhere to say why the answer is empty. The
+// hook this shares a body with must stay silent — a PreToolUse hook that talks
+// when it has nothing is noise on every plan — but the command a person typed
+// owes them the difference between "looked and found nothing", "there was
+// nothing in the plan to look for" and "there is no index to look in" (#2564).
+// Findings keep stdout to themselves, so a measurement run parses it unchanged.
+func runCheckTo(dir string, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	if len(args) != 1 || args[0] != "-" {
 		return fmt.Errorf("check needs '-' to read a plan from stdin")
 	}
@@ -18,8 +29,20 @@ func runCheck(dir string, args []string, stdin io.Reader, stdout io.Writer) erro
 	if err != nil {
 		return fmt.Errorf("check: read plan: %w", err)
 	}
-	for _, finding := range planFindings(dir, string(plan), "") {
+	findings := planFindings(dir, string(plan), "")
+	for _, finding := range findings {
 		fmt.Fprintln(stdout, finding)
+	}
+	if len(findings) > 0 {
+		return nil
+	}
+	switch {
+	case len(planSearchSteps(string(plan))) == 0:
+		fmt.Fprintln(stderr, "deja: nothing in this plan to check — it needs a step naming what it will do")
+	case !planIndexReady(dir):
+		fmt.Fprintln(stderr, "deja: no index to check against yet — `deja index` builds one")
+	default:
+		fmt.Fprintln(stderr, "deja: nothing found for this plan")
 	}
 	return nil
 }

--- a/cmd/deja/check_says_why_test.go
+++ b/cmd/deja/check_says_why_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `deja check -` is the form a person types; the hook it shares its body with
+// is the one that must stay silent. Today both are: an empty plan, a plan with
+// nothing to search on, a store with no index, and a plan deja looked up and
+// found nothing for all print nothing and exit 0, so the reader cannot tell
+// which of the four happened (#2564).
+func TestCheckSaysWhyItFoundNothing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+
+	say := func(plan string) string {
+		t.Helper()
+		var out, errs bytes.Buffer
+		if err := runCheckTo(dir, []string{"-"}, strings.NewReader(plan), &out, &errs); err != nil {
+			t.Fatalf("check: %v", err)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("stdout is for findings only, got %q", out.String())
+		}
+		return errs.String()
+	}
+
+	// No index at all: deja never looked, and saying nothing claims it did.
+	if got := say("Plan: change the pgbouncer pool size."); !strings.Contains(got, "index") {
+		t.Errorf("with no index, check said %q", strings.TrimSpace(got))
+	}
+
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	// A plan with nothing in it to search on.
+	if got := say("   \n  "); !strings.Contains(got, "plan") {
+		t.Errorf("on an empty plan, check said %q", strings.TrimSpace(got))
+	}
+	// And a plan it really did look up.
+	got := say("Plan: change the pgbouncer pool size and the retry budget.")
+	if !strings.Contains(got, "nothing") {
+		t.Errorf("after looking and finding nothing, check said %q", strings.TrimSpace(got))
+	}
+}


### PR DESCRIPTION
Closes #2564.

`deja check -` shares its body with the ExitPlanMode hook, which is right to be silent — a PreToolUse hook that talks when it has nothing is noise on every plan. The command a person types is not the hook, and it printed the same nothing for four different outcomes: a plan with nothing searchable in it, a real miss, no index at all, and an index this build cannot read.

I hit the last one running `check` against my own store: every plan printed nothing, which reads as "nothing found", while `planIndexReady` had switched the path off because the index was written by an older build.

Findings still have stdout to themselves; the sentence goes to stderr.