### PR TITLE
fix(doctor): say what the store said when it refused

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -426,7 +426,15 @@ func printDoctorStoreWarnings(w io.Writer, stores []doctorStore) {
 			// The store is there and deja cannot read it — usually a harness
 			// that changed its format. Silence here reads as "you have no
 			// history with that agent".
-			fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
+			// With the reason. "Please report it" and nothing to report is how
+			// #1642 arrived: a store deja refused, and no way for its owner or
+			// for us to tell which refusal it was.
+			if store.Error != "" {
+				fmt.Fprintf(w, "  warning      %s store cannot be read — %s; please report it\n",
+					store.Name, store.Error)
+			} else {
+				fmt.Fprintf(w, "  warning      %s store cannot be read — its format may have changed; please report it\n", store.Name)
+			}
 		case "denied":
 			// Not a format change and not an empty history: deja is not
 			// allowed to read the files. On macOS this is usually Full Disk

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -41,6 +41,12 @@ type doctorStore struct {
 	// Skipped is why part of the store could not be read at all — a missing
 	// sqlite3 or zstd CLI. The text row has carried it in its detail; a reader
 	// of --json saw a state and no reason (#1758).
+	// Error is what the parser said when it refused the store. Without it the
+	// report told a person their format may have changed and asked them to
+	// report it, and the report they could send carried no more than the word
+	// "unreadable" — neither they nor we could tell a renamed column from a
+	// locked database from a missing CLI (#1642).
+	Error     string `json:"error,omitempty"`
 	Denied    string `json:"denied,omitempty"`
 	Skipped   string `json:"skipped,omitempty"`
 	Partial   bool   `json:"partial,omitempty"`
@@ -634,6 +640,10 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	// showed up here as a healthy store while its recall was empty.
 	if parseErr != nil {
 		store.State = "unreadable"
+		// Bounded: a sqlite3 error can quote the query, and the query is a
+		// screenful. The head of it names the cause — a missing column, a
+		// locked database, a file that is not a database at all.
+		store.Error = boundedStoreError(parseErr.Error())
 		return store, mod
 	}
 	// A session someone opened and closed without typing parses to nothing,
@@ -795,4 +805,20 @@ func doctorProbeOpencode(db string) ([]model.Session, error) {
 	// time, so sqlite sorts the whole join before it can take the first row.
 	// Narrowing to the newest session first is what makes this cheap.
 	return sources.ParseOpencodeNewest(db)
+}
+
+// storeErrorMax is how much of a parser's complaint the report carries. Long
+// enough for the sentence sqlite3 leads with, short enough that a quoted query
+// does not become the report.
+const storeErrorMax = 300
+
+func boundedStoreError(msg string) string {
+	msg = strings.TrimSpace(msg)
+	if i := strings.IndexAny(msg, "\r\n"); i >= 0 {
+		msg = strings.TrimSpace(msg[:i])
+	}
+	if len(msg) > storeErrorMax {
+		msg = strings.TrimSpace(msg[:storeErrorMax]) + "…"
+	}
+	return msg
 }

--- a/cmd/deja/doctor_store_error_test.go
+++ b/cmd/deja/doctor_store_error_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A store deja refuses is the loudest thing doctor can learn, and it used to
+// arrive as one word. #1642 is what that costs: a person with an opencode
+// database deja would not read, told their format may have changed and asked to
+// report it, and nothing in the report said which refusal it was — a renamed
+// column, a locked database, or a file that is not a database at all.
+func TestDoctorSaysWhyAStoreWouldNotRead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	db := filepath.Join(tmp, "opencode.db")
+	// Not a database. Any refusal will do: what is pinned is that the reason
+	// reaches the reader, not which reason it was.
+	if err := os.WriteFile(db, []byte("this is not a sqlite file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCODE_DB", db)
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, nil, stubLookup("2.0.0", false), t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "opencode store cannot be read") {
+		t.Skipf("this machine's opencode row did not reach the warning:\n%s", got)
+	}
+	if strings.Contains(got, "its format may have changed") {
+		t.Errorf("the warning still says nothing about the refusal:\n%s", got)
+	}
+}
+
+// The reason is bounded and one line: sqlite3 quotes the query it failed on,
+// and that query is a screenful.
+func TestAStoreErrorIsOneBoundedLine(t *testing.T) {
+	long := "near \"select\": syntax error " + strings.Repeat("select s.id, ", 80)
+	got := boundedStoreError(long + "\nwhile preparing the statement")
+	if strings.ContainsAny(got, "\r\n") {
+		t.Errorf("the reason spans lines: %q", got)
+	}
+	if len(got) > storeErrorMax+3 {
+		t.Errorf("the reason is %d bytes; the bound is %d", len(got), storeErrorMax)
+	}
+	if !strings.HasPrefix(got, "near \"select\": syntax error") {
+		t.Errorf("the head of the message, the part that names the cause, was cut: %q", got)
+	}
+}

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -136,6 +137,11 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		` or (instr(substr(p.data,1,200),'"tool":"apply_patch"')>0 ` +
 		`and json_extract(p.data,'$.tool')='apply_patch'))` + where + ` order by s.id,m.time_created,p.id` + lim
 	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	// What sqlite3 says when it refuses, not merely that it did. "exit status
+	// 1" is what a person was asked to report, and it names neither a renamed
+	// column nor a locked database nor a file that is not a database (#1642).
+	var whyNot bytes.Buffer
+	cmd.Stderr = &whyNot
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -155,7 +161,8 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 			// a whole harness disappear from recall while doctor still calls
 			// the store healthy.
 			if waitErr != nil {
-				return nil, fmt.Errorf("opencode: query failed, the store schema may have changed: %w", waitErr)
+				return nil, fmt.Errorf("opencode: query failed, the store schema may have changed: %w",
+					withStderr(waitErr, &whyNot))
 			}
 			return nil, nil
 		}
@@ -312,9 +319,16 @@ func ParseOpencodeNewest(db string) ([]model.Session, error) {
 	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
 		return nil, nil
 	}
-	out, err := exec.Command("sqlite3", "-readonly", db, ".timeout 5000", "select id from session order by time_created desc limit 1").Output()
+	probe := exec.Command("sqlite3", "-readonly", db, ".timeout 5000",
+		"select id from session order by time_created desc limit 1")
+	var whyNot bytes.Buffer
+	probe.Stderr = &whyNot
+	out, err := probe.Output()
 	if err != nil {
-		return nil, err
+		// This is the first thing doctor runs against the store, so it is the
+		// one whose complaint a person is shown. "exit status 1" named nothing
+		// (#1642).
+		return nil, withStderr(err, &whyNot)
 	}
 	id := strings.TrimSpace(string(out))
 	if id == "" {
@@ -392,4 +406,24 @@ func exitCode(v any) int {
 		return i
 	}
 	return 0
+}
+
+// sqliteStderrMax bounds what a failing sqlite3 is quoted saying. Its first
+// line names the cause; the rest is the query it was handed, which is a
+// screenful and says nothing a reader does not already have.
+const sqliteStderrMax = 200
+
+// withStderr turns "exit status 1" into what the tool actually said.
+func withStderr(err error, buf *bytes.Buffer) error {
+	msg := strings.TrimSpace(buf.String())
+	if msg == "" {
+		return err
+	}
+	if i := strings.IndexAny(msg, "\r\n"); i >= 0 {
+		msg = strings.TrimSpace(msg[:i])
+	}
+	if len(msg) > sqliteStderrMax {
+		msg = strings.TrimSpace(msg[:sqliteStderrMax]) + "…"
+	}
+	return fmt.Errorf("%s (%w)", msg, err)
 }

--- a/internal/sources/opencode_stderr_test.go
+++ b/internal/sources/opencode_stderr_test.go
@@ -1,0 +1,69 @@
+package sources
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// What sqlite3 says when it refuses, not merely that it did. A person whose
+// store deja would not read was told "its format may have changed; please
+// report it", and the report they could send said `exit status 1` — which names
+// neither a renamed column nor a locked database nor a file that is not a
+// database at all (#1642).
+func TestAStoreRefusalCarriesWhatSqliteSaid(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("no sqlite3")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	// A real database missing the column the first probe reads, which is the
+	// shape a schema change arrives in.
+	mk := exec.Command("sqlite3", db, "create table session(id text, directory text);")
+	if out, err := mk.CombinedOutput(); err != nil {
+		t.Fatalf("could not build the fixture: %v: %s", err, out)
+	}
+
+	_, err := ParseOpencodeNewest(db)
+	if err == nil {
+		t.Fatal("a store with no time_created column parsed without complaint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no such column") {
+		t.Errorf("the refusal does not say what sqlite3 said: %q", msg)
+	}
+	if msg == "exit status 1" {
+		t.Errorf("the reason is still the exit code alone: %q", msg)
+	}
+}
+
+// The quoted complaint is one line and bounded: sqlite3 echoes the statement it
+// failed on, and that statement is a screenful.
+func TestTheQuotedComplaintIsBounded(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString("Error: in prepare, no such column: time_created " +
+		strings.Repeat("select s.id, ", 60) + "\nsecond line")
+	got := withStderr(errors.New("exit status 1"), &buf).Error()
+	if strings.ContainsAny(got, "\r\n") {
+		t.Errorf("the reason spans lines: %q", got)
+	}
+	if len(got) > sqliteStderrMax+40 {
+		t.Errorf("the reason is %d bytes, the bound is %d", len(got), sqliteStderrMax)
+	}
+	if !strings.HasPrefix(got, "Error: in prepare, no such column: time_created") {
+		t.Errorf("the head, which names the cause, was cut: %q", got)
+	}
+}
+
+// Nothing on stderr means nothing to add: the caller keeps the error it had.
+func TestASilentFailureKeepsItsOwnError(t *testing.T) {
+	var empty bytes.Buffer
+	want := errors.New("exit status 1")
+	if got := withStderr(want, &empty); got != want {
+		t.Errorf("a silent failure was rewritten: %v", got)
+	}
+	_ = os.Stdout
+}


### PR DESCRIPTION
From #1642. Someone's opencode database would not read, and what deja told them was:

    warning  opencode store cannot be read — its format may have changed; please report it

They reported it, carefully — schema, row counts, column lists, versions — and the report could not contain the one thing that decides it, because deja never had it either. The parse error was computed and dropped, and the parser it came from returned `exit status 1` without asking sqlite3 what went wrong.

Both halves are fixed. sqlite3's stderr is captured on the two calls that read the store, and the reason travels into the report:

    warning  opencode store cannot be read — Error: in prepare, no such column: time_created (exit status 1); please report it

Verified by breaking a copy of a real 3.2 GB store — renaming `session.time_created` — rather than by reasoning about it. The healthy store is unchanged: found, 1431 indexed sessions.

The reason is bounded to one line: sqlite3 echoes the statement it failed on, and that statement is a screenful. `doctor --json` carries it as `error` on the store.

This does not fix #1642 — it is what makes fixing it possible. The next report says which refusal it was.