### PR TITLE
fix(uninstall): do not put back an older deja's own skill

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -696,7 +696,7 @@ func restoreReplacedGuidance(path, harness string) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
-	if bytes.Equal(bytes.TrimSpace(b), bytes.TrimSpace([]byte(guidanceText(harness)))) {
+	if isOurGuidance(b, harness) {
 		return false, os.Remove(bak)
 	}
 	if err := os.WriteFile(path, b, 0o644); err != nil {
@@ -708,4 +708,24 @@ func restoreReplacedGuidance(path, harness string) (bool, error) {
 	restoredGuidance[path] = true
 	fmt.Printf("skill: put back %s, the copy install replaced\n", shortHome(path))
 	return true, nil
+}
+
+// dejaSkillDescription is the line deja writes into every skill's frontmatter.
+// A file carrying it is deja's own — from this build or an older one, which is
+// the case that matters: an older skill has no marks, so install treats it as a
+// stranger's and backs it up, and putting that back on the way out leaves deja's
+// words on a machine deja was just removed from (#2585, the shape of #2575).
+//
+// What it costs: a reader who rewrote the body and kept deja's description
+// verbatim is read as deja rather than as themselves. Their own description —
+// one line, the part a person changes first when they make the skill theirs —
+// is what separates the two.
+const dejaSkillDescription = "description: Search the user's past AI coding sessions."
+
+func isOurGuidance(b []byte, harness string) bool {
+	if bytes.Equal(bytes.TrimSpace(b), bytes.TrimSpace([]byte(guidanceText(harness)))) {
+		return true
+	}
+	head, _, _ := strings.Cut(string(b), "\n---")
+	return strings.Contains(head, dejaSkillDescription)
 }

--- a/cmd/deja/guidance_older_test.go
+++ b/cmd/deja/guidance_older_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A skill an older deja wrote is deja's, not the reader's. Install treats it as
+// a stranger's file — it carries no marks — backs it up, and since #2581
+// uninstall puts that backup back: so uninstalling deja left deja's own older
+// guidance on disk, which is what #2575 exists to prevent. Its own frontmatter
+// says whose it is (#2585).
+func TestUninstallDoesNotPutBackAnOlderDejaSkill(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	skill := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(skill, "SKILL.md")
+	// deja's own frontmatter, an older body.
+	older := skillFile("Before re-deriving past work, search deja when the user refers to past work.")
+	if older == guidanceText("claude-code") {
+		t.Fatal("the fixture is this build's own guidance, so this measures nothing")
+	}
+	if err := os.WriteFile(path, []byte(older), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Fatalf("install did not back the older skill up: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(path); err == nil {
+		t.Errorf("an older deja skill was put back after uninstall:\n%s", strings.SplitN(string(b), "\n\n", 2)[0])
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("its backup is still there: %v", err)
+	}
+}
+
+// And a skill the reader wrote is still theirs, even where they kept deja's
+// name for the directory.
+func TestUninstallStillPutsBackTheReadersOwnSkill(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	skill := filepath.Join(home, ".claude", "skills", "deja-history")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(skill, "SKILL.md")
+	mine := "---\nname: deja-history\ndescription: my own version\n---\n\nAsk deja first. This file is mine.\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil || string(b) != mine {
+		t.Errorf("the reader's own skill did not come back: %v\n%s", err, b)
+	}
+}


### PR DESCRIPTION
Closes #2585, following #2581.

Two deja builds on one machine: the older one's skill carries no marks, so install reads it as a stranger's file and backs it up, and #2581's restore then puts it back. The file is deja's own guidance, so uninstalling deja left deja's words on disk — the thing #2575 exists to prevent.

The guard compared the backup with *this* build's guidance text, which an older build never equals. Its frontmatter says whose the file is: deja writes one description into every skill it generates, and a person making the skill theirs changes that line first. deja's own — from any build — is dropped; anything else still goes back.