### PR TITLE
fix(uninstall): take back the empty configs deja created

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -942,6 +942,32 @@ func matchLineEndings(old, next []byte) []byte {
 	return b.Bytes()
 }
 
+// createdByThisRun collects the configs this process created, so the record can
+// keep them and a later uninstall can take back a file that turns out to hold
+// nothing but empty containers (#2583).
+var createdByThisRun []string
+
+// structurallyEmptyConfig reports that a config holds nothing but the empty
+// containers deja's writers leave behind. #840 deletes a file whose content is
+// gone entirely; the structured writers never produce zero bytes — an emptied
+// mcp.json is `{"mcpServers":{}}` — so the same rule needs the same reading of
+// "nothing left in it".
+func structurallyEmptyConfig(b []byte) bool {
+	trimmed := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\n' || r == '\t' || r == '\r' {
+			return -1
+		}
+		return r
+	}, string(b))
+	switch trimmed {
+	case "", "{}", "[]", "null",
+		`{"mcpServers":{}}`, `{"mcp":{}}`, `{"mcp":{"servers":{}}}`,
+		`{"context_servers":{}}`, `{"servers":{}}`, "mcp_servers:":
+		return true
+	}
+	return false
+}
+
 func writeIfChanged(path string, old, next []byte) (string, error) {
 	// Before the comparison, not after: a CRLF config converted afterwards
 	// would differ from `old` on every run, so each repeat install would
@@ -969,6 +995,24 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 			}
 			return "removed", nil
 		}
+		// The same rule for the structured writers, which never reach zero
+		// bytes. Only for a file deja created: a config the reader already had
+		// keeps its place, emptied of deja and of nothing else (#2583).
+		if structurallyEmptyConfig(next) && wiringCreated(path) {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return "", err
+			}
+			// The directory too, when deja made it and nothing else is in it.
+			// os.Remove fails on a directory that is not empty, which is the
+			// condition wanted (same rule as pruneGuidanceDirs).
+			if dir := filepath.Dir(path); isRealDir(dir) {
+				_ = os.Remove(dir)
+			}
+			return "removed", nil
+		}
+	}
+	if _, err := os.Stat(path); os.IsNotExist(err) && !removingWiring {
+		createdByThisRun = append(createdByThisRun, path)
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err

--- a/cmd/deja/uninstall_shells_test.go
+++ b/cmd/deja/uninstall_shells_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #840 taught uninstall to delete a config that turned out to be entirely
+// deja's: "removing something must not leave more behind than it found". The
+// test for that is byte-emptiness, which only the markdown and TOML writers
+// reach — every structured writer leaves `{"mcpServers":{}}` instead. So
+// installing the whole family and uninstalling it leaves sixteen shells of
+// files deja created itself (#2583).
+func TestUninstallRemovesTheShellsItCreated(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if !strings.Contains(home, "TestUninstallRemovesTheShells") {
+		t.Fatalf("refusing to install into %q", home)
+	}
+	targets := []string{"claude-code", "cursor", "gemini", "kimi", "qwen", "copilot", "pi", "omp"}
+	for _, target := range targets {
+		if _, err := captureRun(t, "install", target, "--no-index", "--no-guidance"); err != nil {
+			t.Fatalf("install %s: %v", target, err)
+		}
+	}
+	// The premise: those installs created files that were not there before.
+	if _, err := os.Stat(filepath.Join(home, ".cursor", "mcp.json")); err != nil {
+		t.Fatalf("install wrote no config: %v", err)
+	}
+	for _, target := range targets {
+		if _, err := captureRun(t, "uninstall", target); err != nil {
+			t.Fatalf("uninstall %s: %v", target, err)
+		}
+	}
+	var left []string
+	_ = filepath.Walk(home, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || !fi.Mode().IsRegular() {
+			return nil
+		}
+		// deja's own state is not a harness config.
+		if strings.Contains(p, filepath.Join(".config", "deja")) {
+			return nil
+		}
+		left = append(left, strings.TrimPrefix(p, home))
+		return nil
+	})
+	if len(left) > 0 {
+		t.Errorf("uninstall left %d files deja created:\n  %s", len(left), strings.Join(left, "\n  "))
+	}
+}
+
+// A config the reader already had keeps its place, emptied of deja and nothing
+// else — deleting that one would be taking away a file deja never made.
+func TestUninstallKeepsAConfigItDidNotCreate(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\n  \"mcpServers\": {}\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index", "--no-guidance"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("a config deja did not create was removed: %v", err)
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -27,6 +27,13 @@ type wiringState struct {
 	// set of configs into a home nobody installed into, left the real ones
 	// pointing at the old binary, and marked the record repaired (#885).
 	Home string `json:"home,omitempty"`
+	// Created are the config paths that did not exist before deja wrote them.
+	// #840 established that a file which turns out to be entirely deja's is
+	// deleted on the way out rather than left empty; that test is byte-emptiness,
+	// which the structured writers never reach — they leave `{"mcpServers":{}}`.
+	// Knowing which files deja made is what lets the same rule apply to them
+	// without ever removing a config the reader already had (#2583).
+	Created []string `json:"created,omitempty"`
 	// Exe is the binary path the configs were written with. A move without a
 	// version change is ordinary — a relink, a reinstall of the same release,
 	// a `go install` over a manual download — and left every config pointing
@@ -99,7 +106,23 @@ func recordWiring(targets []string, uninstall bool) {
 			return
 		}
 	}
-	st = wiringState{Version: version, Targets: kept, Exe: exe, Home: homeDir()}
+	created := append([]string(nil), st.Created...)
+	seen := map[string]bool{}
+	for _, p := range created {
+		seen[p] = true
+	}
+	for _, p := range createdByThisRun {
+		if !seen[p] {
+			created = append(created, p)
+			seen[p] = true
+		}
+	}
+	// A path deja no longer wired is not one it will be asked about again.
+	if len(kept) == 0 {
+		created = nil
+	}
+	sort.Strings(created)
+	st = wiringState{Version: version, Targets: kept, Created: created, Exe: exe, Home: homeDir()}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -162,4 +185,19 @@ func refreshWiringAfterUpgrade() []string {
 	}
 	recordWiring(st.Targets, false)
 	return changed
+}
+
+// wiringCreated reports that deja created this config rather than finding it.
+func wiringCreated(path string) bool {
+	for _, p := range readWiringState().Created {
+		if p == path {
+			return true
+		}
+	}
+	for _, p := range createdByThisRun {
+		if p == path {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Closes #2583.

#840 established that a config which turns out to be entirely deja's is deleted rather than left empty. Its test is byte-emptiness, which only the markdown and TOML writers reach — every structured writer leaves `{"mcpServers":{}}`. So installing the family into a clean home and uninstalling all of it left sixteen files, each created by deja and holding nothing.

The same rule now covers a structurally empty config, and only for a file deja recorded creating: a config the reader already had keeps its place, emptied of deja and of nothing else.