### PR TITLE
fix(doctor): report the schedule that runs the sync

### DIFF
--- a/cmd/deja/doctor_peers.go
+++ b/cmd/deja/doctor_peers.go
@@ -3,6 +3,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -22,6 +25,7 @@ import (
 func doctorPeers(w io.Writer, dir string, now time.Time) {
 	list, why := peers.Snapshot()
 	fmt.Fprintln(w, "Sync:")
+	doctorSyncTimer(w)
 	if why != "" {
 		// Load treats a malformed file as "no peers" so a sync cannot be
 		// stopped by one, and says doctor is where that surfaces. Without this
@@ -264,3 +268,39 @@ func importedFromLine(from map[string]int) string {
 // doctorImportedNames bounds how many machine names the line carries; the rest
 // are counted rather than listed.
 const doctorImportedNames = 4
+
+// doctorSyncTimer reports the schedule that runs the sync.
+//
+// The section above exists because a sync that stops does not announce itself,
+// and the thing that runs it was the one piece of wiring with no row anywhere:
+// `install --all` writes a launchd plist or a systemd unit and nothing
+// afterwards looked at it. The failure worth catching is not exotic — deja is
+// upgraded or moved, the file keeps naming the old path, and the hourly sync
+// stops (#2636).
+func doctorSyncTimer(w io.Writer) {
+	if !syncTimerSchedulable(runtime.GOOS) {
+		return
+	}
+	exe, scheduled := syncTimerBinary(runtime.GOOS)
+	if !scheduled {
+		fmt.Fprintf(w, "  %-12s not scheduled — `deja install sync-timer` runs `deja sync` every %d min\n",
+			"timer", syncAutoInterval/60)
+		return
+	}
+	if exe != "" {
+		if _, err := os.Stat(exe); err != nil {
+			fmt.Fprintf(w, "  %-12s scheduled, but %s is no longer there — run `deja install sync-timer` again\n",
+				"timer", exe)
+			return
+		}
+	}
+	fmt.Fprintf(w, "  %-12s every %d min · %s\n", "timer", syncAutoInterval/60, syncTimerPath(runtime.GOOS))
+}
+
+// syncTimerPath names the file the reader would open to check for themselves.
+func syncTimerPath(goos string) string {
+	if goos == "linux" {
+		return filepath.Join(syncAutoUnitDir(), "deja-sync.timer")
+	}
+	return syncAutoPlistPath()
+}

--- a/cmd/deja/doctor_sync_timer_test.go
+++ b/cmd/deja/doctor_sync_timer_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeSyncPlist puts the file install writes there by hand. Nothing is loaded
+// into launchd: the suite must never register a live agent (see
+// runServiceManager's guard).
+func writeSyncPlist(t *testing.T, exe string) {
+	t.Helper()
+	path := syncAutoPlistPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(syncAutoPlist(exe)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSyncUnit(t *testing.T, exe string) {
+	t.Helper()
+	dir := syncAutoUnitDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "deja-sync.service"), []byte(syncAutoService(exe)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "deja-sync.timer"), []byte(syncAutoTimer()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSyncTimerFor(t *testing.T, exe string) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "darwin":
+		writeSyncPlist(t, exe)
+	case "linux":
+		writeSyncUnit(t, exe)
+	default:
+		t.Skip("no timer on this platform")
+	}
+}
+
+func doctorSyncSection(t *testing.T, dir string) string {
+	t.Helper()
+	var b bytes.Buffer
+	doctorPeers(&b, dir, time.Now())
+	return b.String()
+}
+
+// The Sync section exists because a sync that stops does not announce itself.
+// The thing that runs the sync was not on it: `install --all` writes a timer
+// and nothing afterwards reported on it (#2636).
+func TestDoctorSaysTheSyncTimerIsNotScheduled(t *testing.T) {
+	if !syncTimerSchedulable(runtime.GOOS) {
+		t.Skip("no timer on this platform")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	out := doctorSyncSection(t, t.TempDir())
+	if !strings.Contains(out, "timer") {
+		t.Fatalf("the Sync section never mentions the timer:\n%s", out)
+	}
+	if !strings.Contains(out, "deja install sync-timer") {
+		t.Fatalf("nothing says how to schedule it:\n%s", out)
+	}
+}
+
+// Scheduled, and pointing at a binary that is gone: deja moved or was upgraded,
+// the file kept the old path, and the hourly sync stopped.
+func TestDoctorSaysTheSyncTimerPointsAtAMissingBinary(t *testing.T) {
+	if !syncTimerSchedulable(runtime.GOOS) {
+		t.Skip("no timer on this platform")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	writeSyncTimerFor(t, filepath.Join(home, "gone", "deja"))
+	out := doctorSyncSection(t, t.TempDir())
+	if !strings.Contains(out, "no longer there") {
+		t.Fatalf("a timer pointing at a missing binary reads as healthy:\n%s", out)
+	}
+}
+
+// Scheduled and pointing at a binary that exists: say so plainly and stop.
+func TestDoctorSaysTheSyncTimerIsScheduled(t *testing.T) {
+	if !syncTimerSchedulable(runtime.GOOS) {
+		t.Skip("no timer on this platform")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	exe := filepath.Join(home, "deja")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSyncTimerFor(t, exe)
+	out := doctorSyncSection(t, t.TempDir())
+	if !strings.Contains(out, "every 30 min") {
+		t.Fatalf("the schedule is not reported:\n%s", out)
+	}
+	if strings.Contains(out, "no longer there") {
+		t.Fatalf("a healthy timer was called broken:\n%s", out)
+	}
+}

--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -213,6 +213,69 @@ func removeOurUnit(path string) string {
 	return "removed"
 }
 
+// syncTimerBinary returns the binary the scheduled timer names, and whether a
+// timer is scheduled at all.
+//
+// Read back out of the file rather than remembered: the file is what the
+// service manager runs, and the failure worth catching is that it disagrees
+// with where deja is now — an upgrade or a move leaves the old path behind and
+// the hourly sync stops without a word (#2636). The same staleness
+// refreshWiringAfterUpgrade handles on the harness side.
+func syncTimerBinary(goos string) (exe string, scheduled bool) {
+	switch goos {
+	case "darwin":
+		b, err := os.ReadFile(syncAutoPlistPath())
+		if err != nil {
+			return "", false
+		}
+		// The first <string> under ProgramArguments is the binary; install
+		// writes it XML-escaped, so it comes back unescaped here.
+		body := string(b)
+		i := strings.Index(body, "<array>")
+		if i < 0 {
+			return "", true
+		}
+		rest := body[i:]
+		start := strings.Index(rest, "<string>")
+		end := strings.Index(rest, "</string>")
+		if start < 0 || end < start {
+			return "", true
+		}
+		return xmlUnescape(rest[start+len("<string>") : end]), true
+	case "linux":
+		b, err := os.ReadFile(filepath.Join(syncAutoUnitDir(), "deja-sync.service"))
+		if err != nil {
+			return "", false
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if !strings.HasPrefix(line, "ExecStart=") {
+				continue
+			}
+			v := strings.TrimPrefix(line, "ExecStart=")
+			if !strings.HasPrefix(v, `"`) {
+				return "", true
+			}
+			v = v[1:]
+			if j := strings.LastIndex(v, `" `); j >= 0 {
+				v = v[:j]
+			}
+			return systemdUnescape(v), true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+// xmlUnescape and systemdUnescape undo what the two writers escape, so the path
+// read back out of a file is the path that was put in.
+func xmlUnescape(s string) string {
+	return strings.NewReplacer("&lt;", "<", "&gt;", ">", "&quot;", `"`, "&apos;", "'", "&amp;", "&").Replace(s)
+}
+
+func systemdUnescape(s string) string {
+	return strings.NewReplacer(`\"`, `"`, "$$", "$", "%%", "%", `\\`, `\`).Replace(s)
+}
+
 // systemdEscape keeps a path from being read as anything but a path. The same
 // reason as xmlEscape below, for the other format: a unit file resolves %-
 // specifiers, substitutes $variables and reads C escapes in its values, so

--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -228,13 +228,20 @@ func syncTimerBinary(goos string) (exe string, scheduled bool) {
 		if err != nil {
 			return "", false
 		}
-		// The first <string> under ProgramArguments is the binary; install
-		// writes it XML-escaped, so it comes back unescaped here.
+		// Anchored on the key, not on the first <array>: a hand-edited plist
+		// can carry another array above this one, and reading the wrong
+		// element would have doctor call a healthy timer broken. install
+		// writes the path XML-escaped, so it comes back unescaped here.
 		body := string(b)
-		i := strings.Index(body, "<array>")
+		k := strings.Index(body, "<key>ProgramArguments</key>")
+		if k < 0 {
+			return "", true
+		}
+		i := strings.Index(body[k:], "<array>")
 		if i < 0 {
 			return "", true
 		}
+		i += k
 		rest := body[i:]
 		start := strings.Index(rest, "<string>")
 		end := strings.Index(rest, "</string>")

--- a/cmd/deja/systemd_escape_test.go
+++ b/cmd/deja/systemd_escape_test.go
@@ -40,3 +40,35 @@ func TestSyncTimerFilesNameTheSameUnit(t *testing.T) {
 		t.Fatalf("the timer file changed shape:\n%s", syncAutoTimer())
 	}
 }
+
+// The path is read back out of the unit to report on the timer (#2636), so the
+// two directions have to meet.
+func TestSystemdEscapeRoundTrips(t *testing.T) {
+	for _, p := range []string{
+		"/usr/local/bin/deja",
+		`/Users/me/a\b/deja`,
+		`/Users/me/"q"/deja`,
+		"/Users/50%off/bin/deja",
+		"/Users/me/$HOME/deja",
+		`/a\"b%c$d/deja`,
+		"/Users/My Tools/deja",
+	} {
+		if got := systemdUnescape(systemdEscape(p)); got != p {
+			t.Errorf("round trip changed the path:\n in  %q\n out %q\n via %q", p, got, systemdEscape(p))
+		}
+	}
+}
+
+// And the plist's, which is the same question for the other format.
+func TestXMLEscapeRoundTrips(t *testing.T) {
+	for _, p := range []string{
+		"/usr/local/bin/deja",
+		`/Users/John & "Jane" Smith/bin/deja`,
+		"/Users/&amp;lt;/deja",
+		"/Users/o'brien/bin/deja",
+	} {
+		if got := xmlUnescape(xmlEscape(p)); got != p {
+			t.Errorf("round trip changed the path:\n in  %q\n out %q\n via %q", p, got, xmlEscape(p))
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2636.

The Sync section exists because a sync that stops does not announce itself. The thing that runs it had no row: `install --all` writes a launchd plist or a systemd unit, and nothing afterwards looked at either.

    Sync:
      timer        not scheduled — `deja install sync-timer` runs `deja sync` every 30 min
      timer        scheduled, but /old/path/deja is no longer there — run `deja install sync-timer` again
      timer        every 30 min · ~/Library/LaunchAgents/com.deja-vu.sync.plist

The binary is read back out of the file, because the file is what the service manager runs and the failure worth catching is that it disagrees with where deja is now. Both unescapers round-trip against their writers, pinned.
