### PR TITLE
docs: the site and the zh README say milliseconds too

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 <p align="center"><b>其他记忆工具都从空白开始，往后记录。deja 一开始就是满的。</b></p>
 
 <p align="center">
-LongMemEval-S 上 <b>85.3% hit@1</b> &middot; LoCoMo 上 <b>69.6%</b> &middot; 5&nbsp;GB 历史上的查询在<b>亚毫秒</b>级<br>
+LongMemEval-S 上 <b>85.3% hit@1</b> &middot; LoCoMo 上 <b>69.6%</b> &middot; 5&nbsp;GB 历史上的查询在<b>毫秒</b>级<br>
 <sub>两套评测都在本仓库里，几分钟即可在公开数据集上跑完 &middot;
 <a href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">自己核对这些数字</a></sub>
 </p>

--- a/cmd/deja/site_latency_claim_test.go
+++ b/cmd/deja/site_latency_claim_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #2608 fixed the English README's banner. The same claim lives in the places
+// someone reads before they install anything — the site's hero stat, the
+// Chinese README, a guide page — and the site's own token-cost page states the
+// honest pair beside it ("about 0.4 ms in process, around 25 ms on the
+// LongMemEval-S haystacks"). Measured in process on a 137 MB index an exact
+// answer is 3.4–6.2 ms (#2610).
+func TestNothingOutsideTheReadmePromisesSubMillisecond(t *testing.T) {
+	root := "../.."
+	var offenders []string
+	err := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if fi.IsDir() {
+			switch fi.Name() {
+			case ".git", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch filepath.Ext(p) {
+		case ".md", ".html", ".json", ".toml", ".yml", ".yaml":
+		default:
+			return nil
+		}
+		// The changelog is a record of what was said at the time.
+		if strings.Contains(p, "CHANGELOG") {
+			return nil
+		}
+		b, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return nil
+		}
+		text := string(b)
+		for _, claim := range []string{"sub-millisecond", "亚毫秒", "under a millisecond", "in under a millisecond"} {
+			if strings.Contains(text, claim) {
+				offenders = append(offenders, strings.TrimPrefix(p, root+"/")+": "+claim)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("a lookup is milliseconds, not sub-millisecond, on a real store:\n  %s", strings.Join(offenders, "\n  "))
+	}
+}

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -99,7 +99,7 @@
 <p>The pre-compaction turns are still on disk in full — compaction rewrites the agent's context, not its transcript. deja reads the transcript, so the commands and errors the summary dropped are still searchable, and <a href="after-compaction.html">getting them back</a> is one query.</p>
 
 <h2>Why not a bigger window</h2>
-<p>A larger window moves the wall without removing it, and every token in context is paid on every turn of the session. A 5 GB history searched in under a millisecond and returned as a 1.5 KB digest is a different shape of answer than a 200k-token window that holds the same history and charges for it continuously.</p>
+<p>A larger window moves the wall without removing it, and every token in context is paid on every turn of the session. A 5 GB history searched in milliseconds and returned as a 1.5 KB digest is a different shape of answer than a 200k-token window that holds the same history and charges for it continuously.</p>
 
 <h2>The part that is not about this</h2>
 <p>The index covers every agent's transcripts on the machine — <a href="where-sessions-are-stored.html">each in its own format</a> — including sessions from before deja was installed. Indexing and search are local: no model, no embeddings, nothing leaves the machine (<a href="privacy.html">privacy</a>).</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -344,7 +344,7 @@ footer a:hover{color:var(--ph-hi)}
 
 <div class="proof reveal">
   <div><b data-count="85.3" data-dp="1">0<i>%</i></b><span class="lab">hit@1 · LongMemEval-S</span></div>
-  <div><b data-count="0.4" data-dp="1">0<i>ms</i></b><span class="lab">median lookup over 5 GB</span></div>
+  <div><b data-count="0.4" data-dp="1">0<i>ms</i></b><span class="lab">median lookup, <code>deja bench recall</code></span></div>
   <div><b>0</b><span class="lab">models, keys or cloud accounts</span></div>
 </div>
 


### PR DESCRIPTION
Closes #2610, following #2609.

The claim #2609 fixed in the English README was in three more places, all read before anyone installs anything: the Chinese banner (亚毫秒), the site's hero stat (0.4 ms labelled "median lookup over 5 GB") and a guide sentence ("A 5 GB history searched in under a millisecond").

The site's own token-cost page already states the honest pair a few clicks away — "about 0.4 ms in process, around 25 ms on the LongMemEval-S haystacks".

The translated banner and the guide say milliseconds; the hero keeps 0.4 ms and names where it comes from (`deja bench recall`) rather than attaching it to 5 GB of someone's history. A repo-wide sweep over the docs pins it, translations included; the changelog is exempt because it records what was said at the time.