### PR TITLE
fix(sync): count an imported session's words and messages

### DIFF
--- a/internal/index/import_words_test.go
+++ b/internal/index/import_words_test.go
@@ -1,0 +1,83 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The same session on two machines has to be ranked the same way. #2558 gave
+// the import path the counts behind Touched; Words and Counted were still
+// dropped, and both feed ranking — Words is the length BM25 normalises by, and
+// a zero there is exactly the marathon-wins case search.go's comment describes;
+// Counted is the corpus size in messages, where a session with no count
+// degrades to one document (#2569).
+func TestImportedSessionIsCountedLikeALocalOne(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(home, "claude", "-w-app")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setHome(t, home)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(home, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	line := func(role, text, at string) string {
+		return `{"type":"` + role + `","sessionId":"s1","cwd":"/w/app","timestamp":"` + at +
+			`","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n"
+	}
+	body := line("user", "why does the pool starve under load?", "2026-08-01T10:00:00Z") +
+		line("assistant", "the fix was the retry budget, not the pool", "2026-08-01T10:02:00Z") +
+		line("user", "and what did the pool change cost us?", "2026-08-01T10:03:00Z") +
+		line("assistant", "two hours and a revert", "2026-08-01T10:04:00Z")
+	if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local := filepath.Join(tmp, "local.db")
+	t.Setenv("DEJA_INDEX_DIR", local)
+	if err := Ensure(local, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	exp := filepath.Join(tmp, "export")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExportFull(local, exp); err != nil {
+		t.Fatal(err)
+	}
+	remote := filepath.Join(tmp, "remote.db")
+	if _, err := Import(remote, exp); err != nil {
+		t.Fatal(err)
+	}
+
+	find := func(dir string) SessionMeta {
+		t.Helper()
+		metas, err := AllMeta(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range metas {
+			if m.ID == "s1" || m.OrigID == "s1" {
+				return m
+			}
+		}
+		t.Fatalf("session not found among %d metas in %s", len(metas), dir)
+		return SessionMeta{}
+	}
+	here, there := find(local), find(remote)
+	if here.Words == 0 {
+		t.Fatal("the local session has no word count, so this measures nothing")
+	}
+	if there.Words != here.Words {
+		t.Errorf("imported words=%d, local words=%d — the two machines normalise the same session differently",
+			there.Words, here.Words)
+	}
+	if there.Counted != here.Counted {
+		t.Errorf("imported counted=%d, local counted=%d — the corpus size disagrees across the sync",
+			there.Counted, here.Counted)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1551,6 +1551,35 @@ func askedFromRecords(recs []Record) []uint64 {
 	return out
 }
 
+// countedFromRecords is the message count local ingest keeps as Counted: the
+// records that are a turn of the conversation, not the work records deja
+// derives beside them. It feeds the corpus size the ranking divides by, so an
+// imported session with none counted as a single document (#2569).
+func countedFromRecords(recs []Record) int {
+	n := 0
+	for _, r := range recs {
+		if r.Role == roleFiles || r.Role == roleCommand || r.Role == roleEdit {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// wordsFromRecords is sessionWords over the same records: the document length
+// BM25 normalises by. Without it an imported session is scored on the length of
+// the match alone, which is the marathon-wins case search.go describes.
+func wordsFromRecords(recs []Record) int {
+	ms := make([]model.Message, 0, len(recs))
+	for _, r := range recs {
+		if r.Role == roleFiles || r.Role == roleCommand || r.Role == roleEdit {
+			continue
+		}
+		ms = append(ms, model.Message{Role: r.Role, Text: r.Text})
+	}
+	return sessionWords(ms)
+}
+
 // notAsked rejects the text a harness writes under the user role: hook
 // envelopes, interruption notices, resume preambles, the compaction summary.
 // It repeats across sessions by construction, so without this the most

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -930,6 +930,11 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 		if a := askedFromRecords(recsByKey[key]); len(a) > 0 {
 			meta.Asked = a
 		}
+		// And the two counts ranking divides by. A batch carries the records it
+		// carries, so these add up across batches the way the local
+		// incremental path adds them up across appends (#2569).
+		batchCounted := countedFromRecords(recsByKey[key])
+		batchWords := wordsFromRecords(recsByKey[key])
 		// And the friction signal, for the same reason: without meta.Hit the
 		// brief's one wall line never counted an error a peer kept hitting,
 		// though `deja friction` and stats both did.
@@ -965,8 +970,12 @@ func appendImportedRecords(dir string, m *Manifest, recsByKey map[string][]Recor
 			// this one, so OR with what the row already carried rather than
 			// letting a later batch clear the mark.
 			meta.GaveUp = old.GaveUp || batchGaveUp
+			meta.Counted = old.Counted + batchCounted
+			meta.Words = old.Words + batchWords
 		} else {
 			meta.GaveUp = batchGaveUp
+			meta.Counted = batchCounted
+			meta.Words = batchWords
 			meta.Ord = nextOrd
 			nextOrd++
 		}


### PR DESCRIPTION
Closes #2569, following #2558.

The same session, indexed locally and imported from a peer:

    local    counted=5 words=39 gaveup=true asked=1 hit=1
    imported counted=0 words=0  gaveup=true asked=1 hit=1

Both missing fields feed ranking. `Words` is the length BM25 normalises by, applied only when non-zero — without it a peer's session is scored on the length of the match alone, which is the marathon-wins case the comment in search.go describes. `Counted` is the corpus size in messages, and a session with none counts as a single document.

Derived from the records import already walks, and added across batches the way GaveUp, Asked and Hit already are.