### PR TITLE
fix(doctor): say which file the damage is in

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1329,8 +1329,12 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 	// answer anything, and said "up to date" until #735. The next search
 	// rebuilds it, which is worth saying too — the reader has not lost memory,
 	// only this build of the index.
-	if index.Damaged(dir) {
-		fmt.Fprintln(w, "  integrity damaged — records or postings are missing; the next search rebuilds the index")
+	if reason := indexDamageReason(dir); reason != "" {
+		// What broke, not a summary of the four ways it can: a manifest that
+		// will not decode is not missing records, and the sentence sent the
+		// reader — and whoever reads the doctor output they paste into an
+		// issue — after the wrong file (#2695).
+		fmt.Fprintf(w, "  integrity damaged — %s; the next search rebuilds the index\n", reason)
 		return
 	}
 	switch idx.State {

--- a/cmd/deja/doctor_damaged_test.go
+++ b/cmd/deja/doctor_damaged_test.go
@@ -48,6 +48,11 @@ func TestDoctorReportsADamagedIndex(t *testing.T) {
 	if !strings.Contains(out, "the next search rebuilds") {
 		t.Errorf("no recovery named:\n%s", out)
 	}
+	// And which file: one sentence for four breakages named records and
+	// postings for two that were neither (#2695).
+	if !strings.Contains(out, "postings") {
+		t.Errorf("the line does not say what broke:\n%s", out)
+	}
 	// "up to date" must not sit under a damage line.
 	if strings.Contains(out, "freshness up to date") {
 		t.Errorf("still claims freshness:\n%s", out)

--- a/cmd/deja/hook_plan.go
+++ b/cmd/deja/hook_plan.go
@@ -48,7 +48,14 @@ type planFinding struct {
 // indexDamaged is a variable for the same reason indexFormatDirection is: a
 // test can put `check` in front of a damaged store without shipping a way to
 // break one (#2682).
-var indexDamaged = index.Damaged
+// indexDamaged is the reason read as a bool, so a test that stubs one cannot
+// put the two into a state the store itself can never be in.
+var indexDamaged = func(dir string) bool { return indexDamageReason(dir) != "" }
+
+// indexDamageReason is the same seam for the sentence doctor prints: which
+// file is not what the manifest says, rather than a summary of every way a
+// store can break (#2695).
+var indexDamageReason = index.DamageReason
 
 var planIndexReady = func(dir string) bool {
 	return index.HasManifest(dir) &&

--- a/internal/index/damage_reason_test.go
+++ b/internal/index/damage_reason_test.go
@@ -1,0 +1,114 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// One sentence covered four breakages, and named the wrong file in two of them
+// (#2695). Each store here is broken exactly one way.
+func TestDamageReasonNamesWhatBroke(t *testing.T) {
+	build := func(t *testing.T) string {
+		t.Helper()
+		tmp := t.TempDir()
+		setHome(t, filepath.Join(tmp, "home"))
+		t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+		t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+		t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
+		root := filepath.Join(tmp, "claude", "proj-p")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","sessionId":"s1","timestamp":"2026-07-21T10:00:00Z",` +
+			`"message":{"role":"user","content":"terraform apply --zonkoshard 7"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(root, "s1.jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		dir := filepath.Join(tmp, "index.db")
+		if err := Ensure(dir, "", true, nil); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+
+	healthy := build(t)
+	if got := DamageReason(healthy); got != "" {
+		t.Fatalf("a healthy store was called damaged: %q", got)
+	}
+	if Damaged(healthy) {
+		t.Fatal("Damaged disagrees with DamageReason on a healthy store")
+	}
+
+	cases := []struct {
+		name  string
+		spoil func(t *testing.T, dir string)
+		want  string
+	}{
+		{"a manifest that will not decode", func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, "manifest.gob"), []byte("not a gob"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "manifest"},
+		{"a session table that will not decode", func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, "sessions.gob"), []byte("not a gob"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "session table"},
+		{"a record log cut short", func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, "records.bin"), nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "record log"},
+		{"postings that went missing", func(t *testing.T, dir string) {
+			if err := os.RemoveAll(filepath.Join(dir, "buckets")); err != nil {
+				t.Fatal(err)
+			}
+		}, "the postings directory is not there"},
+		{"a postings directory left empty", func(t *testing.T, dir string) {
+			// What `rm buckets/*.bin` and a copy that skipped the contents
+			// leave behind, which is not the same as losing the directory.
+			buckets := filepath.Join(dir, "buckets")
+			entries, err := os.ReadDir(buckets)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, e := range entries {
+				if err := os.Remove(filepath.Join(buckets, e.Name())); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}, "the postings directory is empty"},
+		{"a record log with a tail the manifest never committed", func(t *testing.T, dir string) {
+			f, err := os.OpenFile(filepath.Join(dir, "records.bin"), os.O_APPEND|os.O_WRONLY, 0o644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.Write([]byte("a record from a build that crashed")); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+		}, "longer than the manifest committed"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := build(t)
+			c.spoil(t, dir)
+			got := DamageReason(dir)
+			if !strings.Contains(got, c.want) {
+				t.Errorf("reason %q does not say %q", got, c.want)
+			}
+			if !Damaged(dir) {
+				t.Errorf("Damaged says the store is fine while the reason is %q", got)
+			}
+		})
+	}
+
+	// A store that was never built is not a damaged one.
+	if got := DamageReason(t.TempDir()); got != "" {
+		t.Errorf("an empty directory was called damaged: %q", got)
+	}
+}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -382,21 +382,32 @@ func recordsReadable(dir string, m Manifest) bool {
 }
 
 func recordsIntactSized(dir string, m Manifest, tolerateLonger bool) bool {
+	return recordsDamage(dir, m, tolerateLonger) == ""
+}
+
+// recordsDamage is recordsIntactSized with the answer said out loud: "" when
+// the store holds what the manifest committed, and otherwise which file is not
+// what it should be. One sentence covered all of these, and named records and
+// postings for breakages that were neither (#2695).
+func recordsDamage(dir string, m Manifest, tolerateLonger bool) string {
 	if m.RecordsSize <= 0 {
-		return true // empty index, or one written before the size stamp existed
+		return "" // empty index, or one written before the size stamp existed
 	}
 	// Plain stat, deliberately: every caller reads the manifest first, and that
 	// read waits the swap out — measured, removing the wait here changes
 	// nothing (#1319).
 	fi, err := os.Stat(filepath.Join(dir, "records.bin"))
 	if err != nil {
-		return false
+		return "the record log is not there"
 	}
 	// Shorter: a crash truncated the log. Longer: a crash landed records the
 	// manifest never committed, or an incremental append is in flight; either
 	// way the tail is unreferenced, so a reader may treat it as a snapshot.
-	if fi.Size() < m.RecordsSize || (!tolerateLonger && fi.Size() != m.RecordsSize) {
-		return false
+	if fi.Size() < m.RecordsSize {
+		return "the record log is shorter than the manifest committed"
+	}
+	if !tolerateLonger && fi.Size() != m.RecordsSize {
+		return "the record log is longer than the manifest committed"
 	}
 	// The postings live in buckets/, and losing that directory is not
 	// hypothetical: a partial copy, an interrupted sync, a `find -delete` that
@@ -411,7 +422,7 @@ func recordsIntactSized(dir string, m Manifest, tolerateLonger bool) bool {
 	if len(m.Sessions) > 0 {
 		bi, err := os.Stat(filepath.Join(dir, "buckets"))
 		if err != nil || !bi.IsDir() {
-			return false
+			return "the postings directory is not there"
 		}
 		// An empty directory is the same loss as a missing one, and it is what
 		// `rm buckets/*.bin` and a copy that skipped the contents both leave
@@ -419,7 +430,7 @@ func recordsIntactSized(dir string, m Manifest, tolerateLonger bool) bool {
 		// search answered "no matches in 3 indexed sessions" about text that
 		// was still in the record log (#946).
 		if !hasBucketFile(filepath.Join(dir, "buckets")) {
-			return false
+			return "the postings directory is empty"
 		}
 		// Losing part of the directory is the same loss spread thinner, and it
 		// is the shape a partial copy or an interrupted sync actually leaves.
@@ -429,10 +440,10 @@ func recordsIntactSized(dir string, m Manifest, tolerateLonger bool) bool {
 		// larger count belongs to a build this manifest does not describe, and
 		// the freshness check already covers that.
 		if m.BucketFiles > 0 && countBucketFiles(filepath.Join(dir, "buckets")) < m.BucketFiles {
-			return false
+			return "some postings files are missing"
 		}
 	}
-	return true
+	return ""
 }
 
 // countBucketFiles counts the postings files a buckets directory holds.
@@ -458,6 +469,15 @@ func countBucketFiles(dir string) int {
 // What was wrong is the answer `doctor` gave: "built, up to date" about a store
 // that could not return a single result (#735).
 func Damaged(dir string) bool {
+	return DamageReason(dir) != ""
+}
+
+// DamageReason is Damaged with the finding named: "" for a store that is
+// whole, and otherwise the file that is not what the manifest says. The
+// remedy is the same either way — the next search rebuilds — but a reader,
+// and whoever reads the doctor output they paste into an issue, is sent after
+// the right file (#2695).
+func DamageReason(dir string) string {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -471,12 +491,20 @@ func Damaged(dir string) bool {
 		// doctor stats the file, calls the index built and up to date, and the
 		// next search rebuilds it from scratch.
 		if _, statErr := statIndexFile(filepath.Join(dir, "manifest.gob")); statErr == nil {
-			return true
+			// Which of the two: readManifest reads manifest.gob and then the
+			// session table beside it, and either can be the one that will not
+			// decode.
+			var core manifestCore
+			if readGob(filepath.Join(dir, "manifest.gob"), &core) != nil {
+				return "the manifest will not decode"
+			}
+			return "the session table will not decode"
 		}
-		return false
+		return ""
 	}
-	if recordsIntact(dir, m) {
-		return false
+	reason := recordsDamage(dir, m, false)
+	if reason == "" {
+		return ""
 	}
 	// The manifest and the record log were read a moment apart, and a rebuild
 	// can land between them: the manifest is the old one, records.bin is the
@@ -488,17 +516,21 @@ func Damaged(dir string) bool {
 	// Only while a build actually holds the lock: a store that is short with
 	// nothing running is short, and answering that immediately is what every
 	// other caller depends on.
+	// The reason from above, not a second look: asking twice does the stat and
+	// the directory read again on every hook against a damaged store, and a
+	// rebuild that lands between the two calls would answer "whole" for a store
+	// this one already found short.
 	if !RebuildInProgress(dir) {
-		return true
+		return reason
 	}
 	waitOutSwapWindow()
 	m2, err := readManifest(dir)
 	if err != nil {
 		// The manifest went away under us, which is the swap itself rather than
 		// damage; the next call sees the new one.
-		return false
+		return ""
 	}
-	return !recordsIntact(dir, m2)
+	return recordsDamage(dir, m2, false)
 }
 
 // RebuildInProgress reports whether another process holds the index lock. A


### PR DESCRIPTION
doctor said "records or postings are missing" for a manifest that will not
decode, a session table that will not decode, a truncated record log and an
emptied postings directory alike — wrong about the file in two of the four.

`index.DamageReason` names what deja already knows, and `Damaged` is now that
answer read as a bool. The remedy half of the line is unchanged: the next
search still rebuilds.
