### PR TITLE
fix(recall): print the ignore rule's line once, and on files and blame

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/termwidth"
 )
@@ -109,6 +110,12 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		// mention it" reads as looked-and-absent, the same misread search and
 		// last already avoid by naming the rule (#686, #680).
 		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
+			fmt.Fprint(stdout, note)
+			return nil
+		}
+		// The same for the rule that keeps a tree out of recall: it took the
+		// answer and left the sentence reading as looked-and-absent (#2632).
+		if note := ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(q))); note != "" {
 			fmt.Fprint(stdout, note)
 			return nil
 		}

--- a/cmd/deja/ignore_note_test.go
+++ b/cmd/deja/ignore_note_test.go
@@ -47,3 +47,17 @@ func TestFilesAndBlameSayWhatTheIgnoreRuleKeptOut(t *testing.T) {
 		})
 	}
 }
+
+// A miss under an active filter takes its own branch and never reaches
+// printNoMatches, so it says the line itself rather than losing it with the
+// guard that stopped the doubling (#2632).
+func TestSearchUnderAFilterStillNamesTheIgnoreRule(t *testing.T) {
+	ignoredTreeStore(t)
+	out, err := captureRunStderr(t, "--project", "keep", "widget pipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(out, "the ignore rule keeps"); n != 1 {
+		t.Fatalf("the line is printed %d times, want once:\n%s", n, out)
+	}
+}

--- a/cmd/deja/ignore_note_test.go
+++ b/cmd/deja/ignore_note_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The miss path prints the line so it lands before "try fewer words", where
+// rewording is the wrong advice; the block after the cap note printed it again,
+// so every search that missed said the same sentence twice (#2632).
+func TestSearchSaysWhatTheIgnoreRuleKeptOutOnce(t *testing.T) {
+	ignoredTreeStore(t)
+	out, err := captureRunStderr(t, "widget pipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(out, "the ignore rule keeps"); n != 1 {
+		t.Fatalf("the line is printed %d times, want once:\n%s", n, out)
+	}
+}
+
+// files and blame apply the rule and said nothing, directly under the policy
+// note that exists for the same misread: the topic did match, a rule withheld
+// it (#686, #680).
+func TestFilesAndBlameSayWhatTheIgnoreRuleKeptOut(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"files", []string{"files", "widget"}},
+		{"blame", []string{"blame", "/w/scratch/widget/pipeline.go"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ignoredTreeStore(t)
+			out, err := captureRun(t, tc.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			errOut, err := captureRunStderr(t, tc.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			all := out + errOut
+			if !strings.Contains(all, "the ignore rule keeps 3 sessions") {
+				t.Fatalf("nothing names the rule that emptied the answer:\n%s", all)
+			}
+		})
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1242,6 +1242,9 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 			fmt.Fprintf(os.Stderr, "deja: %q matched nothing under %s\n", o.Query, activeFilters(o, sinceRaw, harnessRaw))
 			fmt.Fprint(os.Stderr, emptyRoleNote(dir, o.Role))
 			fmt.Fprint(os.Stderr, olderThanWindow(dir, o.Since))
+			// This branch does not go through printNoMatches, which is where
+			// the line lives for the other miss, so it says it itself.
+			fmt.Fprint(os.Stderr, ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(o.Query))))
 		default:
 			printNoMatches(os.Stderr, dir, o.Query, o.Regex)
 		}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1265,8 +1265,14 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 	// The answer can also be short for a reason no flag lifts. Counted over the
 	// sessions holding every term, so an ordinary search in a store with a big
 	// ignored tree stays quiet (#2562).
-	if note := ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(o.Query))); note != "" {
-		fmt.Fprint(os.Stderr, note)
+	//
+	// Only where there is an answer to be short: printNoMatches says the same
+	// thing on the way to "try fewer words", and a miss printed it twice
+	// (#2632).
+	if len(hits) > 0 {
+		if note := ignoredHiddenNoteFor("answer", index.IgnoredWithAllTerms(dir, query.Tokens(o.Query))); note != "" {
+			fmt.Fprint(os.Stderr, note)
+		}
 	}
 	// The window this is being printed into, so the lines can be budgeted
 	// rather than assumed 80 wide. Only for a terminal: a pipe gets the whole
@@ -2322,6 +2328,15 @@ func runBlame(dir string, args []string) error {
 			fmt.Fprint(os.Stderr, note)
 			return nil
 		}
+		// And the other rule that empties this answer, which said nothing here
+		// while the listing and search both named it (#2632). Before the count
+		// below, for the same reason it goes before "try fewer words": a
+		// denominator that includes the ignored sessions reads as a store that
+		// was searched and came back empty.
+		if note := ignoredHiddenNoteFor("answer", ignoredTouching(dir, target)); note != "" {
+			fmt.Fprint(os.Stderr, note)
+			return nil
+		}
 		// "run deja index" is advice for an empty store. With sessions in the
 		// index it is advice for a state the tool is not in — indexing changes
 		// nothing and doctor reports the stores as found — and it sends the
@@ -2390,6 +2405,33 @@ func blameHits(dir string, target search.BlameTarget, o search.BlameOptions, act
 // manifest. Measured on 500 sessions all touching one file: 0.08s uncapped
 // against 0.02s capped, with the same ten at the top.
 const blameToucherCap = 50
+
+// ignoredTouching counts the sessions that touched this file and are covered by
+// the ignore rule. Not IgnoredWithAllTerms, which the other surfaces use: that
+// reads the text postings, and a file path reaches the index as a `files`
+// record, which is served by role and never ranked — so the count for a blame
+// has to come from the same Touched lists blame itself reads (#2632).
+func ignoredTouching(dir string, target search.BlameTarget) int {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return 0
+	}
+	pol := policy.Load()
+	base := strings.ToLower(filepath.Base(target.FullPath))
+	n := 0
+	for _, meta := range metas {
+		if !pol.Ignored(meta.Path, meta.Project) {
+			continue
+		}
+		for _, p := range meta.Touched {
+			if strings.ToLower(filepath.Base(filepath.FromSlash(p))) == base {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
 
 // withFileTouchers adds the sessions that edited or opened the file but never
 // said its name.


### PR DESCRIPTION
Fixes #2632. The rest of #2630.

A search that missed printed the line twice — `printNoMatches` puts it before "try fewer words", where rewording is the wrong advice, and the block after the cap note printed it again. That block now fires only when there is an answer to be short.

`files` and `blame` applied the rule and said nothing, directly under the policy note that exists for the same misread. blame's count comes from the manifest's Touched lists rather than the text postings: a file path reaches the index as a `files` record, which is served by role and never ranked.
