### PR TITLE
fix(index): say when a record walk straddled a rebuild

### DIFF
--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -1032,6 +1032,70 @@ func HasRecordOfRole(dir, role string) bool {
 	return found
 }
 
+// betweenManifestAndRecords is the swap window, exposed so it can be entered
+// on purpose. Racing a rebuild to reach it took 27,531 reads and hit it zero
+// times; the window is real either way, and a test that cannot enter it pins
+// nothing (#2627). nil outside tests.
+var betweenManifestAndRecords func()
+
+// manifestStamp identifies the generation of the store on disk. mtime and size
+// rather than Manifest.Generation: it is the pair readManifestCached already
+// keys its cache on, it needs no decode, and it changes on any rewrite.
+func manifestStamp(dir string) string {
+	fi, err := os.Stat(filepath.Join(dir, "manifest.gob"))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%d/%d", fi.ModTime().UnixNano(), fi.Size())
+}
+
+// walkRecordsStable runs a record walk and reports whether it read one
+// generation of the store.
+//
+// A reader takes the manifest, then opens records.bin by path and resolves
+// every record's key through the manifest it read. swapIndexDir can land
+// between those two steps; swap_window.go covers the ENOENT that produces, but
+// not this — a manifest from one generation against records from the next
+// resolves only the sessions both hold. Measured on a 20-session store rebuilt
+// to 60, the walk returned 20 records, no error, and nothing to tell the
+// caller. This walk feeds `deja how`, restore's inventory and the "no record of
+// that role" note, where a short answer reads as "this machine never did that"
+// (#2627).
+//
+// Reported rather than retried: the caller has already been handed the records
+// of the first pass, so walking again would hand it the store twice. Saying the
+// read straddled a rebuild lets the caller ask again, which is the only safe
+// version of the same idea.
+//
+// An incremental append is not that. It continues the interning table it found
+// (appendIncremental takes tablesFromManifest(old)) and carries the manifest
+// forward unchanged but for the new files, so the old manifest stays true of
+// the log it was written against and a record for a session it does not know
+// is skipped. That rewrites manifest.gob without being a straddle, which is why
+// the generation decides rather than the stamp: a full build stamps a new one,
+// an append keeps the old.
+func walkRecordsStable(dir string, walk func(m Manifest) error) error {
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return err
+	}
+	before := manifestStamp(dir)
+	if betweenManifestAndRecords != nil {
+		betweenManifestAndRecords()
+	}
+	if err := walk(m); err != nil {
+		return err
+	}
+	if manifestStamp(dir) == before {
+		return nil
+	}
+	after, err := readManifestCached(dir)
+	if err != nil || after.Generation == m.Generation {
+		return nil
+	}
+	return errors.New("the index was rebuilt while this read was in flight — run it again")
+}
+
 // EachRecordOfRole streams every record of one role with the session it came
 // from. Ranked retrieval is the wrong instrument when the caller has an exact
 // key and needs every match rather than the best ones — restore is that case
@@ -1040,17 +1104,15 @@ func EachRecordOfRole(dir, role string, fn func(SessionMeta, Record)) error {
 	if dir == "" {
 		dir = DefaultDir()
 	}
-	m, err := readManifestCached(dir)
-	if err != nil {
-		return err
-	}
-	return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
-		if r.Role != role {
-			return
-		}
-		if meta, ok := m.Sessions[r.Key]; ok {
-			fn(meta, r)
-		}
+	return walkRecordsStable(dir, func(m Manifest) error {
+		return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
+			if r.Role != role {
+				return
+			}
+			if meta, ok := m.Sessions[r.Key]; ok {
+				fn(meta, r)
+			}
+		})
 	})
 }
 

--- a/internal/index/walk_stable_test.go
+++ b/internal/index/walk_stable_test.go
@@ -1,0 +1,138 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// straddleStore writes sessions whose commands share no vocabulary between
+// calls, so a rebuild interns a different table.
+func straddleStore(t *testing.T, home string) (dir string, write func(prefix, cmd string, n int)) {
+	t.Helper()
+	root := filepath.Join(home, "claude")
+	setHome(t, home)
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	write = func(prefix, cmd string, n int) {
+		t.Helper()
+		for i := 0; i < n; i++ {
+			id := fmt.Sprintf("%s%d", prefix, i)
+			p := filepath.Join(root, "proj", id+".jsonl")
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := `{"type":"assistant","sessionId":"` + id + `","cwd":"/w/p","timestamp":"2026-07-01T10:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` +
+				fmt.Sprintf(cmd, i) + `"}}]}}` + "\n"
+			if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	return filepath.Join(home, "index.db"), write
+}
+
+// A reader takes the manifest, then opens records.bin by path. swap_window.go
+// absorbs the ENOENT a swap produces; nothing covered the straddle — a manifest
+// from one generation against records from the next resolves only the sessions
+// both hold, and answered a third of the store with no error and nothing to
+// tell the caller (#2627).
+func TestARecordWalkSaysWhenItStraddledARebuild(t *testing.T) {
+	home := t.TempDir()
+	dir, write := straddleStore(t, home)
+	write("s", "go test ./alpha%d -run Beta%d", 20)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The rebuild lands between the manifest read and the record walk, which
+	// is the window itself rather than a race against it.
+	done := false
+	betweenManifestAndRecords = func() {
+		if done {
+			return
+		}
+		done = true
+		write("t", "cargo build --features gamma%d", 40)
+		if err := Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() { betweenManifestAndRecords = nil }()
+
+	n := 0
+	err := EachRecordOfRole(dir, "command", func(SessionMeta, Record) { n++ })
+	if err == nil {
+		t.Fatalf("a walk across two generations reported success with %d of 60 records", n)
+	}
+	if !strings.Contains(err.Error(), "rebuilt") {
+		t.Fatalf("the error does not say what happened: %v", err)
+	}
+}
+
+// A store nobody is rebuilding answers as it always did.
+func TestARecordWalkOfAQuietStoreIsUnchanged(t *testing.T) {
+	home := t.TempDir()
+	dir, write := straddleStore(t, home)
+	write("s", "go test ./alpha%d -run Beta%d", 20)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	if err := EachRecordOfRole(dir, "command", func(SessionMeta, Record) { n++ }); err != nil {
+		t.Fatalf("a quiet store answered with an error: %v", err)
+	}
+	if n != 20 {
+		t.Fatalf("the store holds 20 command records, the walk found %d", n)
+	}
+}
+
+// An append is not a straddle. appendIncremental continues the interning table
+// it found and carries the manifest forward, generation included, so the
+// manifest read before it stays true of the log. Erroring here would make every
+// hook that reads while a session is still being written give up for nothing.
+func TestARecordWalkAcceptsAnAppendUnderIt(t *testing.T) {
+	home := t.TempDir()
+	dir, write := straddleStore(t, home)
+	write("s", "go test ./alpha%d -run Beta%d", 20)
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// A session that grew, not a new one: a new file is a full build, and the
+	// incremental path is the one a live session takes.
+	grow := filepath.Join(home, "claude", "proj", "s0.jsonl")
+	done := false
+	betweenManifestAndRecords = func() {
+		if done {
+			return
+		}
+		done = true
+		f, err := os.OpenFile(grow, os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"assistant","sessionId":"s0","cwd":"/w/p","timestamp":"2026-07-01T10:05:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./alpha0 -run Beta7"}}]}}` + "\n"
+		if _, err := f.WriteString(line); err != nil {
+			t.Fatal(err)
+		}
+		_ = f.Close()
+		if err := Ensure(dir, "", false, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() { betweenManifestAndRecords = nil }()
+
+	before, _ := readManifest(dir)
+	n := 0
+	err := EachRecordOfRole(dir, "command", func(SessionMeta, Record) { n++ })
+	after, _ := readManifest(dir)
+	if before.Generation != after.Generation {
+		t.Skip("this store rebuilt rather than appended; the append path is what this pins")
+	}
+	if err != nil {
+		t.Fatalf("an append under the walk was reported as a rebuild: %v", err)
+	}
+	if n < 20 {
+		t.Fatalf("the walk lost records it had before the append: %d of at least 20", n)
+	}
+}


### PR DESCRIPTION
Fixes #2627.

A record walk reads the manifest, then opens `records.bin` by path. `swap_window.go` covers the ENOENT a swap produces — 27,531 reads against 143 real swaps came back clean — but not the straddle: a manifest from one generation against records from the next resolves only the sessions both hold. Forced on a 20-session store rebuilt to 60, the walk returned 20 records and a nil error.

Now the walk stamps `manifest.gob` and checks it afterwards. An incremental append is not a straddle — it continues the interning table it found and carries the generation forward — so the generation decides, and only a rebuild is reported.

The window is entered on purpose in the tests rather than raced for; racing it took 27k reads to hit zero times.
