### PR TITLE
fix(uninstall): put back the skill install replaced

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -225,9 +225,21 @@ func dropRetiredGuidance(harness string, uninstall bool) (note string, err error
 			// deleted, so a skill someone wrote themselves is never touched.
 			if filepath.Base(path) == "SKILL.md" &&
 				filepath.Base(filepath.Dir(path)) == "deja-history" &&
+				!restoredGuidance[path] &&
 				strings.Contains(string(old), "name: deja-history") {
 				if err := os.Remove(path); err != nil {
 					return note, err
+				}
+				// Put back what install replaced, before the directory is
+				// considered empty: install promised the reader's copy was
+				// kept, and removing deja's file without restoring it left
+				// that copy as a .bak beside nothing (#2581).
+				restored, rerr := restoreReplacedGuidance(path, harness)
+				if rerr != nil {
+					return note, rerr
+				}
+				if restored {
+					continue
 				}
 				// Take the directory too, but only if we emptied it.
 				_ = os.Remove(filepath.Dir(path))
@@ -388,8 +400,22 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 			if sharedSkillHarnesses[harness] && sharedSkillStillWanted(harness) {
 				return installResult{Path: path, Action: "kept", Note: retiredNote}, nil
 			}
+			if restoredGuidance[path] {
+				return installResult{Path: path, Action: "kept", Note: retiredNote}, nil
+			}
 			if err := os.Remove(path); err != nil {
 				return installResult{}, err
+			}
+			// And put back what install replaced. It said where the copy went
+			// — "your copy is at …SKILL.md.bak" — and removing deja's file
+			// without restoring it left the reader's own skill as a backup
+			// beside nothing (#2581).
+			restored, rerr := restoreReplacedGuidance(path, harness)
+			if rerr != nil {
+				return installResult{}, rerr
+			}
+			if restored {
+				return installResult{Path: path, Action: "restored", Note: retiredNote}, nil
 			}
 			return installResult{Path: path, Action: "removed", Note: retiredNote}, nil
 		} else {
@@ -651,4 +677,35 @@ func guidanceOutput(harness string, result installResult) string {
 		line += "\n" + strings.Repeat(" ", len(harness)+2) + result.Note
 	}
 	return line
+}
+
+// restoredGuidance is what this run has already put back. `uninstall claude-code`
+// runs the auto variant too, and the second pass met the reader's own file,
+// matched it on `name: deja-history` — which it must, to be that skill — and
+// deleted what the first pass had just restored (#2581).
+var restoredGuidance = map[string]bool{}
+
+// restoreReplacedGuidance puts back the file install replaced, and reports
+// whether it did. A backup holding deja's own text — an older guidance version,
+// snapshotted by a later install — is dropped instead: nobody asked for that
+// file, and leaving deja's own words behind after an uninstall is what #2575
+// was about.
+func restoreReplacedGuidance(path, harness string) (bool, error) {
+	bak := path + ".bak"
+	b, err := os.ReadFile(bak)
+	if err != nil {
+		return false, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(b), bytes.TrimSpace([]byte(guidanceText(harness)))) {
+		return false, os.Remove(bak)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return false, err
+	}
+	if err := os.Remove(bak); err != nil {
+		return false, err
+	}
+	restoredGuidance[path] = true
+	fmt.Printf("skill: put back %s, the copy install replaced\n", shortHome(path))
+	return true, nil
 }

--- a/cmd/deja/guidance_restore_test.go
+++ b/cmd/deja/guidance_restore_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Install replaces a guidance file it did not write and says where the reader's
+// copy went: "your copy is at …SKILL.md.bak". Uninstall then removed deja's
+// file and left that copy sitting beside nothing — so a person who had written
+// their own deja-history skill lost it by installing and uninstalling, with
+// only a .bak and no line saying to rename it (#2581).
+func TestUninstallPutsBackTheGuidanceItReplaced(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	skill := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(skill, "SKILL.md")
+	mine := "---\nname: deja-history\ndescription: my own version\n---\n\nThis file is mine.\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: deja replaced it and kept the copy it promised.
+	if b, err := os.ReadFile(path); err != nil || string(b) == mine {
+		t.Fatalf("install did not replace the reader's skill: %v", err)
+	}
+	if b, err := os.ReadFile(path + ".bak"); err != nil || string(b) != mine {
+		t.Fatalf("install did not keep the copy it promised: %v", err)
+	}
+
+	if _, err := captureRun(t, "uninstall", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the reader's own skill is gone after uninstall: %v", err)
+	}
+	if string(b) != mine {
+		t.Errorf("the file at that path is not the reader's own:\n%s", b)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("the copy was put back and the backup left behind too: %v", err)
+	}
+}
+
+// A guidance file deja wrote itself leaves nothing behind: no file, no backup.
+func TestUninstallRemovesGuidanceItWroteWithNoLeftovers(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".claude", "skills", "deja-history", "SKILL.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install wrote no guidance: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("deja's own guidance survived the uninstall: %v", err)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("a backup of deja's own guidance survived: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #2581.

Install replaces a `deja-history` skill it did not write and says where the reader's copy went. Uninstall removed deja's file and left that copy beside nothing:

    uninstall says   claude-code: guidance removed …/SKILL.md
    files now        SKILL.md.bak
    the reader's own file?   gone

So someone who wrote their own version of that skill lost it by installing deja and uninstalling it again.

Now the copy goes back, and a backup holding deja's own text is dropped instead. The auto pass no longer removes what the first pass restored — `uninstall claude-code` runs claude-auto too, and the restored file matches `name: deja-history` exactly as it must.

Everything else about guidance was already clean: installing all twenty targets and uninstalling them leaves no SKILL.md, deja.md, AGENTS.md or backups.