### PR TITLE
fix(mcp): exit when the parent is gone and nobody has spoken for five minutes

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -150,7 +150,7 @@ var commands = map[string]command{
 	"remember":      runRemember,
 	"promote":       func(dir string, rest []string) error { return runPromote(dir, rest, os.Stdout) },
 	"forget":        runForget,
-	"mcp":           func(dir string, _ []string) error { return serveMCP(dir, os.Stdin, os.Stdout) },
+	"mcp":           func(dir string, _ []string) error { return serveMCPProcess(dir, os.Stdin, os.Stdout) },
 	"hook-prompt": func(dir string, rest []string) error {
 		if sayIfTypedByHand("hook-prompt") {
 			return nil

--- a/cmd/deja/mcp_orphan.go
+++ b/cmd/deja/mcp_orphan.go
@@ -68,7 +68,13 @@ func serveMCPProcess(dir string, r io.Reader, w io.Writer) error {
 	var lastRead atomic.Int64
 	lastRead.Store(time.Now().UnixNano())
 
+	// Windows reports -1 when the parent cannot be read; processAlive calls
+	// that dead, and the AND would quietly collapse into the idle timeout the
+	// design rejected. No recorded parent, no watch — EOF still works.
 	ppid := os.Getppid()
+	if ppid <= 0 {
+		return serveMCP(dir, r, w)
+	}
 	stop := startOrphanWatch(
 		ppid,
 		func() time.Time {

--- a/cmd/deja/mcp_orphan.go
+++ b/cmd/deja/mcp_orphan.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// mcpOrphanGrace is the window a quiet but live client gets after its launcher
+// exits before deja can mistake it for an orphan. Five minutes is longer than
+// any request/response gap a real session should produce, but short enough that
+// leaked servers do not accumulate across a working day. A client that closes
+// cleanly reaches EOF within seconds; this only bounds how long an inherited
+// write handle can keep the server alive after its parent is gone (#2397).
+const mcpOrphanGrace = 5 * time.Minute
+
+const mcpOrphanTick = 30 * time.Second
+
+// startOrphanWatch stops the leaked-handle orphan from #2397. A dead parent
+// alone means nothing because launchers legitimately exit, and silence alone
+// means nothing because quiet clients stay connected. Only both together mark
+// the orphan; a client that dies without leaking a handle already ends the
+// server through EOF within seconds.
+func startOrphanWatch(ppid int, lastRead func() time.Time, grace, tick time.Duration, exit func()) (stop func()) {
+	ticker := time.NewTicker(tick)
+	done := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if !processAlive(ppid) && time.Since(lastRead()) > grace {
+					exit()
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	return func() {
+		once.Do(func() {
+			close(done)
+		})
+	}
+}
+
+type mcpStampReader struct {
+	r        io.Reader
+	lastRead *atomic.Int64
+}
+
+func (r *mcpStampReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	if n > 0 || err == nil {
+		r.lastRead.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+func serveMCPProcess(dir string, r io.Reader, w io.Writer) error {
+	var lastRead atomic.Int64
+	lastRead.Store(time.Now().UnixNano())
+
+	ppid := os.Getppid()
+	stop := startOrphanWatch(
+		ppid,
+		func() time.Time {
+			return time.Unix(0, lastRead.Load())
+		},
+		mcpOrphanGrace,
+		mcpOrphanTick,
+		func() {
+			fmt.Fprintf(os.Stderr, "deja: mcp parent pid %d is gone and nothing has been read for %s; exiting the orphaned server (#2397)\n", ppid, mcpOrphanGrace)
+			os.Exit(0)
+		},
+	)
+	defer stop()
+
+	return serveMCP(dir, &mcpStampReader{r: r, lastRead: &lastRead}, w)
+}

--- a/cmd/deja/mcp_orphan_test.go
+++ b/cmd/deja/mcp_orphan_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -25,12 +26,16 @@ func mcpOrphanHelper(mode string) *exec.Cmd {
 	return cmd
 }
 
+// deadMCPProcessPID returns a pid that no longer runs while the *exec.Cmd
+// still holds its process handle — the exact state where OpenProcess keeps
+// succeeding, so a FindProcess-only processAlive fails here by construction.
 func deadMCPProcessPID(t *testing.T) int {
 	t.Helper()
 	cmd := mcpOrphanHelper("exit")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("run helper process: %v", err)
 	}
+	t.Cleanup(func() { runtime.KeepAlive(cmd) })
 	return cmd.Process.Pid
 }
 

--- a/cmd/deja/mcp_orphan_test.go
+++ b/cmd/deja/mcp_orphan_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMCPOrphanHelperProcess(t *testing.T) {
+	switch os.Getenv("DEJA_MCP_ORPHAN_HELPER") {
+	case "":
+		return
+	case "wait":
+		time.Sleep(time.Hour)
+	}
+	os.Exit(0)
+}
+
+func mcpOrphanHelper(mode string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestMCPOrphanHelperProcess$")
+	cmd.Env = append(os.Environ(), "DEJA_MCP_ORPHAN_HELPER="+mode)
+	return cmd
+}
+
+func deadMCPProcessPID(t *testing.T) int {
+	t.Helper()
+	cmd := mcpOrphanHelper("exit")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run helper process: %v", err)
+	}
+	return cmd.Process.Pid
+}
+
+func liveMCPProcess(t *testing.T) (*exec.Cmd, func()) {
+	t.Helper()
+	cmd := mcpOrphanHelper("wait")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper process: %v", err)
+	}
+	return cmd, func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+}
+
+func TestProcessAlive(t *testing.T) {
+	if !processAlive(os.Getpid()) {
+		t.Fatal("current process reported dead")
+	}
+
+	pid := deadMCPProcessPID(t)
+	if processAlive(pid) {
+		t.Fatalf("waited process %d reported alive", pid)
+	}
+}
+
+func TestOrphanWatchKeepsLiveParentDespiteSilence(t *testing.T) {
+	cmd, stopParent := liveMCPProcess(t)
+	defer stopParent()
+
+	exited := make(chan struct{}, 1)
+	stop := startOrphanWatch(
+		cmd.Process.Pid,
+		func() time.Time { return time.Now().Add(-time.Hour) },
+		10*time.Millisecond,
+		5*time.Millisecond,
+		func() { exited <- struct{}{} },
+	)
+	defer stop()
+
+	select {
+	case <-exited:
+		t.Fatal("watch exited while the parent was alive")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestOrphanWatchKeepsRecentlyActiveDeadParent(t *testing.T) {
+	pid := deadMCPProcessPID(t)
+	lastRead := time.Now()
+	exited := make(chan struct{}, 1)
+	stop := startOrphanWatch(
+		pid,
+		func() time.Time { return lastRead },
+		2*time.Second,
+		5*time.Millisecond,
+		func() { exited <- struct{}{} },
+	)
+	defer stop()
+
+	select {
+	case <-exited:
+		t.Fatal("watch exited before the read grace period elapsed")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestOrphanWatchExitsForDeadSilentParent(t *testing.T) {
+	pid := deadMCPProcessPID(t)
+	exited := make(chan struct{}, 1)
+	stop := startOrphanWatch(
+		pid,
+		func() time.Time { return time.Now().Add(-time.Hour) },
+		10*time.Millisecond,
+		5*time.Millisecond,
+		func() { exited <- struct{}{} },
+	)
+	defer stop()
+
+	select {
+	case <-exited:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("watch did not exit for a dead parent after prolonged silence")
+	}
+}
+
+func TestMCPStampReaderUpdatesLastRead(t *testing.T) {
+	var lastRead atomic.Int64
+	lastRead.Store(time.Now().Add(-time.Hour).UnixNano())
+	before := time.Now().UnixNano()
+
+	r := &mcpStampReader{
+		r:        strings.NewReader("x"),
+		lastRead: &lastRead,
+	}
+	buf := make([]byte, 1)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if n != 1 || string(buf) != "x" {
+		t.Fatalf("read = %d, %q; want 1, %q", n, buf, "x")
+	}
+	if got := lastRead.Load(); got < before {
+		t.Fatalf("last read = %d; want at least %d", got, before)
+	}
+}

--- a/cmd/deja/mcp_orphan_unix.go
+++ b/cmd/deja/mcp_orphan_unix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// processAlive reports whether pid still names a process: signal 0 probes
+// without delivering, because FindProcess accepts any pid on unix. EPERM still
+// proves the process exists. PID reuse can make a departed parent look alive,
+// which fails safe by leaving the server waiting rather than ending a possibly
+// healthy connection (#2397).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	defer p.Release()
+	err = p.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, os.ErrPermission)
+}

--- a/cmd/deja/mcp_orphan_unix.go
+++ b/cmd/deja/mcp_orphan_unix.go
@@ -21,7 +21,9 @@ func processAlive(pid int) bool {
 	if err != nil {
 		return false
 	}
-	defer p.Release()
+	// Release frees the handle; nothing can be done if it fails and the answer
+	// below is what the caller asked for.
+	defer func() { _ = p.Release() }()
 	err = p.Signal(syscall.Signal(0))
 	return err == nil || errors.Is(err, os.ErrPermission)
 }

--- a/cmd/deja/mcp_orphan_windows.go
+++ b/cmd/deja/mcp_orphan_windows.go
@@ -17,7 +17,9 @@ func processAlive(pid int) bool {
 	const processQueryLimitedInformation = 0x1000
 	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
-		return false
+		// A process this one may not open still exists — the unix side reads
+		// EPERM the same way.
+		return err == syscall.ERROR_ACCESS_DENIED
 	}
 	defer syscall.CloseHandle(h)
 	var code uint32

--- a/cmd/deja/mcp_orphan_windows.go
+++ b/cmd/deja/mcp_orphan_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+// processAlive reports whether pid still names a running process. OpenProcess
+// succeeding is not enough — a pid stays openable after exit while any handle
+// to it is held, which is exactly the situation around a leaked-handle orphan
+// — so the exit code is what answers. A process that chose STILL_ACTIVE (259)
+// as its exit code reads as running, which fails safe the same way PID reuse
+// does: the server keeps waiting (#2397).
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	const processQueryLimitedInformation = 0x1000
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(h)
+	var code uint32
+	if err := syscall.GetExitCodeProcess(h, &code); err != nil {
+		return true
+	}
+	const stillActive = 259
+	return code == stillActive
+}


### PR DESCRIPTION
Fixes #2397, in the both-and-only-both shape decided there: the server exits when the recorded parent pid is gone **and** nothing has been read for a grace period. A live client that keeps talking is never touched however its process tree looks; a launcher that exits while its client keeps talking is never touched either.

`serveMCP` itself is untouched — the command table now calls a `serveMCPProcess` wrapper that records `os.Getppid()`, stamps an atomic last-read time on every successful read through a thin `io.Reader`, and runs the watch on a 30-second tick beside the blocking read. Every existing serveMCP test reads the same server it always did. When both conditions hold, the server says why on stderr and exits:

```
deja: mcp parent pid 38656 is gone and nothing has been read for 5m0s; exiting the orphaned server (#2397)
```

**The grace period, answered rather than assumed.** Five minutes, and the comment on the constant says what it protects: it is the window a quiet-but-live client whose launcher already exited has before deja could misread it as an orphan — longer than any request gap a real session produces, short enough that leaked servers do not accumulate across a working day. A client that dies cleanly never reaches this path; EOF still ends the server in seconds. On this machine's three clients, registered through the `cmd /c` entry the issue describes, cmd waits on deja, so in the trees observed here the dead-parent half stays false while the client lives.

**"Does this pid still exist" needed one platform split after all.** The obvious Windows answer — `os.FindProcess` erroring for a missing pid — is wrong in exactly this bug's neighborhood: an exited pid stays openable while any handle to it is held, and the first draft's test caught its own implementation reporting a waited-on child as alive. The Windows side now asks `GetExitCodeProcess` for `STILL_ACTIVE`; unix probes with signal 0, EPERM counting as alive. PID reuse fails safe in both directions: a recycled pid reads as alive and the server merely keeps waiting.

**Verified on the repro, on Windows 11.** Built this branch, ran the issue's driver against it — inheritable write handle, sibling spawned with inheritance on, driver dead via `os._exit`, then the cmd shim killed to match the field tree. The sibling held the pipe the whole time, and the server exited on its own when the grace ran out, 4m46s after the parent died, with the stderr line above. Without the leak lines the EOF path still ends it — measured at 0.2 s on this build after an abrupt client kill.

Tests are testable-off-Windows as intended: a helper process stands in for the parent, killed or waited to make it dead, and the three-way table (live parent + silence, dead parent + recent read, dead parent + silence) pins that only the last one exits. `TestProcessAlive` fails on the FindProcess-only implementation.

On the `cmd /c` question from the thread: the shim traces to #170, wired for a field report on #9, so whether any of today's clients accepts a bare exe path needs checking per client — happy to probe that separately, since dropping it only shortens the tree and neither causes nor fixes the inheritance leak.
