### PR TITLE
fix(install): keep a JSON config's indent and key order

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1161,7 +1161,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	} else {
 		m["deja"], note = mergeDejaEntry(m["deja"], mcpServerEntry(exe))
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -1451,7 +1451,7 @@ func installStatusline(exe string, uninstall bool) (installResult, error) {
 		// user last typed.
 		root["statusLine"] = map[string]any{"type": "command", "command": cmd, "refreshInterval": 1000}
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -1733,7 +1733,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -1790,7 +1790,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 		command, args := mcpCommandArgs(exe)
 		servers["deja"], note = mergeDejaEntry(servers["deja"], map[string]any{"command": command, "args": args})
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -1838,7 +1838,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"command": command, "args": args})
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -1895,7 +1895,7 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	} else {
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -42,7 +42,7 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
 		delete(root, "hooks")
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}
@@ -400,7 +400,7 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 	if len(hooks) == 0 {
 		delete(root, "hooks")
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_cursor.go
+++ b/cmd/deja/install_cursor.go
@@ -45,7 +45,7 @@ func installCursorHooks(exe string, uninstall bool) (installResult, error) {
 	if len(root) == 0 && len(bytes.TrimSpace(old)) == 0 {
 		return installResult{Path: path, Action: "unchanged"}, nil
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -133,7 +133,7 @@ func enableGeminiHooks() error {
 		return nil
 	}
 	cfg["enabled"] = true
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return err
 	}

--- a/cmd/deja/install_grok.go
+++ b/cmd/deja/install_grok.go
@@ -73,7 +73,7 @@ func installGrokUserSettings(exe string, uninstall bool) (installResult, error) 
 	} else {
 		root["mcp"] = mcp
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -48,7 +48,7 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	root = updateClaudeHook(root, "UserPromptSubmit", exe+" hook-prompt", "", false)
 	// Scoped to the tools that change something, so it never fires on a read.
 	root = updateClaudeHook(root, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", false)
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -109,7 +109,7 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		internal["enabled"] = true
 		entries[openclawHookName] = map[string]any{"enabled": true}
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -99,7 +99,7 @@ func setOpenClawPluginEnabled(on bool) (string, error) {
 		}
 		entries[openclawPluginID] = map[string]any{"enabled": true}
 	}
-	next, err := json.MarshalIndent(root, "", "  ")
+	next, err := marshalConfigLike(old, root)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/deja/json_shape.go
+++ b/cmd/deja/json_shape.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// marshalConfigLike renders a config in the shape the reader wrote it in.
+//
+// The goose writer explains why it edits text rather than round-tripping: a
+// config holds settings someone wrote by hand, and re-serialising drops the
+// ordering they left there. The JSON writers do round-trip — fourteen of them
+// unmarshal into map[string]any and MarshalIndent with two spaces — so an
+// install that touched one block rewrote the whole document: a four-space file
+// came back at two, and the top-level keys came back alphabetised, because Go
+// sorts map keys (#2640).
+//
+// Two of those are cheap to give back and this is the one place all fourteen
+// pass through. What it does not give back is an inline object or array staying
+// inline: that needs the writer to stop round-tripping at all.
+func marshalConfigLike(old []byte, root map[string]any) ([]byte, error) {
+	next, err := json.MarshalIndent(root, "", jsonIndentOf(old))
+	if err != nil {
+		return nil, err
+	}
+	return reorderTopLevel(old, next, jsonIndentOf(old)), nil
+}
+
+// jsonIndentOf is the indent unit the file already used. Two spaces for a file
+// deja is creating, which has no shape to keep, and for one written on a single
+// line, where there is nothing to read an indent from.
+func jsonIndentOf(old []byte) string {
+	for _, line := range strings.Split(string(old), "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == "" || trimmed == line {
+			continue
+		}
+		return line[:len(line)-len(trimmed)]
+	}
+	return "  "
+}
+
+// reorderTopLevel puts the keys back in the order the reader had them.
+//
+// Keys deja added are left where marshalling put them: they were not in the
+// reader's file, so there is no order of theirs to restore, and appending them
+// at the end would be a choice rather than a restoration.
+func reorderTopLevel(old, next []byte, indent string) []byte {
+	order := topLevelKeyOrder(old)
+	if len(order) < 2 {
+		return next
+	}
+	blocks, head, tail, ok := topLevelBlocks(next, indent)
+	if !ok {
+		return next
+	}
+	seen := map[string]bool{}
+	var out [][]byte
+	for _, k := range order {
+		if b, present := blocks[k]; present && !seen[k] {
+			seen[k] = true
+			out = append(out, b)
+		}
+	}
+	// Whatever marshalling produced that the reader did not have, in the order
+	// it came out.
+	for _, k := range marshalledKeyOrder(next, indent) {
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, blocks[k])
+		}
+	}
+	if len(out) != len(blocks) {
+		return next
+	}
+	var b bytes.Buffer
+	b.Write(head)
+	for i, block := range out {
+		b.Write(block)
+		if i < len(out)-1 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('\n')
+	}
+	b.Write(tail)
+	return b.Bytes()
+}
+
+// topLevelKeyOrder reads the keys of a JSON object in the order they appear.
+func topLevelKeyOrder(b []byte) []string {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil
+	}
+	var keys []string
+	for dec.More() {
+		k, err := dec.Token()
+		if err != nil {
+			return nil
+		}
+		name, ok := k.(string)
+		if !ok {
+			return nil
+		}
+		keys = append(keys, name)
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil
+		}
+	}
+	return keys
+}
+
+// topLevelBlocks cuts MarshalIndent's output into one text block per key, with
+// the opening and closing braces kept aside. It relies on the shape
+// MarshalIndent produces — every top-level key starts a line at exactly one
+// indent — and gives up rather than guess on anything else.
+func topLevelBlocks(next []byte, indent string) (blocks map[string][]byte, head, tail []byte, ok bool) {
+	lines := strings.Split(strings.TrimRight(string(next), "\n"), "\n")
+	if len(lines) < 2 || lines[0] != "{" || lines[len(lines)-1] != "}" {
+		return nil, nil, nil, false
+	}
+	blocks = map[string][]byte{}
+	var cur string
+	var buf []string
+	flush := func() {
+		if cur != "" {
+			joined := strings.Join(buf, "\n")
+			blocks[cur] = []byte(strings.TrimSuffix(joined, ","))
+		}
+	}
+	for _, line := range lines[1 : len(lines)-1] {
+		if strings.HasPrefix(line, indent) && !strings.HasPrefix(line, indent+" ") && !strings.HasPrefix(line, indent+"\t") {
+			if name, isKey := topLevelKeyOf(line, indent); isKey {
+				flush()
+				cur, buf = name, []string{line}
+				continue
+			}
+		}
+		if cur == "" {
+			return nil, nil, nil, false
+		}
+		buf = append(buf, line)
+	}
+	flush()
+	return blocks, []byte("{\n"), []byte("}"), true
+}
+
+// topLevelKeyOf reads the key a MarshalIndent line opens, if it opens one.
+func topLevelKeyOf(line, indent string) (string, bool) {
+	rest := strings.TrimPrefix(line, indent)
+	if !strings.HasPrefix(rest, `"`) {
+		return "", false
+	}
+	var name string
+	end := strings.Index(rest[1:], `":`)
+	if end < 0 {
+		return "", false
+	}
+	if err := json.Unmarshal([]byte(rest[:end+2]), &name); err != nil {
+		return "", false
+	}
+	return name, true
+}
+
+// marshalledKeyOrder is topLevelKeyOrder for what marshalling produced.
+func marshalledKeyOrder(next []byte, indent string) []string {
+	var keys []string
+	lines := strings.Split(string(next), "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, indent) || strings.HasPrefix(line, indent+" ") || strings.HasPrefix(line, indent+"\t") {
+			continue
+		}
+		if name, ok := topLevelKeyOf(line, indent); ok {
+			keys = append(keys, name)
+		}
+	}
+	return keys
+}

--- a/cmd/deja/json_shape_test.go
+++ b/cmd/deja/json_shape_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The JSON writers round-trip through map[string]any and MarshalIndent, so an
+// install rewrote the whole document: a four-space file came back at two and
+// the top-level keys came back in alphabetical order (#2640).
+func TestInstallKeepsTheShapeOfAJSONConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name, target, rel, body string
+		wants                   []string
+	}{
+		{
+			name:   "four-space indent",
+			target: "cursor",
+			rel:    ".cursor/mcp.json",
+			body:   "{\n    \"mcpServers\": {\n        \"theirs\": {\n            \"command\": \"x\"\n        }\n    }\n}\n",
+			wants:  []string{"\n    \"mcpServers\""},
+		},
+		{
+			name:   "the order they wrote",
+			target: "cursor",
+			rel:    ".cursor/mcp.json",
+			body:   "{\n  \"zzz\": 1,\n  \"mcpServers\": {\n    \"theirs\": {\n      \"command\": \"x\"\n    }\n  },\n  \"aaa\": 2\n}\n",
+			wants:  []string{"\"zzz\""},
+		},
+		{
+			name:   "a tab-indented file",
+			target: "cursor",
+			rel:    ".cursor/mcp.json",
+			body:   "{\n\t\"mcpServers\": {\n\t\t\"theirs\": {\n\t\t\t\"command\": \"x\"\n\t\t}\n\t}\n}\n",
+			wants:  []string{"\n\t\"mcpServers\""},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("USERPROFILE", home)
+			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+			path := filepath.Join(home, filepath.FromSlash(tc.rel))
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installTarget(tc.target, "/bin/deja", false); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(b)
+			if !strings.Contains(got, `"deja"`) {
+				t.Fatalf("install wrote no entry:\n%s", got)
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(got, want) {
+					t.Fatalf("the file came back in a shape the reader did not write (%q missing):\n%s", want, got)
+				}
+			}
+			// The order they wrote, for the keys that were already there.
+			if tc.name == "the order they wrote" {
+				zzz, aaa := strings.Index(got, `"zzz"`), strings.Index(got, `"aaa"`)
+				if zzz < 0 || aaa < 0 || zzz > aaa {
+					t.Fatalf("the top-level keys were reordered:\n%s", got)
+				}
+			}
+		})
+	}
+}
+
+// A config deja creates has no shape to keep, so it gets the house style.
+func TestInstallWritesTwoSpacesIntoAConfigItCreated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	if _, err := installTarget("cursor", "/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".cursor", "mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "\n  \"mcpServers\"") {
+		t.Fatalf("a config deja wrote itself is not in the house style:\n%s", b)
+	}
+}


### PR DESCRIPTION
Fixes #2640.

Fourteen writers unmarshal into `map[string]any` and `MarshalIndent(root, "", "  ")`, so an install that touched one block rewrote the whole document: a four-space file came back at two, and the top-level keys came back alphabetised because Go sorts map keys. `.claude.json` and `settings.json` are files people edit by hand.

    cursor, four-space indent   comes back at four
    cursor, key order           "zzz", "mcpServers", "aaa" stays in that order
    gemini settings.json        "theme" stays above "mcpServers"

Both are given back at the one place all fourteen pass through. A config deja creates has no shape to keep and gets the house style.

Not fixed, and deliberately not smuggled in: an inline object or array is still expanded. That needs the writer to stop round-tripping at all, which is a different decision.
