### PR TITLE
fix(brief,stats): count what recall can serve

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -54,7 +54,7 @@ func briefWithholdingRule(withheld map[string]int, total int) string {
 // then it goes wherever the writer goes (#2108); `deja help` always works.
 func runBrief(dir string, w io.Writer) error {
 	justGreeted := false
-	ov, err := index.Overview(dir)
+	ov, err := index.OverviewServable(dir)
 	if err != nil || ov.Sessions == 0 {
 		// Nothing indexed yet. Printing usage here is what a fresh install used
 		// to do, and it is the wrong answer to `deja`: the reader has just
@@ -67,7 +67,7 @@ func runBrief(dir string, w io.Writer) error {
 				return err
 			}
 			justGreeted = greeted
-			if ov, err = index.Overview(dir); err != nil {
+			if ov, err = index.OverviewServable(dir); err != nil {
 				return err
 			}
 		}

--- a/cmd/deja/counts_after_rule_test.go
+++ b/cmd/deja/counts_after_rule_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// halvedStore holds ten sessions deja may serve and twenty the ignore rule
+// keeps out, on two different days so a date range gives them away.
+func halvedStore(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	if err := os.MkdirAll(filepath.Dir(policy.Path()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(policy.Path(), []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	write := func(dir, id, day string) {
+		writeClaudeFixture(t, filepath.Join(root, dir, id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/` + strings.TrimPrefix(dir, "-w-") + `","timestamp":"2026-07-` + day + `T10:00:00Z","message":{"role":"user","content":"the widget pipeline keeps stalling"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/` + strings.TrimPrefix(dir, "-w-") + `","timestamp":"2026-07-` + day + `T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/x/widget-` + id + `.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	for i := 0; i < 10; i++ {
+		write("-w-keep", "k"+string(rune('a'+i)), "01")
+	}
+	for i := 0; i < 20; i++ {
+		write("-w-scratch", "s"+string(rune('a'+i)), "02")
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The brief is the first screen anyone sees, and it counted the whole manifest
+// while its own `recent` rows three lines below showed only what recall serves
+// — and dated its range to a day no servable session was worked on (#2650).
+func TestBriefCountsWhatRecallCanServe(t *testing.T) {
+	halvedStore(t)
+	out, err := captureRun(t, "brief")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "30 session") {
+		t.Fatalf("the brief counts sessions the ignore rule keeps out:\n%s", out)
+	}
+	if !strings.Contains(out, "10 session") {
+		t.Fatalf("the brief does not count what recall can serve:\n%s", out)
+	}
+	if strings.Contains(out, "Jul 2 2026") {
+		t.Fatalf("the range covers a day only ignored sessions were worked on:\n%s", out)
+	}
+}
+
+// The same rule for the span count, which sat on a screen already reporting the
+// filtered session count one line above.
+func TestStatsCountsSpansItCouldRestore(t *testing.T) {
+	halvedStore(t)
+	out, err := captureRun(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "10 sessions indexed") {
+		t.Fatalf("the fixture changed; this pins nothing:\n%s", out)
+	}
+	if strings.Contains(out, "30 spans") {
+		t.Fatalf("the span count includes the tree the rule keeps out:\n%s", out)
+	}
+	if !strings.Contains(out, "10 spans") {
+		t.Fatalf("the span count is not what recall can serve:\n%s", out)
+	}
+}
+
+// doctor reports what the index holds, which is the whole store — that number
+// is right there and stays.
+func TestDoctorStillCountsTheWholeStore(t *testing.T) {
+	halvedStore(t)
+	out, err := captureRun(t, "doctor", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"indexed_sessions": 30`) && !strings.Contains(out, `"indexed_sessions":30`) {
+		t.Fatalf("doctor should still report every indexed session:\n%s", out)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1839,7 +1839,9 @@ func olderThanWindow(dir string, since time.Duration) string {
 	if since <= 0 {
 		return ""
 	}
-	ov, err := index.Overview(dir)
+	// Servable: this is advice on a search that came back empty, so the
+	// sessions it counts have to be the ones search could have read (#2650).
+	ov, err := index.OverviewServable(dir)
 	if err != nil || ov.Sessions == 0 || ov.Newest.IsZero() {
 		return ""
 	}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
 // IsCurrentVersion reports whether the index on disk was written by this
@@ -556,6 +558,23 @@ type OverviewStats struct {
 // Overview summarizes the index from manifest metadata alone — no record
 // reads — so the zero-argument brief stays instant.
 func Overview(dir string) (OverviewStats, error) {
+	return overview(dir, false)
+}
+
+// OverviewServable is Overview over the sessions recall can actually serve.
+//
+// The two differ by the ignore rule, and the difference is not cosmetic: on a
+// store where that rule covers two thirds of the sessions, Overview reports
+// three times the sessions the screens beside it show and dates the range to a
+// day none of the servable work happened on. `doctor` wants the first number —
+// it reports what the index holds. The brief and the "older than that window"
+// line want the second, because both describe what a reader can be given
+// (#2650).
+func OverviewServable(dir string) (OverviewStats, error) {
+	return overview(dir, true)
+}
+
+func overview(dir string, servable bool) (OverviewStats, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -563,6 +582,7 @@ func Overview(dir string) (OverviewStats, error) {
 	if err != nil {
 		return OverviewStats{}, err
 	}
+	pol := policy.Load()
 	var o OverviewStats
 	now := time.Now()
 	day := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
@@ -573,6 +593,9 @@ func Overview(dir string) (OverviewStats, error) {
 	week := now.AddDate(0, 0, -7)
 	hs := map[string]bool{}
 	for _, meta := range m.Sessions {
+		if servable && pol.Ignored(meta.Path, meta.Project) {
+			continue
+		}
 		o.Sessions++
 		hs[meta.Harness] = true
 		if StampedAhead(meta.Updated, now) {

--- a/internal/index/overview_servable_test.go
+++ b/internal/index/overview_servable_test.go
@@ -1,0 +1,96 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// halvedStore indexes sessions in two projects, one of which the reader's
+// ignore rule keeps out of recall.
+func halvedStore(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	setHome(t, home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	if err := os.MkdirAll(filepath.Dir(policy.Path()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(policy.Path(), []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	write := func(project, id, day string) {
+		p := filepath.Join(root, "-w-"+project, id+".jsonl")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","sessionId":"` + id + `","cwd":"/w/` + project + `","timestamp":"2026-07-` + day + `T10:00:00Z","message":{"role":"user","content":"the widget pipeline"}}` + "\n" +
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/` + project + `","timestamp":"2026-07-` + day + `T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/x/` + id + `.go","old_string":"a","new_string":"b"}}]}}` + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		write("keep", fmt.Sprintf("k%d", i), "01")
+	}
+	for i := 0; i < 6; i++ {
+		write("scratch", fmt.Sprintf("s%d", i), "02")
+	}
+	dir := filepath.Join(home, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Overview reports what the index holds, which is what `deja doctor` asks for.
+// OverviewServable reports what recall can serve, which is what the brief and
+// the "older than that window" line describe — and counting the first on those
+// screens put three times the sessions on the brief that its own rows showed,
+// dated to a day none of them happened on (#2650).
+func TestOverviewServableLeavesOutTheIgnoredTree(t *testing.T) {
+	dir := halvedStore(t)
+
+	whole, err := Overview(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if whole.Sessions != 9 {
+		t.Fatalf("the whole store holds 9 sessions, Overview says %d", whole.Sessions)
+	}
+
+	servable, err := OverviewServable(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if servable.Sessions != 3 {
+		t.Fatalf("recall can serve 3 sessions, OverviewServable says %d", servable.Sessions)
+	}
+	// The range too: the ignored six are the only work on the second of July.
+	if got := servable.Newest.UTC().Format("2006-01-02"); got != "2026-07-01" {
+		t.Fatalf("the servable range ends %s, on a day only ignored sessions were worked on", got)
+	}
+	if !whole.Newest.After(servable.Newest) {
+		t.Fatalf("the two ranges should differ on this store: whole %s, servable %s", whole.Newest, servable.Newest)
+	}
+}
+
+// The span count is what `restore` would hand back, and restore refuses a tree
+// the ignore rule covers.
+func TestSpanInventoryCountsOnlyWhatRestoreWouldGiveBack(t *testing.T) {
+	dir := halvedStore(t)
+	spans, files, err := SpanInventory(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spans != 3 {
+		t.Fatalf("3 sessions are servable and each replaced one span, got %d", spans)
+	}
+	if files != 3 {
+		t.Fatalf("those three spans are in three files, got %d", files)
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
 // recordLogScans counts walks of the record log. There are no per-session
@@ -1139,8 +1141,17 @@ func SpanInventory(dir string) (spans, files int, err error) {
 		return 0, 0, err
 	}
 	seen := map[string]bool{}
+	pol := policy.Load()
 	err = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
 		if r.Role != roleEdit {
+			return
+		}
+		// What this machine could hand back, not what the log happens to hold:
+		// `restore` refuses a span from a tree the ignore rule covers (#2630),
+		// so counting it here promised something the command would decline
+		// (#2650).
+		meta, ok := m.Sessions[r.Key]
+		if !ok || pol.Ignored(meta.Path, meta.Project) {
 			return
 		}
 		spans++


### PR DESCRIPTION
Fixes #2650.

30 sessions, 20 of them under `{"ignore":["*scratch*"]}`. search, last, files, friction and the session line of stats all count the ten. Two numbers did not:

    brief   deja-vu dev · 30 sessions across 1 agent
            covering   Jul 1 2026 → Jul 2 2026      ← only ignored work is on Jul 2
    stats   Recover   30 spans your agents replaced, across 30 files

The brief is the first screen anyone sees and it disagreed with its own `recent` rows three lines below; stats disagreed with itself in one screen.

`index.Overview` and `SpanInventory` are right for `deja doctor`, which reports what the index holds — that number stays, pinned. `OverviewServable` is the same walk under the rule, for the brief and for the "every one of the N indexed sessions is older than that window" line, which is advice on a search miss and so has to count what search could read. The span count follows what `restore` will actually hand back, since it refuses an ignored tree since #2630.
