### PR TITLE
fix(filters): accept the project label the listing prints

### DIFF
--- a/cmd/deja/imported_label_test.go
+++ b/cmd/deja/imported_label_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// labelStore indexes one local session and one that arrived by sync.
+func labelStore(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-w-beta", "b1.jsonl"), "b1", []string{
+		`{"type":"user","sessionId":"b1","cwd":"/w/beta","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the beta rollout"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(root, "-w-alpha", "a1.jsonl"), "a1", []string{
+		`{"type":"user","sessionId":"a1","cwd":"/w/alpha","timestamp":"2026-07-02T10:00:00Z","message":{"role":"user","content":"the alpha pipeline"}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The label `deja last` prints for an imported session — the sending machine in
+// place of the "imported:" prefix — was accepted by no filter, so the one
+// string a reader can copy off that screen worked nowhere (#2644).
+func TestTheProjectFilterTakesTheLabelTheListingPrints(t *testing.T) {
+	for _, tc := range []struct {
+		name, project, from, want string
+		match                     bool
+	}{
+		{"the label a listing prints", "imported:alpha", "mini", "mini:alpha", true},
+		{"the stored form", "imported:alpha", "mini", "imported:alpha", true},
+		{"the bare project", "imported:alpha", "mini", "alpha", true},
+		{"the machine alone", "imported:alpha", "mini", "mini", true},
+		{"another machine's label", "imported:alpha", "mini", "laptop:alpha", false},
+		{"another project on this machine", "imported:beta", "mini", "mini:alpha", false},
+		{"a local session is untouched", "alpha", "", "mini:alpha", false},
+		{"a local session by its own name", "alpha", "", "alpha", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectFilterMatches(tc.project, tc.from, tc.want); got != tc.match {
+				t.Fatalf("--project %q against %q from %q = %v, want %v", tc.want, tc.project, tc.from, got, tc.match)
+			}
+		})
+	}
+}
+
+// And the label on the screen is built by the same function the filter reads,
+// so the two cannot drift apart.
+func TestTheListingLabelAndTheFilterAgree(t *testing.T) {
+	s := model.Session{Project: "imported:alpha", From: "mini"}
+	shown := displayProject(s)
+	if shown != "mini:alpha" {
+		t.Fatalf("the listing label changed: %q", shown)
+	}
+	if !projectFilterMatches(s.Project, s.From, shown) {
+		t.Fatalf("the label the listing prints does not select the session it names")
+	}
+}
+
+// End to end, on a store: the filter still selects what it always did.
+func TestProjectFilterStillSelectsALocalProject(t *testing.T) {
+	labelStore(t)
+	out, err := captureRun(t, "last", "--project", "alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha") || strings.Contains(out, "beta") {
+		t.Fatalf("the project filter no longer selects a plain project:\n%s", out)
+	}
+}

--- a/cmd/deja/imported_label_test.go
+++ b/cmd/deja/imported_label_test.go
@@ -37,7 +37,9 @@ func TestTheProjectFilterTakesTheLabelTheListingPrints(t *testing.T) {
 		{"the label a listing prints", "imported:alpha", "mini", "mini:alpha", true},
 		{"the stored form", "imported:alpha", "mini", "imported:alpha", true},
 		{"the bare project", "imported:alpha", "mini", "alpha", true},
-		{"the machine alone", "imported:alpha", "mini", "mini", true},
+		// The machine alone stays --from's question: the project filter would
+		// otherwise select everything that machine sent.
+		{"the machine alone", "imported:alpha", "mini", "mini", false},
 		{"another machine's label", "imported:alpha", "mini", "laptop:alpha", false},
 		{"another project on this machine", "imported:beta", "mini", "mini:alpha", false},
 		{"a local session is untouched", "alpha", "", "mini:alpha", false},

--- a/cmd/deja/provenance.go
+++ b/cmd/deja/provenance.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"strings"
-
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
 // displayProject is the project label a reader sees. A session that arrived by
@@ -16,12 +15,12 @@ import (
 // what resume checks before offering a command for another machine's session,
 // and what the note lifecycle keys on. This is the rendering, not the record.
 func displayProject(s model.Session) string {
-	if s.From == "" {
-		return s.Project
-	}
-	rest, ok := strings.CutPrefix(s.Project, "imported:")
-	if !ok {
-		return s.Project
-	}
-	return s.From + ":" + rest
+	return query.DisplayProject(s.Project, s.From)
+}
+
+// projectFilterMatches is the other half of the same rule: what the screen
+// shows has to be a string a filter accepts, or the label is a dead end
+// (#2644).
+func projectFilterMatches(project, from, want string) bool {
+	return query.ProjectMatches(project, from, want)
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2152,7 +2152,7 @@ func scanRecordsWithVariants(dir string, m Manifest, o query.Options, offsets []
 		if o.Harness != "" && !harnessMatches(meta.Harness, o.Harness) {
 			return
 		}
-		if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
+		if !query.ProjectMatches(meta.Project, meta.From, o.Project) {
 			return
 		}
 		if !fromMatches(meta.From, o.From) {
@@ -2319,7 +2319,7 @@ func sessionMetaMatches(meta SessionMeta, o query.Options) bool {
 	if o.Harness != "" && !harnessMatches(meta.Harness, o.Harness) {
 		return false
 	}
-	if o.Project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(o.Project)) {
+	if !query.ProjectMatches(meta.Project, meta.From, o.Project) {
 		return false
 	}
 	if !fromMatches(meta.From, o.From) {

--- a/internal/query/project.go
+++ b/internal/query/project.go
@@ -22,6 +22,13 @@ func ProjectMatches(project, from, want string) bool {
 	if strings.Contains(strings.ToLower(project), strings.ToLower(want)) {
 		return true
 	}
+	// Only for a want that carries the separator. Without that guard,
+	// `--project mini` would select every session from a machine called mini
+	// rather than a project of that name — a wider answer than the flag has
+	// ever given, and `--from` is the flag for a machine.
+	if !strings.Contains(want, ":") {
+		return false
+	}
 	shown := DisplayProject(project, from)
 	return shown != project && strings.Contains(strings.ToLower(shown), strings.ToLower(want))
 }

--- a/internal/query/project.go
+++ b/internal/query/project.go
@@ -1,0 +1,42 @@
+package query
+
+import "strings"
+
+// ProjectMatches reports whether a --project filter selects this session.
+//
+// The stored project of an imported session carries an "imported:" prefix, and
+// `deja last` renders it with the sending machine's name in place of that
+// prefix — which is the answer to "where did this come from" once three
+// machines are exchanging history. That rendering was the one label no filter
+// accepted: `--project Host:alpha` matched nothing while `--project
+// imported:alpha` matched, so the string a reader can copy off the screen
+// worked nowhere (#2644).
+//
+// Both forms match here. The stored one keeps its substring rule, which is what
+// makes `--project alpha` and `--project imported` both work; the rendered one
+// is matched the same way once the machine name is put back.
+func ProjectMatches(project, from, want string) bool {
+	if want == "" {
+		return true
+	}
+	if strings.Contains(strings.ToLower(project), strings.ToLower(want)) {
+		return true
+	}
+	shown := DisplayProject(project, from)
+	return shown != project && strings.Contains(strings.ToLower(shown), strings.ToLower(want))
+}
+
+// DisplayProject is the label a reader is shown for a session's project: the
+// machine it came from in place of the "imported:" prefix, and the stored
+// project otherwise. It lives here so the filter and the screen cannot drift
+// apart.
+func DisplayProject(project, from string) string {
+	if from == "" {
+		return project
+	}
+	rest, ok := strings.CutPrefix(project, "imported:")
+	if !ok {
+		return project
+	}
+	return from + ":" + rest
+}

--- a/internal/query/project_test.go
+++ b/internal/query/project_test.go
@@ -1,0 +1,48 @@
+package query
+
+import "testing"
+
+// The label a listing prints for an imported session was accepted by no filter,
+// so the one string a reader can copy off that screen worked nowhere (#2644).
+func TestProjectMatches(t *testing.T) {
+	for _, tc := range []struct {
+		name, project, from, want string
+		match                     bool
+	}{
+		{"no filter takes everything", "alpha", "", "", true},
+		{"the stored form", "imported:alpha", "mini", "imported:alpha", true},
+		{"the bare project", "imported:alpha", "mini", "alpha", true},
+		{"the label a listing prints", "imported:alpha", "mini", "mini:alpha", true},
+		{"case does not matter", "imported:Alpha", "Mini", "mini:alpha", true},
+		{"another machine's label", "imported:alpha", "mini", "laptop:alpha", false},
+		{"another project on that machine", "imported:beta", "mini", "mini:alpha", false},
+		// The machine on its own stays --from's question: a project filter that
+		// took it would select everything that machine sent.
+		{"the machine alone", "imported:alpha", "mini", "mini", false},
+		{"a local session has no second form", "alpha", "", "mini:alpha", false},
+		{"a local session by its own name", "alpha", "", "alpha", true},
+		// A session with a sending machine but no prefix — nothing to rewrite,
+		// so only the stored name matches.
+		{"from without the prefix", "alpha", "mini", "mini:alpha", false},
+		{"a want with a colon and no match", "alpha", "", "a:b", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProjectMatches(tc.project, tc.from, tc.want); got != tc.match {
+				t.Fatalf("ProjectMatches(%q, %q, %q) = %v, want %v", tc.project, tc.from, tc.want, got, tc.match)
+			}
+		})
+	}
+}
+
+func TestDisplayProject(t *testing.T) {
+	for _, tc := range []struct{ project, from, want string }{
+		{"alpha", "", "alpha"},
+		{"imported:alpha", "mini", "mini:alpha"},
+		{"alpha", "mini", "alpha"},
+		{"imported:alpha", "", "imported:alpha"},
+	} {
+		if got := DisplayProject(tc.project, tc.from); got != tc.want {
+			t.Errorf("DisplayProject(%q, %q) = %q, want %q", tc.project, tc.from, got, tc.want)
+		}
+	}
+}

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -12,6 +12,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
 type BlameTarget struct {
@@ -124,7 +126,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		if o.Harness != "" && session.Harness != o.Harness {
 			continue
 		}
-		if o.Project != "" && !strings.Contains(strings.ToLower(session.Project), strings.ToLower(o.Project)) {
+		if !query.ProjectMatches(session.Project, session.From, o.Project) {
 			continue
 		}
 		if !cut.IsZero() && session.Updated.Before(cut) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -190,7 +190,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		if o.Harness != "" && s.Harness != o.Harness {
 			continue
 		}
-		if o.Project != "" && !strings.Contains(strings.ToLower(s.Project), strings.ToLower(o.Project)) {
+		if !query.ProjectMatches(s.Project, s.From, o.Project) {
 			continue
 		}
 		// By the id prefix a hit prints, and by the id a session was synced


### PR DESCRIPTION
Fixes #2644. The other half of #2642.

`deja last` renders an imported session's project as `Host:alpha` — the sending machine in place of the "imported:" prefix, which is the answer to "where did this come from" once machines are exchanging history. No filter accepted that string:

    --project imported:alpha                  2 rows
    --project Vladislavs-MacBook-Pro:alpha    0 rows

So the one label a reader can copy off that screen worked nowhere.

Both forms match now, through one rule in `internal/query` that the four project filters and the listing's label share, so the screen and the filter cannot drift apart. No wording changes: `--project alpha`, `--project imported` and the stored form all still select what they did, pinned along with the negatives — another machine's label, another project on the same machine, and a local session that never had a prefix.
