### PR TITLE
docs: say millisecond lookups, which the table supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ before a file is edited or a command runs, and after one fails. Keys and tokens 
 the index is built, so what reaches the model is safe to send.</p>
 
 <p align="center">
-<b>85.3% hit@1</b> on LongMemEval-S &middot; <b>69.6%</b> on LoCoMo &middot; <b>sub-millisecond</b> lookups over 5&nbsp;GB of history<br>
+<b>85.3% hit@1</b> on LongMemEval-S &middot; <b>69.6%</b> on LoCoMo &middot; <b>millisecond</b> lookups over 5&nbsp;GB of history<br>
 <sub>Both harnesses ship in this repo and run on the public datasets in minutes &middot;
 <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">check the numbers yourself</a></sub>
 </p>

--- a/cmd/deja/readme_latency_claim_test.go
+++ b/cmd/deja/readme_latency_claim_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The README states a lookup latency twice: once in the banner and once in the
+// performance table, which cites where each number comes from. They disagreed —
+// the banner said "sub-millisecond lookups over 5 GB of history" while the table
+// says the benchmark's ~0.4 ms is on a synthetic corpus and a real haystack is
+// ~25 ms. Measured on this machine's 137 MB index, an exact answer is 3.4–6.2 ms
+// in process and the relevance tier 215 ms (#2608).
+func TestTheReadmeBannerAgreesWithItsOwnTable(t *testing.T) {
+	b, err := os.ReadFile("../../README.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	banner := ""
+	for _, line := range strings.Split(text, "\n") {
+		if strings.Contains(line, "hit@1") && strings.Contains(line, "lookups") {
+			banner = line
+			break
+		}
+	}
+	if banner == "" {
+		t.Fatal("the banner line is gone, so this measures nothing")
+	}
+	// The table is the sourced claim: whatever the banner says has to be
+	// reachable from it.
+	if !strings.Contains(text, "`deja bench recall`") {
+		t.Fatal("the performance table no longer names its source")
+	}
+	if regexp.MustCompile(`(?i)sub-millisecond`).MatchString(banner) {
+		t.Errorf("the banner promises a latency the table contradicts:\n  %s", strings.TrimSpace(banner))
+	}
+	// And it still says something about lookups rather than dropping the claim.
+	if !strings.Contains(banner, "lookup") {
+		t.Errorf("the banner stopped saying anything about lookups:\n  %s", strings.TrimSpace(banner))
+	}
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -18,7 +18,7 @@ DeepSeek Harness, Hermes and Zed.
 deja turns those files into one memory layer that all of them can read.
 
 One Go binary. No LLM, no embeddings, no API key, nothing leaves the machine.
-**85.3% hit@1** on LongMemEval-S, **sub-millisecond** lookups over 5 GB of history.
+**85.3% hit@1** on LongMemEval-S, **millisecond** lookups over 5 GB of history.
 
 ```sh
 npx @vshulcz/deja-vu "connection pool exhausted"   # search, no install


### PR DESCRIPTION
Closes #2608, following #2598.

Most numbers deja states are measured and sourced — the performance table names `deja bench recall` for its ~0.4 ms and gives ~25 ms on the LongMemEval haystacks separately. The banner compresses them into a claim the table contradicts: `sub-millisecond` is the synthetic corpus's number, `over 5 GB of history` is a real store's size.

Measured in process on this machine's 137 MB index: posting intersection 1.3–2.3 ms, whole exact answer 3.4–6.2 ms, relevance tier ~215 ms.

`millisecond` is true of both, and the sourced detail stays where it already is. The npm README carried the same sentence.