### PR TITLE
docs(index): say what Total counts on the relevance tier

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -419,6 +419,14 @@ type SearchResult struct {
 	// inside retrieval, so a caller counting Sessions is measuring the
 	// window rather than the match. Zero Total means the tier reports no
 	// figure of its own and the caller's count stands.
+	//
+	// "Matched" means different things per tier, and the number a reader sees
+	// in "showing 33 of 414" is this one. Measured on a 1,365-session store,
+	// for "what did we decide about the retry budget": 2 sessions hold every
+	// term, 819 hold at least one, and 414 cleared the relevance tier's own
+	// bar — so Total counts what the tier was willing to rank, which is why
+	// the line above it says the answer is ranked by relevance rather than
+	// matched (#2612).
 	Total  int
 	Capped bool
 	// TermIDF is what the relevance ranking judged each query term to be worth.


### PR DESCRIPTION
Closes #2612 — a measurement, not a bug.

The exact tier answers in 3–6 ms and the relevance tier in ~215 ms. A reader can tell which answered: the CLI says "no exact match; showing sessions ranked by relevance", the MCP envelope says "No session is about this … the nearest by wording", and the per-prompt hook has one tier with a gate of its own.

What was not written down is what the count beside it means. On this 1,365-session store, for "what did we decide about the retry budget": 2 sessions hold every term, 819 hold at least one, and 414 is what the tier ranked — and 414 is the number printed.

The measurement goes on the field, so the next reader of `SearchResult.Total` does not re-derive what the number in front of a person means.