### PR TITLE
fix(uninstall): know codex's, grok's and aider's wiring too

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -890,11 +890,14 @@ func mentionsDeja(b []byte) bool {
 	for _, marker := range []string{
 		"hook-prompt", "hook-context", "hook-tool", "hook-goose", "hook-plan",
 		"hook-precompact", "hook-antigravity", "deja:", "\"deja\"", "deja-recall",
-		// The two harnesses that do not write the word on its own: zed names
-		// the server, dsh opens a block. Without them their snapshots survived
-		// an uninstall carrying deja's whole entry, which is the one thing
-		// this test exists to prevent (#2575).
-		zedServerID, dshBlockStart,
+		// The harnesses that do not write the word on its own: zed names the
+		// server, dsh opens a block, codex and grok put the name in a TOML
+		// table header, and aider only points at deja's context file. Without
+		// them their snapshots survived an uninstall carrying deja's whole
+		// entry, which is the one thing this exists to prevent (#2575, #2578).
+		// TestEveryInstalledConfigIsRecognisableAsDejas installs every target
+		// and holds this list against what they actually write.
+		zedServerID, dshBlockStart, "[mcp_servers.deja]", "aider-context.md",
 	} {
 		if bytes.Contains(b, []byte(marker)) {
 			return true

--- a/cmd/deja/install_markers_test.go
+++ b/cmd/deja/install_markers_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every config an installer writes has to be recognisable as deja's own, or the
+// uninstall cannot take back the snapshot it made of it (#2575) and the reader
+// keeps a file naming a binary they removed. The marker list is written by hand
+// against twenty installers, so it is checked by installing all of them rather
+// than by reading it: zed and dsh were missing, and after them codex, grok and
+// aider (#2578). A new harness now fails here until its spelling is known.
+func TestEveryInstalledConfigIsRecognisableAsDejas(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	// This test installs; a wrong home would rewire the machine it runs on.
+	if home == "" || !strings.Contains(home, "TestEveryInstalledConfig") {
+		t.Fatalf("refusing to install into %q", home)
+	}
+	seen := map[string]bool{}
+	walk := func(fn func(path string, body []byte)) {
+		_ = filepath.Walk(home, func(p string, fi os.FileInfo, err error) error {
+			if err != nil || !fi.Mode().IsRegular() {
+				return nil
+			}
+			// deja's own state and guidance are not a harness config.
+			if strings.Contains(p, filepath.Join(".config", "deja")) {
+				return nil
+			}
+			b, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return nil
+			}
+			fn(p, b)
+			return nil
+		})
+	}
+	walk(func(p string, _ []byte) { seen[p] = true })
+
+	for _, target := range []string{
+		"claude-code", "codex", "opencode", "cursor", "gemini", "antigravity", "qwen", "kimi",
+		"hermes", "pi", "omp", "deepseek", "openclaw", "cline", "goose", "grok", "copilot",
+		"roo", "aider", "zed",
+	} {
+		if _, err := captureRun(t, "install", target, "--no-index", "--no-guidance"); err != nil {
+			t.Fatalf("install %s: %v", target, err)
+		}
+	}
+
+	written := 0
+	walk(func(p string, b []byte) {
+		if seen[p] {
+			return
+		}
+		written++
+		if !mentionsDeja(b) {
+			line := strings.Join(strings.Fields(string(b)), " ")
+			if len(line) > 120 {
+				line = line[:120] + "…"
+			}
+			t.Errorf("%s is deja's own wiring and mentionsDeja does not know it — an uninstall will leave its backup behind:\n  %s",
+				strings.TrimPrefix(p, home), line)
+		}
+	})
+	// The premise: the installers really did write something here.
+	if written < 10 {
+		t.Fatalf("only %d configs were written, so this measures nothing", written)
+	}
+}


### PR DESCRIPTION
Closes #2578, following #2575.

The marker list is written by hand against twenty installers, so I asked the machine instead: install every target into a temp home and check that what each wrote is recognised. Three were not —

    ~/.codex/config.toml   [mcp_servers.deja]
    ~/.grok/config.toml    [mcp_servers.deja]
    ~/.aider.conf.yml      read: - …/.config/deja/aider-context.md

— with the same consequence as #2575: their backups survive an uninstall holding deja's entry and the path to a binary that may be gone. `doctor` already greps for the TOML header.

The list is now held against reality by that same sweep as a test, so the next harness fails until its spelling is known.