### PR TITLE
fix(cursor): rewrite deja's own hook entry instead of appending another

### DIFF
--- a/cmd/deja/install_cursor.go
+++ b/cmd/deja/install_cursor.go
@@ -60,11 +60,36 @@ func setCursorHook(hooks map[string]any, event, cmd string, uninstall bool) {
 	found := false
 	for _, entryAny := range entries {
 		entry, _ := entryAny.(map[string]any)
-		if entry != nil && entry["command"] == cmd {
+		kind := hookNotDejas
+		if entry != nil {
+			kind = hookCommandKindOf(entry["command"], cmd)
+		}
+		// A wrapper the reader built around deja is theirs to keep — and it
+		// already calls the hook, so writing deja's own line beside it would
+		// run the same thing twice.
+		if kind == hookWrapsDejas {
 			found = true
+			kept = append(kept, entryAny)
+			continue
+		}
+		// An entry deja wrote from a path it no longer runs from is still
+		// deja's. Comparing the whole command read it as a stranger's hook
+		// worth keeping, so a move left cursor running the binary that is
+		// gone alongside the one that is there, and appended one more entry
+		// every time (#2691).
+		if kind == hookDejas {
 			if uninstall {
+				found = true
 				continue
 			}
+			// A file that already collected several of them converges here:
+			// the first becomes this binary's line and the rest go, rather
+			// than being rewritten into byte-identical copies of it.
+			if found {
+				continue
+			}
+			found = true
+			entry["command"] = cmd
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_cursor_test.go
+++ b/cmd/deja/install_cursor_test.go
@@ -90,3 +90,104 @@ func TestInstallCursorHooksIsIdempotentAndReversible(t *testing.T) {
 		t.Fatalf("beforeSubmitPrompt survived uninstall: %v", c)
 	}
 }
+
+// The binary moves and the repair reinstalls cursor. An entry deja wrote from
+// the old path is deja's, not a stranger's: keeping it leaves cursor running a
+// binary that is gone on every session start and every prompt, and one more
+// entry accumulates with every move (#2691).
+func TestInstallCursorHooksRewritesItsOwnEntry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CURSOR_CONFIG_DIR", filepath.Join(home, ".cursor"))
+	if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// One hook of the reader's own, and one they built around deja: neither is
+	// deja's line to rewrite.
+	seed := `{"version":1,"hooks":{"sessionStart":[` +
+		`{"command":"/usr/bin/mine"},` +
+		`{"command":"/old/bin/deja hook-context"},` +
+		`{"command":"cd /tmp && /old/bin/deja hook-context | tee /tmp/log"}` +
+		`]}}`
+	path := filepath.Join(home, ".cursor", "hooks.json")
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installCursorHooks("/new/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got := cursorCommands(t, cursorHooksFile(t, home), "sessionStart")
+	want := []string{
+		"/usr/bin/mine",
+		"/new/bin/deja hook-context",
+		"cd /tmp && /old/bin/deja hook-context | tee /tmp/log",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sessionStart = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sessionStart[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// And uninstall takes back the line deja wrote from wherever it was
+	// written, leaving the reader's two alone.
+	if _, err := installCursorHooks("/newer/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	got = cursorCommands(t, cursorHooksFile(t, home), "sessionStart")
+	want = []string{"/usr/bin/mine", "cd /tmp && /old/bin/deja hook-context | tee /tmp/log"}
+	if len(got) != len(want) {
+		t.Fatalf("after uninstall sessionStart = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("after uninstall sessionStart[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Two shapes the rewrite has to answer for beyond the plain one: a file whose
+// only entry is a wrapper the reader built, and a file that already collected
+// several of deja's own lines from several paths (#2691).
+func TestInstallCursorHooksLeavesOneEntryBehind(t *testing.T) {
+	seedCursor := func(t *testing.T, entries string) string {
+		t.Helper()
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("CURSOR_CONFIG_DIR", filepath.Join(home, ".cursor"))
+		if err := os.MkdirAll(filepath.Join(home, ".cursor"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		seed := `{"version":1,"hooks":{"sessionStart":[` + entries + `]}}`
+		if err := os.WriteFile(filepath.Join(home, ".cursor", "hooks.json"), []byte(seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return home
+	}
+
+	// The wrapper already runs the hook. Adding deja's line beside it runs it
+	// twice per session.
+	wrapper := `{"command":"cd /tmp && /old/bin/deja hook-context | tee /tmp/log"}`
+	home := seedCursor(t, wrapper)
+	if _, err := installCursorHooks("/new/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got := cursorCommands(t, cursorHooksFile(t, home), "sessionStart")
+	if len(got) != 1 || got[0] != "cd /tmp && /old/bin/deja hook-context | tee /tmp/log" {
+		t.Errorf("a wrapper got deja's own line beside it: %v", got)
+	}
+
+	// And the file #2691 was written for: the stale entries go, one line for
+	// this binary stays.
+	home = seedCursor(t, `{"command":"/a/deja hook-context"},{"command":"/b/deja hook-context"}`)
+	if _, err := installCursorHooks("/new/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got = cursorCommands(t, cursorHooksFile(t, home), "sessionStart")
+	if len(got) != 1 || got[0] != "/new/bin/deja hook-context" {
+		t.Errorf("the entries deja left behind were not collected: %v", got)
+	}
+}


### PR DESCRIPTION
Move the binary and cursor ends up with two deja entries — the dead path and
the live one — running both on every session start and every prompt, one more
with every move. Uninstall left the stale ones behind for the same reason.

`setCursorHook` now recognises deja's own entry the way the Claude writer does,
with `hookCommandKindOf`, and rewrites it. A wrapper someone built around deja
is still theirs.
