### PR TITLE
fix(sync): keep the ignored tree from leaving the machine

### DIFF
--- a/internal/index/export_ignore_test.go
+++ b/internal/index/export_ignore_test.go
@@ -1,0 +1,107 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// exportStore holds one session recall may serve and one the ignore rule keeps
+// out, each saying something only it says.
+func exportStore(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	setHome(t, home)
+	root := filepath.Join(home, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	// DEJA_POLICY_FILE, not a file under the home: this package shares one
+	// XDG_CONFIG_HOME across its tests, so a policy written through
+	// policy.Path() outlives the test that wrote it and every later test reads
+	// it — which is how a rule of `*scratch*` silenced the default rule three
+	// tests were pinning.
+	policyFile := filepath.Join(home, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	write := func(project, id, text string) {
+		p := filepath.Join(root, "-w-"+project, id+".jsonl")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","sessionId":"` + id + `","cwd":"/w/` + project + `","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("keep", "k1", "the widget pipeline stalls on shard three")
+	write("scratch", "s1", "scratch work nobody should see off this machine")
+	dir := filepath.Join(home, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func exported(t *testing.T, outDir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var all strings.Builder
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		all.Write(b)
+	}
+	return all.String()
+}
+
+// The export applies the exclude list, and its comment says why: the export is
+// where data leaves, and a privacy control set after the index was built has to
+// hold at that boundary. The ignore rule is the same kind of control and was
+// not applied, so the one tree deja never recalls from was shipped to another
+// machine, where it is served as imported memory (#2654).
+func TestExportLeavesTheIgnoredTreeBehind(t *testing.T) {
+	dir := exportStore(t)
+	out := t.TempDir()
+	n, err := Export(dir, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := exported(t, out)
+	if strings.Contains(body, "nobody should see off this machine") {
+		t.Fatalf("the ignored tree left the machine:\n%s", body)
+	}
+	if !strings.Contains(body, "widget pipeline stalls") {
+		t.Fatalf("the session recall may serve did not travel:\n%s", body)
+	}
+	if n < 1 {
+		t.Fatalf("nothing was exported at all")
+	}
+}
+
+// Held, not settled: the exclude path keeps a record's watermark unmoved so a
+// rule lifted later still sends it. The same has to hold here, or a rule set
+// once would settle that work for good.
+func TestExportCanStillSendWhatTheRuleStopsCovering(t *testing.T) {
+	dir := exportStore(t)
+	if _, err := Export(dir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	// The reader changes their mind.
+	if err := os.WriteFile(os.Getenv("DEJA_POLICY_FILE"), []byte(`{"ignore":["*nothing-here*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out := t.TempDir()
+	if _, err := Export(dir, out); err != nil {
+		t.Fatal(err)
+	}
+	if body := exported(t, out); !strings.Contains(body, "nobody should see off this machine") {
+		t.Fatalf("work held back by a rule that no longer covers it never travels:\n%s", body)
+	}
+}

--- a/internal/index/overview_servable_test.go
+++ b/internal/index/overview_servable_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
 // halvedStore indexes sessions in two projects, one of which the reader's
@@ -17,10 +15,14 @@ func halvedStore(t *testing.T) string {
 	setHome(t, home)
 	root := filepath.Join(home, "claude")
 	t.Setenv("DEJA_CLAUDE_ROOT", root)
-	if err := os.MkdirAll(filepath.Dir(policy.Path()), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(policy.Path(), []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+	// DEJA_POLICY_FILE, not a file under the home: this package shares one
+	// XDG_CONFIG_HOME across its tests, so a policy written through
+	// policy.Path() outlives the test that wrote it and every later test reads
+	// it — which is how a rule of `*scratch*` silenced the default rule three
+	// tests were pinning.
+	policyFile := filepath.Join(home, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	write := func(project, id, day string) {

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -168,6 +169,13 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	// where data leaves, and a pattern set after the index was built has to
 	// hold at that boundary whether or not the index has been rebuilt.
 	ex := sources.NewExcluder()
+	// And the other privacy control, for the same reason at the same boundary.
+	// The ignore rule is what a reader sets when a tree should stay out of
+	// recall — its own documentation calls it the one directory deja never
+	// recalls from without being asked — and it was applied everywhere except
+	// where memory actually leaves the machine, so the export shipped it to a
+	// peer that then served it as imported memory (#2654).
+	pol := policy.Load()
 	// The oldest instant held back per source. A watermark that ran past an
 	// excluded record would settle it forever: remove the pattern later and
 	// that work never syncs again, because the source resumes from a point
@@ -198,7 +206,10 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if !ok {
 			return
 		}
-		if !ex.Empty() && ex.Match(meta.Project) {
+		if (!ex.Empty() && ex.Match(meta.Project)) || pol.Ignored(meta.Path, meta.Project) {
+			// Held, not settled, for both: a watermark that ran past a
+			// withheld record would settle it forever, so lifting the rule
+			// later would never send that work.
 			if tn := r.Time.UnixNano(); !r.Time.IsZero() {
 				if cur, seen := heldFrom[wk]; !seen || tn < cur {
 					heldFrom[wk] = tn


### PR DESCRIPTION
Fixes #2654.

`deja sync export` shipped the tree the ignore rule keeps out of recall. On the receiving machine it becomes `imported:` and is served there, so the rule its own documentation calls "the one directory deja never recalls from without being asked" was the one thing that did not survive leaving the machine.

The reason it was missed is written beside the check that is there. The export applies the exclude list, with a comment saying the export is where data leaves and that a privacy control set after the index was built has to hold at that boundary (#1307). Every word of that applies to the ignore rule.

Same check, same place, and held the same way — without settling the watermark, so a rule lifted later still sends that work. Both directions pinned.

Also fixes a test-only trap found on the way: this package shares one XDG_CONFIG_HOME, so a policy written through `policy.Path()` outlives the test that wrote it. Two helpers did that and silenced the default rule for three tests pinning it; both now use `DEJA_POLICY_FILE`, which is what the cmd tests already do.
