### PR TITLE
fix(hermes): drop the plugins block uninstall created

### DIFF
--- a/cmd/deja/hermes_plugins_block_test.go
+++ b/cmd/deja/hermes_plugins_block_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// hermesConfig is the reader's own file, before deja touches it.
+func hermesConfig(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	path := filepath.Join(sources.HermesHome(), "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The MCP half of this file drops the block it created (#2604). The plugin
+// half wrote `plugins:\n  enabled:\n    - deja\n` where no block existed and
+// took back only the `- deja` line, so an empty block deja made survived every
+// uninstall — and `enabled:` with nothing under it parses as null (#2672).
+func TestUninstallDropsThePluginsBlockItCreated(t *testing.T) {
+	before := "# hermes\nprofile: default\n"
+	path := hermesConfig(t, before)
+	if _, err := installTarget("hermes-auto", "/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "- deja") {
+		t.Fatalf("install did not enable the plugin:\n%s", b)
+	}
+	if _, err := installTarget("hermes-auto", "/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != before {
+		t.Fatalf("the config did not come back as it was:\nwant:\n%s\ngot:\n%s", before, after)
+	}
+}
+
+// A block the reader wrote stays, empty or not: deja takes back its own line
+// and nothing else.
+func TestUninstallKeepsAPluginsBlockTheReaderWrote(t *testing.T) {
+	for _, before := range []string{
+		"# hermes\nprofile: default\n\nplugins:\n  enabled:\n",
+		"# hermes\nprofile: default\n\nplugins:\n  enabled:\n    - theirs\n",
+	} {
+		t.Run(strings.ReplaceAll(before, "\n", "·"), func(t *testing.T) {
+			path := hermesConfig(t, before)
+			if _, err := installTarget("hermes-auto", "/bin/deja", false); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			if _, err := installTarget("hermes-auto", "/bin/deja", true); err != nil {
+				t.Fatalf("uninstall: %v", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != before {
+				t.Fatalf("a block the reader wrote was changed:\nwant:\n%s\ngot:\n%s", before, after)
+			}
+		})
+	}
+}

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -218,6 +218,16 @@ func setHermesPluginEnabled(on bool) error {
 		return nil
 	case !on:
 		s = strings.Replace(s, "\n    - deja", "", 1)
+		// And the block itself, when deja is what put it there. Taking back
+		// only the entry left `plugins:\n  enabled:` behind on every machine
+		// that had no plugins block — an empty key that parses as null — while
+		// the MCP writer one function above already drops what it created
+		// (#2604, #2672). A block the reader wrote stays, empty or not.
+		if blockWasAdded(path, "plugins") {
+			s = strings.Replace(s, "\nplugins:\n  enabled:\n", "\n", 1)
+			s = strings.TrimSuffix(s, "\n\n") + "\n"
+			forgetBlockAdded(path, "plugins")
+		}
 	case strings.Contains(s, "\nplugins:\n  enabled:\n"):
 		s = strings.Replace(s, "\nplugins:\n  enabled:\n", "\nplugins:\n  enabled:\n    - deja\n", 1)
 	case strings.Contains(s, "\nplugins:\n  enabled: []\n"):
@@ -227,6 +237,7 @@ func setHermesPluginEnabled(on bool) error {
 			s += "\n"
 		}
 		s += "\nplugins:\n  enabled:\n    - deja\n"
+		noteBlockAdded(path, "plugins")
 	}
 	_, err = writeIfChanged(path, old, []byte(s))
 	return err


### PR DESCRIPTION
Fixes #2672.

Walked the remove path across the whole family: a machine where every harness is already configured by hand, `install --all --auto`, `uninstall --all --auto`, diff.

Almost everything comes back. The `.bak` files that stay are deliberate (#840), and gemini's `hooksConfig` stays with the uninstall saying so (#2487). One thing had no such reasoning:

    # hermes
    profile: default
    +
    +plugins:
    +  enabled:

Narrowed: `install hermes → uninstall hermes` is clean; anything involving `hermes-auto` leaves the block. The MCP half of that same file already does this right — `installHermesMCP` notes the block it created and drops it on the way out (#2604) — while `setHermesPluginEnabled` created the block and took back only its own `- deja` line, leaving an `enabled:` key that parses as null.

Same provenance, one function below. A block the reader wrote stays, empty or not — pinned both ways, along with the five install/uninstall orders.
