### PR TITLE
fix(uninstall): take a server's sub-tables with its block

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2732,15 +2732,35 @@ func removeTOMLMCPBlock(s, key string) string {
 	var out []string
 	for i := 0; i < len(lines); i++ {
 		found, ok := tomlMCPHeader(lines[i])
-		if !ok || found != key {
+		if !ok || !tomlBlockOwnedBy(found, key) {
 			out = append(out, lines[i])
 			continue
 		}
+		// To the next header, whatever it is. A sub-table of this same server
+		// opens one of its own, and the loop above takes it on the next turn
+		// because it belongs to the key being removed — which is the whole of
+		// the fix for #2716, and why there is no second skip here.
 		i++
-		for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
+		for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(tomlCode(lines[i])), "[") {
 			i++
 		}
 		i--
 	}
 	return strings.Join(out, "\n")
+}
+
+// tomlBlockOwnedBy reports whether a header names the block being removed or
+// one of its sub-tables.
+//
+// TOML lets a server carry sub-tables, and `[mcp_servers.deja.env]` opens with
+// `[` like any other header — so removing the block by walking to the next one
+// stopped there and left the sub-table behind, naming a server that had just
+// gone (#2716). Reading the sub-table as part of the block is enough: the walk
+// stops at its header and the caller's next turn removes it in the same way.
+//
+// The dot is what decides. `deja.env` belongs to `deja`; `deja-vu` does not,
+// and a bare prefix test would take a hand-wired server with it.
+
+func tomlBlockOwnedBy(found, key string) bool {
+	return found == key || strings.HasPrefix(found, key+".")
 }

--- a/cmd/deja/toml_subtable_test.go
+++ b/cmd/deja/toml_subtable_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TOML lets a server carry sub-tables, and their headers open with `[` too.
+// Removing a block by walking to the next such line stopped at the sub-table
+// and left it behind, naming a server that had just gone (#2716).
+func TestRemovingABlockTakesItsSubTables(t *testing.T) {
+	const cfg = `model = "gpt-5"
+
+[mcp_servers.deja]
+command = "/usr/local/bin/deja"
+args = ["mcp"]
+
+[mcp_servers.deja.env]
+DEJA_INDEX_DIR = "/tmp/idx"
+
+[mcp_servers.memory]
+command = "/usr/local/bin/mcp-memory"
+`
+	got := removeTOMLMCPBlock(cfg, "deja")
+	if strings.Contains(got, "[mcp_servers.deja]") {
+		t.Errorf("the block itself survived:\n%s", got)
+	}
+	if strings.Contains(got, "deja.env") {
+		t.Errorf("a sub-table was left naming a server that is gone:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.memory]") {
+		t.Errorf("another server went with it:\n%s", got)
+	}
+	if !strings.Contains(got, `model = "gpt-5"`) {
+		t.Errorf("the reader's own settings went:\n%s", got)
+	}
+}
+
+// The dot is what decides. A bare prefix test would take a differently named
+// server with it, which is the failure this rule has to avoid while fixing the
+// other one.
+func TestASimilarlyNamedServerStays(t *testing.T) {
+	const cfg = `[mcp_servers.deja]
+command = "/usr/local/bin/deja"
+
+[mcp_servers.deja-vu]
+command = "/hand/bin/deja"
+
+[mcp_servers.dejavu-notes]
+command = "/hand/bin/notes"
+`
+	got := removeTOMLMCPBlock(cfg, "deja")
+	for _, keep := range []string{"[mcp_servers.deja-vu]", "[mcp_servers.dejavu-notes]"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("%s was removed with the block that merely shares its opening:\n%s", keep, got)
+		}
+	}
+	if strings.Contains(got, "/usr/local/bin/deja") {
+		t.Errorf("the block deja owns survived:\n%s", got)
+	}
+}
+
+// A sub-table of another server is not this one's to take, whichever order the
+// file happens to hold them in.
+func TestAnotherServersSubTableIsLeftAlone(t *testing.T) {
+	const cfg = `[mcp_servers.deja]
+command = "/usr/local/bin/deja"
+
+[mcp_servers.memory.env]
+KEY = "1"
+`
+	got := removeTOMLMCPBlock(cfg, "deja")
+	if !strings.Contains(got, "[mcp_servers.memory.env]") {
+		t.Errorf("another server's sub-table was taken:\n%s", got)
+	}
+	if !strings.Contains(got, `KEY = "1"`) {
+		t.Errorf("its body went too:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #2716.

TOML lets a server carry sub-tables, and `[mcp_servers.deja.env]` opens with `[` like any other header. Removal walked forward to the next such line, so it stopped at the sub-table and left it behind, naming a server that had just gone:

    [mcp_servers.deja]         → removed
    [mcp_servers.deja.env]     → left

Verified against a real codex config rather than only the unit: install writes deja's block, a sub-table is added to it, uninstall now takes both and leaves the reader's own `[mcp_servers.memory]` and `[mcp_servers.memory.env]` untouched.

The fix is one condition — a header belongs to the block when it is the key or a child of it — and the walk needs nothing else: it stops at the sub-table's header, and the outer loop removes that on its next turn because it belongs to the same key. I wrote a second skip inside the walk first; a mutation showed it was dead, so it is not here.

The dot is what decides, which is the trap this had to avoid while fixing the other one: a bare prefix test takes `[mcp_servers.deja-vu]` with `deja`, and a hand-wired server is exactly what uninstall must not touch (#2269). Pinned by a test with `deja-vu` and `dejavu-notes` beside `deja`, and by one where another server's sub-table stays.

Found reviewing #2648, and it is not from there: the same walk is in `removeCodexDejaBlock` on main, so deja's own block has always had it.