### PR TITLE
fix(uninstall): take back the mcp block deja added

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1042,7 +1042,16 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 	if removingWiring {
 		defer func() {
 			bak := path + ".bak"
-			if b, err := os.ReadFile(bak); err == nil && mentionsDeja(b) {
+			b, err := os.ReadFile(bak)
+			if err != nil {
+				return
+			}
+			// Only deja's own. A snapshot of the reader's config stays even
+			// when the live file has come back to exactly it: that copy is
+			// theirs, and TestUninstallLeavesNoFileOrDirItCreated has said so
+			// since #840 — "the user's own config and its snapshot are not
+			// ours to delete" (#2604).
+			if mentionsDeja(b) {
 				_ = os.Remove(bak)
 			}
 		}()
@@ -1122,9 +1131,18 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 		}
 		m = map[string]any{}
 		root["mcpServers"] = m
+		noteBlockAdded(path, "mcpServers")
 	}
 	if uninstall {
 		delete(m, "deja")
+		// And the block itself, when deja is what put it there: a config the
+		// reader owned came back with an empty `mcpServers` they never wrote,
+		// while the copy install promised sat beside it holding the real thing
+		// (#2604). A block they wrote stays, empty or not.
+		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
+			delete(root, "mcpServers")
+			forgetBlockAdded(path, "mcpServers")
+		}
 	} else {
 		m["deja"], note = mergeDejaEntry(m["deja"], mcpServerEntry(exe))
 	}
@@ -1687,9 +1705,15 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 		}
 		m = map[string]any{}
 		root["mcpServers"] = m
+		noteBlockAdded(path, "mcpServers")
 	}
 	if uninstall {
 		delete(m, "deja")
+		// And the block, when deja is what put it there (#2604).
+		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
+			delete(root, "mcpServers")
+			forgetBlockAdded(path, "mcpServers")
+		}
 	} else {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
@@ -1736,9 +1760,17 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	if servers == nil {
 		servers = map[string]any{}
 		mcp["servers"] = servers
+		noteBlockAdded(path, "mcp.servers")
 	}
 	if uninstall {
 		delete(servers, "deja")
+		if len(servers) == 0 && blockWasAdded(path, "mcp.servers") {
+			delete(mcp, "servers")
+			if len(mcp) == 0 {
+				delete(root, "mcp")
+			}
+			forgetBlockAdded(path, "mcp.servers")
+		}
 	} else {
 		command, args := mcpCommandArgs(exe)
 		servers["deja"], note = mergeDejaEntry(servers["deja"], map[string]any{"command": command, "args": args})
@@ -1778,9 +1810,15 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 		}
 		m = map[string]any{}
 		root["mcpServers"] = m
+		noteBlockAdded(path, "mcpServers")
 	}
 	if uninstall {
 		delete(m, "deja")
+		// And the block, when deja is what put it there (#2604).
+		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
+			delete(root, "mcpServers")
+			forgetBlockAdded(path, "mcpServers")
+		}
 	} else {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"command": command, "args": args})

--- a/cmd/deja/mcp_block_removal_test.go
+++ b/cmd/deja/mcp_block_removal_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A config the reader owns must come back exactly as it was. deja adds the
+// `mcpServers` block when the file has none, and on the way out removed only
+// its own entry — so the reader was left with an empty block they never wrote,
+// and the backup install had promised sat beside it holding the real thing. Of
+// the 22 backups a full round leaves, 13 differ from the live file by exactly
+// that empty container (#2604).
+func TestUninstallTakesBackTheBlockItAdded(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "{\n  \"mine\": \"MINE\"\n}\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index", "--no-guidance"); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(path); err != nil || !strings.Contains(string(b), "deja") {
+		t.Fatalf("install wired nothing here: %v", err)
+	}
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the reader's config is gone: %v", err)
+	}
+	if strings.Contains(string(b), "mcpServers") {
+		t.Errorf("the block deja added is still there:\n%s", b)
+	}
+	if !strings.Contains(string(b), "MINE") {
+		t.Errorf("the reader's own content is gone:\n%s", b)
+	}
+	// The snapshot install promised stays: it is a copy of the reader's own
+	// file, and deleting it is not deja's call — the rule
+	// TestUninstallLeavesNoFileOrDirItCreated has held since #840.
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Errorf("the reader's own snapshot was removed: %v", err)
+	}
+}
+
+// A block the reader wrote themselves stays, empty or not.
+func TestUninstallKeepsABlockItDidNotAdd(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "{\n  \"mcpServers\": {\n    \"theirs\": {\n      \"command\": \"x\"\n    }\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index", "--no-guidance"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "theirs") || !strings.Contains(string(b), "mcpServers") {
+		t.Errorf("the reader's own block did not survive:\n%s", b)
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 )
 
@@ -34,6 +35,11 @@ type wiringState struct {
 	// Knowing which files deja made is what lets the same rule apply to them
 	// without ever removing a config the reader already had (#2583).
 	Created []string `json:"created,omitempty"`
+	// Blocks are the containers deja added to a config that had none —
+	// "<path>#mcpServers". Removing only deja's entry left the reader with an
+	// empty block they never wrote (#2604); knowing deja added it is what
+	// allows taking it back without touching one they wrote themselves.
+	Blocks []string `json:"blocks,omitempty"`
 	// Exe is the binary path the configs were written with. A move without a
 	// version change is ordinary — a relink, a reinstall of the same release,
 	// a `go install` over a manual download — and left every config pointing
@@ -122,7 +128,18 @@ func recordWiring(targets []string, uninstall bool) {
 		created = nil
 	}
 	sort.Strings(created)
-	st = wiringState{Version: version, Targets: kept, Created: created, Exe: exe, Home: homeDir()}
+	blocks := append([]string(nil), st.Blocks...)
+	for _, b := range blocksAddedThisRun {
+		if !slices.Contains(blocks, b) {
+			blocks = append(blocks, b)
+		}
+	}
+	blocks = slices.DeleteFunc(blocks, func(b string) bool { return blocksForgottenThisRun[b] })
+	if len(kept) == 0 {
+		blocks = nil
+	}
+	sort.Strings(blocks)
+	st = wiringState{Version: version, Targets: kept, Created: created, Blocks: blocks, Exe: exe, Home: homeDir()}
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -214,3 +231,28 @@ func wiringCreated(path string) bool {
 // stuckWiring is what this process could not rewire. Read by the session start,
 // which is the only surface a person sees on an ordinary day.
 var stuckWiring []string
+
+// blocksAddedThisRun and blocksForgottenThisRun carry what this process added to
+// or took back from a config, until recordWiring folds them into the record.
+var (
+	blocksAddedThisRun     []string
+	blocksForgottenThisRun = map[string]bool{}
+)
+
+func blockKey(path, name string) string { return path + "#" + name }
+
+// noteBlockAdded records that deja, not the reader, put this container there.
+func noteBlockAdded(path, name string) {
+	blocksAddedThisRun = append(blocksAddedThisRun, blockKey(path, name))
+}
+
+// blockWasAdded reports whether deja added it, in this run or an earlier one.
+func blockWasAdded(path, name string) bool {
+	key := blockKey(path, name)
+	if slices.Contains(blocksAddedThisRun, key) {
+		return true
+	}
+	return slices.Contains(readWiringState().Blocks, key)
+}
+
+func forgetBlockAdded(path, name string) { blocksForgottenThisRun[blockKey(path, name)] = true }


### PR DESCRIPTION
Closes #2604.

Comparing the 22 backups a full round leaves with the files beside them: 9 are identical, and the other 13 differ by exactly one thing —

    live  { "mcpServers": {}, "mine": "MINE" }
    bak   { "mine": "MINE" }

A config the reader owned comes back with an empty `mcpServers` they never wrote. deja adds that block when a file has none (#676 already stops it being added on the way out) and removed only its own entry inside it.

The record already knows which files deja created (#2583); it now records which containers it added, so deja's block goes and the reader's stays — empty or not.

The backups themselves stay: `TestUninstallLeavesNoFileOrDirItCreated` has said since #840 that the user's own config and its snapshot are not deja's to delete, and that holds even when the live file has come back to exactly the snapshot.