### PR TITLE
fix(hook): stop one repository's error being told as a fact about the machine

### DIFF
--- a/cmd/deja/agent_text_cuts_test.go
+++ b/cmd/deja/agent_text_cuts_test.go
@@ -70,9 +70,15 @@ func TestTheTruncationMarkIsAnEllipsis(t *testing.T) {
 // block itself, since that is where the cut lives.
 func TestTheEnvironmentBlockCutsOnRuneBoundaries(t *testing.T) {
 	tmp := hermeticEnv(t)
-	root := filepath.Join(tmp, "claude", "proj-w")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatal(err)
+	// Three project directories: a wall of one repository is no longer a fact
+	// about the machine.
+	var roots []string
+	for i := 0; i < environmentMinProjects; i++ {
+		root := filepath.Join(tmp, "claude", fmt.Sprintf("proj-w%d", i))
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		roots = append(roots, root)
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	// English shape so it is recognised as a wall, Cyrillic tail so the 96-byte
@@ -88,7 +94,7 @@ func TestTheEnvironmentBlockCutsOnRuneBoundaries(t *testing.T) {
 			`{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
 			fmt.Sprint(i%10) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
 			`"content":"` + wall + `"}]}}` + "\n"
-		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(roots[i%len(roots)], sid+".jsonl"), []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -30,7 +30,34 @@ const (
 	// turns, so the block is not a nag that fires per action.
 	environmentWalls = 3
 	environmentMax   = 96
+	// environmentMinProjects is how many projects a wall has to appear in
+	// before it is called a fact about the machine. Two is not enough: a
+	// project's own name arrives in several forms — a worktree, a temporary
+	// checkout, the bare directory — so a string that only ever appeared in one
+	// repository still reads as two. Measured here, a name from deja's own test
+	// fixtures cleared a two-project bar on `run` and `compare/fixes`, both
+	// path fragments of the same tree.
+	environmentMinProjects = 3
 )
+
+// spansProjects reports whether a wall was hit in more than one project.
+//
+// The block claims something about the machine — "the tool or module is still
+// missing" — and an error that only ever appeared while working on one
+// repository is that repository's business. Counted in sessions alone, a string
+// this project's own tests print reads as a fact about the machine and is then
+// told to an agent working somewhere else: measured here, a name from deja's
+// own test fixtures was one of the three walls shown in sixteen unrelated
+// projects, in a block that had nothing else in it.
+func spansProjects(ss []index.SessionMeta) bool {
+	seen := map[string]bool{}
+	for _, s := range ss {
+		if s.Project != "" {
+			seen[s.Project] = true
+		}
+	}
+	return len(seen) >= environmentMinProjects
+}
 
 // environmentBlock names what the machine keeps failing on, or "" when nothing
 // has failed in enough separate sessions to be worth an agent's attention.
@@ -45,7 +72,10 @@ func environmentBlock(dir, activation string) string {
 	// to be per wall rather than one check up front: a machine can hold both
 	// local and imported sessions hitting the same error.
 	pol := policy.Load()
-	walls := index.TopFriction(dir, environmentWalls, nil)
+	// With room to spare: a wall can fail the policy gate or the project bar
+	// below, and asking for exactly three meant one rejection left the block
+	// short of what it had to say.
+	walls := index.TopFriction(dir, environmentWalls*4, nil)
 	if len(walls) == 0 {
 		return ""
 	}
@@ -59,13 +89,16 @@ func environmentBlock(dir, activation string) string {
 		}
 		// The count is what the reader acts on, so a wall whose evidence is
 		// mostly hidden must not keep claiming the full number.
-		if len(keep) >= index.FrictionMinSessions {
+		if len(keep) >= index.FrictionMinSessions && spansProjects(keep) {
 			w.Sessions = keep
 			allowed = append(allowed, w)
 		}
 	}
 	if len(allowed) == 0 {
 		return ""
+	}
+	if len(allowed) > environmentWalls {
+		allowed = allowed[:environmentWalls]
 	}
 	walls = allowed
 	var b strings.Builder

--- a/cmd/deja/environment_projects_test.go
+++ b/cmd/deja/environment_projects_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+func metas(projects ...string) []index.SessionMeta {
+	var out []index.SessionMeta
+	for _, p := range projects {
+		out = append(out, index.SessionMeta{Project: p})
+	}
+	return out
+}
+
+// The block says "this machine", and an error that only ever appeared while
+// working on one repository is that repository's business. Counting sessions
+// alone, a string this project's own tests print reads as a fact about the
+// machine and is then told to an agent working somewhere else.
+func TestAWallOfOneRepositoryIsNotAFactAboutTheMachine(t *testing.T) {
+	// One tree under the names it arrives with: a worktree, a temporary
+	// checkout, the bare directory. Two of those are not two projects, which is
+	// why the bar is three.
+	if spansProjects(metas("run", "run", "compare/fixes", "run")) {
+		t.Error("a wall from one tree under two names passed as machine-wide")
+	}
+	if !spansProjects(metas("api", "web", "infra")) {
+		t.Error("a wall hit in three separate projects was dropped")
+	}
+}
+
+// A session with no project name says nothing either way and must not be
+// counted as one.
+func TestAnUnnamedProjectDoesNotCount(t *testing.T) {
+	if spansProjects(metas("api", "", "", "web")) {
+		t.Error("blank project names were counted toward the bar")
+	}
+}

--- a/cmd/deja/environment_test.go
+++ b/cmd/deja/environment_test.go
@@ -19,19 +19,28 @@ import (
 func seedWalls(t *testing.T, n int) string {
 	t.Helper()
 	tmp := hermeticEnv(t)
-	root := filepath.Join(tmp, "claude", "proj-w")
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Fatal(err)
+	// Three project directories, because the block claims something about the
+	// machine and a wall of one repository no longer qualifies.
+	var roots []string
+	for i := 0; i < environmentMinProjects; i++ {
+		root := filepath.Join(tmp, "claude", fmt.Sprintf("proj-w%d", i))
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		roots = append(roots, root)
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	for i := 0; i < n; i++ {
 		sid := fmt.Sprintf("w%02d", i)
-		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+		// Spread over projects: the block claims something about the machine,
+		// and a wall of one repository no longer qualifies.
+		cwd := fmt.Sprintf("/w/proj%d", i%3)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"` + cwd + `","timestamp":"2026-07-2` +
 			fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"run the checks"}}` + "\n" +
-			`{"type":"user","sessionId":"` + sid + `","cwd":"/w/w","timestamp":"2026-07-2` +
+			`{"type":"user","sessionId":"` + sid + `","cwd":"` + cwd + `","timestamp":"2026-07-2` +
 			fmt.Sprint(i%10) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
 			`"content":"zsh:1: command not found: shellcheck\nModuleNotFoundError: No module named 'yaml'"}]}}` + "\n"
-		if err := os.WriteFile(filepath.Join(root, sid+".jsonl"), []byte(body), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(roots[i%len(roots)], sid+".jsonl"), []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/deja/hook_rebuild_notice_test.go
+++ b/cmd/deja/hook_rebuild_notice_test.go
@@ -19,9 +19,15 @@ import (
 func TestHookReportsTheBuildEvenWhenItHasOnlyEnvironmentFacts(t *testing.T) {
 	tmp := hermeticEnv(t)
 	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	store := filepath.Join(root, "-elsewhere")
-	if err := os.MkdirAll(store, 0o755); err != nil {
-		t.Fatal(err)
+	// One directory per project: a wall of one repository is no longer a fact
+	// about the machine, and this block is built from other projects' walls.
+	var stores []string
+	for i := 0; i < environmentMinProjects; i++ {
+		store := filepath.Join(root, "-elsewhere"+strconv.Itoa(i))
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stores = append(stores, store)
 	}
 	// Sessions from another project, each hitting the same missing tool: that
 	// is what the environment block is built from, and none of it is this
@@ -30,11 +36,11 @@ func TestHookReportsTheBuildEvenWhenItHasOnlyEnvironmentFacts(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		id := "env" + strconv.Itoa(i)
 		b.Reset()
-		b.WriteString(`{"type":"user","message":{"role":"user","content":"run the thing"},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n")
+		b.WriteString(`{"type":"user","message":{"role":"user","content":"run the thing"},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/elsewhere` + strconv.Itoa(i%environmentMinProjects) + `"}` + "\n")
 		// Claude files tool results inside user messages, and friction is
 		// counted from tool output only.
-		b.WriteString(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"zsh:1: command not found: shellcheck"}]},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:01:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n")
-		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+		b.WriteString(`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"zsh:1: command not found: shellcheck"}]},"timestamp":"2026-07-0` + strconv.Itoa(i+1) + `T10:01:00Z","sessionId":"` + id + `","cwd":"/elsewhere` + strconv.Itoa(i%environmentMinProjects) + `"}` + "\n")
+		if err := os.WriteFile(filepath.Join(stores[i%len(stores)], id+".jsonl"), []byte(b.String()), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/deja/mcp_recall_budget_test.go
+++ b/cmd/deja/mcp_recall_budget_test.go
@@ -14,9 +14,15 @@ import (
 func seedFrictionCorpus(t *testing.T) string {
 	t.Helper()
 	tmp := hermeticEnv(t)
-	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
-	if err := os.MkdirAll(store, 0o755); err != nil {
-		t.Fatal(err)
+	// One directory per project: the environment block claims something about
+	// the machine, and a wall of one repository no longer qualifies.
+	var stores []string
+	for i := 0; i < environmentMinProjects; i++ {
+		store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj"+string(rune('0'+i)))
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		stores = append(stores, store)
 	}
 	errs := []string{
 		"command not found: quibblectl",
@@ -30,7 +36,7 @@ func seedFrictionCorpus(t *testing.T) string {
 			id := "sess" + string(rune('a'+s))
 			if i == 3 {
 				b.WriteString(`{"type":"user","timestamp":"` + stamp + `","sessionId":"` + id +
-					`","cwd":"/proj","message":{"role":"user","content":[{"type":"tool_result","content":"` +
+					`","cwd":"/proj` + string(rune('0'+(s/3)%environmentMinProjects)) + `","message":{"role":"user","content":[{"type":"tool_result","content":"` +
 					errs[s%3] + `"}]},"toolUseResult":{"stdout":"","stderr":"` + errs[s%3] + `"}}` + "\n")
 				continue
 			}
@@ -39,10 +45,10 @@ func seedFrictionCorpus(t *testing.T) string {
 				role = "assistant"
 			}
 			b.WriteString(`{"type":"` + role + `","timestamp":"` + stamp + `","sessionId":"` + id +
-				`","cwd":"/proj","message":{"role":"` + role + `","content":"` +
+				`","cwd":"/proj` + string(rune('0'+(s/3)%environmentMinProjects)) + `","message":{"role":"` + role + `","content":"` +
 				strings.Repeat("quibblectl retry budget ", 24) + `"}}` + "\n")
 		}
-		if err := os.WriteFile(filepath.Join(store, "sess"+string(rune('a'+s))+".jsonl"), []byte(b.String()), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(stores[(s/3)%len(stores)], "sess"+string(rune('a'+s))+".jsonl"), []byte(b.String()), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
The session-start block says "this machine, from deja's index across every agent used here" and then names what keeps failing. It counted sessions, not projects, so an error that only ever appeared while working on one repository qualified.

Found by reading what the block actually says in twenty-five projects on this machine. Sixteen of them had a block with no quoted history at all — only these facts — and one of the three was `undefined: snorblefunc in vendor/blarg/api.go`, a name from deja's own test fixtures, indexed from the sessions where those tests ran. An agent starting work in an unrelated repository was told that a module was missing.

A wall now has to appear in three projects before it is called a fact about the machine. Two is not enough: one tree arrives under several names — a worktree, a temporary checkout, the bare directory — and that fixture cleared a two-project bar on `run` and `compare/fixes`, both fragments of the same path.

Candidates are now drawn with room to spare, so a rejected wall does not leave the block short. Measured here: three walls before, of which one was the fixture; three after, all real — `command not found: timeout`, an SSH banner timeout, and `command not found: python`.

Five test fixtures moved with it: they seeded their walls from a single project directory, which is exactly the shape this now rejects. One of them is where the leaked string came from.