### PR TITLE
docs(bench492): what the pass costs, on both corpora

### DIFF
--- a/tools/bench492/README.md
+++ b/tools/bench492/README.md
@@ -22,7 +22,7 @@ runs are not comparable, for the reason in the first lesson below. The first
 reports min/median per cell. Interleaving keeps a machine-wide slowdown from
 landing on one cell; read the min column first, contention only ever adds.
 
-Two lessons from using it, so the next measurement does not relearn them:
+Three lessons from using it, so the next measurement does not relearn them:
 
 - Wall-clock deltas between two *different binaries* carry binary-layout
   noise — around ±15% of a small corpus's build time on the machine this was
@@ -36,6 +36,67 @@ Two lessons from using it, so the next measurement does not relearn them:
   the runner never writes into a live index either way. Take that copy
   before the first build: a live store grows while the run is going, and
   then the cells are timing different bytes.
+- The stub arm has to be a *build* with the `cjkIndexKeys` call in
+  `indexKeys` removed, not a runtime switch. `run_bench.py` only measures —
+  it never compiles anything, it runs `<bin> index --rebuild` for each cell —
+  so any difference between arms has to be baked into the binary handed to
+  `--bin` before the run starts. A build was lost to learning this.
+
+## What the pass costs
+
+Whole-build, both corpora, so the numbers can sit next to each other.
+
+**A real store**, `main` at `9ed8498` (`v0.19.0` plus 28 commits). Mac mini,
+Apple silicon, macOS, `GOMAXPROCS=2`; frozen APFS clone of 5,289 files /
+5,170 sessions / 372,048 indexed messages, 55.4% of messages carrying CJK,
+16.6% of runes CJK, repetition rate 1.378. Two windows of 7 rounds, min of 14:
+
+| | min of 14 |
+|---|---|
+| bigram-free build (`main` with the emitter stubbed) | 87.995 s |
+| **bigram cost** | **+4.289 s** |
+| as a share of the bigram-free build | 4.87% |
+| as a share of the build it is in | 4.65% |
+| `-trimpath` noise floor, same source | **0.250 s (0.27%)** |
+| effect / noise | **17.2×** |
+
+**A generated all-CJK corpus**, 1,200 sessions per arm (not the 5,000 the
+example above uses), 5 interleaved rounds, min:
+
+| arm | bigrams on | off | cost |
+|---|---|---|---|
+| ja | 1.383 s | 0.822 s | +0.561 s, 68% of the bigram-free build |
+| en | 0.294 s | 0.316 s | none, which is the control working |
+
+Index size on the `ja` arm: 14.0 MB against 10.6 MB.
+
+So the bracket is **4.87% on a real store where CJK is 16.6% of runes, and
+68% on an all-Japanese generated one** — same code, two corpora, and the
+answer for any given store sits between them. Neither number alone is the
+answer to "what does the bigram pass cost"; the pair is.
+
+### Why the summary carries its own noise floor
+
+The real-store run above took two windows, and the `-trimpath` cell is the
+only thing that says which one to believe:
+
+| | window 1 | window 2 |
+|---|---|---|
+| bigram cost | +5.814 s | +4.289 s |
+| `-trimpath` spread, identical source | 1.337 s | 0.250 s |
+| effect / noise | 4.4× | 17.2× |
+
+Window 1's noise floor was 5× window 2's, and its per-round `main − stub`
+deltas changed sign twice — two rounds had the stubbed build coming out
+*slower*, which it cannot be: its index is 114.3 MB smaller. Window 1 was
+measuring the machine. Published, it would have been 36% too high, on a rig
+whose own first lesson says not to.
+
+Window 2's floor of 0.250 s is also the strongest available statement that
+the run was clean: an earlier real-store run on `v0.19.0`, weeks apart in a
+separate window on the same machine, measured 0.249 s for the same layout
+spread. Both windows are kept here on purpose — a summary showing only the
+surviving number teaches the wrong lesson about what the third cell is for.
 
 The read-only counterpart is `internal/index/cjkindex_realcorpus492_test.go`,
 behind the `realcorpus492` build tag so a normal `go test ./...` never sees
@@ -44,5 +105,9 @@ it. It replays what a real build walks before `indexKeys` sees a byte
 and reports the one thing no generator can be reasoned into: the bigram
 repetition rate, which is what both dedupe halves are paid for. Measured so
 far — `benchJAText`, the fixture the microbenchmarks use, 4.000; this
-generator, 1.640; a real 365k-message Chinese store, 1.376 (#492). The
-per-message speedups move with it, so quote them against a rate.
+generator, 1.640; a store where CJK is incidental rather than the language of
+the work (635 of 205,490 messages carry any), 1.685; a real 365k-message
+Chinese store, 1.376 (#492). The per-message speedups move with it, so quote
+them against a rate. The generator models the incidental case well and the
+native case is the low end, which is the direction that matters: the dedupe
+halves are worth least exactly where the text is most CJK.


### PR DESCRIPTION
@vshulcz asked for this in #492 after posting the generated-corpus whole build. The README carried the rig but not its results: the repetition table was short the incidental store, and the question in the issue title — what the bigram pass costs on a whole build — had been answered twice in the thread and written down nowhere.

## What went in

**The whole-build cost, from both corpora, in one section.** 4.289 s / 4.87% of a bigram-free build on the real store (`main` at `9ed8498`, 372,048 indexed messages, 55.4% carrying CJK), and +0.561 s / 68% on the generated all-Japanese arm, with the `en` control at no cost. Neither is the answer alone: a reader who takes one without the other is off by more than an order of magnitude in whichever direction they picked. That framing is yours from the issue; I have kept it as the point of the section rather than a footnote to it.

**The rejected window, kept.** The real-store run took two windows, +5.814 s and +4.289 s, and only the `-trimpath` cell separates them — 1.337 s of spread against 0.250 s, and window 1's per-round deltas changed sign twice, which the stub cannot do since its index is 114.3 MB smaller. Publishing window 1 would have been 36% high. Showing only the surviving number would teach the wrong lesson about why the third cell is in the summary at all, which was the reason for putting it there.

**A third lesson: the stub arm has to be a build, not a runtime switch.** You lost a build to this and it belongs in the file.

**The repetition table now has all four rates** — 4.000 fixture, 1.640 generator, 1.685 incidental, 1.376 native — with the sentence about which direction matters, since the dedupe halves are worth least exactly where the text is most CJK.

## Two places I departed from the thread — say the word and either goes back

**The bracket is labelled by CJK rune share, not repetition rate.** Your sentence reads "4.87% on your real store at 1.376 repetition and 68% on an all-Japanese generated one at 1.640". Both pairs are true of these two corpora, but the 4.87→68 gap is a gap in how much of the build is CJK work at all (16.6% of runes against all of them), and labelling it by repetition rate invites the reader to attribute it to dedupe efficiency instead. The repetition rates keep their own paragraph at the end, where they are what is being measured.

**The third lesson gives a different reason than you did.** You gave the runner's per-cell environment. What I could point at in the file is narrower: `run_bench.py` never compiles anything — its docstring says it only measures, it runs `<bin> index --rebuild` per cell, and `cell_env` only overrides `HOME`, the two store paths and `GOMAXPROCS`, so it does not eat an outside variable. The conclusion is the same one you reached; I wrote the mechanism a reader can verify in the file rather than the one I could not.

## Checks

- Documentation only — `git diff --stat` is `tools/bench492/README.md | 71 +++--`, nothing else in the tree.
- Every figure traced to the comment it was measured in: real store to [`5442468812`](https://github.com/vshulcz/deja-vu/issues/492#issuecomment-5442468812), generated to [`5465139373`](https://github.com/vshulcz/deja-vu/issues/492#issuecomment-5465139373), incidental store to [`5437923324`](https://github.com/vshulcz/deja-vu/issues/492#issuecomment-5437923324). Nothing rounded, rescaled or restated.
- Code facts checked against this branch rather than the thread: `cjkIndexKeys` is called from `indexKeys` (`internal/index/retrieval.go:3611`, `indexKeys` opens at 3597), and `internal/index/cjkindex_realcorpus492_test.go` is still the read-only counterpart the last paragraph points at.
- Nothing in the original text changed except the three lines that had to: `Two lessons` → `Three lessons`, and the repetition sentence split to take the fourth rate.