### PR TITLE
fix(uninstall): name the snapshots it keeps

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -140,6 +140,9 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	saidNotes := map[string]bool{}
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
 	type lineItem struct{ target, action, path string }
+	// The real paths, not the display ones: an uninstall reports the snapshots
+	// it left beside the configs it handled, and ~ does not stat (#2676).
+	var touchedPaths []string
 	var done []lineItem
 	guidanceCount := 0
 	mcpCount := 0
@@ -199,6 +202,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 				pruneGuidanceDirs(cr.Path)
 			}
 		}
+		touchedPaths = append(touchedPaths, r.Path)
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
 		} else {
@@ -253,6 +257,16 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		installIndexWarmup(dir, mcpCount, hookCount, guidanceCount,
 			targetArgs[0] == "--auto" || targetArgs[0] == "--all")
 	}
+	// An uninstall keeps the snapshot it took of a config the reader already
+	// had — neither the config nor its snapshot is deja's to delete (#840) —
+	// and said nothing about them, on a screen that otherwise names what it
+	// keeps. #2487 added gemini's line for exactly that reason; nine files on
+	// disk are the same shape (#2676).
+	if uninstall {
+		if line := keptSnapshotsLine(touchedPaths); line != "" {
+			fmt.Fprint(os.Stderr, line)
+		}
+	}
 	if banner {
 		info := append(brandInfo(), "")
 		nameW := 0
@@ -276,6 +290,38 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		printLogoMood(os.Stdout, info, mood)
 	}
 	return nil
+}
+
+// keptSnapshotsLine names the .bak files still beside the configs this run
+// touched. Only those: a snapshot next to a file deja handled is one deja took,
+// while an unrelated .bak in the tree belongs to whoever made it.
+func keptSnapshotsLine(touched []string) string {
+	seen := map[string]bool{}
+	var paths []string
+	for _, p := range touched {
+		if p == "" {
+			continue
+		}
+		bak := p + ".bak"
+		if seen[bak] {
+			continue
+		}
+		if _, err := os.Stat(bak); err != nil {
+			continue
+		}
+		seen[bak] = true
+		paths = append(paths, bak)
+	}
+	if len(paths) == 0 {
+		return ""
+	}
+	sort.Strings(paths)
+	where := reportPath(paths[0])
+	if len(paths) > 1 {
+		where = reportPath(paths[0]) + " and " + fmt.Sprintf("%d more", len(paths)-1)
+	}
+	return fmt.Sprintf("deja: kept %d snapshot%s of configs you already had — %s — yours to remove\n",
+		len(paths), pluralS(len(paths)), where)
 }
 
 func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {

--- a/cmd/deja/uninstall_backups_named_test.go
+++ b/cmd/deja/uninstall_backups_named_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// handWiredMachine is a machine where the harnesses were configured by the
+// reader before deja arrived, so every config deja edits gets a snapshot.
+func handWiredMachine(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	for path, body := range map[string]string{
+		".claude.json":          "{\"mine\":\"MINE\"}\n",
+		".claude/settings.json": "{\"theme\":\"dark\"}\n",
+		".codex/config.toml":    "[tools]\nweb = true\n",
+		".cursor/mcp.json":      "{\"mcpServers\":{\"theirs\":{\"command\":\"x\"}}}\n",
+	} {
+		full := filepath.Join(home, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+// An uninstall keeps the snapshot it took of a config the reader already had —
+// #840 settled that neither the config nor its snapshot is deja's to delete.
+// It said nothing about them, on a screen that otherwise names what it keeps:
+// #2487 added gemini's line for exactly that reason, and nine files on disk are
+// the same shape (#2676).
+func TestUninstallNamesTheSnapshotsItLeaves(t *testing.T) {
+	home := handWiredMachine(t)
+	if _, err := captureRun(t, "install", "--all", "--no-index"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	out, err := captureRunStderr(t, "uninstall", "--all")
+	if err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	left := 0
+	_ = filepath.Walk(home, func(p string, fi os.FileInfo, err error) error {
+		if err == nil && !fi.IsDir() && strings.HasSuffix(p, ".bak") {
+			left++
+		}
+		return nil
+	})
+	if left == 0 {
+		t.Fatal("nothing was backed up, so this pins nothing")
+	}
+	if !strings.Contains(out, ".bak") {
+		t.Fatalf("%d snapshots left on disk and the uninstall names none of them:\n%s", left, out)
+	}
+}
+
+// A machine deja set up from nothing has no snapshots to name, and a line about
+// none of them is noise.
+func TestUninstallSaysNothingWhenItLeftNoSnapshots(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	for _, d := range []string{".claude", ".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRun(t, "install", "--all", "--no-index"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	out, err := captureRunStderr(t, "uninstall", "--all")
+	if err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if strings.Contains(out, ".bak") {
+		t.Fatalf("nothing was snapshotted here, and the uninstall talked about snapshots:\n%s", out)
+	}
+}


### PR DESCRIPTION
Fixes #2676.

`uninstall --all --auto` on a hand-configured machine leaves nine `.bak` files and mentions none of them. They stay on purpose — #840 settled that a config the reader already had, and the snapshot deja took of it, are not deja's to delete — but the screen that keeps them is the same one that names what it keeps everywhere else. #2487 added gemini's `hooksConfig` line for exactly this reason: silence there reads as "nothing of deja's is left".

    deja: kept 8 snapshots of configs you already had — ~/.claude.json.bak and 7 more — yours to remove

Only snapshots beside a config this run handled: an unrelated `.bak` in the tree belongs to whoever made it. A machine deja set up from nothing has none, and says nothing — pinned both ways.
