### PR TITLE
docs(hooks): write down what a hook may spend

### DIFF
--- a/cmd/deja/hook_budget_test.go
+++ b/cmd/deja/hook_budget_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The budget beside hookAdvice is only worth writing if a hook added later has
+// to appear in it. Both lists are the same set: every hook a person can type,
+// and every hook with a number to be held to (#2668).
+func TestEveryHookHasABudgetLine(t *testing.T) {
+	src, err := os.ReadFile("hook_typed_by_hand.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget, _, ok := strings.Cut(string(src), "// hookAdvice is what to reach for")
+	if !ok {
+		t.Fatal("the budget comment is gone; it lives above hookAdvice")
+	}
+	for name := range hookAdvice {
+		if !strings.Contains(budget, name) {
+			t.Errorf("%s has advice but no budget line", name)
+		}
+	}
+	// And the one hook that is not in hookAdvice, because nobody types it by
+	// hand expecting a screen — it still has a number.
+	if !strings.Contains(budget, "hook-context") {
+		t.Error("hook-context has no budget line")
+	}
+}
+
+// The dispatcher is the authority on which hooks exist; a new one must reach
+// the budget rather than be discovered by a reader wondering what it costs.
+func TestEveryDispatchedHookIsInTheBudget(t *testing.T) {
+	src, err := os.ReadFile("hook_typed_by_hand.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget, _, _ := strings.Cut(string(src), "// hookAdvice is what to reach for")
+	for name := range commands {
+		if !strings.HasPrefix(name, "hook-") {
+			continue
+		}
+		if !strings.Contains(budget, name) {
+			t.Errorf("%s is dispatched but has no budget line", name)
+		}
+	}
+}

--- a/cmd/deja/hook_typed_by_hand.go
+++ b/cmd/deja/hook_typed_by_hand.go
@@ -5,6 +5,41 @@ import (
 	"os"
 )
 
+// What a hook may spend, measured on a 1,367-session store with the index
+// settled, five runs each (#2668):
+//
+//	per action, and the ones that must stay cheap
+//	  hook-tool          10 ms
+//	  hook-tool-after    10 ms
+//	  hook-plan          under 10 ms
+//	  hook-prompt        60 to 110 ms
+//	  statusline         10 ms
+//	  hook-goose         20 to 40 ms
+//	  hook-goose-prompt  20 to 30 ms
+//	  hook-precompact    10 to 40 ms
+//
+//	once per session, allowed one expensive run
+//	  hook-context       0.85 s, then 50 ms
+//	  hook-antigravity   0.56 s, then 10 ms
+//
+//	detached, off every blocking path
+//	  hook-refresh       0.42 to 0.74 s, by design (see runHookRefresh)
+//
+// The shape matters more than the numbers. A change that adds a read to a
+// per-action hook has to keep it behind the checks that decide there is nothing
+// to say — which is why #2652 pays for its manifest read only after finding
+// something worth saying. The session-start hooks are allowed their one
+// expensive run because it happens once and its answer is the whole reason the
+// session has memory.
+//
+// Measure with the index settled or the number is the warmup's: with a rebuild
+// running, hook-context measured 0.54 to 0.83 s on every run and hook-prompt
+// answered with nothing at all, both by design.
+//
+// This list sits beside hookAdvice because that map is the only other place
+// that names hooks one by one; a hook dispatched without a line here has no
+// budget to be held to, and a test says so.
+//
 // hookAdvice is what to reach for instead, for the hooks a person is most
 // likely to type after reading them in `deja help`.
 var hookAdvice = map[string]string{


### PR DESCRIPTION
Closes #2668.

Every fix that adds a read to a hook has had to argue about what a hook may spend, from first principles each time. This measures all eleven on a 1,367-session store with the index settled, five runs each, and writes the answer down beside the only other place that names hooks one by one.

    per action        hook-tool 10 ms · hook-tool-after 10 ms · hook-plan <10 ms
                      hook-prompt 60–110 ms · statusline 10 ms
                      hook-goose 20–40 ms · hook-goose-prompt 20–30 ms · hook-precompact 10–40 ms
    once per session  hook-context 0.85 s then 50 ms · hook-antigravity 0.56 s then 10 ms
    detached          hook-refresh 0.42–0.74 s, by design

No bug: the shape is right — the per-action hooks are the cheap ones, the session-start pair pay once, and `hook-refresh` is the detached worker whose own comment says it is off every blocking path.

Two things the measuring taught, both in the comment: measure with the index settled or the number is the warmup's (with a rebuild running, `hook-context` was 0.54–0.83 s *every* run and `hook-prompt` answered with nothing), and a hook dispatched without a budget line now fails a test — which is how the five hooks the first pass had missed were found.
