### PR TITLE
fix(forget): name the flag a session id belongs to

### DIFF
--- a/cmd/deja/forget_selector_test.go
+++ b/cmd/deja/forget_selector_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every other command that takes a session id takes it bare. forget wants
+// --session, which is right for the destructive one; what it said when it did
+// not get it was that the id is an unknown flag, naming nothing the reader
+// could do about it (#2656).
+func TestForgetNamesTheFlagAnIdBelongsTo(t *testing.T) {
+	for _, id := range []string{
+		"imported-1aa758f985c5",
+		"imported-…a758f985c5",
+		"deadbeefcafe",
+	} {
+		t.Run(id, func(t *testing.T) {
+			hermeticEnv(t)
+			_, err := captureRun(t, "forget", id)
+			if err == nil {
+				t.Fatalf("forget accepted a bare id, which is the selector it deliberately does not take")
+			}
+			if strings.Contains(err.Error(), "unknown flag") {
+				t.Fatalf("an id is not a flag: %v", err)
+			}
+			if !strings.Contains(err.Error(), "--session") {
+				t.Fatalf("the message does not name the flag that would have worked: %v", err)
+			}
+			if !strings.Contains(err.Error(), id) {
+				t.Fatalf("the message does not echo what was typed: %v", err)
+			}
+		})
+	}
+}
+
+// A word that really is a flag keeps the flat refusal: naming --session there
+// would send a reader after the wrong thing.
+func TestForgetStillRefusesAnUnknownFlag(t *testing.T) {
+	hermeticEnv(t)
+	_, err := captureRun(t, "forget", "--sessions", "abc")
+	if err == nil || !strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("a mistyped flag should still be called one, got %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2989,6 +2989,14 @@ func runForget(dir string, args []string) error {
 				}
 			}
 		default:
+			// An id is not a flag, and every other command that takes one
+			// takes it bare — `show`, `handoff` and `ctx` all do. forget asks
+			// for --session because it is the destructive one, and saying so
+			// is the whole difference between a dead end and one more word to
+			// type (#2656, the lesson #2191 recorded for --harness).
+			if !strings.HasPrefix(args[i], "-") {
+				return fmt.Errorf("forget: a session id goes after --session — `deja forget --session %s`", args[i])
+			}
 			return fmt.Errorf("forget: unknown flag %q", args[i])
 		}
 	}


### PR DESCRIPTION
Fixes #2656.

Found while checking whether the three printed forms of a session id are all usable. They are — `show`, `--session`, `handoff` and `ctx` each accept the id from the listing, the elided one from a search line, and the id the sending machine knew (#707, #853, #1049 between them). `forget` is the exception:

    $ deja forget imported-1aa758f985c5
    deja: forget: unknown flag "imported-1aa758f985c5"

Wanting `--session` is right for the destructive command. Calling the id a flag, and naming nothing that would have worked, is not.

    deja: forget: a session id goes after --session — `deja forget --session imported-1aa758f985c5`

A word that really is a flag keeps the flat refusal, pinned, so a mistyped `--sessions` is still called what it is.
