### PR TITLE
fix(install): say when another entry already runs deja

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -139,7 +139,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	defer recordWiring(targets, uninstall)
 	saidNotes := map[string]bool{}
 	banner := !uninstall && (targetArgs[0] == "--auto" || targetArgs[0] == "--all") && logoWanted(os.Stdout)
-	type lineItem struct{ target, action, path string }
+	type lineItem struct{ target, action, path, note string }
 	// The real paths, not the display ones: an uninstall reports the snapshots
 	// it left beside the configs it handled, and ~ does not stat (#2676).
 	var touchedPaths []string
@@ -204,7 +204,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		}
 		touchedPaths = append(touchedPaths, r.Path)
 		if banner {
-			done = append(done, lineItem{t, r.Action, shortHome(r.Path)})
+			done = append(done, lineItem{t, r.Action, shortHome(r.Path), r.Note})
 		} else {
 			if r.Path == "" {
 				fmt.Printf("%s: %s\n", t, r.Action)
@@ -277,6 +277,13 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		}
 		for _, d := range done {
 			info = append(info, fmt.Sprintf("%-*s  %s%-9s%s %s", nameW, d.target, logoBold, d.action, logoReset, logoDim+d.path+logoReset))
+			// Under its own row. The table is the documented path — the README
+			// tells people to run `deja install --auto` — so a note that only
+			// the line-by-line output carried was a note almost nobody read
+			// (#2712).
+			if d.note != "" {
+				info = append(info, fmt.Sprintf("%-*s  %s", nameW, "", d.note))
+			}
 		}
 		mood := moodReady
 		if hint := installIndexHint(dir); hint != "" {
@@ -1206,6 +1213,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 		}
 	} else {
 		m["deja"], note = mergeDejaEntry(m["deja"], mcpServerEntry(exe))
+		note = withOtherDejaEntries(note, m)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {
@@ -1644,6 +1652,116 @@ func entryRunsDeja(entry map[string]any) bool {
 	return false
 }
 
+// withOtherDejaEntries folds the note about a second deja server into whatever
+// the write already had to say. Every MCP writer needs it: the file it edits is
+// the one that would hold the other entry.
+func withOtherDejaEntries(note string, servers map[string]any) string {
+	other := otherDejaEntriesNote(servers, "deja")
+	if other == "" {
+		return note
+	}
+	if note != "" {
+		return note + "; " + other
+	}
+	return other
+}
+
+// otherDejaEntriesNote names entries in the same file that also run deja under
+// another key.
+//
+// doctor already reads past the key at what an entry runs, and calls `deja-vu`
+// deja's wiring; install did not, so it wrote a second server beside one it
+// recognised and said only "updated". The harness then starts two on every
+// session, one of them possibly naming a binary that is gone (#2712).
+//
+// Said, not taken: a second entry can be deliberate — another index directory,
+// a pinned older binary — and removing one deja did not write is the damage
+// #2583 and #2600 were about. What the reader cannot do is act on a file whose
+// state nothing reports.
+func otherDejaEntriesNote(servers map[string]any, mine string) string {
+	var names []string
+	for name, entry := range servers {
+		if name == mine {
+			continue
+		}
+		m, _ := entry.(map[string]any)
+		if m != nil && entryIsDejaServer(m) {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	noun, verb, it := "the entry ", "runs", "it"
+	if len(names) > 1 {
+		noun, verb, it = "the entries ", "run", "them"
+	}
+	return fmt.Sprintf("%s%s also %s deja — this harness will start %s alongside deja's own; remove what you do not want",
+		noun, quotedList(names, 3), verb, it)
+}
+
+// entryIsDejaServer is entryRunsDeja for a claim about somebody else's entry.
+//
+// entryRunsDeja answers "may this be merged onto", where a false positive costs
+// a merge onto an entry deja then overwrites anyway. This answers "should the
+// reader be told to remove it", where a false positive is deja pointing at a
+// config line that is none of its business: a filesystem server told to serve
+// `~/code/deja` has the binary's name in its arguments and is not deja.
+//
+// So the name has to be the command — or, for the wrapper shapes where it
+// cannot be (`cmd /c … deja mcp`), it has to be running deja's server rather
+// than appearing in a path.
+func entryIsDejaServer(entry map[string]any) bool {
+	switch c := entry["command"].(type) {
+	case string:
+		if isDejaBinaryToken(c) {
+			return dejaServerArgs(entry)
+		}
+	case []any:
+		if len(c) > 0 {
+			if head, ok := c[0].(string); ok && isDejaBinaryToken(head) {
+				return dejaServerArgs(entry)
+			}
+			for _, v := range c {
+				if s, ok := v.(string); ok && isDejaBinaryToken(s) {
+					return commandListRunsMCP(c)
+				}
+			}
+		}
+	}
+	if args, ok := entry["args"].([]any); ok {
+		for _, v := range args {
+			if s, ok := v.(string); ok && isDejaBinaryToken(s) {
+				return commandListRunsMCP(args)
+			}
+		}
+	}
+	return false
+}
+
+// dejaServerArgs reports whether an entry whose command is deja runs the MCP
+// server rather than something else someone wired by hand.
+func dejaServerArgs(entry map[string]any) bool {
+	args, ok := entry["args"].([]any)
+	if !ok {
+		// A command with no arguments at all is deja's own shape from before
+		// the subcommand was written into the entry.
+		return entry["args"] == nil
+	}
+	return commandListRunsMCP(args)
+}
+
+// commandListRunsMCP reports whether `mcp` is one of these words.
+func commandListRunsMCP(words []any) bool {
+	for _, v := range words {
+		if s, ok := v.(string); ok && s == "mcp" {
+			return true
+		}
+	}
+	return false
+}
+
 // mergeDejaEntry writes deja's wiring onto the entry that was already there.
 // deja owns the command, the args and the type; an env pointing at a store on
 // another disk, a timeout, a `disabled` the reader set — those are theirs, and
@@ -1778,6 +1896,7 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}})
+		note = withOtherDejaEntries(note, m)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {
@@ -1835,6 +1954,7 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		servers["deja"], note = mergeDejaEntry(servers["deja"], map[string]any{"command": command, "args": args})
+		note = withOtherDejaEntries(note, servers)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {
@@ -1883,6 +2003,7 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	} else {
 		command, args := mcpCommandArgs(exe)
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"command": command, "args": args})
+		note = withOtherDejaEntries(note, m)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {
@@ -1940,6 +2061,7 @@ func updateOpencodeJSON(old []byte, exe string, uninstall bool) ([]byte, string,
 		delete(m, "deja")
 	} else {
 		m["deja"], note = mergeDejaEntry(m["deja"], map[string]any{"type": "local", "command": []string{exe, "mcp"}})
+		note = withOtherDejaEntries(note, m)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {

--- a/cmd/deja/install_second_entry_test.go
+++ b/cmd/deja/install_second_entry_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// doctor reads past the key at what an entry runs, and calls `deja-vu` deja's
+// wiring. install did not: it wrote a second server beside it, so the harness
+// started two on every session, one of them possibly pointing at a binary that
+// is gone, and said only "updated" (#2712).
+func TestInstallNamesAnotherEntryThatRunsDeja(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"mcpServers":{"deja-vu":{"command":"/old/bin/deja","args":["mcp"],"type":"stdio"}}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "install", "claude-code", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "deja-vu") {
+		t.Errorf("the entry already running deja went unmentioned:\n%s", out)
+	}
+	if !strings.Contains(out, "also runs deja") {
+		t.Errorf("nothing said what that entry is:\n%s", out)
+	}
+
+	// The reader's file is theirs: deja says what it found and takes nothing
+	// out. A second entry can be deliberate — another index, a pinned binary.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	if _, ok := servers["deja-vu"]; !ok {
+		t.Errorf("install removed an entry it only had to report:\n%s", b)
+	}
+	if _, ok := servers["deja"]; !ok {
+		t.Errorf("install did not write its own entry:\n%s", b)
+	}
+
+	// And a second run says the same thing rather than going quiet: the file
+	// still holds two servers.
+	out, err = captureRun(t, "install", "claude-code", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "also runs deja") {
+		t.Errorf("the second install stopped mentioning it:\n%s", out)
+	}
+}
+
+// An entry that is not deja's is not reported: the line is about deja's own
+// wiring turning up twice, not about what else the reader wired.
+func TestInstallSaysNothingAboutSomebodyElsesServer(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"mcpServers":{"mine":{"command":"/usr/local/bin/mine","args":["serve"]}}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "install", "claude-code", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "also runs deja") {
+		t.Errorf("somebody else's server was reported as deja's:\n%s", out)
+	}
+}
+
+// The name in an argument is not the server. A filesystem server told to serve
+// a checkout called deja carries the binary's name in its arguments, and a line
+// telling the reader to remove it is deja pointing at a config that is none of
+// its business.
+func TestInstallDoesNotClaimAServerThatMerelyNamesAPath(t *testing.T) {
+	for _, c := range []struct{ name, seed string }{
+		{"a path argument", `{"mcpServers":{"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/Users/me/code/deja"]}}}`},
+		{"deja run for something else", `{"mcpServers":{"notes":{"command":"deja","args":["--not-mcp"]}}}`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := sources.ClaudeJSONPath()
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(c.seed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			out, err := captureRun(t, "install", "claude-code", "--no-index")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(out, "also runs deja") {
+				t.Errorf("an entry that only names deja was reported as one:\n%s", out)
+			}
+		})
+	}
+}
+
+// Every MCP writer edits the file that would hold the other entry, so every one
+// of them has to say so — the first version told only Claude Code's reader.
+func TestEveryMCPWriterNamesASecondDejaEntry(t *testing.T) {
+	for _, c := range []struct{ target, file, seed string }{
+		{"cursor", ".cursor/mcp.json",
+			`{"mcpServers":{"deja-vu":{"command":"/old/bin/deja","args":["mcp"]}}}`},
+		{"opencode", ".config/opencode/opencode.json",
+			`{"mcp":{"deja-vu":{"type":"local","command":["/old/bin/deja","mcp"]}}}`},
+		{"openclaw", ".openclaw/openclaw.json",
+			`{"mcp":{"servers":{"deja-vu":{"command":"/old/bin/deja","args":["mcp"]}}}}`},
+	} {
+		t.Run(c.target, func(t *testing.T) {
+			home := hermeticEnv(t)
+			path := filepath.Join(home, "home", c.file)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(c.seed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			out, err := captureRun(t, "install", c.target, "--no-index")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out, "also runs deja") {
+				t.Errorf("%s wrote a second server and said nothing:\n%s", c.target, out)
+			}
+		})
+	}
+}
+
+// Two of them read as a sentence.
+func TestASecondAndThirdEntryReadAsOneSentence(t *testing.T) {
+	hermeticEnv(t)
+	path := sources.ClaudeJSONPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"mcpServers":{` +
+		`"deja-vu":{"command":"/old/bin/deja","args":["mcp"]},` +
+		`"deja-old":{"command":"/older/bin/deja","args":["mcp"]}}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "install", "claude-code", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `the entries "deja-old", "deja-vu" also run deja`) {
+		t.Errorf("two entries did not read as two:\n%s", out)
+	}
+	if !strings.Contains(out, "start them alongside") {
+		t.Errorf("the sentence did not agree with itself:\n%s", out)
+	}
+}


### PR DESCRIPTION
A config holding a deja server under another key — `deja-vu`, which doctor's own
probe calls deja's wiring — got a second one written beside it and the reader
was told only "updated". The harness then starts both, one possibly naming a
binary that is gone.

Every MCP writer says so now, including on the banner path `deja install --auto`
takes. Nothing is removed: the key is one deja never wrote, and a second entry
can be a deliberate pin or a second index.

The claim uses a stricter predicate than the merge does — a filesystem server
told to serve `~/code/deja` has the name in its arguments and is not deja.
