### PR TITLE
fix(sync): send the export in batches scp can accept

### DIFF
--- a/cmd/deja/sync_scp_chunks_test.go
+++ b/cmd/deja/sync_scp_chunks_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Export writes a file per source transcript, so a machine with tens of
+// thousands of records hands scp thousands of paths. Windows refuses a command
+// line over 32,767 characters outright — and it refuses it after the export has
+// run, which is the worst moment to find out (#2002).
+func TestScpSplitsPathsUnderTheCommandLineBound(t *testing.T) {
+	var paths []string
+	for i := 0; i < 23336; i++ {
+		paths = append(paths, fmt.Sprintf(`C:\Users\someone\AppData\Local\Temp\deja-sync-9f3a12bc-17761031960%05d.jsonl`, i))
+	}
+	budget := sshArgsBudget([]string{"-o", "BatchMode=yes"}, "root@example.com", "/tmp/deja-sync-XXXX")
+	chunks := scpChunks(paths, budget)
+	if len(chunks) < 2 {
+		t.Fatalf("23336 paths went out in %d command line(s)", len(chunks))
+	}
+	seen := 0
+	for i, chunk := range chunks {
+		seen += len(chunk)
+		if n := len(strings.Join(chunk, " ")); n > budget {
+			t.Errorf("chunk %d is %d characters, the budget is %d", i, n, budget)
+		}
+		if len(chunk) == 0 {
+			t.Errorf("chunk %d is empty", i)
+		}
+	}
+	if seen != len(paths) {
+		t.Errorf("sent %d paths of %d — the rest would never reach the peer", seen, len(paths))
+	}
+}
+
+// One path longer than the whole budget still goes: refusing to send it is
+// worse than letting the platform complain about that one file.
+func TestAPathBiggerThanTheBudgetStillGoes(t *testing.T) {
+	long := strings.Repeat("x", 40000) + ".jsonl"
+	chunks := scpChunks([]string{long, "b.jsonl"}, 1000)
+	if len(chunks) != 2 {
+		t.Fatalf("chunks = %d, want the long path on its own and the short one after", len(chunks))
+	}
+	if chunks[0][0] != long {
+		t.Error("the long path was dropped")
+	}
+}
+
+// The budget counts what the flags and the destination already spend, so a long
+// host or a long remote directory cannot push the line over on its own.
+func TestTheBudgetLeavesRoomForFlagsAndDestination(t *testing.T) {
+	plain := sshArgsBudget(nil, "h", "/tmp/x")
+	loaded := sshArgsBudget([]string{"-o", strings.Repeat("K", 400)}, strings.Repeat("h", 200), strings.Repeat("/d", 100))
+	if loaded >= plain {
+		t.Errorf("a heavier fixed part left as much room for paths: %d vs %d", loaded, plain)
+	}
+	if loaded < 512 {
+		t.Errorf("budget collapsed to %d; one path at a time is the floor", loaded)
+	}
+}

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -203,10 +203,17 @@ func syncSSHPush(dir, host string, full bool) error {
 	if err != nil {
 		return err
 	}
-	scpArgs := append(append(sshOpts(), "-q"), batches...)
-	scpArgs = append(scpArgs, host+":"+rtmp+"/")
-	if out, err := sshRunner("scp", scpArgs...); err != nil {
-		return fmt.Errorf("scp: %v: %s", err, remoteOutputForEcho(out))
+	// One scp per batch of paths, not one for all of them. Export writes a file
+	// per source transcript, so a machine with tens of thousands of records
+	// hands scp thousands of paths — and Windows refuses a command line over
+	// 32,767 characters with "The filename or extension is too long", after the
+	// export has already run (#2002).
+	for _, chunk := range scpChunks(batches, sshArgsBudget(sshOpts(), host, rtmp)) {
+		scpArgs := append(append(sshOpts(), "-q"), chunk...)
+		scpArgs = append(scpArgs, host+":"+rtmp+"/")
+		if out, err := sshRunner("scp", scpArgs...); err != nil {
+			return fmt.Errorf("scp: %v: %s", err, remoteOutputForEcho(out))
+		}
 	}
 	remote := fmt.Sprintf(`d=$(command -v deja || echo "$HOME/.local/bin/deja"); "$d" sync import %s; rc=$?; rm -rf %s; exit $rc`,
 		shellQuote(rtmp), shellQuote(rtmp))
@@ -331,3 +338,49 @@ func sshCountLine(verb string, n int) string {
 }
 
 func sshExportedLine(n int) string { return sshCountLine("exported", n) }
+
+// scpCommandLineMax is the bound a single scp invocation's paths must stay
+// under. Windows refuses a command line over 32,767 characters outright; the
+// margin below it leaves room for the flags, the destination, and the quoting
+// the shim adds. Unix allows far more, and one bound for both keeps the
+// batching identical everywhere — the failure this exists for was reported
+// after an export had already finished, which is the worst moment to find out.
+const scpCommandLineMax = 24000
+
+// sshArgsBudget is what is left for paths once the fixed part of the command
+// line is counted.
+func sshArgsBudget(opts []string, host, rtmp string) int {
+	fixed := len("scp") + len(" -q ") + len(host) + len(rtmp) + 4
+	for _, o := range opts {
+		fixed += len(o) + 1
+	}
+	budget := scpCommandLineMax - fixed
+	if budget < 512 {
+		// A pathological set of options should still move one file at a time
+		// rather than produce an empty chunk and loop forever.
+		budget = 512
+	}
+	return budget
+}
+
+// scpChunks splits paths into groups whose command line stays inside budget.
+// A single path longer than the budget still gets its own chunk: refusing to
+// send it would be worse than letting the platform complain about that one.
+func scpChunks(paths []string, budget int) [][]string {
+	var out [][]string
+	var cur []string
+	n := 0
+	for _, p := range paths {
+		cost := len(p) + 1
+		if len(cur) > 0 && n+cost > budget {
+			out = append(out, cur)
+			cur, n = nil, 0
+		}
+		cur = append(cur, p)
+		n += cost
+	}
+	if len(cur) > 0 {
+		out = append(out, cur)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #2002.

@huxiaoning read the failure correctly from the message alone: `fork/exec scp.exe: The filename or extension is too long` is Windows refusing a command line over 32,767 characters, and deja was passing every exported file as an argument to one `scp`.

The reason there are so many: export writes one file per *source transcript* (`internal/index/sync.go:180`, keyed on `r.SourcePath`), not one per harness. 23,336 records across thousands of transcripts is thousands of paths on one line.

Now the paths go out in chunks that stay inside a bound, with the flags, the host and the remote directory counted against it — a long host name cannot push the line over on its own. A single path longer than the whole budget still goes in a chunk of its own: refusing to send it would be worse than letting the platform complain about that one file.

24,000 characters rather than the full 32,767: the margin covers the quoting a shim adds, and one bound everywhere keeps the batching identical on every platform. This failure arrives *after* the export has run, which is the worst moment to discover a difference.

Tested on the splitter directly — 23,336 Windows-shaped paths, every chunk inside the budget, every path accounted for — since the failure itself needs a machine I do not have. @huxiaoning, if you are willing to run `deja sync ssh` from that store once this is in, that would close the loop properly.