### PR TITLE
fix(doctor): check the binary in the plugin hooks too

### DIFF
--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -114,7 +114,10 @@ func doctorAutoRecall(w io.Writer) {
 			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", reportPath(path), a.marker)
 		default:
 			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", reportPath(path), note)
-			if exe := hookExeNote(path, a.name+"-auto"); exe != "" {
+			// Only the rows that run the binary. aider's file is a digest of
+			// past sessions and roo's is guidance — neither executes anything,
+			// and both can quote a path for reasons of their own.
+			if exe := hookExeNote(path, a.name+"-auto"); a.marker != "" && exe != "" {
 				fmt.Fprintf(w, "  %-12s %s\n", "", exe)
 			}
 		}

--- a/cmd/deja/doctor_hook_exe.go
+++ b/cmd/deja/doctor_hook_exe.go
@@ -3,51 +3,93 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
+// hookExePath matches an absolute path to deja's own binary. Both forms are
+// written by deja itself: the unix one, and the windows one a windows build
+// reads back. The case fold covers the drive letter and the suffix only — on a
+// case-sensitive filesystem /opt/Deja is a different file, and calling it the
+// binary reports a healthy install broken.
+var hookExePath = regexp.MustCompile("(/[^\\s\"'`\\\\]*/deja(?:\\.[eE][xX][eE])?|[A-Za-z]:[\\\\/][^\\s\"'`\\n]*[\\\\/]deja(?:\\.[eE][xX][eE])?)")
+
+// hookExeRuns matches what follows the path when the path is being run: one of
+// deja's own subcommands, past whatever quoting the file uses.
+var hookExeRuns = regexp.MustCompile(`^["'\\\s]*(hook-[a-z-]+|warmup-status|recall|statusline|mcp)\b`)
+
+// hookExeAssigned matches what precedes the path when a generated plugin binds
+// it to a name of its own — `const DEJA = "…"`, `DEJA = "…"`. The `=` is what
+// keeps a config *key* that ends in deja out: `"DEJA_INDEX_DIR": "…/deja"` is
+// a directory this check has no business reporting on.
+var hookExeAssigned = regexp.MustCompile(`(?i)deja[a-z_]*["']?\s*=\s*["'\\]*$`)
+
 // dejaHookCommandMissing returns the deja binary a hook file runs when that
-// binary is not there, and "" otherwise. The MCP check reads a server entry,
-// where the binary is a field of its own; a hook is a command line, so the
-// binary is its first word and the subcommand follows.
+// binary is not there, and "" otherwise.
+//
+// The MCP check reads a server entry, where the binary is a field of its own.
+// A hook is whatever the harness accepts: a command line, a `const DEJA = …`
+// in a plugin deja generates, a path quoted inside a command. So this reads
+// the path itself rather than the syntax around it — but only where the file
+// is running it or binding it, because these files also carry text nobody
+// executes. aider's is a digest of past sessions, and a transcript that once
+// mentioned a checkout called deja would otherwise be read as a dead hook.
 //
 // Same reasoning as dejaCommandMissing for what is skipped: a bare name is the
 // PATH's business, and a relative path resolves against wherever the reader is
-// standing, so neither can be answered by a stat here. A binary under a
-// directory with a space in its name is skipped for the same reason — the
-// first word is not the whole path, and saying nothing beats calling a working
-// install broken.
+// standing, so neither can be answered by a stat here. A path with a space in
+// it is skipped too — the boundary that ends every other path ends that one in
+// the middle, and saying nothing beats calling a working install broken.
 func dejaHookCommandMissing(path string) string {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
-	for _, m := range commandValue.FindAllStringSubmatch(string(b), -1) {
-		var value string
-		switch {
-		case m[1] != "":
-			value = quotedPathUnescape.Replace(m[1])
-		case m[2] != "":
-			value = m[2]
-		default:
-			value = m[3]
-		}
-		bin, _, _ := strings.Cut(strings.TrimSpace(value), " ")
-		if !commandIsDeja(bin) || !filepath.IsAbs(bin) {
+	text := string(b)
+	for _, loc := range hookExePath.FindAllStringIndex(text, -1) {
+		if !hookExeBoundary(text, loc[0]-1) || !hookExeBoundary(text, loc[1]) {
 			continue
 		}
-		if _, err := os.Stat(bin); err != nil {
-			return bin
+		if !hookExeRuns.MatchString(text[loc[1]:]) && !hookExeAssigned.MatchString(text[:loc[0]]) {
+			continue
+		}
+		// The windows form is written escaped, and the escapes are not part of
+		// the path: stat would miss and the note would print them back.
+		cand := quotedPathUnescape.Replace(text[loc[0]:loc[1]])
+		if !filepath.IsAbs(cand) {
+			continue
+		}
+		if _, err := os.Stat(cand); err != nil {
+			return cand
 		}
 	}
 	return ""
 }
 
+// hookExeBoundary reports whether the byte at i ends a path rather than
+// continuing one. Either end of the file counts: a file holding the path and
+// nothing else is one deja writes too. `:` is deliberately not a boundary — a
+// permission rule reads `Bash(/home/me/bin/deja:*)`, and that is not a hook.
+func hookExeBoundary(text string, i int) bool {
+	if i < 0 || i >= len(text) {
+		return true
+	}
+	switch text[i] {
+	case '"', '\'', '`', '\\', ' ', '\t', '\r', '\n', ',', ';', '=', '(', ')', '[', ']', '{', '}', '|', '&', '<', '>':
+		return true
+	}
+	return false
+}
+
 // hookExeNote is the line a row prints under itself when the hook it just
-// called wired runs a binary that is gone. install target is the -auto one:
-// the plain target writes the MCP entry, and following advice that repairs a
-// different file leaves the hook dead and doctor quiet about it (#2686).
+// called wired runs a binary that is gone. The install target is the -auto
+// one: the plain target writes the MCP entry, and following advice that
+// repairs a different file leaves the hook dead and doctor quiet about it
+// (#2686).
 func hookExeNote(path, target string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
 	missing := dejaHookCommandMissing(path)
 	if missing == "" {
 		return ""

--- a/cmd/deja/doctor_hook_exe_test.go
+++ b/cmd/deja/doctor_hook_exe_test.go
@@ -87,3 +87,125 @@ func TestDoctorNamesHooksRunningABinaryThatIsGone(t *testing.T) {
 		t.Errorf("a hook running the binary that is there was called dead:\n%s", got)
 	}
 }
+
+// The nine plugin-shaped wirings hold the same absolute path in JavaScript,
+// TypeScript, Python, or quoted inside a command — and said "wired" while the
+// binary they run is gone (#2688).
+func TestDoctorNamesPluginHooksRunningABinaryThatIsGone(t *testing.T) {
+	tmp := hermeticEnv(t)
+	gone := filepath.Join(tmp, "old", "deja")
+
+	cases := []struct {
+		name string
+		path string
+		body string
+	}{
+		{"opencode", filepath.Join(opencodeConfigHome(), "opencode", "plugins", "deja.js"),
+			"const raw = await $`\"" + gone + "\" hook-context`.text()\n"},
+		{"hermes", filepath.Join(sources.HermesHome(), "plugins", "deja", "__init__.py"),
+			"DEJA = \"" + gone + "\"\nsubprocess.run([DEJA, \"hook-context\"])\n"},
+		{"goose", gooseHookPath(),
+			"{\"hooks\":{\"session_start\":[{\"command\":\"'" + gone + "' hook-goose\"}]}}\n"},
+	}
+	for _, c := range cases {
+		if err := os.MkdirAll(filepath.Dir(c.path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(c.path, []byte(c.body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var out bytes.Buffer
+	doctorAutoRecall(&out)
+	got := out.String()
+	if n := strings.Count(got, "runs "+gone); n != len(cases) {
+		t.Errorf("%d of %d rows name the binary that is gone:\n%s", n, len(cases), got)
+	}
+	for _, c := range cases {
+		if !strings.Contains(got, "deja install "+c.name+"-auto") {
+			t.Errorf("%s is not told how to repair itself:\n%s", c.name, got)
+		}
+	}
+
+	// And a binary that is there is not called dead — the marker check has
+	// nothing to do with this, so a wired row stays one line.
+	here := filepath.Join(tmp, "deja")
+	if err := os.WriteFile(here, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cases {
+		b, err := os.ReadFile(c.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(c.path, bytes.ReplaceAll(b, []byte(gone), []byte(here)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out.Reset()
+	doctorAutoRecall(&out)
+	got = out.String()
+	if strings.Contains(got, "which is not there") {
+		t.Errorf("a plugin running the binary that is there was called dead:\n%s", got)
+	}
+	// And they are still wired: a check that quietly turned every row stale
+	// would pass the line above.
+	for _, c := range cases {
+		wired := false
+		for _, line := range strings.Split(got, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), c.name+" ") && strings.Contains(line, "wired") {
+				wired = true
+			}
+		}
+		if !wired {
+			t.Errorf("%s no longer reads wired:\n%s", c.name, got)
+		}
+	}
+}
+
+// The files these rows read are not all deja's own code. aider's is a digest
+// of past sessions, so any path a transcript once mentioned is in there, and
+// the hook files themselves carry settings that end in deja without being it
+// (#2688).
+func TestDoctorDoesNotCallAPathInPassingADeadHook(t *testing.T) {
+	tmp := hermeticEnv(t)
+	nowhere := filepath.Join(tmp, "coding", "deja")
+
+	aider := aiderContextPath()
+	if err := os.MkdirAll(filepath.Dir(aider), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A digest of past sessions carries commands those sessions ran, deja's
+	// own among them — the one shape that looks exactly like a live hook.
+	digest := "- Session: ran `" + nowhere + " hook-context` after the rebuild\n"
+	if err := os.WriteFile(aider, []byte(digest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorAutoRecall(&out)
+	if got := out.String(); strings.Contains(got, "which is not there") {
+		t.Errorf("a path quoted in a recalled transcript was read as a hook:\n%s", got)
+	}
+
+	// And a setting whose name ends in deja is a directory, not the binary.
+	claude := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	here := filepath.Join(tmp, "deja")
+	if err := os.WriteFile(here, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{"env":{"DEJA_INDEX_DIR":"` + filepath.Join(tmp, "cache", "deja") + `"},` +
+		`"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"` + here + ` hook-context"}]}]}}`
+	if err := os.WriteFile(claude, []byte(settings), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if got := out.String(); strings.Contains(got, "which is not there") {
+		t.Errorf("an index directory was read as the binary:\n%s", got)
+	}
+}


### PR DESCRIPTION
#2686 reached the six harnesses that keep the hook under a `command` key. The
other nine write the path into a plugin they generate — JS, TS, Python — or
quote it inside the command, and kept saying `wired` with the binary gone.

The check now reads the path itself rather than the syntax around it, with the
quotes and whitespace either side as its boundary. Swept every `-auto` target
live: nothing while the binary is there, all fifteen rows once it moves.
