### PR TITLE
fix(check): tell a damaged index from no index

### DIFF
--- a/cmd/deja/check.go
+++ b/cmd/deja/check.go
@@ -39,6 +39,12 @@ func runCheckTo(dir string, args []string, stdin io.Reader, stdout, stderr io.Wr
 	switch {
 	case len(planSearchSteps(string(plan))) == 0:
 		fmt.Fprintln(stderr, "deja: nothing in this plan to check — it needs a step naming what it will do")
+	case !planIndexReady(dir) && indexDamaged(dir):
+		// The third condition planIndexReady folds in, and the same misread as
+		// the one below it: an index that is damaged is not a missing index,
+		// and doctor is already saying so on the same store while search
+		// answers from the snapshot and rebuilds behind it (#2682).
+		fmt.Fprintln(stderr, "deja: the index is damaged — the next search rebuilds it, or run `deja index --rebuild` now")
 	case !planIndexReady(dir) && indexFormatDirection(dir) < 0:
 		// An index this build will not read is not a missing index, and saying
 		// it is tells someone who has used deja for months that their history

--- a/cmd/deja/check_older_index_test.go
+++ b/cmd/deja/check_older_index_test.go
@@ -12,24 +12,32 @@ import (
 // (#2680).
 func TestCheckTellsAnOlderIndexFromNoIndex(t *testing.T) {
 	for _, tc := range []struct {
-		name  string
-		ready bool
-		older bool
-		want  string
+		name    string
+		ready   bool
+		older   bool
+		damaged bool
+		want    string
 	}{
 		{name: "no index at all", want: "no index to check against yet"},
 		{name: "an index an older build wrote", older: true, want: "written by an older deja"},
+		// The third condition planIndexReady folds in. doctor says "integrity
+		// damaged" on the same store while search answers from the snapshot
+		// and rebuilds behind it (#2682).
+		{name: "a damaged index", damaged: true, want: "the index is damaged"},
 		{name: "a healthy index with nothing to say", ready: true, want: "nothing found for this plan"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			hermeticEnv(t)
 			restoreReady := planIndexReady
 			restoreOlder := indexFormatDirection
+			restoreDamaged := indexDamaged
 			t.Cleanup(func() {
 				planIndexReady = restoreReady
 				indexFormatDirection = restoreOlder
+				indexDamaged = restoreDamaged
 			})
 			planIndexReady = func(string) bool { return tc.ready }
+			indexDamaged = func(string) bool { return tc.damaged }
 			indexFormatDirection = func(string) int {
 				if tc.older {
 					return -1

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -45,6 +45,11 @@ type planFinding struct {
 	sessions []index.SessionMeta
 }
 
+// indexDamaged is a variable for the same reason indexFormatDirection is: a
+// test can put `check` in front of a damaged store without shipping a way to
+// break one (#2682).
+var indexDamaged = index.Damaged
+
 var planIndexReady = func(dir string) bool {
 	return index.HasManifest(dir) &&
 		index.IsCurrentVersion(dir) &&


### PR DESCRIPTION
Fixes #2682. The branch beside #2680.

`planIndexReady` folds three conditions into one boolean. #2680 split out "an index an older build wrote"; a damaged store still landed on "no index to check against yet".

Four ways to damage a store — manifest.gob overwritten, records.bin emptied, buckets/ removed, sessions.gob overwritten — all give the same four answers:

    doctor        integrity damaged — records or postings are missing; the next search rebuilds the index
    search        answering from the index as it was — refreshing in the background
    session hook  announces the rebuild
    check -       deja: no index to check against yet — `deja index` builds one

Three right, one telling the reader their history was never indexed while their other screens say it is damaged and being rebuilt.

    deja: the index is damaged — the next search rebuilds it, or run `deja index --rebuild` now

`indexDamaged` becomes a variable for the same reason `indexFormatDirection` already is: a test can put `check` in front of a damaged store without shipping a way to break one. All four branches pinned.
