### PR TITLE
fix(wording): stop promising recall in a few seconds

### DIFF
--- a/cmd/deja/build_notice_honesty_test.go
+++ b/cmd/deja/build_notice_honesty_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every line deja shows while a build runs promised "in a few seconds".
+// Measured on this machine's 177 MB index, a full rebuild is 59 seconds — and
+// the progress the same line carries says so itself: 3% of the sessions read is
+// not a few seconds from done. The sentences an agent sees while waiting should
+// not claim what deja can already see is false (#2598).
+func TestTheBuildLinesDoNotPromiseSecondsTheyCannotKnow(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		st   warmupStatus
+		want string
+	}{
+		{"just started", warmupStatus{Phase: "sessions", Done: 3, Total: 100}, "3%"},
+		{"nearly done", warmupStatus{Phase: "sessions", Done: 97, Total: 100}, "97%"},
+		{"no count yet", warmupStatus{Phase: "sessions"}, "indexing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			line := tc.st.line()
+			if !strings.Contains(line, tc.want) {
+				t.Fatalf("line = %q, want it to carry %q", line, tc.want)
+			}
+			if strings.Contains(line, "few seconds") {
+				t.Errorf("the line promises seconds it cannot know: %q", line)
+			}
+			// And it still says what it is doing and what the reader waits for.
+			if !strings.Contains(line, "recall") {
+				t.Errorf("the line stopped saying what the reader is waiting for: %q", line)
+			}
+		})
+	}
+
+	// The same claim lived on four surfaces; none of them may make it.
+	t.Run("the other surfaces", func(t *testing.T) {
+		hermeticEnv(t)
+		for _, s := range []string{
+			emptyRecallAnswerPolicy(t.TempDir(), "anything", 0),
+			rememberSavedNote(t.TempDir()),
+		} {
+			if strings.Contains(s, "few seconds") {
+				t.Errorf("still promising seconds: %q", s)
+			}
+		}
+	})
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1256,7 +1256,7 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 		// the command people run when memory looks absent, so this is the
 		// worst place to describe it as absent (#873).
 		if st := readWarmupStatus(dir); st != nil {
-			fmt.Fprintf(w, "  status   building now (%s) — recall comes online in a few seconds\n", st.progress())
+			fmt.Fprintf(w, "  status   building now (%s) — recall comes online when it finishes\n", st.progress())
 			return
 		}
 		// A build requested moments ago has published no progress yet, and
@@ -1264,7 +1264,7 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 		// running — the first build after install is exactly that state
 		// (#925).
 		if warmupJustRequested(dir) {
-			fmt.Fprintln(w, "  status   building now — started moments ago, recall comes online in a few seconds")
+			fmt.Fprintln(w, "  status   building now — started moments ago, recall comes online when it finishes")
 			return
 		}
 		// An index whose disk was unplugged is not a missing index, and

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -201,7 +201,7 @@ func rewireNote(targets []string) string {
 func buildNotice(dir string) string {
 	if st := readWarmupStatus(dir); st != nil {
 		// On a machine no agent has written to, "indexing your history —
-		// recall comes online in a few seconds" is deja's first word to an
+		// recall comes online when it finishes" is deja's first word to an
 		// agent and none of it is so: there is nothing to read, and recall
 		// starts when some agent writes a transcript, not in a few seconds
 		// (#2407). Same claim the CLI makes about the same machine. A build
@@ -243,7 +243,7 @@ func buildNotice(dir string) string {
 	if !warmupJustRequested(dir) {
 		return ""
 	}
-	return "deja is indexing your history — recall comes online in a few seconds"
+	return "deja is indexing your history — recall comes online when it finishes"
 }
 
 // unwritableIndexDir names the directory to fix: the index directory when that

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -519,7 +519,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if line := buildingNowForBlockingTool(dir); line != "" {
 				return "Saved. " + line, nil
 			}
-			return "Saved. deja is refreshing its index; this note becomes findable when that finishes, in a few seconds.", nil
+			return "Saved. " + rememberSavedNote(dir), nil
 		}
 		// The journal is where the user sees what the agent did with their
 		// store; a write belongs there at least as much as a read.
@@ -1435,10 +1435,10 @@ func buildingNowForAgent(dir string) string {
 		return ""
 	}
 	if st := readWarmupStatus(dir); st != nil {
-		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
+		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online when it finishes; ask again then."
 	}
 	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
-		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
+		return "deja is indexing this machine's history. Recall comes online when it finishes; ask again then."
 	}
 	// An index this build cannot read is not one it can answer from, and that
 	// is the state a version bump leaves behind. HasManifest called it present,
@@ -1469,10 +1469,10 @@ func buildingNowForAgent(dir string) string {
 // rather than to hang.
 func buildingNowForBlockingTool(dir string) string {
 	if st := readWarmupStatus(dir); st != nil {
-		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online in a few seconds; ask again then."
+		return "deja is indexing this machine's history (" + st.progress() + "). Recall comes online when it finishes; ask again then."
 	}
 	if index.RebuildInProgress(dir) || warmupJustRequested(dir) {
-		return "deja is indexing this machine's history. Recall comes online in a few seconds; ask again then."
+		return "deja is indexing this machine's history. Recall comes online when it finishes; ask again then."
 	}
 	// Everything else these two have to say — an index written by another
 	// version, an index directory nobody can write — is the same sentence the
@@ -1487,4 +1487,15 @@ func projectsOf(s model.Session) []string {
 		return nil
 	}
 	return []string{s.Project}
+}
+
+// rememberSavedNote is what a remember says when the index is mid-refresh. Not
+// "in a few seconds": the same build measured 59 seconds on a 177 MB index, and
+// what the writer needs to know is that the note is safe and will be findable,
+// not how long that takes (#2598).
+func rememberSavedNote(dir string) string {
+	if line := buildingNowForBlockingTool(dir); line != "" {
+		return line
+	}
+	return "deja is refreshing its index; this note becomes findable when that finishes."
 }

--- a/cmd/deja/statusline.go
+++ b/cmd/deja/statusline.go
@@ -58,7 +58,7 @@ func runStatusline(dir string, stdin io.Reader, stdout io.Writer) error {
 		if index.HasManifest(dir) {
 			fmt.Fprint(stdout, "deja · rebuilding the index · recall is quiet until it finishes")
 		} else {
-			fmt.Fprint(stdout, "deja · indexing your history · recall comes online in a few seconds")
+			fmt.Fprint(stdout, "deja · indexing your history · recall comes online when it finishes")
 		}
 		return nil
 	}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -162,7 +162,12 @@ func (s *warmupStatus) line() string {
 		}
 		pct = fmt.Sprintf(" %d%%", p)
 	}
-	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online in a few seconds", s.phaseName(), pct)
+	// Not "in a few seconds": a full rebuild of a 177 MB index measured 59
+	// seconds, and the progress in this very line says when that claim is
+	// false — 3% of the sessions read is not a few seconds from done. The
+	// reader is told what deja is doing and that recall follows it, which is
+	// the true part (#2598).
+	return fmt.Sprintf("deja: indexing your history (%s%s) — recall comes online when it finishes", s.phaseName(), pct)
 }
 
 // publishBuildProgress installs the file sink for the work that happens before
@@ -226,7 +231,10 @@ func emptyRecallAnswer(dir, q string) string { return emptyRecallAnswerPolicy(di
 func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 	q = clampEcho(q)
 	if st := readWarmupStatus(dir); st != nil {
-		return fmt.Sprintf("deja is still building its index (%s). Nothing can be recalled yet — it finishes within a few seconds, so ask again later in this session rather than concluding there is no history.", st.progress())
+		// The instruction is the useful part — ask again rather than conclude
+		// there is no history — and it does not need a duration deja cannot
+		// know: the same build measured 59 seconds on a 177 MB index (#2598).
+		return fmt.Sprintf("deja is still building its index (%s). Nothing can be recalled yet — ask again later in this session rather than concluding there is no history.", st.progress())
 	}
 	if hidden > 0 {
 		return fmt.Sprintf("%d prior session%s matched %q, but this machine's trust policy (%s) does not allow them on this path. There is prior work here; it is not being shown.",

--- a/extensions/zed/configuration/installation_instructions.md
+++ b/extensions/zed/configuration/installation_instructions.md
@@ -30,5 +30,5 @@ To name a specific binary:
 ```
 
 The first query builds the index over whatever history is already on the
-machine, which takes a few seconds; later queries answer in about a
-millisecond.
+machine — seconds on a fresh one, about a minute on a large history; later
+queries answer in about a millisecond.


### PR DESCRIPTION
Closes #2598.

Reading every sentence deja hands an agent as one set turned up a single claim repeated on nine surfaces — hook-context, the warmup status line, the statusline, four MCP recall replies, the MCP remember reply and two doctor rows:

    recall comes online in a few seconds

A full rebuild of this machine's 177 MB index takes 59 seconds, and the same lines often carry the evidence against the claim beside it: `sessions 3%`.

Each sentence keeps what is useful — what deja is doing, what the reader is waiting for, and on the MCP ones the instruction to ask again rather than conclude there is no history — and drops the duration deja cannot know. The zed installation instructions said the same thing and now name both cases.