### PR TITLE
fix(sources): read a WAL store that nobody has open

### DIFF
--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -281,7 +281,7 @@ func parseCursorDB(db string, since time.Time) ([]model.Session, error) {
 }
 
 func cursorQuery(db, q string) ([]map[string]any, error) {
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	b, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("cursor sqlite: %w", err)

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -145,7 +145,7 @@ func gooseText(v any) string {
 // exists only on newer stores, and naming it on an older one fails the whole
 // query, so it is probed rather than assumed.
 func gooseTypeFilter(db string) string {
-	out, err := exec.Command("sqlite3", "-readonly", db, ".timeout 5000", "pragma table_info(sessions)").Output()
+	out, err := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000", "pragma table_info(sessions)").Output()
 	if err != nil || !bytes.Contains(out, []byte("session_type")) {
 		return ""
 	}
@@ -191,7 +191,7 @@ func parseGooseDBWhere(db, where string, limit int) ([]model.Session, error) {
 		`from sessions s join messages m on m.session_id=s.id ` +
 		`where m.role in ('user','assistant')` + gooseTypeFilter(db) + where +
 		` order by s.id,m.created_timestamp,m.id` + lim
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/internal/sources/grokdb.go
+++ b/internal/sources/grokdb.go
@@ -60,7 +60,7 @@ func ParseGrokDBSince(db string, t time.Time) ([]model.Session, error) {
 		`from sessions s join messages m on m.session_id=s.id` +
 		` where m.role in ('user','assistant')` + where +
 		` order by s.id,m.seq`
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -107,7 +107,7 @@ func parseHermesDBWhere(db, where string) ([]model.Session, error) {
 	q := `select session_id,role,content,timestamp from messages ` +
 		`where role in ('user','assistant') and content is not null and content <> ''` + where +
 		` order by session_id,timestamp,id`
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -136,7 +136,7 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		`and json_extract(p.data,'$.tool')='bash')` +
 		` or (instr(substr(p.data,1,200),'"tool":"apply_patch"')>0 ` +
 		`and json_extract(p.data,'$.tool')='apply_patch'))` + where + ` order by s.id,m.time_created,p.id` + lim
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	// What sqlite3 says when it refuses, not merely that it did. "exit status
 	// 1" is what a person was asked to report, and it names neither a renamed
 	// column nor a locked database nor a file that is not a database (#1642).
@@ -272,7 +272,7 @@ func OpencodeCounts() (sessions, messages int, err error) {
 	if fi, e := os.Stat(OpencodeDB()); e != nil || fi.Size() == 0 {
 		return 0, 0, nil
 	}
-	cmd := exec.Command("sqlite3", "-readonly", OpencodeDB(), ".timeout 5000", "select (select count(*) from session),(select count(*) from part where json_extract(data,'$.type')='text')")
+	cmd := exec.Command("sqlite3", "-readonly", sqliteTarget(OpencodeDB()), ".timeout 5000", "select (select count(*) from session),(select count(*) from part where json_extract(data,'$.type')='text')")
 	b, err := cmd.Output()
 	if err != nil {
 		return 0, 0, err
@@ -319,7 +319,7 @@ func ParseOpencodeNewest(db string) ([]model.Session, error) {
 	if fi, err := os.Stat(db); err != nil || fi.Size() == 0 {
 		return nil, nil
 	}
-	probe := exec.Command("sqlite3", "-readonly", db, ".timeout 5000",
+	probe := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000",
 		"select id from session order by time_created desc limit 1")
 	var whyNot bytes.Buffer
 	probe.Stderr = &whyNot

--- a/internal/sources/sqlitepath.go
+++ b/internal/sources/sqlitepath.go
@@ -1,0 +1,85 @@
+package sources
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A store at rest is one macOS cannot read.
+//
+// opencode, zed, goose, hermes and grok all keep SQLite databases in WAL mode,
+// and SQLite removes the `-wal` and `-shm` sidecars when the last connection
+// closes cleanly. That is the normal resting state of a store nobody is using —
+// which is exactly the state deja reads it in.
+//
+// Apple's bundled sqlite3 cannot open a WAL database read-only in that state:
+//
+//	$ /usr/bin/sqlite3 -readonly t.db "select * from t"
+//	Error: in prepare, unable to open database file (14)
+//
+// Reproduced on macOS 26.5.1 with /usr/bin/sqlite3 3.51.0, which is what a
+// stock Mac puts on PATH. Homebrew's 3.53.4 reads the same file in the same
+// state, and so does the Apple binary itself through a URI with `immutable=1`.
+//
+// It self-heals, which is why it is so hard to catch: any read-write open
+// recreates the sidecars, so whether a store reads tracks whether its agent is
+// running rather than anything about the data. #1642 was reported against a
+// 1 GB opencode store, and the reporter caught it live only on the first call
+// of the day.
+//
+// With no `-wal` beside the file there are no uncheckpointed frames, so nothing
+// is being hidden by declaring the file immutable. That is the whole of the
+// condition: immutable unconditionally would lie to SQLite about writers.
+func sqliteTarget(db string) string {
+	if !walAtRest(db) {
+		return db
+	}
+	return "file:" + uriPath(db) + "?immutable=1"
+}
+
+// walAtRest reports whether the file is a WAL-mode database with no sidecar.
+//
+// Read from the header rather than by asking sqlite3: the answer decides how
+// the query is run, and a round trip that has to fail first cannot be used by
+// the callers that stream their results.
+func walAtRest(db string) bool {
+	if db == "" {
+		return false
+	}
+	if _, err := os.Stat(db + "-wal"); err == nil {
+		return false
+	}
+	f, err := os.Open(db)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	var head [20]byte
+	if n, err := f.Read(head[:]); err != nil || n < len(head) {
+		return false
+	}
+	if string(head[:15]) != "SQLite format 3" {
+		return false
+	}
+	// Bytes 18 and 19 are the file format read and write versions: 2 means WAL,
+	// 1 means the rollback journal, which opens read-only without a sidecar.
+	return head[18] == 2 && head[19] == 2
+}
+
+// uriPath renders a path for a SQLite file: URI. Windows separators become
+// slashes, and every segment is escaped, so a store under a directory with a
+// space, a question mark or a hash reaches sqlite3 whole.
+func uriPath(p string) string {
+	p = filepath.ToSlash(p)
+	lead := ""
+	if strings.HasPrefix(p, "/") {
+		lead, p = "/", strings.TrimPrefix(p, "/")
+	}
+	parts := strings.Split(p, "/")
+	for i, seg := range parts {
+		parts[i] = url.PathEscape(seg)
+	}
+	return lead + strings.Join(parts, "/")
+}

--- a/internal/sources/sqlitepath_test.go
+++ b/internal/sources/sqlitepath_test.go
@@ -1,0 +1,113 @@
+package sources
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func walDB(t *testing.T, dir, name string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("no sqlite3")
+	}
+	db := filepath.Join(dir, name)
+	mk := exec.Command("sqlite3", db,
+		"pragma journal_mode=wal; create table t(x); insert into t values(42);")
+	if out, err := mk.CombinedOutput(); err != nil {
+		t.Fatalf("fixture: %v: %s", err, out)
+	}
+	// The resting state: SQLite removes both sidecars when the last connection
+	// closes cleanly, and some builds leave empty ones behind.
+	_ = os.Remove(db + "-wal")
+	_ = os.Remove(db + "-shm")
+	return db
+}
+
+// A WAL store with no sidecar is the state every one of these databases sits in
+// when its agent is not running, and Apple's bundled sqlite3 cannot open it
+// read-only. deja shells out to whatever sqlite3 is on PATH, which on a stock
+// Mac is that one (#1642).
+func TestAWalStoreAtRestIsReadThroughImmutable(t *testing.T) {
+	db := walDB(t, t.TempDir(), "store.db")
+	target := sqliteTarget(db)
+	if !strings.Contains(target, "immutable=1") {
+		t.Fatalf("a WAL store with no sidecar was handed over as %q", target)
+	}
+	out, err := exec.Command("sqlite3", "-readonly", target, "select x from t").CombinedOutput()
+	if err != nil {
+		t.Fatalf("the store did not read: %v: %s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "42" {
+		t.Errorf("read %q, want the row back", out)
+	}
+}
+
+// With a sidecar there may be frames that have not reached the file, and
+// immutable would hide them. The plain path is what goes.
+func TestAStoreWithAWalSidecarIsLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	db := walDB(t, dir, "live.db")
+	if err := os.WriteFile(db+"-wal", []byte("frames"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := sqliteTarget(db); got != db {
+		t.Errorf("a live store was declared immutable: %q", got)
+	}
+}
+
+// A rollback-journal database opens read-only without a sidecar, so nothing is
+// claimed about it.
+func TestARollbackJournalStoreIsLeftAlone(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("no sqlite3")
+	}
+	db := filepath.Join(t.TempDir(), "plain.db")
+	mk := exec.Command("sqlite3", db, "create table t(x); insert into t values(1);")
+	if out, err := mk.CombinedOutput(); err != nil {
+		t.Fatalf("fixture: %v: %s", err, out)
+	}
+	if got := sqliteTarget(db); got != db {
+		t.Errorf("a rollback-journal store was declared immutable: %q", got)
+	}
+}
+
+// Neither a missing file nor something that is not a database is claimed to be
+// anything: the caller's own error is the better message.
+func TestAMissingOrForeignFileIsLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "nope.db")
+	if got := sqliteTarget(missing); got != missing {
+		t.Errorf("a missing file was rewritten: %q", got)
+	}
+	foreign := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(foreign, []byte("this is not a database at all, truly"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := sqliteTarget(foreign); got != foreign {
+		t.Errorf("a text file was rewritten: %q", got)
+	}
+}
+
+// A store under a directory with a space or a question mark still reaches
+// sqlite3 whole: the URI form escapes per segment.
+func TestAPathWithAwkwardCharactersSurvivesTheURI(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "My Store?v2")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := walDB(t, dir, "store.db")
+	target := sqliteTarget(db)
+	if strings.Contains(target, " ") || strings.Contains(target, "?v2") {
+		t.Fatalf("the path went out unescaped: %q", target)
+	}
+	out, err := exec.Command("sqlite3", "-readonly", target, "select x from t").CombinedOutput()
+	if err != nil {
+		t.Fatalf("the store did not read: %v: %s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "42" {
+		t.Errorf("read %q, want the row back", out)
+	}
+}

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -195,7 +195,7 @@ func zedSinceWhere(t time.Time) string {
 
 func zedRows(db, cols, where string) ([]zedRow, error) {
 	q := "select " + cols + " from threads" + where + " order by updated_at"
-	cmd := exec.Command("sqlite3", "-readonly", "-json", db, ".timeout 5000", q)
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #1642.

@junteakim caught this live and diagnosed it completely: opencode keeps its database in WAL mode, SQLite removes the `-wal` and `-shm` sidecars when the last connection closes cleanly, and **Apple's bundled sqlite3 cannot open a WAL database read-only in that state**. deja shells out to whatever `sqlite3` is on PATH, which on a stock Mac is that one.

    $ /usr/bin/sqlite3 -readonly t.db "select * from t"
    Error: in prepare, unable to open database file (14)

Reproduced here on macOS with /usr/bin/sqlite3 3.51.0, and on a copy of a real 3.2 GB opencode store put into the resting state: the released binary calls it `unreadable`, this one indexes 1437 sessions.

That also explains why nobody could reproduce it, including me: any read-write open recreates the sidecars, so whether a store reads tracks whether its agent is running rather than anything about the data. It heals itself between the report and the investigation.

The fix is the one @junteakim proposed, with the condition he was careful to state: `immutable=1` only when there is no `-wal` beside the file, since then there are no uncheckpointed frames to hide. Unconditional immutable would lie to SQLite about writers.

Decided from the file header rather than by failing first — bytes 18 and 19 say WAL — because the callers that stream their results cannot use a round trip that has to fail. It covers all six stores that shell out to sqlite3: opencode, zed, goose, hermes, grok and cursor, all of them WAL, all of them read at rest.

Paths are escaped per segment on the way into the URI, so a store under a directory with a space or a question mark still arrives whole.

Filed with a schema dump, row counts and version numbers, then chased to a two-line repro with no deja in it. That is the report this fix came from.