### PR TITLE
fix(wiring): the repair rewrites the /deja command too

### DIFF
--- a/cmd/deja/wiring_command_file_test.go
+++ b/cmd/deja/wiring_command_file_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The repair rewrites the wiring. The /deja command holds the same absolute
+// path and was written by the install command rather than by installTarget, so
+// a move left it running a binary that is gone — and `deja install` for the
+// same target, which the repair exists to save the reader, fixed it (#2693).
+func TestTheRepairRewritesTheCommandFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CURSOR_CONFIG_DIR", filepath.Join(home, ".cursor"))
+
+	old := filepath.Join(home, "old", "deja")
+	if _, err := installTarget("cursor-auto", old, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCommandFile(guidanceHarness("cursor-auto"), old, false); err != nil {
+		t.Fatal(err)
+	}
+	command := commandFilePath(guidanceHarness("cursor-auto"))
+	before, err := os.ReadFile(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(before), old) {
+		t.Fatalf("the command file does not name the binary it was written for:\n%s", before)
+	}
+
+	// The state by hand, the way the other wiring tests seed it: what install
+	// records depends on which harnesses the machine running the test has.
+	if err := os.MkdirAll(filepath.Dir(wiringStatePath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"version":"0.0.1","targets":["cursor-auto"],"exe":` + strconv.Quote(old) +
+		`,"home":` + strconv.Quote(homeDir()) + `}`
+	if err := os.WriteFile(wiringStatePath(), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := exeIsTemporary
+	t.Cleanup(func() { exeIsTemporary = restore })
+	exeIsTemporary = func(string) bool { return false }
+
+	if rewired := refreshWiringAfterUpgrade(); len(rewired) == 0 {
+		t.Fatalf("nothing was rewired (stuck: %v)", stuckWiring)
+	}
+	after, err := os.ReadFile(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(after), old) {
+		t.Errorf("the /deja command still runs the binary that is gone:\n%s", after)
+	}
+
+	// And a machine that asked for the plumbing without the text keeps it that
+	// way: the repair rewrites a command file, it does not hand out one.
+	if err := os.Remove(command); err != nil {
+		t.Fatal(err)
+	}
+	state = `{"version":"0.0.2","targets":["cursor-auto"],"exe":` + strconv.Quote(old) +
+		`,"home":` + strconv.Quote(homeDir()) + `}`
+	if err := os.WriteFile(wiringStatePath(), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The repair still runs — otherwise this proves only that it bailed. It
+	// reports nothing changed, which is the point: the wiring already names
+	// this binary and the command file is not there to rewrite.
+	refreshWiringAfterUpgrade()
+	if len(stuckWiring) != 0 {
+		t.Fatalf("the second repair could not write: %v", stuckWiring)
+	}
+	if _, err := os.Stat(command); err == nil {
+		t.Errorf("the repair wrote a command file the machine had declined: %s", command)
+	}
+}
+
+// Goose keeps the command in config.yaml and the workflow in a recipe beside
+// it. Going by the recipe alone would put back a slash command someone took
+// out of the config by hand (#2693).
+func TestTheRepairLeavesAGooseCommandTakenOutByHand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	old := filepath.Join(home, "old", "deja")
+	if _, err := installTarget("goose-auto", old, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCommandFile("goose", old, false); err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(gooseConfigDir(), "config.yaml")
+	b, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gooseSlashCommandPresent() {
+		t.Fatalf("the command was never written:\n%s", b)
+	}
+	// Taken out by hand, recipe left behind.
+	if err := os.WriteFile(config, []byte(removeGooseSlashCommand(string(b))), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(wiringStatePath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	state := `{"version":"0.0.1","targets":["goose-auto"],"exe":` + strconv.Quote(old) +
+		`,"home":` + strconv.Quote(homeDir()) + `}`
+	if err := os.WriteFile(wiringStatePath(), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := exeIsTemporary
+	t.Cleanup(func() { exeIsTemporary = restore })
+	exeIsTemporary = func(string) bool { return false }
+
+	if rewired := refreshWiringAfterUpgrade(); len(rewired) == 0 {
+		t.Fatalf("nothing was rewired (stuck: %v)", stuckWiring)
+	}
+	if gooseSlashCommandPresent() {
+		after, _ := os.ReadFile(config)
+		t.Errorf("the repair put the slash command back:\n%s", after)
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -247,7 +247,16 @@ func refreshWiringAfterUpgrade() []string {
 			stuckWiring = append(stuckWiring, target)
 			continue
 		}
-		if res.Action != "" && res.Action != "unchanged" {
+		cr, cerr := refreshCommandFile(target, exe)
+		if cerr != nil {
+			failed = true
+			stuckWiring = append(stuckWiring, target)
+			continue
+		}
+		// The command counts as a change of its own. It is text the reader can
+		// have edited, and a rewrite that replaces it has to be announced even
+		// when the wiring beside it was already right (#886).
+		if wiringChanged(res) || wiringChanged(cr) {
 			changed = append(changed, target)
 		}
 	}
@@ -272,6 +281,65 @@ func wiringCreated(path string) bool {
 	}
 	for _, p := range createdByThisRun {
 		if p == path {
+			return true
+		}
+	}
+	return false
+}
+
+// refreshCommandFile rewrites the /deja command for a target that already has
+// one. The command holds the same absolute path the wiring does, and was
+// written by the install command rather than by installTarget, so a move left
+// it running a binary that is gone while everything around it was repaired
+// (#2693).
+//
+// Only a file that is already there: a machine installed with --no-guidance
+// has none, and the repair is not the place to hand it text it declined.
+func refreshCommandFile(target, exe string) (installResult, error) {
+	harness := guidanceHarness(target)
+	if !commandFileWritten(harness) {
+		return installResult{}, nil
+	}
+	return installCommandFile(harness, exe, false)
+}
+
+// wiringChanged reports whether a write did something worth telling the reader
+// about.
+func wiringChanged(r installResult) bool {
+	return r.Action != "" && r.Action != "unchanged"
+}
+
+// commandFileWritten reports whether this harness has a /deja command on disk.
+// Goose keeps the command in config.yaml and the workflow in a recipe beside
+// it, so the recipe is what answers for goose.
+func commandFileWritten(harness string) bool {
+	if harness == "goose" {
+		// Both halves. The writer re-adds the slash_commands entry and creates
+		// config.yaml if it has to, so going by the recipe alone would put back
+		// a command someone took out of the config by hand.
+		if _, err := os.Stat(gooseRecipePath()); err != nil {
+			return false
+		}
+		return gooseSlashCommandPresent()
+	}
+	path := commandFilePath(harness)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// gooseSlashCommandPresent reports whether config.yaml still lists deja's
+// slash command, in any of the three quotings removeGooseSlashCommand knows.
+func gooseSlashCommandPresent() bool {
+	b, err := os.ReadFile(filepath.Join(gooseConfigDir(), "config.yaml"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		switch strings.TrimSpace(line) {
+		case `- command: "deja"`, "- command: deja", "- command: 'deja'":
 			return true
 		}
 	}


### PR DESCRIPTION
After a move the repair rewired every target and left `commands/deja.md` for
opencode, cursor and omp, plus goose's recipe, naming the binary that is gone —
`/deja` then failed on every use until someone ran the install the repair
exists to save them.

The repair now rewrites the command file as well, and only one that is already
there: a machine installed with --no-guidance keeps none.
