### PR TITLE
fix(check): tell an older index from no index

### DIFF
--- a/cmd/deja/check.go
+++ b/cmd/deja/check.go
@@ -39,6 +39,12 @@ func runCheckTo(dir string, args []string, stdin io.Reader, stdout, stderr io.Wr
 	switch {
 	case len(planSearchSteps(string(plan))) == 0:
 		fmt.Fprintln(stderr, "deja: nothing in this plan to check — it needs a step naming what it will do")
+	case !planIndexReady(dir) && indexFormatDirection(dir) < 0:
+		// An index this build will not read is not a missing index, and saying
+		// it is tells someone who has used deja for months that their history
+		// was never indexed. doctor has said this properly all along; the
+		// command a person typed owes the same answer (#2680).
+		fmt.Fprintln(stderr, "deja: the index was written by an older deja — this build cannot read it; the next session rebuilds it, or run `deja index` now")
 	case !planIndexReady(dir):
 		fmt.Fprintln(stderr, "deja: no index to check against yet — `deja index` builds one")
 	default:

--- a/cmd/deja/check_older_index_test.go
+++ b/cmd/deja/check_older_index_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// 485 gave `check -` a sentence for each way it comes back empty and left one
+// case it could not tell apart: an index this build will not read is not a
+// missing index, and saying so tells someone who has used deja for months that
+// their history was never indexed. doctor has had the right words all along
+// (#2680).
+func TestCheckTellsAnOlderIndexFromNoIndex(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		ready bool
+		older bool
+		want  string
+	}{
+		{name: "no index at all", want: "no index to check against yet"},
+		{name: "an index an older build wrote", older: true, want: "written by an older deja"},
+		{name: "a healthy index with nothing to say", ready: true, want: "nothing found for this plan"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hermeticEnv(t)
+			restoreReady := planIndexReady
+			restoreOlder := indexFormatDirection
+			t.Cleanup(func() {
+				planIndexReady = restoreReady
+				indexFormatDirection = restoreOlder
+			})
+			planIndexReady = func(string) bool { return tc.ready }
+			indexFormatDirection = func(string) int {
+				if tc.older {
+					return -1
+				}
+				return 0
+			}
+			var out, errOut strings.Builder
+			if err := runCheckTo("", []string{"-"}, strings.NewReader("rewrite the widget pipeline"), &out, &errOut); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(errOut.String(), tc.want) {
+				t.Fatalf("want %q, got:\n%s", tc.want, errOut.String())
+			}
+			if out.String() != "" {
+				t.Fatalf("findings keep stdout to themselves (#2566), got:\n%s", out.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2680. The case #2566 left in the queue.

Age a store's manifest so the index is one this build will not read, then run `check` as the first thing:

    deja: no index to check against yet — `deja index` builds one

There is an index; it was built two minutes ago. `deja doctor` on the same store says what is actually true:

    format   written by an older deja — this build cannot read it; the next
             session rebuilds it, or run `deja index` now

Two screens, one state, opposite claims — and the wrong one is on the command a person runs to ask what deja knows about their plan. Someone who upgrades after months of use is told their history was never indexed.

`planIndexReady` folds three conditions into one boolean, so `check` had one sentence for all of them. Now the older-index case gets doctor's words. The hooks stay silent, which is right — a PreToolUse hook that talks when it has nothing is noise on every plan, and the session-start hook already announces the rebuild.

Measured the rest of the family while I was there: `deja index`, search, `how` and `friction` all rebuild the store automatically and say so; the plan and prompt hooks are silent by design.
