### PR TITLE
fix(hooks): an unknown hook name is not a search

### DIFF
--- a/cmd/deja/hook_typed_by_hand.go
+++ b/cmd/deja/hook_typed_by_hand.go
@@ -69,7 +69,11 @@ func hookTypedByHandNote(name string, terminal bool) string {
 // stdinIsTerminal reports that nothing is piped in. Same test `fix` uses before
 // reading stdin, for the same reason: reading a terminal blocks with no prompt
 // and reads as a hang.
-func stdinIsTerminal() bool {
+//
+// A variable so a test can be the reader as well as the harness: a test binary
+// never has a terminal on stdin, so the branch written for a person typing
+// could not otherwise be exercised (#2718).
+var stdinIsTerminal = func() bool {
 	fi, err := os.Stdin.Stat()
 	return err == nil && fi.Mode()&os.ModeCharDevice != 0
 }

--- a/cmd/deja/hook_unknown_name_test.go
+++ b/cmd/deja/hook_unknown_name_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A config an older deja wrote can name a hook this build no longer has, and
+// install leaves that line where it is — so it runs every session. It fell
+// through to search, which builds the index if it has to and then reports a
+// miss about "hook-session": a session start doing a full index build and
+// answering nothing, once per session (#2718).
+func TestAnUnknownHookNameIsNotAQuery(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","message":{"role":"user","content":"the zonkoshard retry budget"},` +
+		`"timestamp":"2026-08-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	// A harness calling the hook, not a person typing it: `go test` may or may
+	// not have a terminal on stdin, and which branch this takes must not
+	// depend on how the suite was started.
+	restore := stdinIsTerminal
+	t.Cleanup(func() { stdinIsTerminal = restore })
+	stdinIsTerminal = func() bool { return false }
+
+	var out string
+	said := captureStderr(t, func() {
+		var err error
+		out, err = captureRun(t, "hook-session")
+		if err != nil {
+			t.Errorf("a hook name a harness still calls must not fail the session: %v", err)
+		}
+	})
+	// Nothing on stdout: a harness reads that as the hook's answer, and on
+	// some of them a bare line there lands in the model's context.
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("a hook that does not exist answered the harness:\n%s", out)
+	}
+	if !strings.Contains(said, "hook-session") || !strings.Contains(said, "safe to delete") {
+		t.Errorf("nothing said what that line in the config is, or how to fix it:\n%s", said)
+	}
+	if strings.Contains(said, "no matches") || strings.Contains(said, "indexing sessions") {
+		t.Errorf("the hook name was read as a query:\n%s", said)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "manifest.gob")); err == nil {
+		t.Errorf("the index was built by a hook that does not exist")
+	}
+
+	// A real mistyped command is still read as a search — the reading #674
+	// chose, and the right one for a word somebody typed. It goes to stderr,
+	// so what says it ran is the store it built to answer.
+	if _, err := captureRun(t, "sarch"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "manifest.gob")); err != nil {
+		t.Errorf("a mistyped command stopped being read as a search: %v", err)
+	}
+}
+
+// At a terminal the same word is somebody's typo, not a config: they keep the
+// search and the near miss every other mistyped word gets (#674), and telling
+// them a config calls it would be a claim about their machine that is false.
+func TestATypedHookNameIsStillASearch(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","message":{"role":"user","content":"the zonkoshard retry budget"},` +
+		`"timestamp":"2026-08-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := stdinIsTerminal
+	t.Cleanup(func() { stdinIsTerminal = restore })
+	stdinIsTerminal = func() bool { return true }
+
+	said := captureStderr(t, func() {
+		if _, err := captureRun(t, "hook-contxt"); err != nil {
+			t.Error(err)
+		}
+	})
+	if strings.Contains(said, "safe to delete") {
+		t.Errorf("a typo was answered with a claim about the reader's config:\n%s", said)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "index.db", "manifest.gob")); err != nil {
+		t.Errorf("the word somebody typed was not searched for: %v", err)
+	}
+}
+
+// And a query whose first word happens to be one: no harness passes a retired
+// hook extra arguments.
+func TestAQueryStartingWithAHookNameIsStillAQuery(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","message":{"role":"user","content":"hook-session timeout in codex"},` +
+		`"timestamp":"2026-08-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := stdinIsTerminal
+	t.Cleanup(func() { stdinIsTerminal = restore })
+	stdinIsTerminal = func() bool { return false }
+	out, err := captureRun(t, "hook-session", "timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "hook-session timeout in codex") {
+		t.Errorf("a query was swallowed by the guard:\n%s", out)
+	}
+	_ = tmp
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -259,6 +259,28 @@ func run(args []string) error {
 	if cmd, ok := commands[args[0]]; ok {
 		return cmd(dir, args[1:])
 	}
+	// A `hook-…` this build does not have is a line in a config an older deja
+	// wrote, not a query: reading it as one ran a search on every session
+	// start — and built the whole index to answer it — while stdout, where a
+	// hook's output is read from, stayed empty (#2718). commandHint already
+	// treats these names as plumbing nobody types.
+	//
+	// Only when a harness is calling: at a terminal this is somebody who
+	// mistyped `hook-context`, and telling them a config calls it is a claim
+	// about their machine that is not true — they keep the search and the near
+	// miss every other mistyped word gets (#674). And only when it is the whole
+	// command line: `deja hook-session timeout` is a query somebody typed, and
+	// no harness passes a retired hook extra arguments.
+	if len(args) == 1 && strings.HasPrefix(args[0], "hook-") && !stdinIsTerminal() {
+		// On stderr: a harness reads stdout as the hook's answer, and on some
+		// of them a bare line there lands in the model's context. This is a
+		// note for whoever reads the logs, not something to inject.
+		// What to do, and only what is true: install writes the hooks this
+		// build has and leaves a line under a name it does not recognise where
+		// it is (#2719), so pointing at it would be advice that does nothing.
+		fmt.Fprintf(os.Stderr, "deja: %q is not a hook this build has — a config still calls it on every session; that line is safe to delete\n", args[0])
+		return nil
+	}
 	return runBareSearch(dir, args, sourceInstance)
 }
 


### PR DESCRIPTION
`deja hook-session` — a hook name a config written by an older deja can still
call on every session — fell through to bare search: a query, and on a stale or
missing store a whole index build, while stdout stayed empty.

It says what the line is now, on stderr, and exits 0. The name list is written
out rather than read from the dispatch table (that would be an initialisation
cycle) with a test comparing the two.

The advice stops at what is true: install leaves such a line where it is, which
is #2719.
