### PR TITLE
fix(wiring): do not adopt a binary from a temp directory

### DIFF
--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 )
 
 // A hook or plugin deja wrote is a copy of what this binary generates, frozen
@@ -151,6 +152,46 @@ func recordWiring(targets []string, uninstall bool) {
 	_ = os.WriteFile(path, append(b, '\n'), 0o644)
 }
 
+// exeIsTemporary reports whether the running binary is one the wiring must not
+// adopt. A variable so a test can drive both answers: the test binary itself
+// always lives in a temp directory, so the check has to be exercised rather
+// than inherited (#2684).
+var exeIsTemporary = func(p string) bool {
+	if underTestBinary() {
+		return false
+	}
+	return underTempDir(p)
+}
+
+// underTempDir reports whether a path sits under this machine's temp directory,
+// or under the two that are temp everywhere regardless of what TMPDIR says.
+func underTempDir(p string) bool {
+	if p == "" {
+		return false
+	}
+	p = filepath.Clean(p)
+	// Both forms of each root: /tmp resolves to /private/tmp on macOS and
+	// /var/folders to /private/var/folders, and the path being judged may be
+	// written either way — it need not exist, so it cannot be resolved itself.
+	var roots []string
+	for _, root := range []string{os.TempDir(), "/tmp", "/private/tmp"} {
+		if root == "" || root == "/" {
+			continue
+		}
+		root = filepath.Clean(root)
+		roots = append(roots, root)
+		if resolved, err := filepath.EvalSymlinks(root); err == nil && resolved != root {
+			roots = append(roots, resolved)
+		}
+	}
+	for _, root := range roots {
+		if p == root || strings.HasPrefix(p, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
 // refreshWiringAfterUpgrade rewrites the recorded targets when the binary that
 // wrote them is not the one running now. It returns the targets it changed, so
 // a caller with somewhere to print can say so; the hook paths call it and stay
@@ -175,6 +216,15 @@ func refreshWiringAfterUpgrade() []string {
 	// Either the version or the path: a binary that moved writes the same
 	// version into configs that now name a file which is not there (#773).
 	if st.Version == version && (st.Exe == "" || st.Exe == exe) {
+		return nil
+	}
+	// But not a binary that will be gone tomorrow. The repair exists because
+	// deja moves — a release replaces it, a package manager relocates it — and
+	// it cannot tell that from one run of a build somewhere else: a `go run`, a
+	// colleague's checkout, a CI job, a scratch build in a temp directory. Each
+	// of those rewrote every config on the machine to a path that stops
+	// existing, and the reader found out when recall went quiet (#2684).
+	if exeIsTemporary(exe) {
 		return nil
 	}
 	// Only the home the targets were written under: this repairs, it does not

--- a/cmd/deja/wiring_temp_exe_test.go
+++ b/cmd/deja/wiring_temp_exe_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// underTempDir is what decides it, so it is pinned on its own: the paths a real
+// deja lives at, and the ones a scratch build does.
+func TestUnderTempDirKnowsAScratchBuild(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	for _, tc := range []struct {
+		path string
+		temp bool
+	}{
+		{filepath.Join(tmp, "deja"), true},
+		{filepath.Join(tmp, "go-build123", "b001", "exe", "deja"), true},
+		{"/tmp/deja", true},
+		{"/private/tmp/scratch/deja", true},
+		{"/usr/local/bin/deja", false},
+		{"/opt/homebrew/bin/deja", false},
+		{filepath.Join(os.Getenv("HOME"), ".local", "bin", "deja"), false},
+		{"", false},
+	} {
+		if got := underTempDir(tc.path); got != tc.temp {
+			t.Errorf("underTempDir(%q) = %v, want %v", tc.path, got, tc.temp)
+		}
+	}
+}
+
+// The repair exists because deja moves — a release replaces the binary, a
+// package manager relocates it — and every config still names the old path. It
+// cannot tell that from a one-off run of a build somewhere else, so a `go run`,
+// a colleague's checkout or a CI job rewrote every config to a path that will
+// not exist tomorrow (#2684).
+func TestTheRepairRefusesToAdoptATempBinary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	for _, d := range []string{".claude", ".codex", ".cursor"} {
+		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	installed := filepath.Join(home, "opt", "bin", "deja")
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "--all", "--no-index"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	// The wiring was recorded for a binary that lives somewhere real, and the
+	// configs say whatever this in-process install wrote.
+	writeWiringExe(t, installed)
+	before, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restore := exeIsTemporary
+	t.Cleanup(func() { exeIsTemporary = restore })
+
+	// A scratch build runs the session hook once.
+	exeIsTemporary = func(string) bool { return true }
+	if rewired := refreshWiringAfterUpgrade(); len(rewired) != 0 {
+		t.Fatalf("a build in a temp directory was adopted: %v", rewired)
+	}
+	after, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("the config was rewritten for a build in a temp directory:\nwas:\n%s\nnow:\n%s", before, after)
+	}
+
+	// And a real upgrade still repairs itself.
+	exeIsTemporary = func(string) bool { return false }
+	if rewired := refreshWiringAfterUpgrade(); len(rewired) == 0 {
+		t.Fatal("a binary that moved to a real location was not adopted")
+	}
+}

--- a/cmd/deja/wiring_temp_exe_test.go
+++ b/cmd/deja/wiring_temp_exe_test.go
@@ -22,7 +22,9 @@ func TestUnderTempDirKnowsAScratchBuild(t *testing.T) {
 		{"/private/tmp/scratch/deja", true},
 		{"/usr/local/bin/deja", false},
 		{"/opt/homebrew/bin/deja", false},
-		{filepath.Join(os.Getenv("HOME"), ".local", "bin", "deja"), false},
+		// A literal home, not this process's: the suite runs with HOME under a
+		// temp directory, where ~/.local/bin really is temporary.
+		{"/home/someone/.local/bin/deja", false},
 		{"", false},
 	} {
 		if got := underTempDir(tc.path); got != tc.temp {
@@ -80,9 +82,15 @@ func TestTheRepairRefusesToAdoptATempBinary(t *testing.T) {
 		t.Fatalf("the config was rewritten for a build in a temp directory:\nwas:\n%s\nnow:\n%s", before, after)
 	}
 
-	// And a real upgrade still repairs itself.
+	// And a real upgrade still repairs itself. If the environment stopped the
+	// repair for a reason of its own — a target that cannot be written — say so
+	// rather than blame the guard, which is what this test is about.
 	exeIsTemporary = func(string) bool { return false }
-	if rewired := refreshWiringAfterUpgrade(); len(rewired) == 0 {
+	rewired := refreshWiringAfterUpgrade()
+	if len(stuckWiring) > 0 && len(rewired) == 0 {
+		t.Skipf("the repair could not write here: %v", stuckWiring)
+	}
+	if len(rewired) == 0 {
 		t.Fatal("a binary that moved to a real location was not adopted")
 	}
 }

--- a/cmd/deja/wiring_temp_exe_test.go
+++ b/cmd/deja/wiring_temp_exe_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -43,25 +44,25 @@ func TestTheRepairRefusesToAdoptATempBinary(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	for _, d := range []string{".claude", ".codex", ".cursor"} {
-		if err := os.MkdirAll(filepath.Join(home, d), 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}\n"), 0o644); err != nil {
+	codex := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(codex), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	installed := filepath.Join(home, "opt", "bin", "deja")
-	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+	if err := os.WriteFile(codex, []byte("[tools]\nweb = true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := captureRun(t, "install", "--all", "--no-index"); err != nil {
-		t.Fatalf("install: %v", err)
+	// The state written by hand, the way TestWiringRefreshTouchesOnlyRecorded-
+	// Targets does: what install records depends on which harnesses a machine
+	// happens to have, and this test is about the guard, not about detection.
+	if err := os.MkdirAll(filepath.Dir(wiringStatePath()), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	// The wiring was recorded for a binary that lives somewhere real, and the
-	// configs say whatever this in-process install wrote.
-	writeWiringExe(t, installed)
-	before, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	state := `{"version":"0.0.1","targets":["codex"],"exe":"/opt/deja/bin/deja","home":` +
+		strconv.Quote(homeDir()) + `}`
+	if err := os.WriteFile(wiringStatePath(), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(codex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +75,7 @@ func TestTheRepairRefusesToAdoptATempBinary(t *testing.T) {
 	if rewired := refreshWiringAfterUpgrade(); len(rewired) != 0 {
 		t.Fatalf("a build in a temp directory was adopted: %v", rewired)
 	}
-	after, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	after, err := os.ReadFile(codex)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,15 +83,17 @@ func TestTheRepairRefusesToAdoptATempBinary(t *testing.T) {
 		t.Fatalf("the config was rewritten for a build in a temp directory:\nwas:\n%s\nnow:\n%s", before, after)
 	}
 
-	// And a real upgrade still repairs itself. If the environment stopped the
-	// repair for a reason of its own — a target that cannot be written — say so
-	// rather than blame the guard, which is what this test is about.
+	// And a real upgrade still repairs itself.
 	exeIsTemporary = func(string) bool { return false }
 	rewired := refreshWiringAfterUpgrade()
-	if len(stuckWiring) > 0 && len(rewired) == 0 {
-		t.Skipf("the repair could not write here: %v", stuckWiring)
-	}
 	if len(rewired) == 0 {
-		t.Fatal("a binary that moved to a real location was not adopted")
+		t.Fatalf("a binary that moved to a real location was not adopted (stuck: %v)", stuckWiring)
+	}
+	repaired, err := os.ReadFile(codex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(before, repaired) {
+		t.Fatalf("the repair reported %v and changed nothing:\n%s", rewired, repaired)
 	}
 }


### PR DESCRIPTION
Fixes #2684.

One run of a session-start hook from a build that is not the installed one repointed every harness config at that build:

    $ /tmp/scratch/deja hook-context <<< '{"session_id":"n","cwd":"/w/app"}'
    deja rewrote its wiring for claude-code, codex, cursor after an upgrade

    .claude.json           the scratch build
    .codex/config.toml     the scratch build
    .cursor/mcp.json       the scratch build

The repair is right to exist — deja moves, and every config still names the old path — but it cannot tell that from a `go run`, a colleague's checkout, a CI job, or a scratch build in a temp directory, each of which leaves the machine naming a path that stops existing. It happened twice on the machine this was found on, and the second time was noticed only because the wiring file still recorded the first.

Now a binary under the temp directory is not adopted; a genuine upgrade, from one real location to another, repairs itself exactly as before. Both branches pinned, along with `underTempDir` on its own: `$TMPDIR`, `/tmp`, `/private/tmp` and the resolved forms of each, against `/usr/local/bin`, `/opt/homebrew/bin` and `~/.local/bin`.

`exeIsTemporary` is a variable because the test binary always lives in a temp directory, so the check has to be exercised rather than inherited.
