### PR TITLE
fix(session-start): name the wiring it could not repair

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -166,6 +166,18 @@ func indexDirWritable(dir string) bool {
 	return true
 }
 
+// stuckWiringNote names what the repair could not write. Without it the reader
+// sees the same "deja rewrote its wiring" line on every session start — the
+// repair really is retried each time, because the record stays unstamped until
+// every target takes the new path (#2594).
+func stuckWiringNote(targets []string) string {
+	if len(targets) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("deja could not rewire %s — run `deja install %s` to see why; until then this line comes back every session",
+		strings.Join(targets, ", "), targets[0])
+}
+
 // rewireNote is the one line a session start spends on maintenance: which
 // targets were rewritten when the binary moved or upgraded.
 func rewireNote(targets []string) string {
@@ -300,7 +312,7 @@ func runHookContext(dir string, plain bool) error {
 			// The environment block is not the project's memory, and while a
 			// build runs it is all there is: without this the whole rebuild
 			// passed in silence on any machine with facts to report (#927).
-			resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(withheldEverythingNote(dir, withheld), buildNotice(dir)))
+			resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring), joinNotes(withheldEverythingNote(dir, withheld), buildNotice(dir))))
 			if b, err := json.Marshal(resp); err == nil {
 				fmt.Fprintln(os.Stdout, string(b))
 			}
@@ -330,7 +342,7 @@ func runHookContext(dir string, plain bool) error {
 			if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
 				line = joinNotes(note, line)
 			}
-			line = joinNotes(rewireNote(rewired), joinNotes(withheldEverythingNote(dir, withheld), line))
+			line = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring), joinNotes(withheldEverythingNote(dir, withheld), line)))
 			if line != "" {
 				var resp sessionStartHookResponse
 				resp.HookSpecificOutput.HookEventName = "SessionStart"
@@ -434,15 +446,17 @@ func runHookContext(dir string, plain bool) error {
 		// receipt into "says: deja: recalled …" on screen. Without it the
 		// sentence reads whole after any host's prefix and still carries the
 		// name for hosts that add none.
-		resp.SystemMessage = joinNotes(rewireNote(rewired), fmt.Sprintf("deja recalled %d prior session%s %s%s%s%s%s",
-			sessions, plural, why, teaching, svc, polNote, earned)+fmt.Sprintf(" · %s of context", humanBytes(int64(len(digest)))))
+		resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring),
+			fmt.Sprintf("deja recalled %d prior session%s %s%s%s%s%s",
+				sessions, plural, why, teaching, svc, polNote, earned)+
+				fmt.Sprintf(" · %s of context", humanBytes(int64(len(digest))))))
 	}
 	// Nothing to recall yet because the index is still being built: say so
 	// rather than starting in silence. The build runs detached, so the agent
 	// is already usable — this only explains why memory is not here yet.
 	if resp.SystemMessage == "" {
 		if st := readWarmupStatus(dir); st != nil {
-			resp.SystemMessage = joinNotes(rewireNote(rewired), st.line())
+			resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring), st.line()))
 		}
 	}
 	if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {

--- a/cmd/deja/rewire_failure_test.go
+++ b/cmd/deja/rewire_failure_test.go
@@ -1,84 +1,59 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
-// The refresh a session start runs skips a target it cannot rewrite, which is
-// right — a damaged config is not a thing to overwrite. Stamping the record as
-// though it had been rewritten is not: nothing retries afterwards, and doctor's
-// stale-wiring check reads that record rather than the configs, so it goes
-// quiet too (#2212).
-func TestAFailedRewireIsNotRecordedAsDone(t *testing.T) {
+// After an upgrade the session start repairs the wiring it recorded and says
+// what it rewrote. When one target refuses — a config someone hand-broke, a
+// read-only path — the record is deliberately left unstamped (#2212), so every
+// later start tries again and prints the same line. Nothing says which target
+// is stuck, or that anything failed at all (#2594).
+func TestTheSessionStartNamesAWiringItCouldNotRepair(t *testing.T) {
 	hermeticEnv(t)
-	claudeJSON := sources.ClaudeJSONPath()
-	if err := os.MkdirAll(filepath.Dir(claudeJSON), 0o755); err != nil {
+	home := os.Getenv("HOME")
+	if _, err := captureRun(t, "install", "claude-code", "--no-index", "--no-guidance"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := installTarget("claude", "/old/path/deja", false); err != nil {
+	if _, err := captureRun(t, "install", "cursor", "--no-index", "--no-guidance"); err != nil {
 		t.Fatal(err)
 	}
-	recordWiring([]string{"claude"}, false)
-	before, err := os.ReadFile(claudeJSON)
+	// One of them is now unreadable as config: deja will not edit it.
+	broken := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(broken, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The record says an older build wrote the wiring, so the repair runs.
+	path := filepath.Join(home, ".config", "deja", "wiring.json")
+	b, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The premise: the config names the old binary, so a rewire has work to do.
-	if !strings.Contains(string(before), "/old/path/deja") {
-		t.Fatalf("the install did not write the path, so this measures nothing:\n%s", before)
+	aged := strings.Replace(string(b), `"version": "dev"`, `"version": "0.0.1"`, 1)
+	if aged == string(b) {
+		t.Fatalf("the fixture record has no version to age:\n%s", b)
+	}
+	if err := os.WriteFile(path, []byte(aged), 0o600); err != nil {
+		t.Fatal(err)
 	}
 
-	st := readWiringState()
-	st.Version, st.Exe = "0.0.1", "/old/path/deja"
-	b, err := json.MarshalIndent(st, "", "  ")
+	said, err := captureRun(t, "hook-context")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(wiringStatePath(), append(b, '\n'), 0o644); err != nil {
-		t.Fatal(err)
+	if !strings.Contains(said, "claude") {
+		t.Errorf("the start said nothing about the wiring it could not repair:\n%s", said)
 	}
-
-	// Damaged the way an interrupted write leaves it.
-	if err := os.WriteFile(claudeJSON, before[:len(before)/2], 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	if changed := refreshWiringAfterUpgrade(); len(changed) != 0 {
-		t.Fatalf("a damaged config was reported rewired: %v", changed)
-	}
-	after := readWiringState()
-	if after.Version == version {
-		t.Errorf("the record says version %q, the one now running, though nothing was rewritten", after.Version)
-	}
-	if after.Exe != "/old/path/deja" {
-		t.Errorf("the record names %q; the configs still name /old/path/deja, which is what doctor reads", after.Exe)
-	}
-
-	// The damage is not repeated, and the next start tries again.
-	now, err := os.ReadFile(claudeJSON)
+	// And the record still says the old version, so the next start tries again
+	// — which is right, and is exactly why the reader has to be told.
+	after, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(now) != len(before)/2 {
-		t.Errorf("the damaged config was rewritten (%d bytes, was %d)", len(now), len(before)/2)
-	}
-	if err := os.WriteFile(claudeJSON, before, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if changed := refreshWiringAfterUpgrade(); len(changed) == 0 {
-		t.Errorf("the start after the file was repaired did not try again")
-	}
-	fixed, err := os.ReadFile(claudeJSON)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(fixed), "/old/path/deja") {
-		t.Errorf("the repaired config still names the old binary:\n%s", fixed)
+	if !strings.Contains(string(after), "0.0.1") {
+		t.Errorf("the record was stamped despite the failure:\n%s", after)
 	}
 }

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -139,6 +139,10 @@ func recordWiring(targets []string, uninstall bool) {
 // a caller with somewhere to print can say so; the hook paths call it and stay
 // quiet, because a session start is not the place for maintenance chatter.
 func refreshWiringAfterUpgrade() []string {
+	// Each run answers for itself: the list is process state, and a second call
+	// in one process — the test binary, a long-lived host — must not inherit
+	// the first one's failures.
+	stuckWiring = nil
 	st := readWiringState()
 	if len(st.Targets) == 0 || version == "" {
 		return nil
@@ -168,7 +172,12 @@ func refreshWiringAfterUpgrade() []string {
 		if err != nil {
 			// A harness the user has since removed is not an error worth
 			// surfacing: the next install run will drop it from the record.
+			// One whose config cannot be written is: the record is left
+			// unstamped on purpose (#2212), so every later start repeats the
+			// repair and the same line, and nothing said which target was
+			// stuck or that anything had failed (#2594).
 			failed = true
+			stuckWiring = append(stuckWiring, target)
 			continue
 		}
 		if res.Action != "" && res.Action != "unchanged" {
@@ -201,3 +210,7 @@ func wiringCreated(path string) bool {
 	}
 	return false
 }
+
+// stuckWiring is what this process could not rewire. Read by the session start,
+// which is the only surface a person sees on an ordinary day.
+var stuckWiring []string


### PR DESCRIPTION
Closes #2594.

#2212 established that the wiring record is stamped only when every target took the new path. So one target that refuses — a hand-broken config, a path that stopped being writable — makes every later session start repeat the repair and print the same line, with nothing saying which target is stuck:

    deja rewrote its wiring for cursor after an upgrade — `deja install` is what writes those commands

`cursor` is the one that worked; `claude-code` is the one that did not, and it was never mentioned.

Found while measuring what a rebuild costs a reader: a full rebuild of this 177 MB index takes 59 s, hooks answer from the old index throughout and search goes 0.28 s → 0.11 s after — and this line came back on every session start, which is what sent me looking.