### PR TITLE
fix(install): report the targets it wired when one refuses

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -241,19 +241,31 @@ func runInstall(dir string, args []string, uninstall bool) error {
 			note(cliSkillName, err)
 		}
 	}
+	// Held, not returned. "finished what it could" is a summary of the run, and
+	// returning it here made it an early exit from reporting the run: the
+	// banner never rendered, so nobody was told which harnesses had been wired,
+	// and the index build below was skipped, leaving those harnesses wired with
+	// nothing to read (#2721).
+	var refusal error
 	if len(refused) > 0 {
 		verb := "install"
 		if uninstall {
 			verb = "uninstall"
 		}
-		return fmt.Errorf("%s finished what it could; %d target%s refused: %s — %s",
+		refusal = fmt.Errorf("%s finished what it could; %d target%s refused: %s — %s",
 			verb, len(refused), pluralS(len(refused)), strings.Join(refused, "; "), refusalRemedy(refusedErrs))
 	}
 	// Every install builds, not only --auto and --all. Installing is the one
 	// moment a person has already accepted a wait — they just ran an installer
 	// — and spending the build here is what keeps the first real use, usually
-	// the first agent turn, instant.
-	if !uninstall && !noIndex {
+	// the first agent turn, instant. A target that refused does not change that
+	// for the ones that did not (#2721).
+	// Something has to have landed. When every target refused there is nothing
+	// to build a store for and nothing to celebrate, and printing the whole
+	// success screen ahead of the refusal is worse than the silence #2721 was
+	// about.
+	wired := len(done) > 0 || mcpCount+hookCount+guidanceCount > 0
+	if !uninstall && !noIndex && wired {
 		installIndexWarmup(dir, mcpCount, hookCount, guidanceCount,
 			targetArgs[0] == "--auto" || targetArgs[0] == "--all")
 	}
@@ -267,7 +279,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 			fmt.Fprint(os.Stderr, line)
 		}
 	}
-	if banner {
+	if banner && wired {
 		info := append(brandInfo(), "")
 		nameW := 0
 		for _, d := range done {
@@ -296,7 +308,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		}
 		printLogoMood(os.Stdout, info, mood)
 	}
-	return nil
+	return refusal
 }
 
 // keptSnapshotsLine names the .bak files still beside the configs this run

--- a/cmd/deja/install_partial_failure_test.go
+++ b/cmd/deja/install_partial_failure_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The fixture below makes a directory refuse writes, which is a permission bit
+// on unix and a suggestion on windows — where the install would simply succeed
+// and the test would fail for the wrong reason. Same guard the other
+// read-only fixtures in this package use.
+func skipWhereModeBitsDoNotRefuse(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("the directory mode is not enforced here")
+	}
+}
+
+// "install finished what it could" returned before the banner and before the
+// index build, so a run that wired nine harnesses and failed one said nothing
+// about the nine and left them without a store to read (#2721).
+func TestAnInstallThatRefusesOneTargetStillReportsTheRest(t *testing.T) {
+	skipWhereModeBitsDoNotRefuse(t)
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "home")
+	// A codex home, so there is a target that can be written beside the one
+	// that cannot.
+	if err := os.MkdirAll(filepath.Join(tmp, "home", ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// One config deja cannot write, beside one it can.
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	claude := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(claude, []byte(`{"mcpServers":{}}`), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	unwritable := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(unwritable, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unwritable, 0o755) })
+
+	// The banner, which is the screen this is about: the line-by-line output
+	// printed its per-target lines before the old return, so only the table
+	// could lose them.
+	restore := logoWanted
+	t.Cleanup(func() { logoWanted = restore })
+	logoWanted = func(*os.File) bool { return true }
+
+	out, err := captureRun(t, "install", "--all", "--no-index")
+	if err == nil {
+		t.Fatal("a target that could not be written was reported as installed")
+	}
+	if !strings.Contains(err.Error(), "refused") {
+		t.Fatalf("the refusal did not name itself: %v", err)
+	}
+	if !strings.Contains(out, "codex") {
+		t.Errorf("the table never named the target that was written:\n%s\nerror: %v", out, err)
+	}
+	if strings.Contains(out, "claude-code") {
+		t.Errorf("the table named a target that refused:\n%s", out)
+	}
+}
+
+// And the store: a run that wired something ends with a build, because
+// installing is the one moment a person has already accepted a wait. The
+// refusal was taking that away too.
+func TestAnInstallThatRefusesOneTargetStillBuildsTheIndex(t *testing.T) {
+	skipWhereModeBitsDoNotRefuse(t)
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "home")
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","message":{"role":"user","content":"the zonkoshard retry budget"},` +
+		`"timestamp":"2026-08-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{}}`), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	unwritable := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(unwritable, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unwritable, 0o755) })
+
+	if _, err := captureRun(t, "install", "--all"); err == nil {
+		t.Fatal("a target that could not be written was reported as installed")
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "index.db", "manifest.gob")); err != nil {
+		t.Errorf("an install that wired a harness left it with no index: %v", err)
+	}
+}


### PR DESCRIPTION
"install finished what it could" is a summary of the run, and it was being used
as an early exit from reporting the run: the banner never rendered, so nobody
was told which harnesses had been wired, and the index build was skipped, so
the ones that were wired had nothing to read.

The error is held and returned at the end. Exit status is unchanged.
