### PR TITLE
fix(mcp): one answer to what an entry runs

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1041,18 +1040,33 @@ func mcpEntryDejaCommand(v any) string {
 	if m == nil {
 		return ""
 	}
-	if t, ok := m["transport"].(map[string]any); ok {
-		if cmd := mcpEntryDejaCommand(t); cmd != "" {
-			return cmd
+	// The top level first: when an entry carries both, that is the one deja
+	// wrote, and naming the nested one sent the reader after a path deja had
+	// already replaced (#2716).
+	switch c := m["command"].(type) {
+	case string:
+		if commandIsDeja(c) {
+			return strings.TrimSpace(c)
 		}
-	}
-	if cmd, _ := m["command"].(string); commandIsDeja(cmd) {
-		return strings.TrimSpace(cmd)
+	case []any:
+		// opencode writes the command as a list. The recogniser reads that
+		// shape since #2713, and a check that says "wired" without being able
+		// to name the binary cannot report one that is gone.
+		for _, v := range c {
+			if s, ok := v.(string); ok && commandIsDeja(s) {
+				return strings.TrimSpace(s)
+			}
+		}
 	}
 	args, _ := m["args"].([]any)
 	for _, a := range args {
 		if s, ok := a.(string); ok && commandIsDeja(s) {
 			return strings.TrimSpace(s)
+		}
+	}
+	if t, ok := m["transport"].(map[string]any); ok {
+		if cmd := mcpEntryDejaCommand(t); cmd != "" {
+			return cmd
 		}
 	}
 	return ""
@@ -1176,43 +1190,26 @@ func doctorJSONWired(key string) func(string) bool {
 }
 
 // mcpEntryRunsDeja reports whether an MCP server entry launches deja, in any
-// of the shapes clients accept: a bare command, a command plus args, or a
-// nested transport object.
+// of the shapes clients accept: a bare command, a command plus args, a command
+// written as a list, or a nested transport object.
+//
+// One function rather than two. install had grown its own answer, and they
+// disagreed in both directions — a nested transport and a capitalised path
+// were deja here and not there, a list command the other way round (#2713).
 func mcpEntryRunsDeja(v any) bool {
 	m, _ := v.(map[string]any)
 	if m == nil {
 		return false
 	}
-	if t, ok := m["transport"].(map[string]any); ok {
-		if mcpEntryRunsDeja(t) {
-			return true
-		}
-	}
-	cmd, _ := m["command"].(string)
-	if commandIsDeja(cmd) {
-		return true
-	}
-	// Windows and npx-style wiring puts the binary in args instead.
-	args, _ := m["args"].([]any)
-	for _, a := range args {
-		if s, ok := a.(string); ok && commandIsDeja(s) {
-			return true
-		}
-	}
-	return false
+	return entryRunsDeja(m)
 }
 
+// commandIsDeja is the token test, under the name doctor's readers use. One
+// implementation, because two answers to "is this the binary" disagreed on a
+// quoted Windows path: the entry read as wired while nothing could name the
+// command in it, so the missing-binary check had nothing to report (#2716).
 func commandIsDeja(cmd string) bool {
-	cmd = strings.TrimSpace(cmd)
-	if cmd == "" {
-		return false
-	}
-	// A windows path read on a unix build and vice versa: filepath.Base only
-	// knows the separator it was compiled for, and these configs travel.
-	cmd = strings.ReplaceAll(cmd, `\`, "/")
-	base := strings.ToLower(path.Base(cmd))
-	base = strings.TrimSuffix(base, ".exe")
-	return base == "deja"
+	return isDejaBinaryToken(cmd)
 }
 
 func doctorTOMLWired(path string) bool {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1349,10 +1349,14 @@ func lastShellToken(s string) string {
 // isDejaBinaryToken reports whether a token names the deja binary, quoted or
 // not, under any directory, on either platform's separator.
 func isDejaBinaryToken(tok string) bool {
-	tok = strings.Trim(tok, `"'`)
+	tok = strings.Trim(strings.TrimSpace(tok), `"'`)
+	// Both separators whatever this build was compiled for, because configs
+	// travel between machines, and folded because a filesystem that does not
+	// care about case still runs /opt/Deja (#2713).
 	if i := strings.LastIndexAny(tok, `/\`); i >= 0 {
 		tok = tok[i+1:]
 	}
+	tok = strings.ToLower(tok)
 	return tok == "deja" || tok == "deja.exe"
 }
 
@@ -1626,6 +1630,12 @@ func replacedEntryNote(prev, entry any) string {
 // config keeps it: a command string, a command list, or the args behind a
 // wrapper like Windows' `cmd /c`.
 func entryRunsDeja(entry map[string]any) bool {
+	// The shape a client nests: doctor read it and install did not, so one
+	// command called a file wired while the other wrote a second server into
+	// it (#2713).
+	if t, ok := entry["transport"].(map[string]any); ok && entryRunsDeja(t) {
+		return true
+	}
 	var words []string
 	switch c := entry["command"].(type) {
 	case string:
@@ -1713,6 +1723,12 @@ func otherDejaEntriesNote(servers map[string]any, mine string) string {
 // cannot be (`cmd /c … deja mcp`), it has to be running deja's server rather
 // than appearing in a path.
 func entryIsDejaServer(entry map[string]any) bool {
+	// The nested shape, on the same terms: this asks whether the entry is
+	// deja's server, so the answer has to reach wherever the launch is written
+	// (#2713).
+	if t, ok := entry["transport"].(map[string]any); ok && entryIsDejaServer(t) {
+		return true
+	}
 	switch c := entry["command"].(type) {
 	case string:
 		if isDejaBinaryToken(c) {
@@ -1782,6 +1798,15 @@ func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
 	}
 	for k, v := range entry {
 		out[k] = v
+	}
+	// deja owns how the entry is launched, and it writes that at the top level.
+	// An entry written in the nested shape kept its `transport` beside the
+	// command deja had just written, and a client that prefers the nested one
+	// went on launching the old binary while install reported success — the
+	// mixed shape this function exists to avoid, reached through the wider gate
+	// #2713 opened (#2716).
+	if _, ok := out["command"]; ok {
+		delete(out, "transport")
 	}
 	if disabled, _ := out["disabled"].(bool); disabled {
 		// Switching it back on silently would undo a decision deja was not

--- a/cmd/deja/mcp_entry_recogniser_test.go
+++ b/cmd/deja/mcp_entry_recogniser_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// install and doctor each grew their own answer to "does this entry run deja",
+// and they disagreed in both directions: a nested transport object and an
+// /opt/Deja were deja to doctor and invisible to install, and opencode's list
+// form was the reverse. One command then called a file wired while the other
+// wrote a second server into it (#2713).
+func TestBothRecognisersReadAnEntryTheSameWay(t *testing.T) {
+	cases := []struct {
+		name  string
+		entry string
+		deja  bool
+	}{
+		{"the plain shape", `{"command":"/usr/local/bin/deja","args":["mcp"]}`, true},
+		{"a nested transport", `{"transport":{"command":"/usr/local/bin/deja","args":["mcp"]}}`, true},
+		{"a list command", `{"command":["/old/bin/deja","mcp"]}`, true},
+		{"a windows path", `{"command":"C:\\bin\\deja.exe","args":["mcp"]}`, true},
+		{"a capitalised install", `{"command":"/opt/Deja"}`, true},
+		{"the binary behind a wrapper", `{"command":"cmd","args":["/c","/bin/deja","mcp"]}`, true},
+		{"somebody else's server", `{"command":"/usr/local/bin/mine","args":["serve"]}`, false},
+		{"a name that only starts the same", `{"command":"npx","args":["-y","deja-vu-mcp"]}`, false},
+		{"nothing at all", `{}`, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var entry map[string]any
+			if err := json.Unmarshal([]byte(c.entry), &entry); err != nil {
+				t.Fatal(err)
+			}
+			install := entryRunsDeja(entry)
+			doctor := mcpEntryRunsDeja(entry)
+			if install != doctor {
+				t.Errorf("install says %v and doctor says %v about the same entry", install, doctor)
+			}
+			if install != c.deja {
+				t.Errorf("read as deja=%v, want %v", install, c.deja)
+			}
+		})
+	}
+}
+
+// And the answer to "which binary" follows the same shapes: a check that says
+// "wired" but cannot name the command has nothing to report when that command
+// is gone (#2713).
+func TestTheCommandBehindAnEntryIsFoundInEveryShape(t *testing.T) {
+	for _, c := range []struct{ name, entry, want string }{
+		{"the plain shape", `{"command":"/usr/local/bin/deja","args":["mcp"]}`, "/usr/local/bin/deja"},
+		{"a nested transport", `{"transport":{"command":"/usr/local/bin/deja"}}`, "/usr/local/bin/deja"},
+		{"a list command", `{"command":["/old/bin/deja","mcp"]}`, "/old/bin/deja"},
+		{"the binary behind a wrapper", `{"command":"cmd","args":["/c","/bin/deja","mcp"]}`, "/bin/deja"},
+		{"a quoted windows path", `{"command":"\"C:\\bin\\deja.exe\"","args":["mcp"]}`, `"C:\bin\deja.exe"`},
+		{"somebody else's server", `{"command":"/usr/local/bin/mine"}`, ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var entry map[string]any
+			if err := json.Unmarshal([]byte(c.entry), &entry); err != nil {
+				t.Fatal(err)
+			}
+			if got := mcpEntryDejaCommand(entry); got != c.want {
+				t.Errorf("named %q, want %q", got, c.want)
+			}
+			if got := mcpEntryDejaCommand(entry); got != "" && !entryRunsDeja(entry) {
+				t.Errorf("an entry read as not deja still named %q", got)
+			}
+			// And the other direction, which is the one that hides a dead
+			// binary: an entry read as deja whose command nothing can name
+			// leaves the missing-binary check with nothing to report.
+			if entryRunsDeja(entry) && mcpEntryDejaCommand(entry) == "" {
+				t.Error("an entry read as deja named no command at all")
+			}
+		})
+	}
+}
+
+// The wider recogniser reaches the merge as well, and the merge writes the
+// launch at the top level: an entry in the nested shape kept its transport
+// beside the command deja had just written, so a client that prefers the
+// nested one went on running the old binary (#2716).
+func TestMergingOntoANestedEntryLeavesOneLaunchShape(t *testing.T) {
+	var prev map[string]any
+	if err := json.Unmarshal([]byte(`{"type":"local","transport":{"command":["/old/bin/deja","mcp"]}}`), &prev); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := mergeDejaEntry(prev, map[string]any{
+		"type":    "local",
+		"command": []any{"/usr/local/bin/deja", "mcp"},
+	})
+	if _, ok := out["transport"]; ok {
+		b, _ := json.Marshal(out)
+		t.Errorf("the entry carries two ways to launch deja:\n%s", b)
+	}
+	if got := mcpEntryDejaCommand(out); got != "/usr/local/bin/deja" {
+		t.Errorf("the entry names %q, want the binary that was just installed", got)
+	}
+}
+
+// And the note about somebody else's entry reads the nested shape too, or the
+// silence #2712 closed comes back for the harnesses that write it.
+func TestTheSecondEntryNoteReadsTheNestedShape(t *testing.T) {
+	var servers map[string]any
+	seed := `{"deja":{"command":"/usr/local/bin/deja","args":["mcp"]},` +
+		`"deja-vu":{"transport":{"command":"/old/bin/deja","args":["mcp"]}}}`
+	if err := json.Unmarshal([]byte(seed), &servers); err != nil {
+		t.Fatal(err)
+	}
+	if note := otherDejaEntriesNote(servers, "deja"); !strings.Contains(note, "deja-vu") {
+		t.Errorf("a second entry in the nested shape went unmentioned: %q", note)
+	}
+}


### PR DESCRIPTION
A nested `transport` and a capitalised `/opt/Deja` were deja to doctor and
invisible to install; opencode's list-shaped command was the reverse. So one
command could call a file wired while the other wrote a second server into it.

One function now, and `mcpEntryDejaCommand` reads the list shape too — a check
that says "wired" without being able to name the binary cannot report one that
is gone.
