### PR TITLE
fix(last): name --from among the filters that emptied a listing

### DIFF
--- a/cmd/deja/from_filter_test.go
+++ b/cmd/deja/from_filter_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// storeWithSessions indexes a handful of ordinary local sessions.
+func storeWithSessions(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"s1", "s2", "s3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/app","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the beta rollout"}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// `--from` is the one filter activeFilters did not know about, so a --from that
+// matched nothing sent the reader to rebuild a store that was fine — the
+// misread #637 and #1007 closed for the others (#2642).
+func TestAFromThatMatchesNothingNamesTheFilter(t *testing.T) {
+	storeWithSessions(t)
+	out, err := captureRunStderr(t, "last", "--from", "nosuchhost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "no sessions indexed yet") {
+		t.Fatalf("a filter that matched nothing was reported as an empty store:\n%s", out)
+	}
+	if !strings.Contains(out, `from "nosuchhost"`) {
+		t.Fatalf("the filter that emptied the listing is not named:\n%s", out)
+	}
+}
+
+// search does not take --from at all — it is a flag of `deja last`, and the
+// dispatcher says so rather than searching for the text. So the listing is the
+// only screen where this filter can empty an answer.
+func TestSearchRefusesFromAndSaysWhereItBelongs(t *testing.T) {
+	storeWithSessions(t)
+	_, err := captureRun(t, "--from", "nosuchhost", "beta rollout")
+	if err == nil || !strings.Contains(err.Error(), "`deja last`") {
+		t.Fatalf("search should send --from to the command that has it, got %v", err)
+	}
+}
+
+// A listing with no filter at all keeps the advice it had.
+func TestAnEmptyStoreStillSaysToIndex(t *testing.T) {
+	hermeticEnv(t)
+	out, err := captureRunStderr(t, "last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no sessions indexed yet") {
+		t.Fatalf("an empty store should still say what to do:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1940,6 +1940,13 @@ func activeFilters(o search.Options, sinceRaw, harnessRaw string) string {
 	if o.Session != "" {
 		parts = append(parts, fmt.Sprintf("session %q", o.Session))
 	}
+	// The one filter this did not know about, and the one most likely to match
+	// nothing: --from exists for the multi-machine case, and the name a reader
+	// types comes off another machine. Unnamed, it fell through to "no sessions
+	// indexed yet — run `deja index`" on a store that was fine (#2642).
+	if o.From != "" {
+		parts = append(parts, fmt.Sprintf("from %q", o.From))
+	}
 	// The same predicate filterRecentSources uses. parseDur accepts a negative
 	// duration, and a negative Since filters nothing — naming it would report a
 	// filter that was never applied and hide the empty-store advice, which is


### PR DESCRIPTION
Fixes #2642.

Found by setting up two stores and moving memory between them. With A's sessions imported into B, four indexed:

    $ deja last --from nosuchhost
    deja: no sessions indexed yet — run `deja index`, or `deja doctor` …

`activeFilters` named harness, project, role, session and since. `--from` was the one it did not know about, and it is the filter most likely to match nothing — it exists for the multi-machine case and the name comes off another machine.

    deja: no sessions match from "nosuchhost"

An empty store with no filter keeps the advice it had, pinned. Search never reaches this: `--from` is a flag of `deja last`, and the dispatcher already says so.
