### PR TITLE
fix(friction): count the sessions it may read

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -145,9 +145,21 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		// sessions-indexed: a store with six conversations reported zero,
 		// which is the sentence #637 was about — a reader told the index holds
 		// nothing concludes the tool is broken (#705).
-		total, err := index.SessionCount(dir)
+		// Two counts, because they answer two questions. What is on disk
+		// decides whether this machine has any history at all, and what the
+		// rules leave decides how much friction had to read: naming the store
+		// for the second put "none of the 4 indexed sessions" over a note
+		// saying two of them are withheld (#2709, the shape #2707 fixed on the
+		// empty search). Reading the store count for the first is what keeps a
+		// machine whose history is entirely behind a rule from being told it
+		// has none.
+		stored, err := index.SessionCount(dir)
+		total := stored
+		if reach, _, _, ok := reachableSessionCount(dir); ok {
+			total = reach
+		}
 		switch {
-		case err != nil || total == 0:
+		case err != nil || stored == 0:
 			// "no sessions are indexed yet" is a claim about the machine, and
 			// a store deja is not allowed to open produces the same zero —
 			// the failure #1020 closed on last and search. friction is where
@@ -168,9 +180,22 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			// the ignore rule is what keeps them out (#2630).
 			fmt.Fprintf(stdout, "nothing recurring — the ignore rule keeps the %d session%s that recorded tool output out of recall, which is what friction reads errors from\n",
 				len(ignoredSessions), pluralS(len(ignoredSessions)))
+		case len(sessions) == 0 && total == 0:
+			// Every session on this machine is behind a rule, and none of them
+			// recorded tool output — so neither arm above fired and the count
+			// is zero. "none of the 0 indexed sessions" is arithmetic; what
+			// the reader needs is which rule leaves friction nothing to read.
+			fmt.Fprintf(stdout, "nothing recurring — %s keeps every one of the %d indexed session%s out of recall, and friction reads errors from what it may open\n",
+				emptiedBy(pol), stored, pluralS(stored))
 		case len(sessions) == 0:
 			fmt.Fprintf(stdout, "nothing recurring — none of the %d indexed session%s recorded tool output, which is what friction reads errors from\n",
 				total, pluralS(total))
+		case len(sessions) == total:
+			// The parenthetical is there to say how much was not read. When
+			// the rules leave exactly the sessions that recorded tool output,
+			// it repeats the number beside it.
+			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output — no error hit %d separate sessions\n",
+				len(sessions), pluralS(len(sessions)), index.FrictionMinSessions)
 		default:
 			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output (of %d indexed) — no error hit %d separate sessions\n",
 				len(sessions), pluralS(len(sessions)), total, index.FrictionMinSessions)
@@ -205,4 +230,14 @@ func trimFriction(l string) string {
 	// and printed as a broken byte (#1319). The bound includes the mark, so a
 	// line loses one character rather than gaining one.
 	return truncatePlanBytes(l, 79)
+}
+
+// emptiedBy names the rule that leaves a path nothing to read. Both can be in
+// force; the ignore rule is named first because it is the one written by hand
+// in a file the reader edits.
+func emptiedBy(pol policy.Policy) string {
+	if len(pol.IgnorePatterns()) > 0 {
+		return "the ignore rule (" + strings.Join(pol.IgnorePatterns(), ", ") + ")"
+	}
+	return "the trust policy (" + policy.ActivationSearch + ": " + pol.Describe(policy.ActivationSearch) + ")"
 }

--- a/cmd/deja/friction_counts_test.go
+++ b/cmd/deja/friction_counts_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// friction's own note says how many sessions a rule keeps out; the sentence
+// beside it counted the whole store, so one screen said both "none of the 4
+// indexed sessions recorded tool output" and "the ignore rule keeps 2 sessions
+// out of this listing". Every other surface counts what the answer could have
+// held (#2707); this is the one that did not (#2709).
+func TestFrictionCountsWhatItMayRead(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	write := func(project, id, day string) {
+		t.Helper()
+		store := filepath.Join(root, "-"+project)
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := `{"type":"user","message":{"role":"user","content":"deploy the staging cluster"},` +
+			`"timestamp":"2026-08-0` + day + `T10:00:00Z","sessionId":"` + id + `","cwd":"/` + project + `"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Nothing recorded tool output anywhere, and half the store is hidden: the
+	// sentence is about how much friction had to read, which is two.
+	write("keep", "k1", "1")
+	write("keep", "k2", "2")
+	for i := 1; i <= 2; i++ {
+		write("zonkohide", "h"+strconv.Itoa(i), strconv.Itoa(i+2))
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*zonkohide*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err := captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "none of the 2 indexed sessions recorded tool output") {
+		t.Errorf("friction did not count what it may read:\n%s", out)
+	}
+}
+
+// And with nothing hidden the sentence still names the store, because there
+// the two are the same number.
+func TestFrictionStillNamesTheStoreWhenNothingIsHidden(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-keep")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		id := "k" + strconv.Itoa(i)
+		body := `{"type":"user","message":{"role":"user","content":"deploy the staging cluster"},` +
+			`"timestamp":"2026-08-0` + strconv.Itoa(i) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/keep"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "none of the 3 indexed sessions recorded tool output") {
+		t.Errorf("a store with nothing hidden lost its count:\n%s", out)
+	}
+}
+
+// And a machine whose history is entirely behind a rule is not a machine
+// without history. Counting only what friction may read sent that store into
+// the arm written for an empty index — "run `deja index`" over a note saying
+// two rules are hiding things, which is the claim #1020 and #1044 closed
+// elsewhere.
+func TestFrictionDoesNotCallAHiddenStoreAnEmptyMachine(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-zonkohide")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 2; i++ {
+		id := "h" + strconv.Itoa(i)
+		body := `{"type":"user","message":{"role":"user","content":"deploy the staging cluster"},` +
+			`"timestamp":"2026-08-0` + strconv.Itoa(i) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/zonkohide"}` + "\n"
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	policyFile := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*zonkohide*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+
+	out, err := captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "deja index") || strings.Contains(out, "no agent history was found") {
+		t.Errorf("a store hidden by a rule was reported as a machine with no history:\n%s", out)
+	}
+	if !strings.Contains(out, "the ignore rule") {
+		t.Errorf("nothing named the rule that leaves friction nothing to read:\n%s", out)
+	}
+	if !strings.Contains(out, "2 indexed session") {
+		t.Errorf("the sessions on disk went uncounted:\n%s", out)
+	}
+}


### PR DESCRIPTION
One screen said both "none of the 4 indexed sessions recorded tool output" and
"the ignore rule keeps 2 sessions out of this listing". The count came from the
raw store total; it comes from what friction may read now, the same predicate
the empty search line took in #2708.
