### PR TITLE
docs(mcp): say why the parent pid is read once

### DIFF
--- a/cmd/deja/mcp_orphan.go
+++ b/cmd/deja/mcp_orphan.go
@@ -68,6 +68,10 @@ func serveMCPProcess(dir string, r io.Reader, w io.Writer) error {
 	var lastRead atomic.Int64
 	lastRead.Store(time.Now().UnixNano())
 
+	// Read once, deliberately: on unix an orphaned process is reparented and a
+	// live Getppid answers 1 forever after, so only the pid recorded at start
+	// can ever go dead — a later call would watch init and never fire.
+	//
 	// Windows reports -1 when the parent cannot be read; processAlive calls
 	// that dead, and the AND would quietly collapse into the idle timeout the
 	// design rejected. No recorded parent, no watch — EOF still works.

--- a/cmd/deja/mcp_orphan.go
+++ b/cmd/deja/mcp_orphan.go
@@ -68,9 +68,10 @@ func serveMCPProcess(dir string, r io.Reader, w io.Writer) error {
 	var lastRead atomic.Int64
 	lastRead.Store(time.Now().UnixNano())
 
-	// Read once, deliberately: on unix an orphaned process is reparented and a
-	// live Getppid answers 1 forever after, so only the pid recorded at start
-	// can ever go dead — a later call would watch init and never fire.
+	// Read once, deliberately: on unix an orphaned process is reparented — to
+	// init or a subreaper — and a live Getppid answers that adopter from then
+	// on, so only the pid recorded at start can ever go dead. A later call
+	// would watch a process that is alive by construction, and never fire.
 	//
 	// Windows reports -1 when the parent cannot be read; processAlive calls
 	// that dead, and the AND would quietly collapse into the idle timeout the


### PR DESCRIPTION
The line the merge review of #2649 asked for, on its second note: why the parent pid is read once. On unix an orphaned process is reparented — to init or a subreaper — and a live `Getppid` answers that adopter from then on, so only the pid recorded at start can ever go dead; inlining the call would make the watch follow a process that is alive by construction, and never fire. Comment only, no behavior change.
