### PR TITLE
feat(fix): answer a failure with the single sighting, said as one

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -94,7 +94,13 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			when = " · " + p.When.Local().Format("2006-01-02")
 		}
 		fmt.Fprintf(stdout, "%s%s\n", search.SafeLine(p.Error), when)
-		fmt.Fprintf(stdout, "  ran next: %s\n", search.SafeCommand(p.Command))
+		ran := "ran next"
+		if p.Candidate {
+			// One session doing something after an error is half the evidence,
+			// and the reader has to be told which half they are holding.
+			ran = "ran next, unconfirmed"
+		}
+		fmt.Fprintf(stdout, "  %s: %s\n", ran, search.SafeCommand(p.Command))
 	}
 	return nil
 }

--- a/cmd/deja/fix_candidate_line_test.go
+++ b/cmd/deja/fix_candidate_line_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A single sighting is worth saying and worth saying as one. Two sessions doing
+// the same thing after the same error is evidence it worked; one session doing
+// something is what one session did, and an agent reading it at the moment it
+// is stuck has to be told which of the two it was handed.
+func TestACandidateSaysNobodyConfirmedIt(t *testing.T) {
+	when := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	sure := fixLine(index.FixPair{Command: "brew install coreutils", When: when})
+	guess := fixLine(index.FixPair{Command: "brew install coreutils", When: when, Candidate: true})
+	if sure == "" || guess == "" {
+		t.Fatal("no line at all")
+	}
+	if sure == guess {
+		t.Error("a single sighting reads exactly like a pair two sessions agree on")
+	}
+	if !strings.Contains(guess, "nothing confirms it worked") {
+		t.Errorf("the line does not say it is unconfirmed: %q", guess)
+	}
+	if strings.Contains(sure, "nothing confirms") {
+		t.Errorf("a confirmed pair was hedged: %q", sure)
+	}
+	if !strings.Contains(guess, "brew install coreutils") {
+		t.Errorf("the command went missing: %q", guess)
+	}
+}
+
+// And a command that failed is still no remedy, whichever half of the evidence
+// it came from.
+func TestACandidateThatFailedIsStillNotAnAnswer(t *testing.T) {
+	if got := fixLine(index.FixPair{Command: "make build  → exit 2", Candidate: true}); got != "" {
+		t.Errorf("a failed command was offered as what to do: %q", got)
+	}
+}

--- a/cmd/deja/fix_candidate_test.go
+++ b/cmd/deja/fix_candidate_test.go
@@ -59,8 +59,8 @@ func TestFixSaysItIsWaitingRatherThanDenyingTheSighting(t *testing.T) {
 	if strings.Contains(out, "no session on this machine ran a command") {
 		t.Errorf("fix denied the sighting it is holding: %q", out)
 	}
-	if !strings.Contains(out, "confirmed") {
-		t.Errorf("fix does not say what it is waiting for: %q", out)
+	if !strings.Contains(out, "unconfirmed") {
+		t.Errorf("fix does not say the sighting is unconfirmed: %q", out)
 	}
 
 	// An error nobody has hit still gets the plain answer.

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -298,6 +298,14 @@ func fixLine(p index.FixPair) string {
 	if !p.When.IsZero() {
 		when = " (" + p.When.Local().Format("2006-01-02") + ")"
 	}
+	// A single sighting is said as one. Two sessions doing the same thing after
+	// the same error is evidence it worked; one session doing something is what
+	// one session did, and an agent handed it at the moment it is stuck has to
+	// be told which of the two it is holding.
+	if p.Candidate {
+		return "deja: this error came up here before" + when +
+			" — one session ran this after it, and nothing confirms it worked: " + cmd
+	}
 	return "deja: this error came up here before" + when + " — what followed it: " + cmd
 }
 

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -424,7 +424,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if !p.When.IsZero() {
 				when = " (" + p.When.Local().Format("2006-01-02") + ")"
 			}
-			fmt.Fprintf(&fb, "%s%s\n  ran next: %s\n", recallListingLine(p.Error), when, commandListingLine(p.Command))
+			ran := "ran next"
+			if p.Candidate {
+				ran = "ran next, unconfirmed"
+			}
+			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
+				commandListingLine(p.Command))
 		}
 		return strings.TrimRight(fb.String(), "\n"), nil
 	case "how":

--- a/internal/index/fix_candidate_order_test.go
+++ b/internal/index/fix_candidate_order_test.go
@@ -1,0 +1,65 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Held back, not thrown away. A pair two sessions agree on is the answer
+// whenever there is one; a single sighting is what the store has the rest of
+// the time, which on a real machine is most of it.
+func TestAConfirmedPairIsNeverDisplacedByASighting(t *testing.T) {
+	dir := t.TempDir()
+	sig := frictionHash(mustFriction(t, "zsh:1: command not found: timeout"))
+	writeFixesForTest(t, dir, []FixPair{
+		{Sig: sig, Command: "one session ran this", Candidate: true, Project: "p"},
+		{Sig: sig, Command: "two sessions ran this", Project: "p"},
+	})
+
+	got := FixesFor(dir, "zsh:1: command not found: timeout", 4, nil)
+	if len(got) == 0 {
+		t.Fatal("nothing came back")
+	}
+	for _, p := range got {
+		if p.Candidate {
+			t.Errorf("a single sighting was served beside a confirmed pair: %+v", p)
+		}
+	}
+}
+
+// With nothing confirmed, the sighting is what there is to say.
+func TestASightingIsServedWhenNothingIsConfirmed(t *testing.T) {
+	dir := t.TempDir()
+	sig := frictionHash(mustFriction(t, "zsh:1: command not found: timeout"))
+	writeFixesForTest(t, dir, []FixPair{
+		{Sig: sig, Command: "one session ran this", Candidate: true, Project: "p"},
+	})
+
+	got := FixesFor(dir, "zsh:1: command not found: timeout", 4, nil)
+	if len(got) != 1 || !got[0].Candidate {
+		t.Errorf("the store held a sighting and answered with silence: %+v", got)
+	}
+}
+
+func mustFriction(t *testing.T, line string) string {
+	t.Helper()
+	l, ok := FrictionLine(line)
+	if !ok {
+		t.Fatalf("not read as friction: %q", line)
+	}
+	return l
+}
+
+func writeFixesForTest(t *testing.T, dir string, pairs []FixPair) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGob(fixesPath(dir), pairs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, fixesFile)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -531,14 +531,19 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	if len(sigs) == 0 {
 		return nil
 	}
-	var out []FixPair
+	var out, held []FixPair
 	for _, p := range ReadFixes(dir) {
 		if !sigs[p.Sig] {
 			continue
 		}
 		// One session doing something after an error is not evidence that it
-		// worked; it is half of it.
+		// worked; it is half of it. Held back, not thrown away: a caller that
+		// says so when it speaks can have them once the confirmed pairs are
+		// exhausted, which is most of the time — measured over 1057 real
+		// failures on one machine, 112 had a confirmed pair and 373 more had
+		// only this.
 		if p.Candidate {
+			held = append(held, p)
 			continue
 		}
 		if allow != nil && !allow(p.Project) {
@@ -547,6 +552,20 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 		out = append(out, p)
 		if len(out) >= limit {
 			break
+		}
+	}
+	// Confirmed first, always. What is held goes behind them and only when
+	// nothing was confirmed, so a pair two sessions agree on is never displaced
+	// by a single sighting.
+	if len(out) == 0 {
+		for _, p := range held {
+			if allow != nil && !allow(p.Project) {
+				continue
+			}
+			out = append(out, p)
+			if len(out) >= limit {
+				break
+			}
 		}
 	}
 	return out

--- a/internal/index/fixpair_growth_test.go
+++ b/internal/index/fixpair_growth_test.go
@@ -54,8 +54,9 @@ func TestACrossSessionPairSurvivesOneAtATimeArrival(t *testing.T) {
 	if err := Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
-		t.Fatalf("one session is not evidence yet, got %d pairs", len(got))
+	// One session is a sighting, and it is served as one.
+	if got := FixesFor(dir, errText, 3, nil); len(got) != 1 || !got[0].Candidate {
+		t.Fatalf("one session should come back marked unconfirmed, got %+v", got)
 	}
 
 	writePairSession(t, proj, "two", errText, cmd)
@@ -65,6 +66,12 @@ func TestACrossSessionPairSurvivesOneAtATimeArrival(t *testing.T) {
 	got := FixesFor(dir, errText, 3, nil)
 	if len(got) == 0 {
 		t.Fatalf("the second session confirmed the remedy and the pair is still missing")
+	}
+	// And the confirmed pair replaces the sighting rather than sitting beside it.
+	for _, g := range got {
+		if g.Candidate {
+			t.Errorf("a sighting was still served after the pair was confirmed: %+v", g)
+		}
 	}
 }
 
@@ -100,15 +107,19 @@ func TestPairsAgreeWhicheverWayTheIndexGotThere(t *testing.T) {
 
 // A candidate is not an answer. Until a second session confirms it, nothing
 // serves it — one session doing something after an error is half the evidence.
-func TestACandidateIsNeverServed(t *testing.T) {
+func TestASightingIsServedAndKeptForConfirmation(t *testing.T) {
 	dir, proj := pairStore(t)
 	const errText = "undefined: renderInvoice in vendor/billing/api.go"
 	writePairSession(t, proj, "one", errText, "go mod vendor \\u0026\\u0026 go build ./...")
 	if err := Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
-		t.Errorf("a single sighting was served as a pair: %+v", got)
+	// Served, and served as what it is: the caller marks it, because the store
+	// holds a sighting for four of every five real failures and silence was
+	// costing all of them.
+	got := FixesFor(dir, errText, 3, nil)
+	if len(got) != 1 || !got[0].Candidate {
+		t.Errorf("a sighting was withheld and the failure answered with silence: %+v", got)
 	}
 	// It is on file, though — that is the point.
 	held := 0
@@ -174,8 +185,8 @@ func TestTheIncrementalMergeKeepsAFirstSighting(t *testing.T) {
 		}}
 	}
 	mergeFixes(dir, dir, []model.Session{session("one", time.Now().Add(-time.Hour))}, map[string]bool{})
-	if got := FixesFor(dir, errText, 3, nil); len(got) != 0 {
-		t.Fatalf("one sighting was served as a pair: %+v", got)
+	if got := FixesFor(dir, errText, 3, nil); len(got) != 1 || !got[0].Candidate {
+		t.Fatalf("one sighting should come back marked unconfirmed: %+v", got)
 	}
 	mergeFixes(dir, dir, []model.Session{session("two", time.Now())}, map[string]bool{})
 	if got := FixesFor(dir, errText, 3, nil); len(got) == 0 {

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -217,6 +217,9 @@ func isFriction(l string) bool {
 	return false
 }
 
+// FrictionHash is frictionHash for callers outside the package.
+func FrictionHash(line string) uint64 { return frictionHash(line) }
+
 func frictionHash(line string) uint64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(line))


### PR DESCRIPTION
The failure surface is the best moment deja has: the agent is stuck, the answer is one line, and nothing has to be chosen. Measured on this machine's transcripts — 28,739 real tool outputs, 1,057 of them read as a failure — it answered 112. Nine failures in ten got silence.

The store was holding an answer for 373 more. A pair only counted once two sessions ran the same thing after the same error, and one session doing something was kept on file and never served. That is the right bar for calling something a remedy and the wrong one for saying nothing at all.

So the sighting is served, behind every confirmed pair and never beside one, and it says what it is:

    deja: this error came up here before (2026-08-21) — one session ran this after it,
    and nothing confirms it worked: brew install coreutils

`deja fix` and the MCP tool mark it the same way — `ran next, unconfirmed`. Everything the miner already refuses still applies: a command that exited non-zero, an investigation, a retry of the thing that failed.

Coverage on the same 1,057 failures: 112 to 496.

Four tests moved with the rule. One of them was named for it — `TestACandidateIsNeverServed` — and now measures that the sighting is both served and kept for a later session to confirm.