### PR TITLE
fix(last): say how many sessions it left out

### DIFF
--- a/cmd/deja/last_cap_test.go
+++ b/cmd/deja/last_cap_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// manySessions writes n sessions that all mention the same topic.
+func manySessions(t *testing.T, n int) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("s%d", i)
+		writeClaudeFixture(t, filepath.Join(root, "-w-app", id+".jsonl"), id, []string{
+			fmt.Sprintf(`{"type":"user","sessionId":"%s","cwd":"/w/app","timestamp":"2026-07-01T10:%02d:00Z","message":{"role":"user","content":"the widget pipeline keeps stalling on shard %d"}}`, id, i%60, i),
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// `last` caps at ten and said nothing about the rest, while search, how, files,
+// friction and log all name their cut — the misread #1632 closed for search and
+// #2299 for blame (#2638).
+func TestLastSaysHowManyItLeftOut(t *testing.T) {
+	manySessions(t, 40)
+	out, err := captureRunStderr(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "showing 10 of 40") {
+		t.Fatalf("the cut is not named:\n%s", out)
+	}
+	if !strings.Contains(out, "deja last 40") {
+		t.Fatalf("nothing says how to see the rest:\n%s", out)
+	}
+}
+
+// A listing that shows everything says nothing: a line on every run is noise.
+func TestLastSaysNothingWhenItShowsEverything(t *testing.T) {
+	manySessions(t, 4)
+	out, err := captureRunStderr(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "showing") {
+		t.Fatalf("a complete listing announced a cut it did not make:\n%s", out)
+	}
+}
+
+// And when the reader asked for a count of their own, the line is about that
+// count rather than the default.
+func TestLastNamesTheCutTheReaderAskedFor(t *testing.T) {
+	manySessions(t, 40)
+	out, err := captureRunStderr(t, "last", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "showing 5 of 40") {
+		t.Fatalf("the line does not follow the count that was asked for:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -919,7 +919,12 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	if err := checkRole(o.Role); err != nil {
 		return err
 	}
-	ss, err := recentMatching(dir, n, o)
+	// Uncut, because the count the reader is told about has to be the count
+	// they would get by asking again — and the trust policy filters below,
+	// after the cut, so a total taken before it promised rows the policy would
+	// not hand over (#2638). RecentMatching builds the whole matching set
+	// before cutting anyway, so nothing is read twice.
+	ss, _, err := recentMatchingCounted(dir, 0, o)
 	if err != nil {
 		return err
 	}
@@ -928,6 +933,10 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	// consulted it, while `search` under the same rule refused and said so
 	// (#937). Listing counts as browsing: the search activation governs it.
 	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, ss)
+	total := len(ss)
+	if n > 0 && len(ss) > n {
+		ss = ss[:n]
+	}
 	// Printing nothing at all and exiting 0 leaves no way to tell whether the
 	// command worked, found nothing, or failed silently — which is what a
 	// fresh install sees. blame already answers this shape of question.
@@ -972,6 +981,13 @@ func cmdLast(dir string, rest []string, sourceInstance string) error {
 	}
 	if o.JSON {
 		return printRecentJSONWithheld(os.Stdout, ss, sourceInstance, policyHidden)
+	}
+	// The cut is silent everywhere else on this screen: ten rows read as the
+	// whole answer, and the two rules that withhold rows here already have a
+	// line above the list. `last` takes its count as a bare argument, so that
+	// is the form the way out takes (#2638).
+	if total > len(ss) {
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — `deja last %d` shows the rest\n", len(ss), total, total)
 	}
 	for _, s := range ss {
 		// A session whose timestamp was missing or unparseable carries the Go
@@ -2078,6 +2094,13 @@ func recent(dir string, n int) ([]model.Session, error) {
 }
 
 func recentMatching(dir string, n int, o search.Options) ([]model.Session, error) {
+	ss, _, err := recentMatchingCounted(dir, n, o)
+	return ss, err
+}
+
+// recentMatchingCounted is recentMatching with how many matched before the cut,
+// so the listing can say what it left out (#2638).
+func recentMatchingCounted(dir string, n int, o search.Options) ([]model.Session, int, error) {
 	if err := index.Ensure(dir, "", false, os.Stderr); err == nil {
 		if o.Role != "" {
 			// The role has to travel into the index query, not just the filter
@@ -2088,17 +2111,17 @@ func recentMatching(dir string, n int, o search.Options) ([]model.Session, error
 			ss, err := index.SearchWithRecovery(dir, search.Options{All: true, Role: o.Role}, io.Discard)
 			if err == nil {
 				ss = filterRecentSources(ss, o)
-				return search.Recent(ss, n), nil
+				return search.Recent(ss, n), len(ss), nil
 			}
-		} else if ss, err := index.RecentMatching(dir, n, o); err == nil {
-			return ss, nil
+		} else if ss, total, err := index.RecentMatchingCounted(dir, n, o); err == nil {
+			return ss, total, nil
 		}
 	}
 	ss := filterRecentSources(loadFileSources(), o)
 	if o.Harness == "" || o.Harness == "opencode" {
 		ss = append(ss, filterRecentSources(sources.LoadOpencodeRecent(n), o)...)
 	}
-	return search.Recent(ss, n), nil
+	return search.Recent(ss, n), len(ss), nil
 }
 
 func parseLast(args []string) (int, search.Options, string, error) {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1276,19 +1276,28 @@ func Recent(dir string, n int) ([]model.Session, error) {
 }
 
 func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error) {
+	ss, _, err := RecentMatchingCounted(dir, n, o)
+	return ss, err
+}
+
+// RecentMatchingCounted is RecentMatching with the number of sessions that
+// matched before the cut. The listing shows ten and said nothing about the
+// rest, which reads as the whole answer — the misread #1632 closed for search
+// (#2638) — and the count is already in hand here.
+func RecentMatchingCounted(dir string, n int, o query.Options) ([]model.Session, int, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if ok {
 		defer unlock()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	out := make([]model.Session, 0, len(m.Sessions))
 	for _, meta := range m.Sessions {
@@ -1303,10 +1312,11 @@ func RecentMatching(dir string, n int, o query.Options) ([]model.Session, error)
 	// every ranked surface filtered it out (#2541).
 	out = ignoredByPolicy(out)
 	sort.Slice(out, func(i, j int) bool { return newestFirstSession(out[i], out[j]) })
+	total := len(out)
 	if n > 0 && len(out) > n {
 		out = out[:n]
 	}
-	return out, nil
+	return out, total, nil
 }
 
 // displayPath contracts the home directory to ~ in user-facing messages.


### PR DESCRIPTION
Fixes #2638.

`deja last` shows ten and stopped. Measured on a 40-session store: search says "showing 15 of 40 — add --all", `how` says "showing 8 of 40 — raise --limit", `last` said nothing — the misread #1632 closed for search and #2299 for blame, on the listing someone types to see what this machine has been doing.

    deja: showing 10 of 40 — `deja last 40` shows the rest

Counted after the trust policy filters rather than before it. A total taken before would promise rows the policy will not hand over, and the number in the message has to be the number a second run actually shows. `RecentMatching` already built the whole matching set before cutting, so nothing is read twice.
