### PR TITLE
fix(doctor): a hook that runs a binary which is gone is not wired

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -204,6 +204,9 @@ func doctorHooks(w io.Writer) {
 		status = "wired"
 	}
 	fmt.Fprintf(w, "  %-12s %-11s %s\n", "precompact", status, reportPath(path))
+	if note := hookExeNote(path, "claude-auto"); note != "" && (precompact || hookEventWired(hooks, "SessionStart", "hook-context")) {
+		fmt.Fprintf(w, "  %-12s %s\n", "", note)
+	}
 }
 
 // doctorWiringExe reports configs that name a binary which is no longer there.

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -114,6 +114,9 @@ func doctorAutoRecall(w io.Writer) {
 			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", reportPath(path), a.marker)
 		default:
 			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", reportPath(path), note)
+			if exe := hookExeNote(path, a.name+"-auto"); exe != "" {
+				fmt.Fprintf(w, "  %-12s %s\n", "", exe)
+			}
 		}
 	}
 }

--- a/cmd/deja/doctor_hook_exe.go
+++ b/cmd/deja/doctor_hook_exe.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// dejaHookCommandMissing returns the deja binary a hook file runs when that
+// binary is not there, and "" otherwise. The MCP check reads a server entry,
+// where the binary is a field of its own; a hook is a command line, so the
+// binary is its first word and the subcommand follows.
+//
+// Same reasoning as dejaCommandMissing for what is skipped: a bare name is the
+// PATH's business, and a relative path resolves against wherever the reader is
+// standing, so neither can be answered by a stat here. A binary under a
+// directory with a space in its name is skipped for the same reason — the
+// first word is not the whole path, and saying nothing beats calling a working
+// install broken.
+func dejaHookCommandMissing(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, m := range commandValue.FindAllStringSubmatch(string(b), -1) {
+		var value string
+		switch {
+		case m[1] != "":
+			value = quotedPathUnescape.Replace(m[1])
+		case m[2] != "":
+			value = m[2]
+		default:
+			value = m[3]
+		}
+		bin, _, _ := strings.Cut(strings.TrimSpace(value), " ")
+		if !commandIsDeja(bin) || !filepath.IsAbs(bin) {
+			continue
+		}
+		if _, err := os.Stat(bin); err != nil {
+			return bin
+		}
+	}
+	return ""
+}
+
+// hookExeNote is the line a row prints under itself when the hook it just
+// called wired runs a binary that is gone. install target is the -auto one:
+// the plain target writes the MCP entry, and following advice that repairs a
+// different file leaves the hook dead and doctor quiet about it (#2686).
+func hookExeNote(path, target string) string {
+	missing := dejaHookCommandMissing(path)
+	if missing == "" {
+		return ""
+	}
+	return "runs " + missing + ", which is not there — `deja install " + target + "` rewrites it for this binary"
+}

--- a/cmd/deja/doctor_hook_exe_test.go
+++ b/cmd/deja/doctor_hook_exe_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The MCP rows learned in #2216 that "wired" is not "can start". The hook rows
+// print the same word for a hook whose command names a binary that is gone —
+// and the recorded-path check goes quiet as soon as one target is reinstalled
+// from the new location, which stamps the record for every target. Doctor then
+// says nothing at all about a dead recall hook (#2686).
+func TestDoctorNamesHooksRunningABinaryThatIsGone(t *testing.T) {
+	tmp := hermeticEnv(t)
+	gone := filepath.Join(tmp, "old", "deja")
+
+	claude := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]any{"hooks": map[string]any{
+		"SessionStart": []any{map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": gone + " hook-context"},
+		}}},
+		"PreCompact": []any{map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": gone + " hook-precompact"},
+		}}},
+	}}
+	b, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claude, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cursor := filepath.Join(sources.CursorCLIHome(), "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(cursor), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hooks := map[string]any{"hooks": map[string]any{
+		"sessionStart": []any{map[string]any{"command": gone + " hook-context"}},
+	}}
+	if b, err = json.Marshal(hooks); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cursor, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	got := out.String()
+	for _, want := range []string{
+		"runs " + gone + ", which is not there",
+		"deja install claude-auto",
+		"deja install cursor-auto",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("doctor does not say %q:\n%s", want, got)
+		}
+	}
+
+	// A hook that runs a binary which is there says nothing extra.
+	here := filepath.Join(tmp, "deja")
+	if err := os.WriteFile(here, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{claude, cursor} {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, bytes.ReplaceAll(b, []byte(gone), []byte(here)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if got := out.String(); strings.Contains(got, "which is not there") {
+		t.Errorf("a hook running the binary that is there was called dead:\n%s", got)
+	}
+}

--- a/cmd/deja/doctor_without_claude_test.go
+++ b/cmd/deja/doctor_without_claude_test.go
@@ -21,7 +21,16 @@ func TestDoctorShowsEveryHarnessWithoutClaudeCode(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(home, "index.db"))
 
-	if _, err := installTarget("qwen-auto", "/usr/local/bin/deja", false); err != nil {
+	// A binary that is really there: a hook naming one that is not gets a
+	// second line of its own, and this test is about the table, not that.
+	exe := filepath.Join(home, "bin", "deja")
+	if err := os.MkdirAll(filepath.Dir(exe), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installTarget("qwen-auto", exe, false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err == nil {


### PR DESCRIPTION
The MCP rows check the command they wrote (#2216); the hook rows print "wired"
whatever binary is in the file. The other check — the recorded path — stops
helping as soon as one target is reinstalled from a new location, because that
stamps the record for every target.

So a machine where the binary moved and one config was repaired ends up with a
dead `hook-context` on every session start and a doctor that says nothing.

The hook rows now get the same second line, and it names the `-auto` target:
the plain one writes the MCP entry, which is not the file the row is about.
