### PR TITLE
fix(install): follow the indent goose's extensions block already uses

### DIFF
--- a/cmd/deja/goose_indent_test.go
+++ b/cmd/deja/goose_indent_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// YAML lets a mapping be indented by any consistent amount, and the writer
+// used to assume two spaces: a four-space block took our entry as a sibling at
+// two, which made the user's own extension a key inside ours, and the uninstall
+// that followed removed both (#2614).
+func TestInstallGooseFollowsTheIndentTheBlockUses(t *testing.T) {
+	home := t.TempDir()
+	cfg := filepath.Join(home, "cfg")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	dir := filepath.Join(cfg, "goose")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := "GOOSE_MODEL: gpt-5\nextensions:\n    mine:\n        enabled: true\n"
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGoose("/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	conf := gooseConf(t, cfg)
+	if !strings.Contains(conf, "\n    deja:\n") {
+		t.Fatalf("our entry is not at the indent the block uses, so the extension after it is nested in ours:\n%s", conf)
+	}
+	if !strings.Contains(conf, "\n    mine:\n        enabled: true\n") {
+		t.Fatalf("the user's extension is no longer an extension:\n%s", conf)
+	}
+	if _, err := installGoose("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	conf = gooseConf(t, cfg)
+	if strings.Contains(conf, "deja") {
+		t.Fatalf("uninstall left our entry:\n%s", conf)
+	}
+	if conf != existing {
+		t.Fatalf("uninstall did not give the config back as it was:\nwant:\n%s\ngot:\n%s", existing, conf)
+	}
+}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -80,17 +80,22 @@ func installGoose(exe string, uninstall bool) (installResult, error) {
 	next = dropEmptyYAMLKey(next, "extensions:")
 	if !uninstall {
 		cmd, args := mcpCommandArgs(exe)
+		pad := yamlBlockIndent(gooseExtensionsBlock(next))
+		if pad == "" {
+			pad = "  "
+		}
+		key, val := pad, pad+"  "
 		var b strings.Builder
-		b.WriteString("  deja:\n    enabled: true\n    type: stdio\n    name: deja\n")
+		fmt.Fprintf(&b, "%sdeja:\n%senabled: true\n%stype: stdio\n%sname: deja\n", key, val, val, val)
 		// Quote both: on Unix cmd is the exe path, on Windows the exe lands in
 		// args — either way a YAML metacharacter in the path (a ": ", a " #")
 		// would break the config Goose has to read back.
-		fmt.Fprintf(&b, "    cmd: %s\n", yamlQuote(cmd))
-		b.WriteString("    args:\n")
+		fmt.Fprintf(&b, "%scmd: %s\n", val, yamlQuote(cmd))
+		fmt.Fprintf(&b, "%sargs:\n", val)
 		for _, a := range args {
-			fmt.Fprintf(&b, "      - %s\n", yamlQuote(a))
+			fmt.Fprintf(&b, "%s  - %s\n", val, yamlQuote(a))
 		}
-		b.WriteString("    timeout: 60\n")
+		fmt.Fprintf(&b, "%stimeout: 60\n", val)
 		entry := b.String()
 		// An inline value — `extensions: [a, b]` or `extensions: {…}` — is not
 		// followed by a block, so the insert below missed it and appended a
@@ -140,16 +145,22 @@ func normaliseNewlines(s string) (string, bool) {
 
 // removeGooseExtension drops our entry and stops at the next key at the same
 // indent, so a neighbouring extension survives.
+//
+// The entry is looked for at the indent the block itself uses, and at two
+// spaces as well: that is what every build before #2614 wrote, whatever the
+// rest of the block was indented by, and those files still have to come apart.
 func removeGooseExtension(s string) string {
 	lines := strings.Split(s, "\n")
+	pad := yamlBlockIndent(gooseExtensionsBlock(s))
 	out := make([]string, 0, len(lines))
 	for i := 0; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) != "deja:" || !strings.HasPrefix(lines[i], "  ") || strings.HasPrefix(lines[i], "   ") {
+		indent := lines[i][:len(lines[i])-len(strings.TrimLeft(lines[i], " "))]
+		if strings.TrimSpace(lines[i]) != "deja:" || indent == "" || (indent != pad && indent != "  ") {
 			out = append(out, lines[i])
 			continue
 		}
 		i++
-		for i < len(lines) && (strings.HasPrefix(lines[i], "    ") || strings.TrimSpace(lines[i]) == "") {
+		for i < len(lines) && (strings.HasPrefix(lines[i], indent+" ") || strings.TrimSpace(lines[i]) == "") {
 			i++
 		}
 		i--
@@ -158,6 +169,35 @@ func removeGooseExtension(s string) string {
 	// An extensions key with nothing under it parses as null and Goose then
 	// refuses the config.
 	return strings.Replace(s, "extensions:\n\n", "\n", 1)
+}
+
+// gooseExtensionsBlock returns the text after the extensions key, or "" when
+// there is no block form of it to read an indent from.
+func gooseExtensionsBlock(s string) string {
+	i := strings.Index("\n"+s, "\nextensions:\n")
+	if i < 0 {
+		return ""
+	}
+	return s[i+len("\nextensions:\n")-1:]
+}
+
+// yamlBlockIndent returns the indent the entries under a key are written at.
+// YAML accepts any consistent amount and people use four as readily as two, so
+// an entry spliced in at a fixed two spaces would leave the entry after it
+// nested inside ours rather than beside it (#2614). An empty block has no
+// indent to follow and gives "".
+func yamlBlockIndent(block string) string {
+	for _, line := range strings.Split(block, "\n") {
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+		if indent == "" {
+			return ""
+		}
+		return indent
+	}
+	return ""
 }
 
 func gooseConfigDir() string {


### PR DESCRIPTION
Fixes #2614.

The goose writer splices its extension in textually and assumed the block is indented two spaces. When it is four, our entry lands at two, the user's next extension becomes a key inside ours, and `deja uninstall goose` then takes both out — their extension gone without a word.

Now the entry is written at the indent the block already uses, and removed by that indent or by two spaces, since that is what every earlier build wrote regardless.
