### PR TITLE
fix(uninstall): put back a command file install replaced

### DIFF
--- a/cmd/deja/command_file_backup_test.go
+++ b/cmd/deja/command_file_backup_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The four rules #2575 to #2596 established for configs and skills — recognise
+// what is deja's, restore what install replaced, drop deja's own backup, remove
+// what deja created — were applied one file at a time. The command files were
+// never given them: install overwrites a `deja.md` the reader wrote, keeps the
+// backup it promised, and uninstall deletes its own copy without putting theirs
+// back. Eight files are lost that way in a full install/uninstall round (#2600).
+func TestUninstallPutsBackACommandFileItReplaced(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".cursor", "commands", "deja.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "# my own deja command\n\nThis file is mine.\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: deja replaced it and kept a copy.
+	if b, err := os.ReadFile(path); err != nil || string(b) == mine {
+		t.Fatalf("install did not replace the reader's command file: %v", err)
+	}
+	if b, err := os.ReadFile(path + ".bak"); err != nil || string(b) != mine {
+		t.Fatalf("install kept no copy of it: %v", err)
+	}
+
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the reader's own command file is gone: %v", err)
+	}
+	if string(b) != mine {
+		t.Errorf("what is there now is not theirs:\n%s", b)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("the copy was put back and the backup left behind: %v", err)
+	}
+}
+
+// A command file deja wrote itself still goes, with no leftovers.
+func TestUninstallRemovesACommandFileItWrote(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".cursor", "commands", "deja.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install wrote no command file: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("deja's own command file survived: %v", err)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("a backup survived: %v", err)
+	}
+}

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -691,12 +691,20 @@ var restoredGuidance = map[string]bool{}
 // file, and leaving deja's own words behind after an uninstall is what #2575
 // was about.
 func restoreReplacedGuidance(path, harness string) (bool, error) {
+	return restoreReplacedFile(path, func(b []byte) bool { return isOurGuidance(b, harness) })
+}
+
+// restoreReplacedFile is the shared shape: put back the copy install made, or
+// drop it when it holds deja's own words rather than the reader's. ours decides
+// which, per kind of file — a skill by its frontmatter, a command file by the
+// subcommands it names (#2600).
+func restoreReplacedFile(path string, ours func([]byte) bool) (bool, error) {
 	bak := path + ".bak"
 	b, err := os.ReadFile(bak)
 	if err != nil {
 		return false, nil
 	}
-	if isOurGuidance(b, harness) {
+	if ours(b) {
 		return false, os.Remove(bak)
 	}
 	if err := os.WriteFile(path, b, 0o644); err != nil {
@@ -706,7 +714,7 @@ func restoreReplacedGuidance(path, harness string) (bool, error) {
 		return false, err
 	}
 	restoredGuidance[path] = true
-	fmt.Printf("skill: put back %s, the copy install replaced\n", shortHome(path))
+	fmt.Printf("deja: put back %s, the copy install replaced\n", shortHome(path))
 	return true, nil
 }
 

--- a/cmd/deja/install_command_files.go
+++ b/cmd/deja/install_command_files.go
@@ -114,8 +114,24 @@ func installCommandFile(harness, exe string, uninstall bool) (installResult, err
 		if _, err := os.Stat(path); err != nil {
 			return installResult{Path: path, Action: "unchanged"}, nil
 		}
+		// `uninstall cursor` runs cursor-auto too, and the second pass met the
+		// file the first pass had just put back (#2600, the shape #2581 hit).
+		if restoredGuidance[path] {
+			return installResult{Path: path, Action: "kept"}, nil
+		}
 		if err := os.Remove(path); err != nil {
 			return installResult{}, err
+		}
+		// The same rules the skills have since #2581 and #2585: put back what
+		// install replaced, and drop a backup that holds deja's own text. A
+		// full round used to destroy eight files of the reader's this way, the
+		// command files among them (#2600).
+		restored, rerr := restoreReplacedFile(path, isOurCommandFile)
+		if rerr != nil {
+			return installResult{}, rerr
+		}
+		if restored {
+			return installResult{Path: path, Action: "restored"}, nil
 		}
 		return installResult{Path: path, Action: "removed"}, nil
 	}
@@ -126,3 +142,8 @@ func installCommandFile(harness, exe string, uninstall bool) (installResult, err
 	a, err := writeIfChanged(path, old, []byte(commandFileText(harness, exe)))
 	return installResult{Path: path, Action: a}, err
 }
+
+// isOurCommandFile reports that a command file is one deja generated rather than
+// one the reader wrote at the same path. Every generated one names the binary's
+// own subcommands, which is what mentionsDeja reads.
+func isOurCommandFile(b []byte) bool { return mentionsDeja(b) }


### PR DESCRIPTION
Closes #2600.

#2575, #2578, #2581, #2585 and #2596 are five fixes of one shape, each applied to the file in front of it. Sweeping the family instead — install all twenty targets into a home where every path deja writes already holds a file of the reader's, then uninstall all twenty — showed eight of 37 seeded files destroyed. The command files are the largest group: install replaces the reader's `deja.md` and keeps the backup it promises, uninstall removes deja's copy and never puts theirs back.

Same two rules as the skills now, sharing one helper, and the auto pass no longer removes what the first pass restored — the trap #2581 hit.

The reader's configs were already safe (#2583). The remaining seeded losses and the thirteen surviving `.bak` files are recorded in the issue.