### PR TITLE
fix(uninstall): put back the goose recipe install replaced

### DIFF
--- a/cmd/deja/goose_recipe_backup_test.go
+++ b/cmd/deja/goose_recipe_backup_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The goose recipe is the last file with the broken promise #2600 named:
+// install replaces the one already at that path and keeps the copy it promises,
+// uninstall removes deja's version and leaves the reader with a .bak beside
+// nothing (#2602).
+func TestUninstallPutsBackTheGooseRecipeItReplaced(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".config", "goose", "deja-recipe.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "# my own recipe\nversion: 1.0.0\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "goose", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(path + ".bak"); err != nil || string(b) != mine {
+		t.Fatalf("install kept no copy of the recipe it replaced: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "goose"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the reader's own recipe is gone: %v", err)
+	}
+	if string(b) != mine {
+		t.Errorf("what is at that path is not theirs:\n%s", b)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("the copy was put back and the backup left behind: %v", err)
+	}
+}
+
+// A recipe deja wrote itself goes, with nothing left beside it.
+func TestUninstallRemovesTheGooseRecipeItWrote(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	if _, err := captureRun(t, "install", "goose", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".config", "goose", "deja-recipe.yaml")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install wrote no recipe: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "goose"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("deja's own recipe survived: %v", err)
+	}
+	if _, err := os.Stat(path + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("a backup survived: %v", err)
+	}
+}

--- a/cmd/deja/install_goose_command.go
+++ b/cmd/deja/install_goose_command.go
@@ -129,8 +129,17 @@ func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 	// to rewrite the config would leave a command pointing at a file that is
 	// no longer there, which fails when someone types /deja rather than now.
 	if uninstall {
-		if err := os.Remove(recipe); err != nil && !os.IsNotExist(err) {
-			return installResult{}, err
+		if !restoredGuidance[recipe] {
+			if err := os.Remove(recipe); err != nil && !os.IsNotExist(err) {
+				return installResult{}, err
+			}
+			// And put back the recipe install replaced, or drop the copy when
+			// it holds deja's own — the rules the skills and command files
+			// have since #2581 and #2600. Without it the reader's recipe was
+			// destroyed and their copy left as a .bak beside nothing (#2602).
+			if _, err := restoreReplacedFile(recipe, mentionsDeja); err != nil {
+				return installResult{}, err
+			}
 		}
 	}
 	return installResult{Path: path, Action: a}, nil


### PR DESCRIPTION
Closes #2602, continuing #2600.

Re-running the sweep after #2601 leaves three of 37 seeded files destroyed. The goose recipe is the last one with the broken promise: install replaces the file at that path, keeps the copy it says it keeps, and uninstall removed deja's version without putting theirs back.

The other two sit inside `~/.gemini/config/plugins/deja/` — a directory deja creates and names after itself, removed wholesale on the way out. That is "remove what deja created" working as intended; the issue records the difference rather than changing it.