### PR TITLE
fix(fix): keep the ignored tree out of the remedies, and pin the family

### DIFF
--- a/cmd/deja/ignore_every_surface_test.go
+++ b/cmd/deja/ignore_every_surface_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// onlyTheIgnoredTreeKnows builds a store where a word, an error, a command and
+// a file exist solely in the tree the ignore rule keeps out. Anything that
+// prints "zonko" is reading from it.
+func onlyTheIgnoredTreeKnows(t *testing.T) {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	policyFile := filepath.Join(tmp, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"s1", "s2", "s3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-scratch", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer keeps overflowing"}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"panic: zonkobuffer overflow at shard 7"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"terraform apply --zonkoshard 7"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/scratch","timestamp":"2026-07-01T10:03:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/w/scratch/zonko.go","old_string":"a","new_string":"b"}}]}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "-w-keep", "k1.jsonl"), "k1", []string{
+		`{"type":"user","sessionId":"k1","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"morning notes about nothing"}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Five fixes found one surface each — how, restore and friction (#2630), the
+// per-command hook (#2652), sync export (#2654), the friction walls behind the
+// brief and the session-start block (#2658) — and each is pinned on its own.
+// Nothing pinned the set, so the next reader of sessions would be found the
+// same way: by accident (#2660).
+//
+// A command that legitimately echoes the query back — `no command on this
+// machine mentions "zonkoshard"` — must not read as a leak, so the marker is
+// looked for outside the reader's own words.
+//
+// The command in the fixture is a `terraform apply` because the reader only
+// keeps commands it recognises as work (worthIndexing): an invented binary
+// name is never indexed as a command at all, and a sweep built on one would
+// pass without ever asking `how` anything.
+func TestNoSurfaceServesTheIgnoredTree(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		stdin string
+	}{
+		{name: "search", args: []string{"zonkobuffer"}},
+		{name: "search by error paste", args: []string{"panic: zonkobuffer overflow at shard 7"}},
+		{name: "fix", args: []string{"fix", "panic: zonkobuffer overflow at shard 7"}},
+		{name: "how", args: []string{"how", "zonkoshard"}},
+		{name: "friction", args: []string{"friction"}},
+		{name: "last", args: []string{"last"}},
+		{name: "files", args: []string{"files", "zonkobuffer"}},
+		{name: "blame", args: []string{"blame", "zonko.go"}},
+		{name: "brief", args: []string{"brief"}},
+		{name: "stats", args: []string{"stats"}},
+		{name: "restore", args: []string{"restore", "/w/scratch/zonko.go"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			onlyTheIgnoredTreeKnows(t)
+			out, err := captureRun(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			errOut, err := captureRunStderr(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%v: %v", tc.args, err)
+			}
+			for _, line := range strings.Split(out+"\n"+errOut, "\n") {
+				if !strings.Contains(line, "zonko") {
+					continue
+				}
+				// The query, echoed inside a refusal, is the reader's own word
+				// coming back — not a session being served.
+				if echoesTheQuery(line, tc.args) {
+					continue
+				}
+				t.Fatalf("a session the ignore rule keeps out reached %v:\n%s", tc.args, line)
+			}
+		})
+	}
+}
+
+// echoesTheQuery reports whether a line only carries the marker because the
+// command repeated what it was asked.
+func echoesTheQuery(line string, args []string) bool {
+	for _, a := range args {
+		if strings.Contains(a, "zonko") && strings.Contains(line, a) {
+			return true
+		}
+	}
+	return false
+}
+
+// The store really does hold what the sweep is looking for, or every case above
+// passes for the wrong reason.
+func TestTheIgnoredTreeIsReachableWhenTheRuleIsLifted(t *testing.T) {
+	onlyTheIgnoredTreeKnows(t)
+	if err := os.WriteFile(os.Getenv("DEJA_POLICY_FILE"), []byte(`{"ignore":["*nothing-here*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "how", "zonkoshard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "terraform apply --zonkoshard 7") {
+		t.Fatalf("with the rule lifted the command should be there:\n%s", out)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -532,6 +532,18 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 		return nil
 	}
 	var out []FixPair
+	// The ignore rule, applied here rather than by the seven callers: a FixPair
+	// carries the project and the rule matches on the session's path, so no
+	// caller can apply it — the same shape #2652 measured for the commands
+	// table. Three of those callers speak unasked (the session-start block,
+	// hook-plan, hook-tool-after), and `deja fix` offered a remedy out of the
+	// tree the reader excluded while `deja how` refused to name the very same
+	// command (#2660).
+	//
+	// Loaded only once something matched, so an error nobody has hit pays
+	// nothing for the manifest read.
+	var ignored map[string]bool
+	loaded := false
 	for _, p := range ReadFixes(dir) {
 		if !sigs[p.Sig] {
 			continue
@@ -542,6 +554,12 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 			continue
 		}
 		if allow != nil && !allow(p.Project) {
+			continue
+		}
+		if !loaded {
+			ignored, loaded = ProjectsTouchedByIgnore(dir), true
+		}
+		if ignored[p.Project] {
 			continue
 		}
 		out = append(out, p)
@@ -571,6 +589,11 @@ func FixCandidateSeen(dir, text string, allow func(project string) bool) bool {
 			continue
 		}
 		if allow != nil && !allow(p.Project) {
+			continue
+		}
+		// The same rule as FixesFor: saying deja holds a sighting it will not
+		// show is worse than saying nothing (#2660).
+		if ProjectsTouchedByIgnore(dir)[p.Project] {
 			continue
 		}
 		return true


### PR DESCRIPTION
Fixes #2660.

Five iterations each found one more surface reading from the tree the ignore rule keeps out — #2630, #2652, #2654, #2658 — every one by accident. This sweeps the rest on purpose: one store where a word, an error signature, a command and a file exist **only** in the ignored tree, then eleven commands asked about them in one table-driven test.

Ten were already clean. `deja fix` was not:

    panic: zonkobuffer overflow at shard 7 · 2026-07-01
      ran next: $ terraform apply --zonkoshard 7

— a remedy out of the tree the reader excluded, offered while `deja how` refuses to name that very command.

A `FixPair` carries the project and the rule matches on the path, so none of the seven callers can apply it — three of them speak unasked (the session-start block, hook-plan, hook-tool-after). It goes in `FixesFor` and `FixCandidateSeen`, loaded only once something matched, so an error nobody has hit pays nothing.

The test is the point as much as the fix: the next reader of sessions now has to say out loud that it is exempt. A control case checks the store really holds what the sweep looks for, and the fixture uses a `terraform apply` because the reader only indexes commands it recognises as work — a sweep built on an invented binary name passes without ever asking `how` anything, which is how the first version of this test fooled itself.
