### PR TITLE
fix(search): count the ignore rule in the empty-answer line

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1514,10 +1514,18 @@ func printNoMatches(w io.Writer, dir, q string, regex bool) {
 	// a trust rule the two differ, and "no matches in 1 indexed session — try
 	// fewer words" sent the reader after a wording problem in a session the
 	// rule never let search open (#986).
-	if reach, total, ok := reachableSessionCount(dir); ok && reach == 0 && total > 0 {
+	if reach, trusted, total, ok := reachableSessionCount(dir); ok && reach == 0 && total > 0 {
 		fmt.Fprintf(w, "deja: no matches for %q\n", q)
-		fmt.Fprintf(w, "deja: the trust policy withholds every indexed session from this path (%s: %s) — see %s\n",
-			policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch), policy.Path())
+		// Which rule emptied the path. Counting the ignore rule here (#2707)
+		// put a store hidden by a path pattern under a sentence about the
+		// trust policy, quoting a trust rule that allows everything.
+		if trusted == 0 {
+			fmt.Fprintf(w, "deja: the trust policy withholds every indexed session from this path (%s: %s) — see %s\n",
+				policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch), policy.Path())
+		} else {
+			fmt.Fprintf(w, "deja: the ignore rule withholds every indexed session from this path (%s) — see %s\n",
+				strings.Join(policy.Load().IgnorePatterns(), ", "), policy.Path())
+		}
 		return
 	} else if ok {
 		fmt.Fprintf(w, "deja: no matches in %d indexed session%s — try fewer words or --re (query %q)\n", reach, pluralS(reach), q)
@@ -4127,21 +4135,30 @@ func forgetKeyOf(dir string, o index.ForgetOptions) string {
 	return ""
 }
 
-// reachableSessionCount reports how many indexed sessions the search
-// activation may read, and how many are indexed in all.
-func reachableSessionCount(dir string) (int, int, bool) {
+// reachableSessionCount reports how many indexed sessions this path may read,
+// how many of those the trust policy alone allows, and how many there are.
+//
+// Both rules withhold, so both are counted (#2707): the trust policy was here
+// from the start (#986) and the ignore rule was not counted at all, which had
+// the empty answer naming twice the history search would open. The trust-only
+// figure is kept because the reader has to be told which of the two emptied
+// their search.
+func reachableSessionCount(dir string) (reach, trusted, total int, ok bool) {
 	metas, err := index.AllMeta(dir)
 	if err != nil {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
 	pol := policy.Load()
-	reach := 0
 	for _, m := range metas {
-		if pol.Allows(policy.ActivationSearch, m.Project) {
+		if !pol.Allows(policy.ActivationSearch, m.Project) {
+			continue
+		}
+		trusted++
+		if !pol.Ignored(m.Path, m.Project) {
 			reach++
 		}
 	}
-	return reach, len(metas), true
+	return reach, trusted, len(metas), true
 }
 
 // joinCapped lists at most n items and says how many it left out, so a refusal

--- a/cmd/deja/search_policy_scope_test.go
+++ b/cmd/deja/search_policy_scope_test.go
@@ -61,3 +61,73 @@ func TestNoMatchesCountsWhatSearchMayRead(t *testing.T) {
 		t.Errorf("the count still names sessions search cannot read:\n%s", got)
 	}
 }
+
+// The ignore rule withholds sessions the same way and was not counted at all:
+// every other surface said three while the empty answer said six, and told the
+// reader to reword a query against history search never opened (#2707).
+func TestNoMatchesCountsPastTheIgnoreRuleToo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	write := func(project, id, day string) {
+		t.Helper()
+		store := filepath.Join(root, "-"+project)
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","message":{"role":"user","content":"the zonkoshard retry budget in ` + project + `"},` +
+			`"timestamp":"2026-08-0` + day + `T10:00:00Z","sessionId":"` + id + `","cwd":"/` + project + `"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A project name no test name can contain: Ignored substring-matches the
+	// whole session path, and a t.TempDir() under a test called "hide" would
+	// hide every session in the fixture.
+	write("keep", "k1", "1")
+	write("keep", "k2", "2")
+	write("zonkohide", "h1", "3")
+	write("zonkohide", "h2", "4")
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	printNoMatches(&out, dir, "quingleflarp", false)
+	if !strings.Contains(out.String(), "no matches in 4 indexed sessions") {
+		t.Fatalf("the fixture does not hold four sessions to begin with:\n%s", out.String())
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*zonkohide*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out.Reset()
+	printNoMatches(&out, dir, "quingleflarp", false)
+	got := out.String()
+	if !strings.Contains(got, "no matches in 2 indexed sessions") {
+		t.Errorf("the count names sessions the ignore rule keeps out of every answer:\n%s", got)
+	}
+
+	// And when the rule hides everything, the reader is told which rule did
+	// it: counting the ignore rule into the same zero would otherwise put this
+	// store under a sentence about the trust policy, quoting a trust rule that
+	// allows everything.
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	printNoMatches(&out, dir, "quingleflarp", false)
+	got = out.String()
+	if !strings.Contains(got, "the ignore rule withholds every indexed session") {
+		t.Errorf("a store emptied by the ignore rule was not told so:\n%s", got)
+	}
+	if strings.Contains(got, "trust policy") {
+		t.Errorf("the wrong rule was named:\n%s", got)
+	}
+	if strings.Contains(got, "try fewer words") {
+		t.Errorf("the reader was sent after their wording:\n%s", got)
+	}
+}


### PR DESCRIPTION
"no matches in 6 indexed sessions — try fewer words" said six on a store where
the ignore rule hides half of it, and every other surface said three. #986 had
counted the trust policy; the ignore rule was not counted at all.

Counting it exposed a second thing: with a rule that hides everything, the
zero-reach branch blamed the trust policy and quoted a trust rule that allows
everything. It names the rule that actually emptied the path now.
