### PR TITLE
fix(commands): count a command once, whatever it exited with

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -153,7 +153,10 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		if project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(project)) {
 			return
 		}
-		cmd := strings.TrimSpace(firstCommandLine(r.Text))
+		// Without the outcome codex and opencode append: "$ make test  → exit
+		// 2" is the same command as "$ make test", and counting them apart put
+		// one command on two rows of this screen (#2590).
+		cmd := index.CommandWithoutExitStatus(strings.TrimSpace(firstCommandLine(r.Text)))
 		if cmd == "" || len(cmd) > howCommandMax {
 			return
 		}

--- a/cmd/deja/how_exit_test.go
+++ b/cmd/deja/how_exit_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// `deja how` counts its own rows over the record log, so it split a command by
+// the outcome codex and opencode append to it: "$ make test" and
+// "$ make test  → exit 2" as two lines of one screen (#2590).
+func TestHowCountsACommandOnceWhateverItExitedWith(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "codex")
+	t.Setenv("DEJA_CODEX_ROOT", root)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	line := func(text string, min int) string {
+		return `{"type":"function_call","name":"shell","arguments":"{\"command\":[\"bash\",\"-lc\",\"` + text +
+			`\"]}","timestamp":"` + at.Add(time.Duration(min)*time.Minute).Format(time.RFC3339) + `"}`
+	}
+	_ = line
+	// The reader-visible shape is what matters here, so write the records the
+	// way the opencode reader produces them: the command line carries the code.
+	body := ""
+	for i, text := range []string{"$ make test", "$ make test  → exit 2", "$ make test  → exit 2"} {
+		body += `{"type":"user","sessionId":"s1","cwd":"/w/app","timestamp":"` +
+			at.Add(time.Duration(i)*time.Minute).Format(time.RFC3339) +
+			`","message":{"role":"user","content":[{"type":"tool_use","name":"Bash","input":{"command":"` +
+			strings.TrimPrefix(text, "$ ") + `"}}]}}` + "\n"
+	}
+	claude := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-w-app")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claude, "s1.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "how", "make test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "make test") {
+		t.Fatalf("how found nothing, so this measures nothing:\n%s", out)
+	}
+	if strings.Contains(out, "exit") {
+		t.Errorf("the outcome is on the screen as part of the command:\n%s", out)
+	}
+	if n := strings.Count(out, "$ make test"); n != 1 {
+		t.Errorf("one command on %d rows:\n%s", n, out)
+	}
+}

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -81,7 +81,7 @@ func buildCommands(tmp string, ss []model.Session) {
 			if m.Role != roleCommand {
 				continue
 			}
-			cmd := strings.TrimSpace(firstTextLine(m.Text))
+			cmd := withoutExitStatus(strings.TrimSpace(firstTextLine(m.Text)))
 			if cmd == "" || len(cmd) > commandTextMax {
 				continue
 			}
@@ -174,7 +174,7 @@ func buildCommandsFromIndex(tmp string) {
 			collided = true
 			return
 		}
-		cmd := strings.TrimSpace(firstTextLine(r.Text))
+		cmd := withoutExitStatus(strings.TrimSpace(firstTextLine(r.Text)))
 		if cmd == "" || len(cmd) > commandTextMax {
 			return
 		}
@@ -366,10 +366,30 @@ func FileSessions(dir, path string) []SessionMeta {
 // the first line, without the "$ " every parser prefixes a stored invocation
 // with, lowercased.
 func normalizeCommand(s string) string {
-	s = strings.TrimSpace(firstTextLine(s))
+	s = withoutExitStatus(strings.TrimSpace(firstTextLine(s)))
 	s = strings.TrimPrefix(s, "$ ")
 	return strings.ToLower(strings.TrimSpace(s))
 }
+
+// withoutExitStatus drops the outcome codex and opencode append to the command
+// line — "$ make test  → exit 2". It is what the command did, not what it was,
+// and keying the table on it split one command into two rows: the runs that
+// worked and the runs that did not, counted apart, with the failing ones
+// invisible to a lookup made with the command as a harness hands it over. On a
+// real store four commands were split this way, `git status --short` into 445
+// runs and 7 (#2590). The status stays in the records, where the fix-pair miner
+// reads it (commandFailed).
+func withoutExitStatus(s string) string {
+	if i := strings.Index(s, "→ exit "); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+// CommandWithoutExitStatus is withoutExitStatus for the surfaces outside this
+// package that group commands themselves — `deja how` counts its own rows over
+// the record log and split the same command the same way.
+func CommandWithoutExitStatus(s string) string { return withoutExitStatus(s) }
 
 // firstTextLine is the first line of a record, which for a command record is
 // the invocation itself.

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -380,11 +380,29 @@ func normalizeCommand(s string) string {
 // runs and 7 (#2590). The status stays in the records, where the fix-pair miner
 // reads it (commandFailed).
 func withoutExitStatus(s string) string {
-	if i := strings.Index(s, "→ exit "); i >= 0 {
-		return strings.TrimSpace(s[:i])
+	i := strings.LastIndex(s, commandExitMarker)
+	if i < 0 {
+		return s
 	}
-	return s
+	code := s[i+len(commandExitMarker):]
+	if code == "" {
+		return s
+	}
+	// Digits to the end, or it is not the marker: looking for it anywhere cut
+	// `echo "→ exit 0"` down to `echo "`, the trap #2048 already recorded for
+	// the after-hook's reading of the same suffix.
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			return s
+		}
+	}
+	return strings.TrimSpace(s[:i])
 }
+
+// commandExitMarker is the shape a source appends when it knows what a command
+// returned: two spaces, the marker, the digits, end of string
+// (internal/sources/codex.go, internal/sources/opencode.go).
+const commandExitMarker = "  → exit "
 
 // CommandWithoutExitStatus is withoutExitStatus for the surfaces outside this
 // package that group commands themselves — `deja how` counts its own rows over

--- a/internal/index/commands_exit_test.go
+++ b/internal/index/commands_exit_test.go
@@ -50,6 +50,14 @@ func TestTheCommandsTableIgnoresTheExitStatus(t *testing.T) {
 	if strings.Contains(found[0].Command, "exit") {
 		t.Errorf("the row deja shows carries the outcome: %q", found[0].Command)
 	}
+	// A command that merely mentions the marker is still that command: cutting
+	// on the marker anywhere turned `echo "→ exit 0"` into `echo "` once (#2048).
+	if got := withoutExitStatus(`echo "→ exit 0"`); got != `echo "→ exit 0"` {
+		t.Errorf("a command naming the marker was cut to %q", got)
+	}
+	if got := withoutExitStatus("$ make test  → exit 2"); got != "$ make test" {
+		t.Errorf("the real suffix survived: %q", got)
+	}
 	// And the lookup the tool hook makes, with the command as a harness hands
 	// it over, finds all of it.
 	use, ok := CommandHistory(dir, "make test")

--- a/internal/index/commands_exit_test.go
+++ b/internal/index/commands_exit_test.go
@@ -1,0 +1,59 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// codex and opencode record what a command exited with, appended to the command
+// line itself: "$ make test  → exit 2". That is the outcome, not the invocation,
+// and the commands table keyed on the whole line — so one command became two
+// rows, the runs that worked and the runs that did not, counted apart. On this
+// machine's index four commands are split that way, `git status --short` into
+// 445 runs and 7 (#2590).
+func TestTheCommandsTableIgnoresTheExitStatus(t *testing.T) {
+	dir := t.TempDir()
+	at := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	msg := func(text string, min int) model.Message {
+		return model.Message{Role: roleCommand, Text: text, Time: at.Add(time.Duration(min) * time.Minute)}
+	}
+	sessions := []model.Session{
+		{ID: "s1", Harness: "codex", Project: "app", Messages: []model.Message{
+			msg("$ make test", 0),
+			msg("$ make test  → exit 2", 1),
+		}},
+		{ID: "s2", Harness: "codex", Project: "app", Messages: []model.Message{
+			msg("$ make test  → exit 2", 2),
+		}},
+	}
+	buildCommands(dir, sessions)
+	uses := ReadCommands(dir)
+	var found []CommandUse
+	for _, u := range uses {
+		if strings.Contains(strings.ToLower(u.Command), "make test") {
+			found = append(found, u)
+		}
+	}
+	if len(found) != 1 {
+		var got []string
+		for _, u := range found {
+			got = append(got, u.Command)
+		}
+		t.Fatalf("make test is %d rows, want one: %v", len(found), got)
+	}
+	if found[0].Runs != 3 || found[0].Sessions != 2 {
+		t.Errorf("runs=%d sessions=%d, want 3 runs in 2 sessions", found[0].Runs, found[0].Sessions)
+	}
+	if strings.Contains(found[0].Command, "exit") {
+		t.Errorf("the row deja shows carries the outcome: %q", found[0].Command)
+	}
+	// And the lookup the tool hook makes, with the command as a harness hands
+	// it over, finds all of it.
+	use, ok := CommandHistory(dir, "make test")
+	if !ok || use.Runs != 3 {
+		t.Errorf("CommandHistory(make test) = %+v ok=%v", use, ok)
+	}
+}


### PR DESCRIPTION
Closes #2590.

codex and opencode append the exit status to the command line — `$ make test  → exit 2` — and everything that groups commands keyed on the whole line, so one command became two rows:

    $ make test              ran 13 times in 3 sessions
    $ make test  → exit 2    ran 3 times in 2 sessions

On this index 19 of 496 table rows carry a status and four commands are split, `git status --short` into 445 runs and 7. Beyond the double row: the outcome printed as part of the invocation, and `hook-tool` looks up the command as a harness hands it over — no suffix — so the failing runs never counted toward "N sessions ran this".

The status is what the command did, not what it was. Stripped where commands are grouped (the table and `deja how`), left in the records where the fix-pair miner reads it, and read by its exact shape so `echo "→ exit 0"` stays a command — the trap #2048 recorded for the after-hook.