### PR TITLE
fix(hooks): let the action hooks ask for the rebuild an upgrade needs

### DIFF
--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -103,6 +103,15 @@ func planFindings(dir, plan, sessionID string) []string {
 	// This path never asks for a rebuild. A missing, stale, or damaged
 	// snapshot is a silent miss so plan submission cannot block on indexing.
 	if !planIndexReady(dir) {
+		// Ask, do not build. #777 gave the per-prompt and session-start hooks
+		// this: an index in a format this build cannot read answers nothing,
+		// which reads as a user with no history, and nothing else asks for the
+		// rebuild that fixes it. A spawned subagent reaches only these hooks —
+		// install.go says so where it wires Task and Agent — so without this a
+		// fleet works against a stale index until its parent types something
+		// (#2567). requestWarmup writes a sentinel and detaches a child; the
+		// action pays neither the read nor the wait.
+		requestWarmup(dir)
 		return nil
 	}
 

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -78,6 +78,15 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	// other than the caller, so it answers in its own shape. See hook_spawn.go.
 	if isSpawnTool(input.ToolName) {
 		if !planIndexReady(dir) {
+			// Ask, do not build. #777 gave the per-prompt and session-start hooks
+			// this: an index in a format this build cannot read answers nothing,
+			// which reads as a user with no history, and nothing else asks for the
+			// rebuild that fixes it. A spawned subagent reaches only these hooks —
+			// install.go says so where it wires Task and Agent — so without this a
+			// fleet works against a stale index until its parent types something
+			// (#2567). requestWarmup writes a sentinel and detaches a child; the
+			// action pays neither the read nor the wait.
+			requestWarmup(dir)
 			return nil
 		}
 		return runHookSpawn(dir, input, raw, stdout)
@@ -85,6 +94,15 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	// Never build or repair from here. This runs inside an action the user is
 	// waiting on, and a miss costs nothing while a rebuild costs seconds.
 	if !planIndexReady(dir) {
+		// Ask, do not build. #777 gave the per-prompt and session-start hooks
+		// this: an index in a format this build cannot read answers nothing,
+		// which reads as a user with no history, and nothing else asks for the
+		// rebuild that fixes it. A spawned subagent reaches only these hooks —
+		// install.go says so where it wires Task and Agent — so without this a
+		// fleet works against a stale index until its parent types something
+		// (#2567). requestWarmup writes a sentinel and detaches a child; the
+		// action pays neither the read nor the wait.
+		requestWarmup(dir)
 		return nil
 	}
 	line := toolHookLine(dir, hookCWD(input.CWD), input)

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -60,6 +60,15 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 	raw := readHookPayload(stdin, hookStdinWait)
 	_ = json.NewDecoder(bytes.NewReader(raw)).Decode(&input)
 	if !planIndexReady(dir) {
+		// Ask, do not build. #777 gave the per-prompt and session-start hooks
+		// this: an index in a format this build cannot read answers nothing,
+		// which reads as a user with no history, and nothing else asks for the
+		// rebuild that fixes it. A spawned subagent reaches only these hooks —
+		// install.go says so where it wires Task and Agent — so without this a
+		// fleet works against a stale index until its parent types something
+		// (#2567). requestWarmup writes a sentinel and detaches a child; the
+		// action pays neither the read nor the wait.
+		requestWarmup(dir)
 		return nil
 	}
 	// A payload the decoder could not read has no tool name either, and the

--- a/cmd/deja/hook_tool_stale_format_test.go
+++ b/cmd/deja/hook_tool_stale_format_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// #777 taught hook-prompt and hook-context to ask for the rebuild an upgrade
+// makes necessary; the action hooks were left out. A spawned subagent gets no
+// session start and sends no user prompt — install.go says so where it wires
+// Task and Agent — so on a machine that has just upgraded, everything an agent
+// does runs against an index nothing has asked to rebuild (#2567).
+func TestActionHooksAskForTheRebuildAnUpgradeNeeds(t *testing.T) {
+	hermeticEnv(t)
+	// hermeticEnv suppresses the request; the question here is whether the
+	// hooks ask at all, so let it through and count the spawn.
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	spawned := 0
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { spawned++; return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+		run     func(dir string, stdin *strings.Reader, out *bytes.Buffer) error
+	}{
+		{"hook-tool", `{"session_id":"s","cwd":"/w","tool_name":"Bash","tool_input":{"command":"go test ./..."}}`,
+			func(dir string, in *strings.Reader, out *bytes.Buffer) error { return runHookTool(dir, in, out) }},
+		{"hook-tool-after", `{"session_id":"s","cwd":"/w","tool_name":"Bash","tool_input":{"command":"go test ./..."},"tool_response":{"stderr":"undefined: snorblefunc"}}`,
+			func(dir string, in *strings.Reader, out *bytes.Buffer) error { return runHookToolAfter(dir, in, out) }},
+		{"hook-plan", `{"session_id":"s","cwd":"/w","tool_name":"ExitPlanMode","tool_input":{"plan":"Plan: change the pgbouncer pool size."}}`,
+			func(dir string, in *strings.Reader, out *bytes.Buffer) error { return runHookPlan(dir, in, out) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "idx")
+			writeStaleFormatIndex(t, dir)
+			if index.IsCurrentVersion(dir) {
+				t.Fatal("fixture claims the current format version")
+			}
+			spawned = 0
+			var out bytes.Buffer
+			if err := tc.run(dir, strings.NewReader(tc.payload), &out); err != nil {
+				t.Fatal(err)
+			}
+			// Silence is still the contract: the hook must not answer from an
+			// index it cannot read, and must not rebuild inside the action.
+			if out.Len() != 0 {
+				t.Errorf("answered from a stale-format index: %q", out.String())
+			}
+			if spawned != 1 {
+				t.Errorf("requested %d rebuilds, want 1", spawned)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2567.

#777 taught `hook-prompt` and `hook-context` to request a detached rebuild when the index is in a format this build cannot read — otherwise it answers nothing, which reads as a user with no history. The action hooks were left out, and they are the only surface a spawned subagent reaches: `install.go` wires Task and Agent into PreToolUse precisely because that agent gets no session start and sends no user prompt.

Measured on a stale-format index: three action hooks, zero requests. After: one PreToolUse call and the index is rebuilt a second later.

They still never build. `requestWarmup` writes a sentinel and detaches a child, which is what the per-prompt hook already does on the same latency budget.