### PR TITLE
fix(sync): say when the exclude list emptied an import

### DIFF
--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 // importedSessionTotal counts the sessions this index holds that came from
@@ -226,6 +227,13 @@ func runSync(dir string, args []string) error {
 				what = "them"
 			}
 			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — no session id to attribute %s to; the batch may be from a different tool or damaged\n", inc, pluralS(inc), what)
+		}
+		// The reader's own pattern, and the drop most likely to empty a batch
+		// entirely — after which "imported 0 records" is the whole story they
+		// get (#2666).
+		if ex := index.ImportSkippedExcluded(); ex > 0 {
+			fmt.Fprintf(os.Stdout, "deja: %d record%s left out — your exclude list covers their project (%s)\n",
+				ex, pluralS(ex), reportPath(sources.ExcludePath()))
 		}
 		if err != nil {
 			return err

--- a/internal/index/import_excluded_test.go
+++ b/internal/index/import_excluded_test.go
@@ -1,0 +1,79 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A batch whose every record belongs to a project the receiver excludes is
+// dropped — correctly, since the exclude list keeps a project out of this
+// machine's memory and a sync must not put it back. Nothing counted it, so
+// "imported 0 records" read like an empty or already-synced batch, the misread
+// #1118 recorded for the drop one line above (#2666).
+func TestImportCountsWhatTheExcludeListKeptOut(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	// This package shares one XDG_CONFIG_HOME across its tests and
+	// sources.ExcludePath() reads it, so a list written through that path
+	// outlives the test — the trap #2654 hit with the policy file.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	batch := filepath.Join(home, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := ""
+	for _, id := range []string{"a1", "a2", "a3"} {
+		body += `{"harness":"claude","session_id":"` + id + `","project":"alpha","role":"user","text":"the zonkobuffer keeps overflowing","time":"2026-07-01T10:00:00Z","origin":"mini"}` + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-test.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	excl := sources.ExcludePath()
+	if err := os.MkdirAll(filepath.Dir(excl), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(excl, []byte("alpha\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, "index.db")
+	n, err := Import(dir, batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatalf("the excluded project must not be imported, got %d records", n)
+	}
+	if got := ImportSkippedExcluded(); got != 3 {
+		t.Fatalf("three records were dropped by the reader's own pattern, the count says %d", got)
+	}
+}
+
+// And a batch nothing excludes leaves the counter at zero, so the line only
+// appears when it has something to report.
+func TestImportCountsNothingExcludedWhenNoPatternMatches(t *testing.T) {
+	home := t.TempDir()
+	setHome(t, home)
+	// This package shares one XDG_CONFIG_HOME across its tests and
+	// sources.ExcludePath() reads it, so a list written through that path
+	// outlives the test — the trap #2654 hit with the policy file.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	batch := filepath.Join(home, "batch")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"harness":"claude","session_id":"a1","project":"alpha","role":"user","text":"the zonkobuffer keeps overflowing","time":"2026-07-01T10:00:00Z","origin":"mini"}` + "\n"
+	if err := os.WriteFile(filepath.Join(batch, "deja-sync-test.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, "index.db")
+	if _, err := Import(dir, batch); err != nil {
+		t.Fatal(err)
+	}
+	if got := ImportSkippedExcluded(); got != 0 {
+		t.Fatalf("nothing was excluded, the count says %d", got)
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -322,6 +322,16 @@ var lastImportSkippedForgotten int
 // leave alone (#968).
 func ImportSkippedForgotten() int { return lastImportSkippedForgotten }
 
+// lastImportSkippedExcluded holds how many records the last Import dropped
+// because the reader's own exclude list covers their project. Its three
+// neighbours in the same loop are each counted and reported; this one was not,
+// so a batch dropped in full read as an empty or already-synced one — the
+// misread #1118 recorded for the drop beside it (#2666).
+var lastImportSkippedExcluded int
+
+// ImportSkippedExcluded reports that count.
+func ImportSkippedExcluded() int { return lastImportSkippedExcluded }
+
 // lastImportSkippedIncomplete holds how many records the last Import dropped
 // because they could not be attributed to a session — no harness or no
 // session_id. deja's own exports always carry both; a hand-made or foreign
@@ -465,9 +475,11 @@ func Import(dir, inDir string) (int, error) {
 	ownSkipped := 0
 	forgottenSkipped := 0
 	incompleteSkipped := 0
+	excludedSkipped := 0
 	defer func() { lastImportSkippedForgotten = forgottenSkipped }()
 	defer func() { lastImportSkippedOwn = ownSkipped }()
 	defer func() { lastImportSkippedIncomplete = incompleteSkipped }()
+	defer func() { lastImportSkippedExcluded = excludedSkipped }()
 	for _, p := range paths {
 		// A file is imported whole or not at all, so what it contributed is
 		// remembered before it is read and rolled back if it turns out to be
@@ -580,8 +592,10 @@ func Import(dir, inDir string) (int, error) {
 				}
 			}
 			// The exclude list keeps a project out of this machine's memory;
-			// a sync from another machine must not put it back.
+			// a sync from another machine must not put it back. Counted, so
+			// the batch it empties does not read as an empty batch (#2666).
 			if ex.Match(sr.Project) {
+				excludedSkipped++
 				return nil
 			}
 			key := sr.Harness + ":" + importID


### PR DESCRIPTION
Fixes #2666.

Read the import side after #2654 read the export side. Most of it holds: a record with no harness or session id is dropped and counted (#1118), one this machine wrote itself is recognised and counted (#987), one belonging to a forgotten session is dropped and counted (#1016), the project is always stored under an `imported:` prefix so nothing arriving by sync can present itself as local, and fields are sanitised.

The receiver's exclude list is applied too — and said nothing:

    $ deja sync import <dir>     # six records, all in a project this machine excludes
    deja: imported 0 records

Now:

    deja: 6 records left out — your exclude list covers their project (~/.config/deja/exclude)
    deja: imported 0 records

Counted and worded like its three neighbours in the same loop.
