### PR TITLE
fix(uninstall): give the YAML configs back as they were

### DIFF
--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -121,6 +121,7 @@ func installGoose(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return installResult{}, err
 	}
+	next = keepTrailingNewline(string(old), next)
 	if crlf {
 		next = strings.ReplaceAll(next, "\n", "\r\n")
 	}

--- a/cmd/deja/install_goose_command.go
+++ b/cmd/deja/install_goose_command.go
@@ -88,6 +88,17 @@ func dropEmptyYAMLKey(s, key string) string {
 	return strings.Join(out, "\n")
 }
 
+// keepTrailingNewline gives back what the reader's file ended with. Dropping an
+// empty key takes the blank lines after it, and the last of those is the file's
+// own final newline — so a config someone owned came back without it, a diff in
+// their dotfiles for nothing (#2606).
+func keepTrailingNewline(old, next string) string {
+	if strings.HasSuffix(old, "\n") && next != "" && !strings.HasSuffix(next, "\n") {
+		return next + "\n"
+	}
+	return next
+}
+
 func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(gooseConfigDir(), "config.yaml")
 	old, err := os.ReadFile(path)
@@ -121,7 +132,7 @@ func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return installResult{}, err
 	}
-	a, err := writeIfChanged(path, old, []byte(next))
+	a, err := writeIfChanged(path, old, []byte(keepTrailingNewline(string(old), next)))
 	if err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -159,6 +159,16 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 				next += "\n"
 			}
 			next += "\nmcp_servers:\n" + entry
+			noteBlockAdded(path, "mcp_servers")
+		}
+	} else if blockWasAdded(path, "mcp_servers") {
+		// The container goes with the entry when deja is what put it there —
+		// a config the reader owned came back carrying an `mcp_servers:` they
+		// never wrote (#2606, the shape #2604 fixed for the JSON writers). One
+		// they wrote stays, with or without entries under it.
+		if trimmed := dropEmptyYAMLKey(next, "mcp_servers:"); trimmed != next {
+			next = trimmed
+			forgetBlockAdded(path, "mcp_servers")
 		}
 	}
 	a, werr := writeIfChanged(path, old, []byte(next))

--- a/cmd/deja/yaml_config_roundtrip_test.go
+++ b/cmd/deja/yaml_config_roundtrip_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #2604 gave the JSON writers the rule: a container deja added goes with deja,
+// one the reader wrote stays. Sweeping the rest of the family, the two YAML
+// writers still fail their own version of it — hermes leaves the `mcp_servers:`
+// block it added in a config the reader owned, and goose returns the file
+// without the trailing newline it came with (#2606).
+func TestAYamlConfigComesBackAsItWas(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		target  string
+		rel     []string
+		content string
+	}{
+		{"hermes", "hermes", []string{".hermes", "config.yaml"}, "profile: default\n"},
+		{"goose", "goose", []string{".config", "goose", "config.yaml"}, "GOOSE_MODEL: gpt-5\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hermeticEnv(t)
+			home := os.Getenv("HOME")
+			path := filepath.Join(append([]string{home}, tc.rel...)...)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := captureRun(t, "install", tc.target, "--no-index", "--no-guidance"); err != nil {
+				t.Fatal(err)
+			}
+			// The premise: deja really wired itself into that file.
+			if b, err := os.ReadFile(path); err != nil || !strings.Contains(string(b), "deja") {
+				t.Fatalf("install wired nothing here: %v", err)
+			}
+			if _, err := captureRun(t, "uninstall", tc.target); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("the reader's config is gone: %v", err)
+			}
+			if string(b) != tc.content {
+				t.Errorf("the config did not come back as it was:\nwant %q\ngot  %q", tc.content, b)
+			}
+		})
+	}
+}
+
+// A container the reader wrote survives, entries and all.
+func TestAYamlConfigKeepsTheBlockTheReaderWrote(t *testing.T) {
+	hermeticEnv(t)
+	home := os.Getenv("HOME")
+	path := filepath.Join(home, ".hermes", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "profile: default\n\nmcp_servers:\n  theirs:\n    command: \"x\"\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "hermes", "--no-index", "--no-guidance"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "hermes"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "theirs") || !strings.Contains(string(b), "mcp_servers:") {
+		t.Errorf("the reader's own block did not survive:\n%s", b)
+	}
+}


### PR DESCRIPTION
Closes #2606, following #2604.

Swept the rest of the family — a config of the reader's own for codex, grok, goose, hermes, zed, cline, copilot, openclaw, qwen and kimi, install, uninstall, diff. Eight come back byte-identical; two do not.

Hermes is #2604 in YAML: deja adds the `mcp_servers:` block when the file has none and removed only its own entry, so the reader kept a block they never wrote.

Goose is smaller and stranger: the file came back without its trailing newline — `dropEmptyYAMLKey` removes the key and the blank lines after it, and the last of those is the file's own final newline.

After: all ten come back exactly as they were.