### PR TITLE
fix(recall): apply the ignore rule where the record log is read

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -162,6 +162,12 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			// thing, and stdout is what a redirect keeps (#2319).
 			fmt.Fprintf(stdout, "nothing recurring — the trust policy withheld the %d session%s that recorded tool output, which is what friction reads errors from\n",
 				len(withheldSessions), pluralS(len(withheldSessions)))
+		case len(sessions) == 0 && len(ignoredSessions) > 0:
+			// The same claim about the store rather than about the rule, for
+			// the other rule: the sessions with the tool output are there and
+			// the ignore rule is what keeps them out (#2630).
+			fmt.Fprintf(stdout, "nothing recurring — the ignore rule keeps the %d session%s that recorded tool output out of recall, which is what friction reads errors from\n",
+				len(ignoredSessions), pluralS(len(ignoredSessions)))
 		case len(sessions) == 0:
 			fmt.Fprintf(stdout, "nothing recurring — none of the %d indexed session%s recorded tool output, which is what friction reads errors from\n",
 				total, pluralS(total))

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -69,12 +69,21 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	// counting the callback's firings reported one hidden session with ten
 	// error lines as ten (#1639).
 	withheldSessions := map[string]bool{}
+	// And the rule that keeps a tree out of recall altogether. friction reads
+	// the record log rather than ranking, so it never passed through the place
+	// the rule is applied and read the ignored tree's errors as this machine's
+	// own (#2630).
+	ignoredSessions := map[string]bool{}
 	// One pass over the record log rather than a load per session: loading by
 	// identity walks the whole log each time, which put this command at 2m46s
 	// on a 1150-session store.
 	if err := index.EachToolOutput(dir, func(meta index.SessionMeta, r index.Record) {
 		if !pol.Allows(policy.ActivationSearch, meta.Project) {
 			withheldSessions[meta.Harness+":"+meta.ID] = true
+			return
+		}
+		if pol.Ignored(meta.Path, meta.Project) {
+			ignoredSessions[meta.Harness+":"+meta.ID] = true
 			return
 		}
 		key := meta.Harness + ":" + meta.ID
@@ -101,6 +110,9 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	}
 	if note := policyHiddenNote(policy.ActivationSearch, len(withheldSessions)); note != "" {
 		fmt.Fprintln(os.Stderr, note)
+	}
+	if note := ignoredHiddenNoteFor("answer", len(ignoredSessions)); note != "" {
+		fmt.Fprint(os.Stderr, note)
 	}
 
 	type row struct {

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -129,9 +129,12 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)
 	}
-	entries, hidden, err := howEntries(dir, terms, project, policy.ActivationSearch)
+	entries, hidden, ignored, err := howEntries(dir, terms, project, policy.ActivationSearch)
 	if err != nil {
 		return err
+	}
+	if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
+		fmt.Fprint(os.Stderr, note)
 	}
 	if len(entries) == 0 {
 		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
@@ -175,13 +178,23 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 // The count of what was withheld travels with it, because filtering alone turns
 // a leak into a confident "no command mentions that" over records the policy
 // hid, and an agent told nothing exists invents something.
-func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, error) {
+func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, int, error) {
 	pol := policy.Load()
 	hidden := 0
+	// The other rule that takes sessions out of an answer. It is applied inside
+	// retrieval, and this screen reads the record log instead of ranking, so it
+	// was not applied here at all: a tree the reader asked deja to stay out of
+	// answered "how do I run this here" — and the default rule is the temp tree
+	// a background agent makes for itself (#2630).
+	ignored := map[string]bool{}
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
 		if !pol.Allows(activation, meta.Project) {
 			hidden++
+			return
+		}
+		if pol.Ignored(meta.Path, meta.Project) {
+			ignored[meta.Harness+":"+meta.ID] = true
 			return
 		}
 		if project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(project)) {
@@ -223,7 +236,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 	})
 	if err != nil {
-		return nil, hidden, fmt.Errorf("read: %w", err)
+		return nil, hidden, len(ignored), fmt.Errorf("read: %w", err)
 	}
 	out := make([]howEntry, 0, len(byCmd))
 	for _, e := range byCmd {
@@ -241,7 +254,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 		return out[i].Command < out[j].Command
 	})
-	return out, hidden, nil
+	return out, hidden, len(ignored), nil
 }
 
 func pluralRuns(n int) string {

--- a/cmd/deja/how_policy_test.go
+++ b/cmd/deja/how_policy_test.go
@@ -58,7 +58,7 @@ func TestHowHonoursTheChannelsOwnPolicy(t *testing.T) {
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	entries, _, err := howEntries(dir, []string{"zonkomatic"}, "", policy.ActivationSearch)
+	entries, _, _, err := howEntries(dir, []string{"zonkomatic"}, "", policy.ActivationSearch)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/ignore_record_log_test.go
+++ b/cmd/deja/ignore_record_log_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// ignoredTreeStore builds a store where one project is covered by the reader's
+// ignore rule and holds everything worth finding: the command, the replaced
+// span, the recurring error.
+func ignoredTreeStore(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	if err := os.MkdirAll(filepath.Dir(policy.Path()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(policy.Path(), []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-w-keep", "k1.jsonl"), "k1", []string{
+		`{"type":"user","sessionId":"k1","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"morning notes"}}`,
+	})
+	for _, id := range []string{"s1", "s2", "s3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-scratch", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the widget pipeline keeps stalling"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make widget-pipeline"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:30Z","message":{"role":"user","content":[{"type":"tool_result","content":"make: *** [widget-pipeline] Error 2"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/scratch/widget/pipeline.go","old_string":"before-line","new_string":"after-line"}}]}}`,
+		})
+	}
+}
+
+// The ignore rule is applied inside retrieval, and the surfaces that walk the
+// record log instead of ranking did not apply it at all: `how`, `restore` and
+// `friction` answered out of the tree the reader asked deja to stay out of, and
+// with the default rule that tree is the one a background agent makes for
+// itself (#2630).
+func TestTheRecordLogSurfacesObeyTheIgnoreRule(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		leaks string
+	}{
+		{"how", []string{"how", "make widget"}, "make widget-pipeline"},
+		{"restore", []string{"restore", "/w/scratch/widget/pipeline.go"}, "B replaced"},
+		{"friction", []string{"friction"}, "widget-pipeline"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ignoredTreeStore(t)
+			out, err := captureRun(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			if strings.Contains(out, tc.leaks) {
+				t.Fatalf("the ignored tree answered:\n%s", out)
+			}
+		})
+	}
+}
+
+// And say so, rather than reading as a store that holds nothing: the same line
+// the listing and search already print.
+func TestTheRecordLogSurfacesSayWhatTheIgnoreRuleKeptOut(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"how", []string{"how", "make widget"}},
+		{"friction", []string{"friction"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ignoredTreeStore(t)
+			out, err := captureRunStderr(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			if !strings.Contains(out, "the ignore rule keeps 3 sessions") {
+				t.Fatalf("nothing says the rule took the answer out:\n%s", out)
+			}
+		})
+	}
+}

--- a/cmd/deja/ignore_record_log_test.go
+++ b/cmd/deja/ignore_record_log_test.go
@@ -86,3 +86,17 @@ func TestTheRecordLogSurfacesSayWhatTheIgnoreRuleKeptOut(t *testing.T) {
 		})
 	}
 }
+
+// And the sentence on stdout, which is what a redirect keeps: saying the
+// machine never recorded tool output is a claim about the store when the truth
+// is a claim about the rule (#637, #1044, and now #2630).
+func TestFrictionNamesTheRuleRatherThanTheStore(t *testing.T) {
+	ignoredTreeStore(t)
+	out, err := captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "the ignore rule keeps the 3 sessions that recorded tool output out of recall") {
+		t.Fatalf("stdout blames the store for what the rule did:\n%s", out)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -445,11 +445,17 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
 			return "", err
 		}
-		entries, hidden, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
+		entries, hidden, ignored, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
 		if err != nil {
 			return "", err
 		}
 		if len(entries) == 0 {
+			// The same reasoning one line down, for the other rule: an agent
+			// told nothing exists invents one, and the ignore rule is exactly
+			// the case where something does exist (#2630).
+			if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
+				return strings.TrimSpace(note), nil
+			}
 			// Not a flat negative when the policy is what emptied the answer:
 			// an agent told nothing exists invents one, and here something does
 			// exist. The CLI has said so since the note was written; this

--- a/cmd/deja/restore.go
+++ b/cmd/deja/restore.go
@@ -193,6 +193,14 @@ func findRestoreSpans(dir string, path string) ([]restoreSpan, error) {
 		if !pol.Allows(policy.ActivationSearch, meta.Project) {
 			return
 		}
+		// Same rule, same reason as how and friction: this walks the record log
+		// rather than ranking, so it never reached the place the ignore rule is
+		// applied and offered spans out of a tree deja was asked to skip
+		// (#2630). Silently: restore names files, and a file it cannot restore
+		// is better absent than listed.
+		if pol.Ignored(meta.Path, meta.Project) {
+			return
+		}
 		if len(seen) >= restoreMaxSessions && !seen[meta.Harness+":"+meta.ID] {
 			return
 		}


### PR DESCRIPTION
Fixes #2630.

The ignore rule is applied inside retrieval. `how`, `restore` and `friction` walk the record log instead of ranking, so they never reached it: on a store with `{"ignore":["*scratch*"]}` all three answered entirely out of that tree, while `deja last --role command` on the same store said what it kept out and showed nothing.

The default rule is `*/.claude/jobs/*`, so this reaches machines that never wrote a policy file.

Each now applies the rule, and `how` and `friction` print the line the listing and search already use. `restore` stays silent — it names files, and a file it cannot restore is better absent than listed.
