### PR TITLE
fix(sync-timer): escape the binary path in the systemd unit

### DIFF
--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -144,7 +144,7 @@ Description=deja: exchange memory with the machines this one syncs with
 [Service]
 Type=oneshot
 ExecStart="%s" sync
-`, exe)
+`, systemdEscape(exe))
 }
 
 func syncAutoTimer() string {
@@ -211,6 +211,16 @@ func removeOurUnit(path string) string {
 		return "unchanged"
 	}
 	return "removed"
+}
+
+// systemdEscape keeps a path from being read as anything but a path. The same
+// reason as xmlEscape below, for the other format: a unit file resolves %-
+// specifiers, substitutes $variables and reads C escapes in its values, so
+// /Users/50%off/bin/deja ran /Users/50<os-id>ff/bin/deja and a path holding a
+// quote did not parse at all (#2621).
+func systemdEscape(s string) string {
+	r := strings.NewReplacer("\\", "\\\\", "%", "%%", "$", "$$", `"`, `\"`)
+	return r.Replace(s)
 }
 
 // xmlEscape keeps a path with an ampersand or a quote in it from producing a

--- a/cmd/deja/install_sync_timer_test.go
+++ b/cmd/deja/install_sync_timer_test.go
@@ -134,9 +134,13 @@ func TestSyncTimerUnitsSurviveAnAwkwardPath(t *testing.T) {
 		}
 		// systemd takes the first whitespace-delimited word as the binary
 		// unless it is quoted, so an unquoted path with a space runs the
-		// wrong thing — or nothing.
-		if !strings.Contains(line, `"`+exe+`"`) {
+		// wrong thing — or nothing. Quoted, and with the quotes inside the
+		// path escaped, or the string ends early (#2621).
+		if !strings.Contains(line, `"`+systemdEscape(exe)+`"`) {
 			t.Errorf("ExecStart does not quote the path: %s", line)
+		}
+		if strings.Contains(line, `/Users/John & "Jane" Smith/`) {
+			t.Errorf("ExecStart carries the quotes unescaped: %s", line)
 		}
 	}
 }

--- a/cmd/deja/systemd_escape_test.go
+++ b/cmd/deja/systemd_escape_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The plist writer escapes the binary path because a home directory is a
+// user-chosen string. The unit file wrote it raw, so a path holding a systemd
+// specifier, a variable, a C escape or a quote ran something other than what
+// deja installed — or did not parse at all (#2621).
+func TestSyncTimerUnitEscapesThePath(t *testing.T) {
+	cases := []struct {
+		name, exe, want string
+	}{
+		{"percent is a specifier", "/Users/50%off/bin/deja", `ExecStart="/Users/50%%off/bin/deja" sync`},
+		{"dollar is a variable", "/Users/me/$HOME/deja", `ExecStart="/Users/me/$$HOME/deja" sync`},
+		{"backslash is an escape", `/Users/me/a\b/deja`, `ExecStart="/Users/me/a\\b/deja" sync`},
+		{"a quote ends the string", `/Users/me/"q"/deja`, `ExecStart="/Users/me/\"q\"/deja" sync`},
+		{"a space needs the quotes", "/Users/me/My Tools/deja", `ExecStart="/Users/me/My Tools/deja" sync`},
+		{"an ordinary path is untouched", "/usr/local/bin/deja", `ExecStart="/usr/local/bin/deja" sync`},
+		// A backslash before a quote: each is escaped once, and neither
+		// escape is fed back through the other.
+		{"a backslash then a quote", `/Users/me/a\"b/deja`, `ExecStart="/Users/me/a\\\"b/deja" sync`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			unit := syncAutoService(tc.exe)
+			if !strings.Contains(unit, tc.want) {
+				t.Fatalf("want the line\n  %s\nin\n%s", tc.want, unit)
+			}
+		})
+	}
+}
+
+// The timer file names no path, so it has nothing to escape; this only pins
+// that the two files stay in step if one of them grows one.
+func TestSyncTimerFilesNameTheSameUnit(t *testing.T) {
+	if !strings.Contains(syncAutoTimer(), "[Timer]") || strings.Contains(syncAutoTimer(), "ExecStart") {
+		t.Fatalf("the timer file changed shape:\n%s", syncAutoTimer())
+	}
+}


### PR DESCRIPTION
Fixes #2621.

The plist escapes the binary path; the unit file wrote it raw. A path holding `%` (a specifier), `$` (a variable), `\` (a C escape) or `"` (ends the quoted word) ran something other than what deja installed, or did not parse.

Nine exotic paths through the plist writer lint clean under `plutil -lint`; four of the same nine produced a broken unit. There is no systemd on the machine this was found on, so the escaped text is pinned by test rather than executed.
