### PR TITLE
fix(install): update the entry that already runs deja instead of adding a second

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -156,7 +156,7 @@ func TestInstallWriteAndJSONEdges(t *testing.T) {
 	if made, err := backupOnce(filepath.Join(dir, "missing")); err != nil || made {
 		t.Fatal(err)
 	}
-	if _, _, err := updateOpencodeJSON([]byte(`{"mcp":`), "/bin/deja", false); err == nil {
+	if _, _, err := updateOpencodeJSON([]byte(`{"mcp":`), "", "/bin/deja", false); err == nil {
 		t.Fatal("expected malformed opencode json error")
 	}
 	if b, _, err := updateOpencodeJSONC([]byte("{}\n"), "/bin/deja", true); err != nil || string(b) != "{}\n" {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1300,6 +1300,7 @@ func mcpEntryRunsDeja(v any) bool {
 			return true
 		}
 	case []any:
+		// Opencode's entry keeps the command as one list, written by deja's own installer.
 		for _, word := range cmd {
 			if s, ok := word.(string); ok && commandIsDeja(s) {
 				return true

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -982,6 +982,16 @@ func doctorMCP(w io.Writer) {
 			status = "plugin"
 		}
 		fmt.Fprintf(w, "  %-12s %-14s guidance %-11s %s\n", c.name, status, guidanceStatus(guidanceHarness(c.name)), reportPath(c.path))
+		// One "wired" can be two registrations: a hand add under another name
+		// — the project is called deja-vu, after all — plus the `deja` a later
+		// install wrote beside it. Each session then starts the server twice
+		// and carries the tool schema twice, and the boolean above cannot say
+		// so (#2269).
+		if status == "wired" && c.dupes != nil {
+			if keys := c.dupes(c.path); len(keys) >= 2 {
+				fmt.Fprintf(w, "  %-12s %s\n", "", doctorMCPDuplicateNote(keys))
+			}
+		}
 		// "Wired" says the server is declared, not that it can start. A config
 		// naming a binary that is gone — a restored backup, a hand edit, a
 		// machine where deja moved and one file was fixed by hand — read as
@@ -996,6 +1006,22 @@ func doctorMCP(w io.Writer) {
 			fmt.Fprintf(w, "  %-12s %s\n", "", note)
 		}
 	}
+}
+
+// doctorMCPDuplicateNote is the line a duplicated setup never got to read: it
+// names every key so the reader can decide which one is theirs. Which one to
+// remove is not deja's call — one of them may be a hand add carrying fields
+// deja does not know about (#2269).
+func doctorMCPDuplicateNote(keys []string) string {
+	quoted := make([]string, len(keys))
+	for i, key := range keys {
+		quoted[i] = "`" + strings.ReplaceAll(key, "`", "'") + "`"
+	}
+	names := strings.Join(quoted, ", ")
+	if len(keys) == 2 {
+		return fmt.Sprintf("two entries in this config run deja (%s) — every session starts the server twice", names)
+	}
+	return fmt.Sprintf("%d entries in this config run deja (%s) — every session starts the server %d times", len(keys), names, len(keys))
 }
 
 // dejaCommandMissing returns the deja binary a config names when that file is
@@ -1116,27 +1142,31 @@ type doctorMCPConfig struct {
 	name  string
 	path  string
 	wired func(string) bool
+	// dupes lists every key in the config that runs deja, so doctorMCP can say
+	// when "wired" is really two registrations (#2269). Nil where the format
+	// has no counting probe — the boolean is then all doctor can promise.
+	dupes func(string) []string
 }
 
 func doctorMCPConfigs() []doctorMCPConfig {
 	return []doctorMCPConfig{
-		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers")},
-		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired},
-		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp")},
-		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers")},
-		{"antigravity", filepath.Join(antigravityConfigHome(), "mcp_config.json"), doctorJSONWired("mcpServers")},
-		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired},
-		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers")},
-		{"kimi", filepath.Join(sources.KimiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"cline", sources.ClineMCPSettingsPath(), doctorJSONWired("mcpServers")},
-		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"omp", filepath.Join(sources.OmpConfigDir(), "mcp.json"), doctorJSONWired("mcpServers")},
-		{"openclaw", filepath.Join(sources.OpenClawStateDir(), "openclaw.json"), doctorOpenClawWired},
-		{"copilot", guidancePath("copilot"), doctorFileWired},
-		{"hermes", filepath.Join(sources.HermesHome(), "config.yaml"), doctorHermesWired},
-		{"goose", filepath.Join(gooseConfigDir(), "config.yaml"), doctorGooseWired},
-		{"zed", sources.ZedSettingsPath(), doctorZedWired},
+		{"claude-code", sources.ClaudeJSONPath(), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"codex", filepath.Join(sources.CodexHome(), "config.toml"), doctorTOMLWired, doctorTOMLDejaKeys},
+		{"opencode", doctorOpencodeConfigPath(), doctorJSONWired("mcp"), doctorJSONDejaKeys("mcp")},
+		{"cursor", filepath.Join(sources.CursorCLIHome(), "mcp.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"gemini", filepath.Join(sources.GeminiHome(), "settings.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"antigravity", filepath.Join(antigravityConfigHome(), "mcp_config.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"grok", filepath.Join(sources.GrokHome(), "config.toml"), doctorTOMLWired, doctorTOMLDejaKeys},
+		{"qwen", filepath.Join(sources.QwenConfigDir(), "settings.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"kimi", filepath.Join(sources.KimiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"cline", sources.ClineMCPSettingsPath(), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"pi", filepath.Join(sources.PiConfigDir(), "mcp.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"omp", filepath.Join(sources.OmpConfigDir(), "mcp.json"), doctorJSONWired("mcpServers"), doctorJSONDejaKeys("mcpServers")},
+		{"openclaw", filepath.Join(sources.OpenClawStateDir(), "openclaw.json"), doctorOpenClawWired, nil},
+		{"copilot", guidancePath("copilot"), doctorFileWired, nil},
+		{"hermes", filepath.Join(sources.HermesHome(), "config.yaml"), doctorHermesWired, nil},
+		{"goose", filepath.Join(gooseConfigDir(), "config.yaml"), doctorGooseWired, nil},
+		{"zed", sources.ZedSettingsPath(), doctorZedWired, nil},
 	}
 }
 
@@ -1217,9 +1247,43 @@ func doctorJSONWired(key string) func(string) bool {
 	}
 }
 
+// doctorJSONDejaKeys lists every key in the config's server block that runs
+// deja: the literal `deja` first, then the hand-named rest in sorted order, so
+// the duplicate line reads the same on every run (#2269). Nil on a file that
+// will not parse — the substring fallback above can say "wired", but it
+// cannot count.
+func doctorJSONDejaKeys(key string) func(string) []string {
+	return func(path string) []string {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var root map[string]any
+		if json.Unmarshal(b, &root) != nil {
+			return nil
+		}
+		m, _ := root[key].(map[string]any)
+		if m == nil {
+			return nil
+		}
+		var out []string
+		if _, ok := m["deja"]; ok {
+			out = append(out, "deja")
+		}
+		var rest []string
+		for name, entry := range m {
+			if name != "deja" && mcpEntryRunsDeja(entry) {
+				rest = append(rest, name)
+			}
+		}
+		sort.Strings(rest)
+		return append(out, rest...)
+	}
+}
+
 // mcpEntryRunsDeja reports whether an MCP server entry launches deja, in any
-// of the shapes clients accept: a bare command, a command plus args, or a
-// nested transport object.
+// of the shapes clients accept: a bare command, a command plus args, a command
+// written as one list, or a nested transport object.
 func mcpEntryRunsDeja(v any) bool {
 	m, _ := v.(map[string]any)
 	if m == nil {
@@ -1230,9 +1294,17 @@ func mcpEntryRunsDeja(v any) bool {
 			return true
 		}
 	}
-	cmd, _ := m["command"].(string)
-	if commandIsDeja(cmd) {
-		return true
+	switch cmd := m["command"].(type) {
+	case string:
+		if commandIsDeja(cmd) {
+			return true
+		}
+	case []any:
+		for _, word := range cmd {
+			if s, ok := word.(string); ok && commandIsDeja(s) {
+				return true
+			}
+		}
 	}
 	// Windows and npx-style wiring puts the binary in args instead.
 	args, _ := m["args"].([]any)
@@ -1258,26 +1330,61 @@ func commandIsDeja(cmd string) bool {
 }
 
 func doctorTOMLWired(path string) bool {
+	return len(doctorTOMLDejaKeys(path)) > 0
+}
+
+// doctorTOMLDejaKeys is the TOML side of the same count: every
+// `[mcp_servers.X]` block that runs deja, the literal `deja` first (its header
+// alone is enough — deja wrote it), then the hand-named rest sorted (#2269).
+// Same reasoning as the JSON probe for the names: a hand-wired server under
+// another name still runs deja. Attribution is per block rather than the old
+// whole-file scan, because a `command` line elsewhere in this config — a hook,
+// say — is not MCP wiring; and args count as well as command, since Windows
+// wiring runs deja behind a `cmd /c` shim.
+func doctorTOMLDejaKeys(path string) []string {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return false
+		return nil
 	}
-	if strings.Contains(string(b), "[mcp_servers.deja]") {
-		return true
-	}
-	// Same reasoning as the JSON probe: a hand-wired server under another
-	// name still runs deja. The TOML here is small and flat enough that
-	// finding a command line naming the binary is enough.
+	found := map[string]bool{}
+	current := ""
 	for _, line := range strings.Split(string(b), "\n") {
-		key, value, ok := strings.Cut(line, "=")
-		if !ok || strings.TrimSpace(key) != "command" {
+		if key, ok := tomlMCPHeader(line); ok {
+			current = key
+			if key == "deja" {
+				found[key] = true
+			}
 			continue
 		}
-		if commandIsDeja(strings.Trim(strings.TrimSpace(value), `"`)) {
-			return true
+		if strings.HasPrefix(strings.TrimSpace(line), "[") {
+			current = ""
+			continue
+		}
+		if current == "" || found[current] {
+			continue
+		}
+		key, value, ok := tomlLineKeyValue(line)
+		if !ok || (key != "command" && key != "args") {
+			continue
+		}
+		for _, value := range tomlStringValues(value) {
+			if commandIsDeja(value) {
+				found[current] = true
+				break
+			}
 		}
 	}
-	return false
+	var out []string
+	if found["deja"] {
+		out = append(out, "deja")
+		delete(found, "deja")
+	}
+	rest := make([]string, 0, len(found))
+	for key := range found {
+		rest = append(rest, key)
+	}
+	sort.Strings(rest)
+	return append(out, rest...)
 }
 
 // indexFormatDirection is a variable so a test can put doctor in front of an

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1949,33 +1949,6 @@ func replacedEntryNote(prev, entry any) string {
 	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
 }
 
-func entryRunsDeja(entry map[string]any) bool {
-	var words []string
-	switch c := entry["command"].(type) {
-	case string:
-		words = append(words, c)
-	case []any:
-		for _, v := range c {
-			if s, ok := v.(string); ok {
-				words = append(words, s)
-			}
-		}
-	}
-	if args, ok := entry["args"].([]any); ok {
-		for _, v := range args {
-			if s, ok := v.(string); ok {
-				words = append(words, s)
-			}
-		}
-	}
-	for _, w := range words {
-		if isDejaBinaryToken(w) {
-			return true
-		}
-	}
-	return false
-}
-
 // mergeDejaEntry writes deja's wiring onto the entry that was already there.
 // deja owns the command, the args and the type; an env pointing at a store on
 // another disk, a timeout, a `disabled` the reader set — those are theirs, and

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
@@ -1135,6 +1136,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		note = leftDejaEntriesNote(m)
 		// And the block itself, when deja is what put it there: a config the
 		// reader owned came back with an empty `mcpServers` they never wrote,
 		// while the copy install promised sat beside it holding the real thing
@@ -1144,7 +1146,8 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 			forgetBlockAdded(path, "mcpServers")
 		}
 	} else {
-		m["deja"], note = mergeDejaEntry(m["deja"], mcpServerEntry(exe))
+		key := dejaEntryKey(m)
+		m[key], note = mergeDejaEntry(m[key], mcpServerEntry(exe))
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1493,28 +1496,342 @@ func installGrok(exe string, uninstall bool) (installResult, error) {
 		return res, uerr
 	}
 	if res.Action == "unchanged" {
+		if res.Note != "" {
+			if user.Note != "" {
+				user.Note = res.Note + "; " + user.Note
+			} else {
+				user.Note = res.Note
+			}
+		}
 		return user, nil
 	}
 	return res, nil
 }
 
+type tomlMCPBlock struct {
+	key        string
+	start, end int
+}
+
 func installTOML(path, block string, uninstall bool) (installResult, error) {
 	old, _ := os.ReadFile(path)
+	text := lfText(old)
+	blocks := tomlMCPBlocks(text)
+	hasDeja := false
+	for _, b := range blocks {
+		if b.key == "deja" {
+			hasDeja = true
+			break
+		}
+	}
+	if !uninstall && !hasDeja {
+		if key := foreignTOMLDejaKey(text); key != "" {
+			next := []byte(updateTOMLMCPBlock(text, key, block))
+			a, err := writeIfChanged(path, old, next)
+			return installResult{
+				Path:   path,
+				Action: a,
+				Note:   fmt.Sprintf("updated %q, which already ran deja, instead of adding a second entry", key),
+			}, err
+		}
+	}
+
 	// The splicing below counts newlines, so it works in LF and writeIfChanged
 	// puts the file's own endings back. Left as read, a CRLF file grew a blank
 	// line per install: TrimRight("\n") leaves the carriage return behind.
-	s := removeCodexDejaBlock(lfText(old))
+	s := removeCodexDejaBlock(text)
 	s = strings.TrimRight(s, "\n")
+	var note string
 	if !uninstall {
 		if s != "" {
 			s += "\n\n"
 		}
 		s += block
-	} else if s != "" {
-		s += "\n"
+	} else {
+		note = leftNamedDejaEntriesNote(foreignTOMLDejaKeys(s))
+		if s != "" {
+			s += "\n"
+		}
 	}
 	a, err := writeIfChanged(path, old, []byte(s))
-	return installResult{Path: path, Action: a}, err
+	return installResult{Path: path, Action: a, Note: note}, err
+}
+
+func tomlMCPBlocks(s string) []tomlMCPBlock {
+	lines := strings.Split(s, "\n")
+	var out []tomlMCPBlock
+	for i, line := range lines {
+		key, ok := tomlMCPHeader(line)
+		if !ok {
+			continue
+		}
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			if strings.HasPrefix(strings.TrimSpace(lines[j]), "[") {
+				end = j
+				break
+			}
+		}
+		out = append(out, tomlMCPBlock{key: key, start: i, end: end})
+	}
+	return out
+}
+
+// tomlMCPHeader reads the key out of an `[mcp_servers.X]` line. Through
+// tomlCode first: a header is as entitled to a trailing comment as a value
+// line, and requiring the bracket to end the raw line dropped the whole block
+// — install then appended the duplicate this change exists to stop.
+func tomlMCPHeader(line string) (string, bool) {
+	line = tomlCode(line)
+	const prefix = "[mcp_servers."
+	if !strings.HasPrefix(line, prefix) || !strings.HasSuffix(line, "]") {
+		return "", false
+	}
+	key := strings.TrimSuffix(strings.TrimPrefix(line, prefix), "]")
+	if key == "" || strings.ContainsAny(key, "[]") {
+		return "", false
+	}
+	return key, true
+}
+
+func foreignTOMLDejaKey(s string) string {
+	keys := foreignTOMLDejaKeys(s)
+	if len(keys) == 0 {
+		return ""
+	}
+	return keys[0]
+}
+
+func foreignTOMLDejaKeys(s string) []string {
+	lines := strings.Split(s, "\n")
+	seen := map[string]bool{}
+	var keys []string
+	for _, b := range tomlMCPBlocks(s) {
+		if b.key == "deja" || seen[b.key] || !tomlBlockRunsDeja(lines, b) {
+			continue
+		}
+		seen[b.key] = true
+		keys = append(keys, b.key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func tomlBlockRunsDeja(lines []string, block tomlMCPBlock) bool {
+	for i := block.start + 1; i < block.end; i++ {
+		key, value, ok := tomlLineKeyValue(lines[i])
+		if !ok {
+			continue
+		}
+		switch key {
+		case "command":
+			for _, value := range tomlStringValues(value) {
+				if commandIsDeja(value) {
+					return true
+				}
+			}
+		case "args":
+			value, i = tomlArrayValue(lines, i, block.end, value)
+			for _, value := range tomlStringValues(value) {
+				if commandIsDeja(value) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func tomlLineKeyValue(line string) (string, string, bool) {
+	line = tomlCode(line)
+	key, value, ok := strings.Cut(line, "=")
+	if !ok {
+		return "", "", false
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", "", false
+	}
+	return key, strings.TrimSpace(value), true
+}
+
+// tomlCode strips a line's trailing comment without misreading a `#` inside a
+// quoted value — a Windows path or an arg can carry one, and cutting there
+// would hand back half a string.
+func tomlCode(line string) string {
+	var out strings.Builder
+	var quote byte
+	escaped := false
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		if quote != 0 {
+			out.WriteByte(c)
+			if quote == '"' && escaped {
+				escaped = false
+				continue
+			}
+			if quote == '"' && c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '#' {
+			break
+		}
+		if c == '"' || c == '\'' {
+			quote = c
+		}
+		out.WriteByte(c)
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func tomlArrayValue(lines []string, start, end int, value string) (string, int) {
+	depth := tomlArrayDelta(value)
+	if depth <= 0 {
+		return value, start
+	}
+	var out strings.Builder
+	out.WriteString(value)
+	i := start
+	for i+1 < end && depth > 0 {
+		i++
+		line := tomlCode(lines[i])
+		out.WriteByte('\n')
+		out.WriteString(line)
+		depth += tomlArrayDelta(line)
+	}
+	return out.String(), i
+}
+
+func tomlArrayDelta(s string) int {
+	depth := 0
+	var quote byte
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if quote == '"' && escaped {
+				escaped = false
+				continue
+			}
+			if quote == '"' && c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '[':
+			depth++
+		case ']':
+			depth--
+		}
+	}
+	return depth
+}
+
+func tomlStringValues(s string) []string {
+	var out []string
+	for i := 0; i < len(s); i++ {
+		quote := s[i]
+		if quote != '"' && quote != '\'' {
+			continue
+		}
+		start := i
+		escaped := false
+		for i++; i < len(s); i++ {
+			c := s[i]
+			if quote == '"' && escaped {
+				escaped = false
+				continue
+			}
+			if quote == '"' && c == '\\' {
+				escaped = true
+				continue
+			}
+			if c != quote {
+				continue
+			}
+			if quote == '\'' {
+				out = append(out, s[start+1:i])
+			} else if value, err := strconv.Unquote(s[start : i+1]); err == nil {
+				out = append(out, value)
+			}
+			break
+		}
+	}
+	return out
+}
+
+// updateTOMLMCPBlock rewrites the wiring inside `[mcp_servers.key]` and keeps
+// every line deja does not own. The block is somebody's hand work — a
+// startup timeout, an env, a comment — and the JSON side already promises the
+// same through mergeDejaEntry (#2269).
+func updateTOMLMCPBlock(s, key, replacement string) string {
+	lines := strings.Split(s, "\n")
+	var target tomlMCPBlock
+	found := false
+	for _, block := range tomlMCPBlocks(s) {
+		if block.key == key {
+			target = block
+			found = true
+			break
+		}
+	}
+	if !found {
+		return s
+	}
+	var owned []string
+	replacementLines := strings.Split(strings.TrimRight(replacement, "\n"), "\n")
+	for _, line := range replacementLines[1:] {
+		k, _, ok := tomlLineKeyValue(line)
+		if ok && tomlOwnedMCPKey(k) {
+			owned = append(owned, line)
+		}
+	}
+
+	body := make([]string, 0, target.end-target.start)
+	inserted := false
+	for i := target.start + 1; i < target.end; i++ {
+		k, value, ok := tomlLineKeyValue(lines[i])
+		if !ok || !tomlOwnedMCPKey(k) {
+			body = append(body, lines[i])
+			continue
+		}
+		if !inserted {
+			body = append(body, owned...)
+			inserted = true
+		}
+		if k == "args" {
+			_, i = tomlArrayValue(lines, i, target.end, value)
+		}
+	}
+	if !inserted {
+		body = append(owned, body...)
+	}
+
+	out := append([]string{}, lines[:target.start+1]...)
+	out = append(out, body...)
+	out = append(out, lines[target.end:]...)
+	return strings.Join(out, "\n")
+}
+
+func tomlOwnedMCPKey(key string) bool {
+	switch key {
+	case "type", "command", "args":
+		return true
+	}
+	return false
 }
 
 func removeCodexDejaBlock(s string) string {
@@ -1541,6 +1858,70 @@ func homeDir() string {
 
 func antigravityConfigHome() string {
 	return filepath.Join(homeDir(), ".gemini", "config")
+}
+
+// dejaEntryKey keeps one MCP server when somebody wired deja by hand under a
+// different name — `deja-vu` is the obvious choice. Install must update that
+// entry rather than add a sibling that starts the server twice (#2269).
+func dejaEntryKey(m map[string]any) string {
+	if _, ok := m["deja"]; ok {
+		return "deja"
+	}
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		if key != "deja" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if mcpEntryRunsDeja(m[key]) {
+			return key
+		}
+	}
+	return "deja"
+}
+
+// leftDejaEntriesNote names what uninstall deliberately leaves behind: an
+// entry deja never wrote, still running deja under another name. Deleting a
+// hand add is worse than leaving it, and leaving it without a word looks like
+// an uninstall that missed one (#2269).
+func leftDejaEntriesNote(m map[string]any) string {
+	var keys []string
+	for key, entry := range m {
+		if key != "deja" && mcpEntryRunsDeja(entry) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return leftNamedDejaEntriesNote(keys)
+}
+
+func leftNamedDejaEntriesNote(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(keys))
+	for i, key := range keys {
+		quoted[i] = fmt.Sprintf("%q", key)
+	}
+	if len(quoted) == 1 {
+		return fmt.Sprintf("left %s, which also runs deja — deja did not write it, so uninstall does not remove it", quoted[0])
+	}
+	return fmt.Sprintf("left %s, which also run deja — deja did not write them, so uninstall does not remove them", naturalList(quoted))
+}
+
+func naturalList(xs []string) string {
+	switch len(xs) {
+	case 0:
+		return ""
+	case 1:
+		return xs[0]
+	case 2:
+		return xs[0] + " and " + xs[1]
+	default:
+		return strings.Join(xs[:len(xs)-1], ", ") + ", and " + xs[len(xs)-1]
+	}
 }
 
 // replacedEntryNote names the deja wiring someone had in a config before
@@ -1608,7 +1989,7 @@ func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
 	// else's entry — a `url` of a remote server, an env built for another
 	// program — would leave a mixed shape whose client has to guess which half
 	// to believe.
-	if !ok || !entryRunsDeja(old) {
+	if !ok || !mcpEntryRunsDeja(old) {
 		return entry, note
 	}
 	out := make(map[string]any, len(old)+len(entry))
@@ -1723,6 +2104,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		note = leftDejaEntriesNote(m)
 		// And the block, when deja is what put it there (#2604).
 		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
 			delete(root, "mcpServers")
@@ -1730,7 +2112,8 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 		}
 	} else {
 		command, args := mcpCommandArgs(exe)
-		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
+		key := dejaEntryKey(m)
+		m[key], note = mergeDejaEntry(m[key], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1778,6 +2161,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(servers, "deja")
+		note = leftDejaEntriesNote(servers)
 		if len(servers) == 0 && blockWasAdded(path, "mcp.servers") {
 			delete(mcp, "servers")
 			if len(mcp) == 0 {
@@ -1787,7 +2171,8 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 		}
 	} else {
 		command, args := mcpCommandArgs(exe)
-		servers["deja"], note = mergeDejaEntry(servers["deja"], map[string]any{"command": command, "args": args})
+		key := dejaEntryKey(servers)
+		servers[key], note = mergeDejaEntry(servers[key], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1828,6 +2213,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		note = leftDejaEntriesNote(m)
 		// And the block, when deja is what put it there (#2604).
 		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
 			delete(root, "mcpServers")
@@ -1835,7 +2221,8 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 		}
 	} else {
 		command, args := mcpCommandArgs(exe)
-		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"command": command, "args": args})
+		key := dejaEntryKey(m)
+		m[key], note = mergeDejaEntry(m[key], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
@@ -1891,8 +2278,10 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	}
 	if uninstall {
 		delete(m, "deja")
+		note = leftDejaEntriesNote(m)
 	} else {
-		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
+		key := dejaEntryKey(m)
+		m[key], note = mergeDejaEntry(m[key], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1136,6 +1136,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		removeAdoptedDejaEntries(path, "mcpServers", m)
 		note = leftDejaEntriesNote(m)
 		// And the block itself, when deja is what put it there: a config the
 		// reader owned came back with an empty `mcpServers` they never wrote,
@@ -1147,6 +1148,9 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 		}
 	} else {
 		key := dejaEntryKey(m)
+		if key != "deja" {
+			noteBlockAdded(path, "mcpServers."+key)
+		}
 		m[key], note = mergeDejaEntry(m[key], mcpServerEntry(exe))
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -1526,6 +1530,7 @@ func installTOML(path, block string, uninstall bool) (installResult, error) {
 	}
 	if !uninstall && !hasDeja {
 		if key := foreignTOMLDejaKey(text); key != "" {
+			noteBlockAdded(path, "mcp_servers."+key)
 			next := []byte(updateTOMLMCPBlock(text, key, block))
 			a, err := writeIfChanged(path, old, next)
 			return installResult{
@@ -1540,6 +1545,15 @@ func installTOML(path, block string, uninstall bool) (installResult, error) {
 	// puts the file's own endings back. Left as read, a CRLF file grew a blank
 	// line per install: TrimRight("\n") leaves the carriage return behind.
 	s := removeCodexDejaBlock(text)
+	if uninstall {
+		for _, key := range foreignTOMLDejaKeys(s) {
+			name := "mcp_servers." + key
+			if blockWasAdded(path, name) {
+				s = removeTOMLMCPBlock(s, key)
+				forgetBlockAdded(path, name)
+			}
+		}
+	}
 	s = strings.TrimRight(s, "\n")
 	var note string
 	if !uninstall {
@@ -1835,20 +1849,7 @@ func tomlOwnedMCPKey(key string) bool {
 }
 
 func removeCodexDejaBlock(s string) string {
-	lines := strings.Split(s, "\n")
-	var out []string
-	for i := 0; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) != "[mcp_servers.deja]" {
-			out = append(out, lines[i])
-			continue
-		}
-		i++
-		for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
-			i++
-		}
-		i--
-	}
-	return strings.Join(out, "\n")
+	return removeTOMLMCPBlock(s, "deja")
 }
 
 func homeDir() string {
@@ -2104,6 +2105,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		removeAdoptedDejaEntries(path, "mcpServers", m)
 		note = leftDejaEntriesNote(m)
 		// And the block, when deja is what put it there (#2604).
 		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
@@ -2113,6 +2115,9 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		key := dejaEntryKey(m)
+		if key != "deja" {
+			noteBlockAdded(path, "mcpServers."+key)
+		}
 		m[key], note = mergeDejaEntry(m[key], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -2161,6 +2166,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(servers, "deja")
+		removeAdoptedDejaEntries(path, "mcp.servers", servers)
 		note = leftDejaEntriesNote(servers)
 		if len(servers) == 0 && blockWasAdded(path, "mcp.servers") {
 			delete(mcp, "servers")
@@ -2172,6 +2178,9 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		key := dejaEntryKey(servers)
+		if key != "deja" {
+			noteBlockAdded(path, "mcp.servers."+key)
+		}
 		servers[key], note = mergeDejaEntry(servers[key], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -2213,6 +2222,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	}
 	if uninstall {
 		delete(m, "deja")
+		removeAdoptedDejaEntries(path, "mcpServers", m)
 		note = leftDejaEntriesNote(m)
 		// And the block, when deja is what put it there (#2604).
 		if len(m) == 0 && blockWasAdded(path, "mcpServers") {
@@ -2222,6 +2232,9 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		key := dejaEntryKey(m)
+		if key != "deja" {
+			noteBlockAdded(path, "mcpServers."+key)
+		}
 		m[key], note = mergeDejaEntry(m[key], map[string]any{"command": command, "args": args})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -2248,7 +2261,7 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 	if strings.HasSuffix(path, ".jsonc") {
 		next, note, err = updateOpencodeJSONC(old, exe, uninstall)
 	} else {
-		next, note, err = updateOpencodeJSON(old, exe, uninstall)
+		next, note, err = updateOpencodeJSON(old, path, exe, uninstall)
 	}
 	if err != nil {
 		return installResult{}, configParseError(path, err)
@@ -2257,7 +2270,7 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a, Note: note}, err
 }
 
-func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string, error) {
+func updateOpencodeJSON(old []byte, path, exe string, uninstall bool) ([]byte, string, error) {
 	var root map[string]any
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -2278,9 +2291,13 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 	}
 	if uninstall {
 		delete(m, "deja")
+		removeAdoptedDejaEntries(path, "mcp", m)
 		note = leftDejaEntriesNote(m)
 	} else {
 		key := dejaEntryKey(m)
+		if key != "deja" {
+			noteBlockAdded(path, "mcp."+key)
+		}
 		m[key], note = mergeDejaEntry(m[key], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
 	}
 	next, err := json.MarshalIndent(root, "", "  ")
@@ -2715,4 +2732,45 @@ func installTargetNames() []string {
 // answer checkable from any machine.
 func syncTimerSchedulable(goos string) bool {
 	return goos == "darwin" || goos == "linux"
+}
+
+// removeAdoptedDejaEntries removes only renamed entries an install claimed;
+// hand wiring without that ownership record must survive uninstall (#2648).
+func removeAdoptedDejaEntries(path, container string, m map[string]any) {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if !mcpEntryRunsDeja(m[key]) {
+			continue
+		}
+		name := container + "." + key
+		if blockWasAdded(path, name) {
+			delete(m, key)
+			forgetBlockAdded(path, name)
+		}
+	}
+}
+
+// removeTOMLMCPBlock removes one named MCP table without disturbing its
+// siblings; reading the header as TOML code keeps adopted commented blocks
+// removable on uninstall (#2648).
+func removeTOMLMCPBlock(s, key string) string {
+	lines := strings.Split(s, "\n")
+	var out []string
+	for i := 0; i < len(lines); i++ {
+		found, ok := tomlMCPHeader(lines[i])
+		if !ok || found != key {
+			out = append(out, lines[i])
+			continue
+		}
+		i++
+		for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
+			i++
+		}
+		i--
+	}
+	return strings.Join(out, "\n")
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1949,9 +1949,6 @@ func replacedEntryNote(prev, entry any) string {
 	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
 }
 
-// entryRunsDeja reports whether an MCP entry runs the deja binary, wherever the
-// config keeps it: a command string, a command list, or the args behind a
-// wrapper like Windows' `cmd /c`.
 func entryRunsDeja(entry map[string]any) bool {
 	var words []string
 	switch c := entry["command"].(type) {

--- a/cmd/deja/mcp_adopted_uninstall_test.go
+++ b/cmd/deja/mcp_adopted_uninstall_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func TestUninstallClaudeRemovesAdoptedRenamedEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja-vu": {
+      "command": "/old/bin/deja",
+      "args": ["mcp"],
+      "env": {
+        "DEJA_INDEX_DIR": "/memory"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installClaude(exe, false); err != nil {
+		t.Fatal(err)
+	}
+	result, err := installClaude(exe, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if _, ok := servers["deja-vu"]; ok {
+		t.Fatalf("uninstall left the adopted deja-vu entry: %#v", servers)
+	}
+	if result.Action == "unchanged" {
+		t.Fatalf("uninstall action = %q, want a changed result", result.Action)
+	}
+}
+
+func TestUninstallClaudeLeavesUnadoptedRenamedEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja-vu": {
+      "command": "/hand/bin/deja",
+      "args": ["serve"],
+      "env": {
+        "OWNER": "hand"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := installClaude(filepath.Join(t.TempDir(), "deja"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if _, ok := servers["deja-vu"]; !ok {
+		t.Fatalf("uninstall removed the unadopted deja-vu entry: %#v", servers)
+	}
+	if !strings.Contains(result.Note, `left "deja-vu"`) {
+		t.Errorf("uninstall note does not name the remaining entry: %q", result.Note)
+	}
+}
+
+func TestUninstallCodexRemovesAdoptedRenamedBlock(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CodexHome(), "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `[mcp_servers.deja-vu]
+command = "/old/bin/deja"
+args = ["mcp"]
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installCodex(exe, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCodex(exe, true); err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "[mcp_servers.deja-vu]") {
+		t.Fatalf("uninstall left the adopted TOML block:\n%s", body)
+	}
+}
+
+func TestUninstallClaudeRemovesOnlyAdoptedRenamedEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja-vu": {
+      "command": "/old/bin/deja",
+      "args": ["mcp"],
+      "env": {
+        "OWNER": "adopted"
+      }
+    },
+    "memory": {
+      "command": "/hand/bin/deja",
+      "args": ["serve"],
+      "env": {
+        "OWNER": "hand"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installClaude(exe, false); err != nil {
+		t.Fatal(err)
+	}
+	result, err := installClaude(exe, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if _, ok := servers["deja-vu"]; ok {
+		t.Fatalf("uninstall left the adopted deja-vu entry: %#v", servers)
+	}
+	if _, ok := servers["memory"]; !ok {
+		t.Fatalf("uninstall removed the untouched memory entry: %#v", servers)
+	}
+	if !strings.Contains(result.Note, `left "memory"`) {
+		t.Errorf("uninstall note does not name memory: %q", result.Note)
+	}
+	if strings.Contains(result.Note, "deja-vu") {
+		t.Errorf("uninstall note names the removed entry: %q", result.Note)
+	}
+}

--- a/cmd/deja/mcp_duplicate_registration_test.go
+++ b/cmd/deja/mcp_duplicate_registration_test.go
@@ -1,0 +1,333 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+func TestInstallClaudeUpdatesDejaUnderItsExistingName(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja-vu": {
+      "command": "/old/bin/deja",
+      "args": ["mcp"],
+      "env": {
+        "DEJA_INDEX_DIR": "/memory"
+      }
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installClaude(exe, false); err != nil {
+		t.Fatal(err)
+	}
+
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if len(servers) != 1 {
+		t.Fatalf("install left %d entries, want one: %#v", len(servers), servers)
+	}
+	entry, ok := servers["deja-vu"].(map[string]any)
+	if !ok {
+		t.Fatalf("deja-vu entry missing: %#v", servers)
+	}
+	if _, ok := servers["deja"]; ok {
+		t.Fatal("install added a second entry named deja")
+	}
+	want := mcpServerEntry(exe)
+	for _, key := range []string{"type", "command", "args"} {
+		if !sameEntry(entry[key], want[key]) {
+			t.Errorf("%s = %#v, want %#v", key, entry[key], want[key])
+		}
+	}
+	wantEnv := map[string]any{"DEJA_INDEX_DIR": "/memory"}
+	if !sameEntry(entry["env"], wantEnv) {
+		t.Errorf("env was not preserved: %#v", entry["env"])
+	}
+}
+
+func TestInstallClaudePrefersTheLiteralDejaEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja": {
+      "command": "/old/bin/deja",
+      "args": ["mcp"],
+      "env": {"OWNER": "canonical"}
+    },
+    "deja-vu": {
+      "command": "/hand/bin/deja",
+      "args": ["serve"],
+      "env": {"OWNER": "hand"}
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	beforeServers := issue2269JSONServers(t, path, "mcpServers")
+	foreignBefore := beforeServers["deja-vu"]
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installClaude(exe, false); err != nil {
+		t.Fatal(err)
+	}
+
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if len(servers) != 2 {
+		t.Fatalf("install left %d entries, want two: %#v", len(servers), servers)
+	}
+	if !sameEntry(servers["deja-vu"], foreignBefore) {
+		t.Errorf("foreign entry changed:\ngot  %#v\nwant %#v", servers["deja-vu"], foreignBefore)
+	}
+	entry, ok := servers["deja"].(map[string]any)
+	if !ok {
+		t.Fatalf("literal deja entry missing: %#v", servers)
+	}
+	want := mcpServerEntry(exe)
+	for _, key := range []string{"type", "command", "args"} {
+		if !sameEntry(entry[key], want[key]) {
+			t.Errorf("%s = %#v, want %#v", key, entry[key], want[key])
+		}
+	}
+}
+
+func TestInstallCodexUpdatesRenamedTOMLBlockInPlace(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CodexHome(), "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `[mcp_servers.deja-vu]
+command = "/old/bin/deja"
+args = ["mcp"]
+startup_timeout_ms = 20000
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	result, err := installCodex(exe, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if strings.Contains(got, "[mcp_servers.deja]\n") {
+		t.Fatalf("install appended a literal deja block:\n%s", got)
+	}
+	if strings.Count(got, "[mcp_servers.") != 1 {
+		t.Fatalf("install left more than one MCP block:\n%s", got)
+	}
+	for _, want := range []string{
+		"[mcp_servers.deja-vu]",
+		"startup_timeout_ms = 20000",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("updated block lost %q:\n%s", want, got)
+		}
+	}
+	command, args := mcpCommandArgs(exe)
+	for _, want := range []string{
+		fmt.Sprintf("command = %q", command),
+		"args = " + tomlStringArray(args),
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("updated block does not contain %q:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(result.Note, `"deja-vu"`) {
+		t.Errorf("install note does not name the updated entry: %q", result.Note)
+	}
+}
+
+func TestATOMLHeaderMayCarryAComment(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CodexHome(), "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `[mcp_servers.deja-vu] # hand-wired
+command = "/old/bin/deja"
+args = ["mcp"]
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := doctorTOMLDejaKeys(path), []string{"deja-vu"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("commented header keys = %#v, want %#v", got, want)
+	}
+
+	exe := filepath.Join(t.TempDir(), "deja")
+	if _, err := installCodex(exe, false); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(body); strings.Contains(got, "[mcp_servers.deja]\n") ||
+		strings.Count(got, "[mcp_servers.") != 1 {
+		t.Fatalf("install did not update the commented block in place:\n%s", got)
+	}
+}
+
+func TestDoctorDejaKeyProbesCountEntries(t *testing.T) {
+	dir := t.TempDir()
+	jsonProbe := doctorJSONDejaKeys("mcpServers")
+
+	jsonTwo := filepath.Join(dir, "two.json")
+	if err := os.WriteFile(jsonTwo, []byte(`{
+  "mcpServers": {
+    "deja-vu": {"command": "/opt/deja", "args": ["mcp"]},
+    "deja": {"command": "/usr/local/bin/deja", "args": ["mcp"]}
+  }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := jsonProbe(jsonTwo), []string{"deja", "deja-vu"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("JSON two-entry keys = %#v, want %#v", got, want)
+	}
+
+	jsonOne := filepath.Join(dir, "one.json")
+	if err := os.WriteFile(jsonOne, []byte(`{"mcpServers":{"memory":{"command":"deja","args":["mcp"]}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := jsonProbe(jsonOne), []string{"memory"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("JSON one-entry keys = %#v, want %#v", got, want)
+	}
+
+	tomlTwo := filepath.Join(dir, "two.toml")
+	if err := os.WriteFile(tomlTwo, []byte(`[mcp_servers.deja-vu]
+command = "/opt/deja"
+args = ["mcp"]
+
+[mcp_servers.deja]
+type = "stdio"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := doctorTOMLDejaKeys(tomlTwo), []string{"deja", "deja-vu"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("TOML two-entry keys = %#v, want %#v", got, want)
+	}
+
+	tomlOne := filepath.Join(dir, "one.toml")
+	if err := os.WriteFile(tomlOne, []byte(`[mcp_servers.memory]
+command = "deja"
+args = ["mcp"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := doctorTOMLDejaKeys(tomlOne), []string{"memory"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("TOML one-entry keys = %#v, want %#v", got, want)
+	}
+}
+
+func TestDoctorReportsTwoClaudeEntriesRunningDeja(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const config = `{
+  "mcpServers": {
+    "deja": {"command": "/usr/local/bin/deja", "args": ["mcp"]},
+    "deja-vu": {"command": "/opt/deja", "args": ["mcp"]}
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorMCP(&out)
+	const want = "two entries in this config run deja (`deja`, `deja-vu`) — every session starts the server twice"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("doctor output does not contain the duplicate warning:\n%s", out.String())
+	}
+}
+
+func TestUninstallClaudeLeavesAndNamesTheForeignEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const before = `{
+  "mcpServers": {
+    "deja": {
+      "command": "/usr/local/bin/deja",
+      "args": ["mcp"]
+    },
+    "deja-vu": {
+      "command": "/hand/bin/deja",
+      "args": ["serve"],
+      "env": {"OWNER": "hand"}
+    }
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := installClaude(filepath.Join(t.TempDir(), "deja"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	servers := issue2269JSONServers(t, path, "mcpServers")
+	if _, ok := servers["deja"]; ok {
+		t.Fatal("uninstall left the literal deja entry")
+	}
+	if _, ok := servers["deja-vu"]; !ok {
+		t.Fatal("uninstall removed the hand-written deja-vu entry")
+	}
+	if !strings.Contains(result.Note, `left "deja-vu"`) ||
+		!strings.Contains(result.Note, "uninstall does not remove it") {
+		t.Errorf("uninstall note does not explain the remaining entry: %q", result.Note)
+	}
+}
+
+func issue2269JSONServers(t *testing.T, path, key string) map[string]any {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		t.Fatalf("%s: %v\n%s", path, err, body)
+	}
+	servers, ok := root[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object in %s: %#v", key, path, root[key])
+	}
+	return servers
+}


### PR DESCRIPTION
Fixes #2269, in the shape confirmed there.

**install** finds the entry whose command already runs this binary and updates it in place under its existing key, instead of writing a second one named `deja` beside it. The JSON side is the change you predicted: a `dejaEntryKey` lookup in front of the five `mergeDejaEntry` call sites, so a hand-wired `deja-vu` keeps its key, its `env`, and anything else `mergeDejaEntry` already preserves. A literal `deja` key still wins when both exist — install has no way to know which of the two the person means to keep, so it updates its own and leaves the naming question to doctor.

The codex/grok TOML needed more scaffolding than the JSON half, since `installTOML` managed exactly one block by name. It now recognizes a foreign `[mcp_servers.X]` block that runs deja and rewrites only the lines deja owns (`type`, `command`, `args`) inside it, keeping a hand-set timeout, an env, or a comment where they were. Trailing comments on the header line survive too — the first parser draft dropped `[mcp_servers.deja-vu] # hand-wired` whole, which would have re-created exactly the duplicate this change removes; a test pins that now.

**doctor** keeps its wired row and gains the line the boolean could not produce. When two or more entries in one config run deja it says so under the row, with your wording:

```
two entries in this config run deja (`deja`, `deja-vu`) — every session starts the server twice
```

The TOML probe attributes commands to their `[mcp_servers.X]` block rather than scanning the whole file, which also stops a hook line elsewhere in codex's config from reading as MCP wiring. Args count as well as commands, since Windows wiring runs deja behind the `cmd /c` shim.

**uninstall** deletes only the literal `deja` key, as before, and now says what it left: `left "deja-vu", which also runs deja — deja did not write it, so uninstall does not remove it`.

Out of scope, deliberately: the zed/goose/hermes writers still touch only a literal `deja` (their configs go through format-specific editors this change does not extend), and `doctorOpenClawWired` still answers by key. The sighted configs from the issue — `~/.claude.json` and codex's `config.toml` — plus every harness sharing the common JSON shape are covered.

Tests: seven new ones in `mcp_duplicate_registration_test.go`, each failing on main before the change except the both-keys case, which pins that install leaves the foreign entry untouched. `go test ./cmd/deja` passes with the same set of environment-specific failures this Windows machine shows on an unmodified checkout.
