### PR TITLE
fix(hook): honour DEJA_RECALL=off for the environment block too

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -191,6 +191,13 @@ func rewireNote(targets []string) string {
 	return fmt.Sprintf("deja rewrote its wiring for %s after an upgrade — `deja install` is what writes those commands", strings.Join(targets, ", "))
 }
 
+// recallIsOff reports the documented kill switch. One reader rather than a
+// string compare per call site: the second site is what let the environment
+// block past it (#2699).
+func recallIsOff() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("DEJA_RECALL")), search.RecallOff)
+}
+
 // buildNotice is what a session start says while a build runs: the published
 // progress if there is any, the bare promise if the build was only just asked
 // for, and the reason instead when the index cannot be written at all. It is
@@ -296,7 +303,12 @@ func runHookContext(dir string, plain bool) error {
 		// checkout — and exactly where knowing what this machine is missing
 		// helps most. The block is about the machine, not the project, so it
 		// does not depend on the digest having found anything.
-		if env, from := environmentBlockFrom(dir, policy.ActivationAuto); env != "" {
+		// The switch, again: the digest above is empty either because there is
+		// nothing to recall or because recall is off, and this branch cannot
+		// tell those apart. It used to build the block regardless, so a
+		// machine with the kill switch set still had text drawn from its
+		// indexed sessions injected into every session start (#2699).
+		if env, from := environmentBlockFrom(dir, policy.ActivationAuto); env != "" && !recallIsOff() {
 			out := frameRecall(env)
 			// The block is about the machine and names no project, so without
 			// the projects behind its walls a forget of one of them could not
@@ -682,7 +694,7 @@ func cachedHookDigest(dir string) (string, int, int64, []string, int, []string, 
 // in the same process with the first one's project (#2182, #2185).
 func cachedHookDigestFor(dir, fromPayload string) (string, int, int64, []string, int, []string, []string) {
 	cwd := hookCWD(fromPayload)
-	if strings.ToLower(strings.TrimSpace(os.Getenv("DEJA_RECALL"))) == search.RecallOff {
+	if recallIsOff() {
 		return "", 0, 0, nil, 0, nil, nil
 	}
 	// Before the cache read: a hit returns without reaching the version guard

--- a/cmd/deja/hook_recall_off_test.go
+++ b/cmd/deja/hook_recall_off_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// DEJA_RECALL=off is the kill switch. The digest honours it; the environment
+// block went around it, because the "nothing to recall" branch builds that
+// block without consulting the switch — so every session start still received
+// text drawn from the indexed sessions the switch was set to keep out (#2699).
+func TestRecallOffInjectsNothingAtAll(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-elsewhere")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Four sessions hitting the same missing tool: that is what the block is
+	// built from, and none of it is this project's memory.
+	for i := 1; i <= 4; i++ {
+		id := "e" + strconv.Itoa(i)
+		body := `{"type":"user","message":{"role":"user","content":"run the thing"},` +
+			`"timestamp":"2026-07-0` + strconv.Itoa(i) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n" +
+			`{"type":"user","message":{"role":"user","content":[{"type":"tool_result",` +
+			`"content":"zsh:1: command not found: zonkotool"}]},` +
+			`"timestamp":"2026-07-0` + strconv.Itoa(i) + `T10:01:00Z","sessionId":"` + id + `","cwd":"/elsewhere"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/nowhere")
+	// hermeticEnv leaves DEJA_RECALL alone, and a developer who exports it
+	// would fail the first leg rather than the one that matters.
+	t.Setenv("DEJA_RECALL", "")
+
+	// Without the switch, this machine's walls reach the session.
+	out, err := captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "zonkotool") {
+		t.Fatalf("the fixture never produced an environment block, so the test proves nothing:\n%s", out)
+	}
+
+	t.Setenv("DEJA_RECALL", "off")
+	out, err = captureRun(t, "hook-context")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "zonkotool") {
+		t.Errorf("the kill switch was set and the session still got the environment block:\n%s", out)
+	}
+	if strings.Contains(out, "deja-recall") {
+		t.Errorf("the kill switch was set and something was still injected:\n%s", out)
+	}
+}


### PR DESCRIPTION
`DEJA_RECALL=off` emptied the digest, and then the "nothing to recall" branch
built the environment block anyway — this machine's repeated tool failures,
drawn from the same indexed sessions, injected on every session start.

One reader for the switch now, and that branch consults it. The other call site
was already downstream of the check.
