### PR TITLE
fix(uninstall): give the CLI skill the same backup rules

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -723,9 +723,12 @@ func restoreReplacedGuidance(path, harness string) (bool, error) {
 const dejaSkillDescription = "description: Search the user's past AI coding sessions."
 
 func isOurGuidance(b []byte, harness string) bool {
-	if bytes.Equal(bytes.TrimSpace(b), bytes.TrimSpace([]byte(guidanceText(harness)))) {
+	if harness != "" && bytes.Equal(bytes.TrimSpace(b), bytes.TrimSpace([]byte(guidanceText(harness)))) {
 		return true
 	}
 	head, _, _ := strings.Cut(string(b), "\n---")
-	return strings.Contains(head, dejaSkillDescription)
+	// Either skill deja writes: the MCP one and the CLI one carry their own
+	// fixed description, and a person making one of them theirs edits that line
+	// first (#2585, #2596).
+	return strings.Contains(head, dejaSkillDescription) || strings.Contains(head, cliSkillDesc)
 }

--- a/cmd/deja/skill_cli.go
+++ b/cmd/deja/skill_cli.go
@@ -123,6 +123,16 @@ func removeCLISkill() error {
 	if err := os.Remove(path); err != nil {
 		return err
 	}
+	// The same two rules the deja-history skill has: put back what install
+	// replaced, and drop a backup that is deja's own words rather than leaving
+	// them on a machine deja was removed from (#2581, #2585, #2596).
+	restored, rerr := restoreReplacedGuidance(path, "")
+	if rerr != nil {
+		return rerr
+	}
+	if restored {
+		return nil
+	}
 	// Only the directory deja named itself, and only a real one: os.Remove
 	// unlinks a symlink whatever stands behind it, so a skills tree someone
 	// keeps in their dotfiles would go while the skills it points at stayed

--- a/cmd/deja/skill_cli_backup_test.go
+++ b/cmd/deja/skill_cli_backup_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The CLI skill gets the same treatment as the MCP one on the way in — replaced
+// with a backup when deja has no record of writing it — and none of it on the
+// way out. #2581 taught the deja-history path to put the reader's copy back and
+// #2585 taught it to drop a copy that is deja's own; deja-search was left with
+// neither, so an older deja's own skill survives an uninstall (#2596).
+func TestUninstallHandlesTheCLISkillsBackupToo(t *testing.T) {
+	t.Run("an older deja's own copy goes", func(t *testing.T) {
+		home := cliSkillFixture(t, cliSkillFileWithBody("An older deja wrote this body."))
+		path := filepath.Join(home, ".agents", "skills", "deja-search", "SKILL.md")
+		if _, err := os.Stat(path + ".bak"); err != nil {
+			t.Fatalf("install kept no backup, so this measures nothing: %v", err)
+		}
+		if _, err := captureRun(t, "uninstall", "codex"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("deja's own CLI skill survived: %v", err)
+		}
+		if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+			t.Errorf("a backup of deja's own CLI skill survived the uninstall")
+		}
+	})
+
+	t.Run("the reader's own copy comes back", func(t *testing.T) {
+		mine := "---\nname: deja-search\ndescription: my own version\n---\n\nThis file is mine.\n"
+		home := cliSkillFixture(t, mine)
+		path := filepath.Join(home, ".agents", "skills", "deja-search", "SKILL.md")
+		if _, err := captureRun(t, "uninstall", "codex"); err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil || string(b) != mine {
+			t.Errorf("the reader's own CLI skill did not come back: %v\n%s", err, b)
+		}
+	})
+}
+
+// cliSkillFixture puts a deja-search skill in place, installs over it, and
+// returns the home it did that in.
+func cliSkillFixture(t *testing.T, content string) string {
+	t.Helper()
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	dir := filepath.Join(home, ".agents", "skills", "deja-search")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "codex", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// cliSkillFileWithBody is deja's own CLI skill with a different body, which is
+// what an older build left behind.
+func cliSkillFileWithBody(body string) string {
+	return "---\nname: " + cliSkillName + "\ndescription: " + cliSkillDesc + "\n---\n\n" + body + "\n"
+}


### PR DESCRIPTION
Closes #2596, following #2581 and #2585.

Walking the fixed first lines deja writes turned up one file carrying no marker deja knows: `~/.agents/skills/deja-search/SKILL.md`. It is replaced-and-backed-up on the way in like the MCP skill, and ignored on the way out — so an older deja's own CLI skill survives an uninstall as a `.bak`, and a reader's own version of it is never put back.

Same two rules now, and an ownership test that knows both descriptions deja writes. `cliSkillDesc` has one commit in its history and has never changed, so the signal covers every build that ever wrote that skill.