### PR TITLE
fix(hook-tool): stop speaking from a tree the ignore rule keeps out

### DIFF
--- a/cmd/deja/hook_ignore_test.go
+++ b/cmd/deja/hook_ignore_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// ignoredCommandStore holds a command run only in a tree the ignore rule keeps
+// out of recall, and one kept session that never ran it.
+func ignoredCommandStore(t *testing.T, command string) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	if err := os.MkdirAll(filepath.Dir(policy.Path()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(policy.Path(), []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"s1", "s2", "s3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-scratch", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"deploy the thing"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + command + `"}}]}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "-w-keep", "k1.jsonl"), "k1", []string{
+		`{"type":"user","sessionId":"k1","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"morning notes"}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// #2630 taught how, restore and friction the ignore rule. The hook that speaks
+// unasked was left: it read the commands table, which keys by project, and
+// stated a count out of the tree the reader excluded (#2652).
+func TestTheCommandHookObeysTheIgnoreRule(t *testing.T) {
+	ignoredCommandStore(t, "terraform apply -auto-approve")
+	out := commandHookLine(os.Getenv("DEJA_INDEX_DIR"), "/w/keep", "terraform apply -auto-approve")
+	if strings.Contains(out, "has run that command") {
+		t.Fatalf("the hook spoke from the tree the ignore rule keeps out:\n%s", out)
+	}
+	if out != "" {
+		t.Fatalf("nothing else is left to say about it:\n%s", out)
+	}
+}
+
+// A command run where recall may go keeps its line.
+func TestTheCommandHookStillSpeaksForAKeptProject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"k1", "k2"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-keep", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"deploy the thing"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"terraform apply -auto-approve"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out := commandHookLine(os.Getenv("DEJA_INDEX_DIR"), "/w/keep", "terraform apply -auto-approve")
+	if !strings.Contains(out, "has run that command") {
+		t.Fatalf("the hook went quiet about a command it may speak of:\n%s", out)
+	}
+}

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -238,6 +238,28 @@ func commandHookLine(dir, cwd, cmd string) string {
 	if sessions < 1 {
 		return ""
 	}
+	// And the rule that keeps a tree out of recall. `how` refuses to answer
+	// from it and says so; this line was stating the same history into an
+	// agent's context unasked (#2652). It has to come from the sessions,
+	// because the table above keys by project and the rule matches on the
+	// path — which costs a manifest read, so it is paid only here, after the
+	// cheap checks have found something worth saying. A command with no
+	// history, and every inspection command, returned long before this.
+	if ignored := index.ProjectsTouchedByIgnore(dir); len(ignored) > 0 {
+		sessions, last = 0, time.Time{}
+		for proj, pu := range use.ByProject {
+			if !pol.Allows(policy.ActivationAuto, proj) || ignored[proj] {
+				continue
+			}
+			sessions += pu.Sessions
+			if pu.Last.After(last) {
+				last = pu.Last
+			}
+		}
+		if sessions < 1 {
+			return ""
+		}
+	}
 	when := ""
 	if !last.IsZero() {
 		when = ", last " + last.Local().Format("2006-01-02")

--- a/internal/index/ignored_projects_test.go
+++ b/internal/index/ignored_projects_test.go
@@ -1,0 +1,31 @@
+package index
+
+import (
+	"testing"
+)
+
+// The commands table keys by project while the ignore rule matches on the
+// session's path, so the callers that read that table cannot apply the rule
+// exactly. This names the projects it touches at all, which is the safe
+// direction for them (#2652).
+func TestProjectsTouchedByIgnore(t *testing.T) {
+	dir := halvedStore(t)
+	touched := ProjectsTouchedByIgnore(dir)
+	if !touched["w/scratch"] {
+		t.Fatalf("the ignored project is not named: %v", touched)
+	}
+	if touched["w/keep"] {
+		t.Fatalf("a project the rule does not touch was named: %v", touched)
+	}
+	if len(touched) != 1 {
+		t.Fatalf("one project is covered by this rule, got %v", touched)
+	}
+}
+
+// A store with no rule in force names nothing, and a missing store answers
+// nothing rather than failing the caller.
+func TestProjectsTouchedByIgnoreOnAStoreWithoutOne(t *testing.T) {
+	if got := ProjectsTouchedByIgnore(t.TempDir()); len(got) != 0 {
+		t.Fatalf("an unreadable store should name no projects, got %v", got)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1490,6 +1490,36 @@ func ignoredByPolicy(ss []model.Session) []model.Session {
 	return out
 }
 
+// ProjectsTouchedByIgnore names the projects holding at least one session the
+// ignore rule keeps out of recall.
+//
+// For the callers that read the commands table rather than the sessions. That
+// table keys by project, and the rule matches on the session's path or its
+// project — measured on a real store under the default `*/.claude/jobs/*`, all
+// 305 ignored sessions matched by path and none by project, and the project
+// they sit in is called "run". So a table keyed by project cannot apply the
+// rule exactly, and the honest approximation is to drop a project the rule
+// touches at all: a project mixing ignored and kept sessions is under-reported,
+// which is the right way to be wrong for a line that speaks without being asked
+// (#2652).
+func ProjectsTouchedByIgnore(dir string) map[string]bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	metas, err := AllMeta(dir)
+	if err != nil {
+		return nil
+	}
+	pol := policy.Load()
+	out := map[string]bool{}
+	for _, meta := range metas {
+		if pol.Ignored(meta.Path, meta.Project) {
+			out[meta.Project] = true
+		}
+	}
+	return out
+}
+
 // IgnoredMatching counts the sessions a listing would have shown if the ignore
 // rule did not cover them. Every other rule that withholds rows in deja says
 // how many; this one dropped 253 of 400 on a real store and said nothing


### PR DESCRIPTION
Fixes #2652. The last surface #2630 left.

    $ deja how terraform
    deja: the ignore rule keeps 6 sessions out of this answer (*scratch*)
    no command on this machine mentions "terraform"

    $ … | deja hook-tool
    This machine has run that command in 6 sessions, last 2026-07-06.

The CLI refuses and says why; the hook stated the same history into the agent's context, unasked.

The table the hook reads keys by project and the rule matches on the path. Measured on a real 1,367-session store under the default `*/.claude/jobs/*`: 305 ignored sessions, all matched by path, none by project — their project is called "run". So filtering by project name alone fixes nothing on the machine that rule exists for.

What the table supports is the safe direction: drop a project the rule touches at all. A project mixing ignored and kept sessions is under-reported, which is the right way to be wrong for a line nobody asked for. The exact fix needs the table to carry the path, which is an index format change.

Cost: the check needs a manifest read, so it is paid only after the cheap checks have found something worth saying — an inspection command and a command with no history return long before it. Measured on the real store: 10 ms warm, 0.46 s on a cold cache, against 0 ms and 0.03 s.
