### PR TITLE
fix(index): record the files a session really worked on

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -257,10 +257,21 @@ type SessionMeta struct {
 	Hit []uint64 `json:",omitempty"`
 }
 
-// touchedFileCap bounds what goes in SessionMeta.Touched. Enough to say
-// something useful about a session, small enough that a store of a thousand
-// sessions pays kilobytes for it.
-const touchedFileCap = 6
+// touchedFileCap bounds what goes in SessionMeta.Touched.
+//
+// Six was enough to say something about a session and wrong for the thing that
+// reads it: the line before an edit asks how many sessions touched this file,
+// and a session that worked on forty recorded six. Measured over 334 distinct
+// files an agent really edited on this machine, 257 of them had been touched by
+// no session at all as far as the index knew, while 268 were spoken about in
+// sessions the store holds. The surface was blind to three files in four.
+//
+// Forty, from the three points measured: files with no history 257 -> 218 -> 190
+// at 6, 20 and 40, and files the hook can speak about 26 -> 30 -> 36. It costs
+// 700 KB of a 195 MB index and 3 ms on the hook that reads it — measured on the
+// same store, where the line went from silent on 12 of 12 real edits to
+// speaking on 4.
+const touchedFileCap = 40
 
 // askedQuestionCap bounds the hashes stored per session.
 const askedQuestionCap = 8

--- a/internal/index/touched_cap_test.go
+++ b/internal/index/touched_cap_test.go
@@ -1,0 +1,56 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session records what it worked on so the line before an edit can say how
+// many sessions touched this file. Six was enough to describe a session and too
+// few to answer that question: measured over 334 files an agent really edited,
+// 257 had been touched by no session at all as far as the index knew, while 268
+// were spoken about in sessions the store holds.
+func TestASessionRecordsTheFilesItReallyWorkedOn(t *testing.T) {
+	var ms []model.Message
+	for i := 0; i < 30; i++ {
+		// Recurrence decides the order, so give the later files fewer touches:
+		// what is pinned is that the tail is kept at all, not that it is ranked
+		// differently than before.
+		for r := 0; r < 30-i; r++ {
+			ms = append(ms, model.Message{
+				Role: roleFiles,
+				Text: fmt.Sprintf("internal/index/file%02d.go", i),
+			})
+		}
+	}
+	got, hits := topTouchedCounted(ms)
+	if len(got) < 20 {
+		t.Errorf("a session that worked on 30 files recorded %d of them", len(got))
+	}
+	if len(got) > touchedFileCap {
+		t.Errorf("recorded %d files, the cap is %d", len(got), touchedFileCap)
+	}
+	if len(hits) != len(got) {
+		t.Errorf("%d paths carry %d counts", len(got), len(hits))
+	}
+	// The most-touched file still leads: the cap decides how long the tail is,
+	// not what the head is.
+	if got[0] != "internal/index/file00.go" {
+		t.Errorf("the file worked on most is not first: %q", got[0])
+	}
+}
+
+// And the bound still bounds: a session that touched hundreds does not carry
+// hundreds into every hook that reads the manifest.
+func TestTheRecordedListIsStillBounded(t *testing.T) {
+	var ms []model.Message
+	for i := 0; i < 500; i++ {
+		ms = append(ms, model.Message{Role: roleFiles, Text: fmt.Sprintf("pkg/f%03d.go", i)})
+	}
+	got, _ := topTouchedCounted(ms)
+	if len(got) != touchedFileCap {
+		t.Errorf("recorded %d files of 500, want the cap of %d", len(got), touchedFileCap)
+	}
+}


### PR DESCRIPTION
The hook before an edit says how many sessions touched this file. It reads `SessionMeta.Touched`, which held six paths — enough to describe a session, and the wrong number for the question being asked of it. A session that worked on forty files recorded six, so the other thirty-four had no history as far as the index knew.

Measured over 334 distinct files an agent really edited on this machine, taken from its own transcripts:

- **257 of them had been touched by no session at all** according to the index
- **268 of them are spoken about** in sessions the store holds

So the surface was blind to three files in four, and not because the history was missing.

Three points, same store, full rebuild each:

| cap | sessions.gob | files with no history | files the hook can speak about |
|---|---|---|---|
| 6 | 823 KB | 257 | 26 |
| 20 | 1.31 MB | 218 | 30 |
| 40 | 1.52 MB | 190 | 36 |

Forty costs 700 KB on a 195 MB index — 0.4% — and 3 ms on the hook that reads it, median 20 ms to 23 ms. On twelve real edits from this repository the line went from speaking **0 times** to **4**.

This raises a bound rather than lowering a bar: `toolHookMinFileSessions` is untouched, so a file still needs five sessions behind it before the hook says anything. What changes is that a session now admits what it worked on.

bench prompt unchanged on every arm, e2e green, `go test ./...` clean.