### PR TITLE
fix(doctor): say when an exclude pattern is not applied yet

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1246,7 +1246,17 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 		loc = dir
 	}
 	fmt.Fprintf(w, "  location %s\n", reportPath(loc))
-	fmt.Fprintf(w, "  exclusions %d active patterns\n", len(sources.ExclusionPatterns()))
+	// "Active" is what a reader checks this screen for, and it was false in the
+	// one state they check it in: the pattern is written, the index is not
+	// rebuilt, and the next search still serves the project they meant to hide.
+	// The list applies at ingest, so it covers nothing already indexed until a
+	// rebuild — the sentence `deja index` prints for the same reason (#1307,
+	// #2664).
+	if n := len(sources.ExclusionPatterns()); n > 0 && index.ExclusionsChanged(dir) {
+		fmt.Fprintf(w, "  exclusions %d pattern%s, not applied to sessions already indexed — `deja index --rebuild`\n", n, pluralS(n))
+	} else {
+		fmt.Fprintf(w, "  exclusions %d active patterns\n", n)
+	}
 	// A precise non-claim: users deciding what to trust deserve to read the
 	// boundary in the tool itself, not only in the security docs.
 	fmt.Fprintln(w, "  security plaintext on disk — protected by file permissions only, no encryption or access control")

--- a/cmd/deja/doctor_exclusions_test.go
+++ b/cmd/deja/doctor_exclusions_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// excludeAfterIndex indexes a store and only then writes the pattern, which is
+// the sequence a reader actually performs: see a project they did not want
+// indexed, write the rule, look again.
+func excludeAfterIndex(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"x1", "x2", "x3"} {
+		writeClaudeFixture(t, filepath.Join(root, "-w-secret", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/secret","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer keeps overflowing"}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+func writeExclude(t *testing.T, body string) {
+	t.Helper()
+	path := sources.ExcludePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// doctor is the screen that says what is in force — it prints the trust policy
+// per activation and the ignore rule by name. For the exclude list it said
+// "N active patterns", which is false in the one state a reader is in when
+// they look: pattern written, index not rebuilt, and the next search still
+// serving the project they meant to hide (#2664).
+func TestDoctorSaysAnExcludePatternIsNotAppliedYet(t *testing.T) {
+	excludeAfterIndex(t)
+	writeExclude(t, "secret\n")
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "exclusions") {
+		t.Fatalf("doctor no longer reports the exclude list at all:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, "exclusions") {
+			continue
+		}
+		if strings.Contains(line, "active") && !strings.Contains(line, "rebuild") {
+			t.Fatalf("doctor calls a pattern active that covers nothing already indexed:\n%s", line)
+		}
+		if !strings.Contains(line, "rebuild") {
+			t.Fatalf("doctor does not say what would apply the pattern:\n%s", line)
+		}
+	}
+}
+
+// Once the index is built under the same list, the line is a plain statement
+// again.
+func TestDoctorSaysNothingExtraWhenTheExcludeListIsInForce(t *testing.T) {
+	excludeAfterIndex(t)
+	writeExclude(t, "secret\n")
+	if _, err := captureRun(t, "index", "--rebuild"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "doctor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "exclusions") && strings.Contains(line, "rebuild") {
+			t.Fatalf("the pattern is in force; nothing should point at a rebuild:\n%s", line)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2664.

Swept the other two ways a session stops being available, after the ignore rule (#2661) and the trust policy (#2663).

`deja forget` is absolute: three sessions forgotten, all eleven surfaces clean — it drops the records and rebuilds, so there is nothing left to leak.

The exclude list applies at ingest, so a pattern written after the build covers nothing already indexed. That is the design (#1307), and `deja index` says so plainly. `deja doctor` — the screen that reports what is in force, per activation for the trust policy and by name for the ignore rule — said:

    exclusions 1 active patterns

in exactly the state where it is false: pattern written, not rebuilt, next search still serving the project the reader meant to hide.

    exclusions 1 pattern, not applied to sessions already indexed — `deja index --rebuild`

Once the index is built under the same list the line is a plain count again, pinned both ways. The fingerprint it reads is the one `deja index` already uses for the same sentence.
