### PR TITLE
fix(how): say when every recorded run of a command failed

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -49,6 +49,40 @@ type howEntry struct {
 	Runs     int
 	Sessions map[string]bool
 	Last     time.Time
+	// Outcomes is the number of runs a source recorded an exit status for —
+	// on a real store about one in a hundred — and Failures how many of those
+	// were not zero. Both, because "every run failed" is only true when deja
+	// knows what every run did.
+	Outcomes  int
+	Failures  int
+	ExitCode  int
+	MixedExit bool
+}
+
+// failedEveryTime reports whether deja knows the outcome of every run of this
+// command and every one of them failed. A command that sometimes fails is
+// ordinary; a command deja has no outcome for is most of the store.
+func (e howEntry) failedEveryTime() bool {
+	return e.Outcomes > 0 && e.Outcomes == e.Runs && e.Failures == e.Outcomes
+}
+
+// failureNote is what the count line says about a command that never once
+// worked here. `how` answers "how do I run this here", so offering such a
+// command in the shape of one that has always worked is the sharpest miss the
+// screen can make (#2624). It is not a ranking signal: one command record in a
+// hundred carries an outcome at all, so ordering on it would be arbitrary.
+func (e howEntry) failureNote() string {
+	if !e.failedEveryTime() {
+		return ""
+	}
+	what := "every run recorded here failed"
+	if e.Runs == 1 {
+		what = "the one run recorded here failed"
+	}
+	if e.MixedExit {
+		return " · " + what
+	}
+	return fmt.Sprintf(" · %s (exit %d)", what, e.ExitCode)
 }
 
 func runHow(dir string, args []string, stdout io.Writer) error {
@@ -116,8 +150,8 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 			when = " · last " + e.Last.Local().Format("2006-01-02")
 		}
 		fmt.Fprintf(stdout, "%s\n", search.SafeCommand(e.Command))
-		fmt.Fprintf(stdout, "  ran %s in %s%s\n",
-			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
+		fmt.Fprintf(stdout, "  ran %s in %s%s%s\n",
+			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when, e.failureNote())
 	}
 	// The cap said nothing, so eight of thirteen ways to run the tests read as
 	// thirteen — the misread the search screen already avoids (#1632). On
@@ -156,7 +190,8 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		// Without the outcome codex and opencode append: "$ make test  → exit
 		// 2" is the same command as "$ make test", and counting them apart put
 		// one command on two rows of this screen (#2590).
-		cmd := index.CommandWithoutExitStatus(strings.TrimSpace(firstCommandLine(r.Text)))
+		line := strings.TrimSpace(firstCommandLine(r.Text))
+		cmd := index.CommandWithoutExitStatus(line)
 		if cmd == "" || len(cmd) > howCommandMax {
 			return
 		}
@@ -172,6 +207,16 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 			byCmd[low] = e
 		}
 		e.Runs++
+		if code, ok := index.CommandExitStatus(line); ok {
+			e.Outcomes++
+			if code != 0 {
+				if e.Failures > 0 && code != e.ExitCode {
+					e.MixedExit = true
+				}
+				e.ExitCode = code
+				e.Failures++
+			}
+		}
 		e.Sessions[r.Key] = true
 		if r.Time.After(e.Last) {
 			e.Last = r.Time

--- a/cmd/deja/how_failed_test.go
+++ b/cmd/deja/how_failed_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// writeHowRuns writes one session per command text, so each run counts as a
+// separate session the way `how` weighs them.
+func writeHowRuns(t *testing.T, texts []string) {
+	t.Helper()
+	at := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	dir := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-w-app")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, text := range texts {
+		id := "s" + string(rune('1'+i))
+		body := `{"type":"user","sessionId":"` + id + `","cwd":"/w/app","timestamp":"` +
+			at.Add(time.Duration(i)*time.Hour).Format(time.RFC3339) +
+			`","message":{"role":"user","content":[{"type":"tool_use","name":"Bash","input":{"command":"` +
+			text + `"}}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// `deja how` strips the outcome codex and opencode append so one command is
+// one row (#2590), and then looked at it no further: a command whose every
+// recorded run on this machine failed was offered as the way it is done here,
+// in the same shape as one that has always worked (#2624).
+func TestHowSaysWhenEveryRecordedRunFailed(t *testing.T) {
+	hermeticEnv(t)
+	writeHowRuns(t, []string{"npm run build  → exit 127", "npm run build  → exit 127"})
+	out, err := captureRun(t, "how", "npm run build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "2 sessions") {
+		t.Fatalf("the two runs are no longer one command:\n%s", out)
+	}
+	if !strings.Contains(out, "every run recorded here failed (exit 127)") {
+		t.Fatalf("nothing on the line says the command never once worked:\n%s", out)
+	}
+}
+
+// A command that sometimes fails is ordinary, and a command deja has no
+// outcome for is most of the store: neither earns the line.
+func TestHowStaysQuietWhenTheHistoryIsNotAllFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		texts []string
+	}{
+		{"mixed outcomes", []string{"npm run build  → exit 127", "npm run build  → exit 0"}},
+		{"one run has no outcome", []string{"npm run build  → exit 127", "npm run build"}},
+		{"no outcome at all", []string{"npm run build", "npm run build"}},
+		{"every run worked", []string{"npm run build  → exit 0", "npm run build  → exit 0"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hermeticEnv(t)
+			writeHowRuns(t, tc.texts)
+			out, err := captureRun(t, "how", "npm run build")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(out, "failed") {
+				t.Fatalf("the line claims a failing history it does not have:\n%s", out)
+			}
+		})
+	}
+}
+
+// The same note over MCP: the agent reading that answer is the one most likely
+// to run the command straight back (#2624).
+func TestMCPHowSaysWhenEveryRecordedRunFailed(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-h")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	for _, id := range []string{"h1", "h2"} {
+		body := `{"type":"assistant","sessionId":"` + id + `","cwd":"/w/h","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"npm run build  \u2192 exit 127"}}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got, err := callMCPTool(dir, "how", json.RawMessage(`{"what":"npm run build"}`))
+	if err != nil {
+		t.Fatalf("how: %v", err)
+	}
+	if !strings.Contains(got, "every run recorded here failed (exit 127)") {
+		t.Fatalf("the agent is not told the command never once worked:\n%s", got)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -472,7 +472,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if !e.Last.IsZero() {
 				when = ", last " + e.Last.Local().Format("2006-01-02")
 			}
-			fmt.Fprintf(&hb, "%s\n  ran %s in %s%s\n", commandListingLine(e.Command), pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when)
+			// The same note the CLI prints: the agent reading this is the
+			// one most likely to run the command back without looking.
+			fmt.Fprintf(&hb, "%s\n  ran %s in %s%s%s\n", commandListingLine(e.Command), pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when, e.failureNote())
 		}
 		return strings.TrimRight(hb.String(), "\n"), nil
 	case "remember":

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -409,6 +409,28 @@ const commandExitMarker = "  → exit "
 // the record log and split the same command the same way.
 func CommandWithoutExitStatus(s string) string { return withoutExitStatus(s) }
 
+// CommandExitStatus reads the outcome withoutExitStatus strips, for the
+// surfaces that group commands themselves and then have to say what those runs
+// did. The same strict shape: two spaces, the marker, digits to the end.
+func CommandExitStatus(s string) (int, bool) {
+	i := strings.LastIndex(s, commandExitMarker)
+	if i < 0 {
+		return 0, false
+	}
+	code := s[i+len(commandExitMarker):]
+	if code == "" {
+		return 0, false
+	}
+	n := 0
+	for _, r := range code {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n, true
+}
+
 // firstTextLine is the first line of a record, which for a command record is
 // the invocation itself.
 func firstTextLine(s string) string {


### PR DESCRIPTION
Fixes #2624.

`how` strips the `→ exit N` suffix so one command is one row (#2590), then never looked at it. On a 1,565-session store 124 distinct commands have a recorded outcome for every run and every one of them failed — printed exactly like a command that has always worked.

Now the count line says so, on the CLI and over MCP:

    $ npm run build
      ran twice in 2 sessions · last 2026-08-01 · every run recorded here failed (exit 127)

Only when deja knows the outcome of every run and all of them are non-zero. Mixed history and the 99% of records with no outcome at all are unchanged, and nothing about ranking moves.
