### PR TITLE
fix(hooks): say what they are when typed at a terminal

### DIFF
--- a/cmd/deja/hook_typed_by_hand.go
+++ b/cmd/deja/hook_typed_by_hand.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// hookAdvice is what to reach for instead, for the hooks a person is most
+// likely to type after reading them in `deja help`.
+var hookAdvice = map[string]string{
+	"hook-prompt":     `deja "<what you want to remember>"`,
+	"hook-tool":       `deja how "<the command>" · deja blame <file>`,
+	"hook-tool-after": `deja fix "<the error>"`,
+	"hook-plan":       "deja check - (the same lookup, reading a plan from stdin)",
+}
+
+// hookTypedByHandNote is the line a hook prints when it was typed at a terminal
+// rather than run by a harness. Each hook reads a JSON payload on stdin and
+// answers with silence when there is nothing to say — the right contract for a
+// hook, and unreadable for a person, who waits out the stdin bound and gets an
+// empty screen. `deja check` earned the same treatment in #2564; these are
+// listed in `deja help`, so they are typed (#2571).
+func hookTypedByHandNote(name string, terminal bool) string {
+	if !terminal {
+		return ""
+	}
+	note := fmt.Sprintf("deja: %s is a harness hook — it reads a JSON payload on stdin and stays silent when it has nothing to add", name)
+	if advice, ok := hookAdvice[name]; ok {
+		note += "\ndeja: for the same memory by hand: " + advice
+	}
+	return note
+}
+
+// stdinIsTerminal reports that nothing is piped in. Same test `fix` uses before
+// reading stdin, for the same reason: reading a terminal blocks with no prompt
+// and reads as a hang.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+// sayIfTypedByHand prints the note and reports whether the command should stop.
+func sayIfTypedByHand(name string) bool {
+	note := hookTypedByHandNote(name, stdinIsTerminal())
+	if note == "" {
+		return false
+	}
+	fmt.Fprintln(os.Stderr, note)
+	return true
+}

--- a/cmd/deja/hook_typed_by_hand_test.go
+++ b/cmd/deja/hook_typed_by_hand_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// `deja help` lists hook-prompt, hook-plan, hook-tool and hook-tool-after, so
+// people type them. Each reads a JSON payload from the harness; typed at a
+// terminal they wait out the stdin bound and print nothing, which reads as
+// "deja knows nothing" rather than "this one is not for you" (#2571).
+func TestAHookTypedAtATerminalSaysWhatItIs(t *testing.T) {
+	hermeticEnv(t)
+	// A character device on stdin is what a terminal looks like; /dev/tty is
+	// not available in CI, and os.Stdin under `go test` is not a terminal
+	// either, so the check is exercised through its own helper.
+	for _, name := range []string{"hook-prompt", "hook-tool", "hook-tool-after", "hook-plan"} {
+		if note := hookTypedByHandNote(name, true); note == "" {
+			t.Errorf("%s says nothing when typed at a terminal", name)
+		} else if !strings.Contains(note, name) {
+			t.Errorf("%s: note does not name the command: %q", name, note)
+		}
+	}
+	// Piped, nothing changes: this is the path every harness uses.
+	if note := hookTypedByHandNote("hook-prompt", false); note != "" {
+		t.Errorf("a piped hook printed %q", note)
+	}
+	// And the real stdin under test is a pipe or a file, never a terminal, so
+	// the helper agrees with the world it runs in.
+	if fi, err := os.Stdin.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
+		t.Skip("stdin is a terminal here")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -152,6 +152,9 @@ var commands = map[string]command{
 	"forget":        runForget,
 	"mcp":           func(dir string, _ []string) error { return serveMCP(dir, os.Stdin, os.Stdout) },
 	"hook-prompt": func(dir string, rest []string) error {
+		if sayIfTypedByHand("hook-prompt") {
+			return nil
+		}
 		plain := len(rest) > 0 && (rest[0] == "--plain" || rest[0] == "-plain")
 		return runHookPromptMode(dir, os.Stdin, os.Stdout, plain)
 	},
@@ -159,12 +162,21 @@ var commands = map[string]command{
 		return runHookAntigravity(dir, os.Stdin, os.Stdout)
 	},
 	"hook-plan": func(dir string, _ []string) error {
+		if sayIfTypedByHand("hook-plan") {
+			return nil
+		}
 		return runHookPlan(dir, os.Stdin, os.Stdout)
 	},
 	"hook-tool": func(dir string, _ []string) error {
+		if sayIfTypedByHand("hook-tool") {
+			return nil
+		}
 		return runHookTool(dir, os.Stdin, os.Stdout)
 	},
 	"hook-tool-after": func(dir string, _ []string) error {
+		if sayIfTypedByHand("hook-tool-after") {
+			return nil
+		}
 		return runHookToolAfter(dir, os.Stdin, os.Stdout)
 	},
 	"check": func(dir string, rest []string) error {


### PR DESCRIPTION
Closes #2571.

`deja help` lists four hooks, so people type them. Each waits out its stdin bound and prints nothing — the right contract for something a harness runs on every prompt, and indistinguishable from "deja knows nothing" for the person who typed it. `check` had the same problem until #2564, and `fix` already refuses to read a terminal for the same reason.

    $ deja hook-prompt
    deja: hook-prompt is a harness hook — it reads a JSON payload on stdin and stays silent when it has nothing to add
    deja: for the same memory by hand: deja "<what you want to remember>"

Piped input — every harness — is untouched.