### PR TITLE
fix(files): point a miss at the records served by role

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -134,6 +134,12 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 			return nil
 		}
 		fmt.Fprintf(stdout, "no sessions mention %q\n", q)
+		// This screen matches on where a topic was discussed, which is what its
+		// comment above defends and what the measurement behind it says. A
+		// topic that lives only in a filename or a command is therefore a miss
+		// here and an answer next door — and this is the surface most likely to
+		// be handed a filename (#2646). The same two lines search ends on.
+		fmt.Fprint(stdout, roleServedHint(dir, q))
 		return nil
 	}
 	// Retrieval hands candidates back in map order, so taking the first 250 of

--- a/cmd/deja/files_hint_test.go
+++ b/cmd/deja/files_hint_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `files` matches by proximity to where a topic was discussed, which is
+// deliberate and measured — so a topic nobody said out loud correctly matches
+// nothing. What it did was stop there, on the surface most likely to be handed
+// a filename, while blame and how both answer it (#2646).
+func TestFilesPointsAtTheRecordsServedByRole(t *testing.T) {
+	roleServedStore(t)
+	out, err := captureRun(t, "files", "widgetpipeline")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "no sessions mention") {
+		t.Fatalf("the fixture no longer misses, so this pins nothing:\n%s", out)
+	}
+	if !strings.Contains(out, "deja blame") {
+		t.Fatalf("nothing says a file on this machine matches it:\n%s", out)
+	}
+	if !strings.Contains(out, "deja how") {
+		t.Fatalf("nothing says a command on this machine matches it:\n%s", out)
+	}
+}
+
+// A topic this machine never saw is answered as before.
+func TestFilesSaysNothingExtraForAnUnknownTopic(t *testing.T) {
+	roleServedStore(t)
+	out, err := captureRun(t, "files", "zonkomatic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "deja blame") || strings.Contains(out, "deja how") {
+		t.Fatalf("a word this machine never saw was pointed somewhere:\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #2646.

`files` matches by proximity to where a topic was discussed. That is deliberate and the comment above it carries the measurement: aggregating every file a matching session touched gave the same five files for every topic, one correct answer in five queries. Nothing about the matching changes here.

What changes is where the miss leaves the reader. A topic that exists only as a filename and a command is a miss on this screen and an answer on the two next door, and `files` is the surface most likely to be handed one:

    no sessions mention "widgetpipeline"
    deja: 1 command this machine ran matches it — `deja how widgetpipeline`
    deja: 3 sessions touched widgetpipeline.go — `deja blame widgetpipeline.go`

The same two lines search ends on since #2634, on the same condition. On stdout, where every other sentence this screen prints goes.
