### PR TITLE
fix(search): point a miss at the records served by role

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1529,9 +1529,122 @@ func printNoMatches(w io.Writer, dir, q string, regex bool) {
 	if hint := commandHint(q); hint != "" {
 		fmt.Fprint(w, hint)
 	}
+	// Last of the reasons a miss is not a miss, and the only one where deja is
+	// holding the answer rather than withholding it.
+	if hint := roleServedHint(dir, q); hint != "" {
+		fmt.Fprint(w, hint)
+	}
 	if note := hiddenByOwnSettings(); note != "" {
 		fmt.Fprint(w, note)
 	}
+}
+
+// roleServedHint names the answer deja is holding but ranking will never
+// return.
+//
+// Commands, file lists and edits are 38% of the record log and none of it
+// reaches ranking, on purpose: a path that happens to contain the words of a
+// question is not an answer to it. `how` and `blame` serve those roles when
+// asked for by role — so a word that lives only in a command or a filename
+// misses here while both of them answer it, and "try fewer words" is counsel no
+// rewording can follow, the same wrong turn #2562 and #686 closed for the other
+// reasons a miss is not a miss (#2634).
+//
+// Neither half costs a record-log scan: the commands table is a prebuilt
+// artefact and the touched-file lists are one metadata read.
+func roleServedHint(dir, q string) string {
+	terms := query.Tokens(q)
+	if len(terms) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	if n := commandsMatchingWords(dir, terms); n > 0 {
+		match := "match"
+		if n == 1 {
+			match = "matches"
+		}
+		fmt.Fprintf(&out, "deja: %d command%s this machine ran %s it — `deja how %s`\n",
+			n, pluralS(n), match, q)
+	}
+	if n, name := sessionsTouchingWords(dir, terms); n > 0 {
+		fmt.Fprintf(&out, "deja: %d session%s touched %s — `deja blame %s`\n", n, pluralS(n), name, name)
+	}
+	return out.String()
+}
+
+// commandsMatchingWords counts the commands in the recurring-command table that
+// hold every one of these words.
+//
+// Commands rather than sessions, because the table cannot give an honest
+// session count here: one session that ran two matching commands appears under
+// both, ByProject is capped at commandProjectCap, and summing either would
+// state a number that is wrong in a direction the reader cannot see. How many
+// commands match is exact, and it is the number that decides whether `deja how`
+// is worth typing.
+//
+// The trust policy keys on the project, which is what the table carries, so a
+// command is counted only where a project this path may read has it. The ignore
+// rule matches on path or project and the table has no path, so a session
+// ignored by path alone is not excluded here — the same gap `hook-tool` has.
+func commandsMatchingWords(dir string, terms []string) int {
+	pol := policy.Load()
+	n := 0
+	for _, u := range index.ReadCommands(dir) {
+		low := strings.ToLower(u.Command)
+		matched := true
+		for _, t := range terms {
+			if !commandMentions(low, strings.ToLower(t)) {
+				matched = false
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		for proj := range u.ByProject {
+			if pol.Allows(policy.ActivationSearch, proj) && !pol.Ignored("", proj) {
+				n++
+				break
+			}
+		}
+	}
+	return n
+}
+
+// sessionsTouchingWords counts the sessions that touched a file whose name
+// holds every one of these words, and names one such file so the reader has
+// something to hand to blame.
+func sessionsTouchingWords(dir string, terms []string) (int, string) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return 0, ""
+	}
+	pol := policy.Load()
+	n, name := 0, ""
+	for _, meta := range metas {
+		if !pol.Allows(policy.ActivationSearch, meta.Project) || pol.Ignored(meta.Path, meta.Project) {
+			continue
+		}
+		for _, p := range meta.Touched {
+			base := filepath.Base(filepath.FromSlash(p))
+			low := strings.ToLower(base)
+			matched := true
+			for _, t := range terms {
+				if !strings.Contains(low, strings.ToLower(t)) {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				n++
+				if name == "" {
+					name = base
+				}
+				break
+			}
+		}
+	}
+	return n, name
 }
 
 // hiddenByOwnSettings names the states the reader created themselves and can

--- a/cmd/deja/miss_role_served_test.go
+++ b/cmd/deja/miss_role_served_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// roleServedStore holds a topic that exists only in records served by role: a
+// command that was run and a file that was edited, never a word of prose.
+func roleServedStore(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"s1", "s2", "s3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/app","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"carry on"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/app","timestamp":"2026-07-01T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"make widgetpipeline"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/app","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/app/widgetpipeline.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Commands, file lists and edits never reach ranking, on purpose. So a search
+// for a word that lives only there misses — while `how` and `blame` answer it —
+// and "try fewer words" is counsel no rewording can follow (#2634).
+func TestAMissPointsAtTheRecordsServedByRole(t *testing.T) {
+	roleServedStore(t)
+	out, err := captureRunStderr(t, "widgetpipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no matches") {
+		t.Fatalf("the fixture no longer misses, so this pins nothing:\n%s", out)
+	}
+	if !strings.Contains(out, "deja how") {
+		t.Fatalf("nothing says a command on this machine matches it:\n%s", out)
+	}
+	if !strings.Contains(out, "deja blame") {
+		t.Fatalf("nothing says a file on this machine matches it:\n%s", out)
+	}
+}
+
+// A miss that really is a miss keeps its short answer: a line on every failed
+// search is noise that teaches people to skip the last line.
+func TestAnOrdinaryMissSaysNothingExtra(t *testing.T) {
+	roleServedStore(t)
+	out, err := captureRunStderr(t, "zonkomatic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "deja how") || strings.Contains(out, "deja blame") {
+		t.Fatalf("a word this machine never saw was pointed somewhere:\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #2634.

Commands, file lists and edits never reach ranking, on purpose. So a word that lives only in a command or a filename misses here while `how` and `blame` both answer it, and "try fewer words" is counsel no rewording can follow.

`printNoMatches` already names every other reason a miss is not a miss — empty store, forgotten sessions, exclusion patterns, the trust policy, the ignore rule, which word to drop, a mistyped subcommand. This is the last one, and the only one where deja is holding the answer rather than withholding it.

Commands rather than sessions in the count: one session that ran two matching commands appears under both and `ByProject` is capped, so a session count would be wrong in a direction the reader cannot see. Neither half costs a record-log scan — the commands table is a prebuilt gob and the touched lists are one metadata read.
