### PR TITLE
fix(search): count withheld sessions by the word forms the tiers match

### DIFF
--- a/internal/index/ignored_forms_test.go
+++ b/internal/index/ignored_forms_test.go
@@ -1,0 +1,60 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The withheld count (#2562) intersects raw term postings, while the tiers
+// stem: a query typed as "pool" is answered by a session that says "pools".
+// Measured over 22 real queries the two agreed everywhere, but the case is
+// constructible, and there the line goes quiet exactly when it is needed —
+// search serves nothing, the rule is why, and nobody says so (#2573).
+func TestTheWithheldCountFollowsTheWordFormsSearchDoes(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	root := filepath.Join(home, "claude")
+	jobs := filepath.Join(root, ".claude", "jobs", "abc", "-w-app")
+	real := filepath.Join(root, "-w-app")
+	for _, d := range []string{jobs, real} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(dir, sid, text string) {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/app","timestamp":"2026-01-02T03:04:05Z",` +
+			`"message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, sid+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The withheld session writes the plural; the reader types the singular.
+	write(jobs, "scratch", "the quokka pools kept starving under load")
+	write(real, "keeper", "the invoice renderer lost its footer")
+
+	setHome(t, home)
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: this store really does know the plural as another form.
+	if forms := OtherWordForms(dir, []string{"pool"}); len(forms["pool"]) == 0 {
+		t.Fatal("the store knows no other form of \"pool\", so this measures nothing")
+	}
+	if n := IgnoredWithAllTerms(dir, []string{"quokka", "pool", "starving"}); n != 1 {
+		t.Errorf("withheld = %d, want the session that says \"pools\"", n)
+	}
+	// The exact spelling still counts once, not twice.
+	if n := IgnoredWithAllTerms(dir, []string{"quokka", "pools", "starving"}); n != 1 {
+		t.Errorf("withheld = %d for the exact spelling", n)
+	}
+	// And a query the rule does not touch stays at zero.
+	if n := IgnoredWithAllTerms(dir, []string{"invoice", "renderer"}); n != 0 {
+		t.Errorf("withheld = %d for a served answer", n)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2447,26 +2447,51 @@ func IgnoredWithAllTerms(dir string, terms []string) int {
 	if len(terms) == 0 {
 		return 0
 	}
-	keys := make([]string, 0, len(terms))
-	for _, t := range terms {
-		keys = append(keys, "t"+t)
-	}
-	posts, err := intersectPostings(dir, keys)
-	if err != nil || len(posts) == 0 {
-		return 0
-	}
 	servable := servableSids(dir)
 	if servable == nil {
 		return 0
 	}
-	seen := map[uint32]bool{}
-	for _, p := range posts {
-		if servable[p.Sid] || seen[p.Sid] {
-			continue
+	// Each term matches any of its forms, the way the tiers match. Counting the
+	// exact spelling alone left the line silent for a reader who typed "pool"
+	// while the withheld session wrote "pools" — the moment it is most needed,
+	// since search then serves nothing and the rule is why (#2573).
+	forms := OtherWordForms(dir, terms)
+	var per []map[uint32]bool
+	for _, term := range terms {
+		hit := map[uint32]bool{}
+		for _, form := range append([]string{term}, forms[term]...) {
+			posts, err := postingsFor(dir, "t"+form)
+			if err != nil {
+				continue
+			}
+			for _, p := range posts {
+				if !servable[p.Sid] {
+					hit[p.Sid] = true
+				}
+			}
 		}
-		seen[p.Sid] = true
+		if len(hit) == 0 {
+			return 0
+		}
+		per = append(per, hit)
 	}
-	return len(seen)
+	if len(per) == 0 {
+		return 0
+	}
+	n := 0
+	for sid := range per[0] {
+		all := true
+		for _, hit := range per[1:] {
+			if !hit[sid] {
+				all = false
+				break
+			}
+		}
+		if all {
+			n++
+		}
+	}
+	return n
 }
 
 func intersectPostings(dir string, keys []string) ([]posting, error) {


### PR DESCRIPTION
Closes #2573, following #2562.

The withheld count intersected raw term postings while the tiers stem. Over 22 real queries on this store — ten typed, twelve taken from the ignored sessions' own titles, six of them with substantial counts — raw and stemmed agree everywhere, so nothing was wrong on real traffic. The constructible case is the one that matters:

    withheld session   "the quokka pools kept starving under load"
    reader types       quokka pool starving
    withheld           raw=0  stemmed=1

Search serves nothing, the rule is why, and the line stays quiet — the silence #2562 was written to end. Each term now matches any of its forms, as the tiers do.