### PR TITLE
fix(goose): a key with entries is not empty at one space

### DIFF
--- a/cmd/deja/goose_yaml_indent_test.go
+++ b/cmd/deja/goose_yaml_indent_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A key is empty when nothing is nested under it, and "nested" was read as
+// "starts with two spaces". One space is valid YAML and is not two, so an
+// uninstall dropped the key and left the reader's own entries behind as a
+// stray list — a config goose then cannot read at all (#2724).
+func TestAKeyWithEntriesIsNotEmptyAtAnyIndent(t *testing.T) {
+	for _, c := range []struct{ name, indent string }{
+		{"one space", " "},
+		{"two spaces", "  "},
+		{"four spaces", "    "},
+		{"a tab, which YAML does not allow but this must not mangle", "\t"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			in := "slash_commands:\n" +
+				c.indent + "- command: \"mine\"\n" +
+				c.indent + "  recipe_path: /tmp/mine.yaml\nother: 1\n"
+			got := dropEmptyYAMLKey(in, "slash_commands:")
+			if !strings.Contains(got, "slash_commands:") {
+				t.Errorf("the key was dropped while its entries stayed:\n%s", got)
+			}
+			if got != in {
+				t.Errorf("a key with entries was rewritten:\nwant:\n%s\ngot:\n%s", in, got)
+			}
+		})
+	}
+}
+
+// And the reason the function exists: a key with nothing under it parses as
+// null, and goose refuses the whole config.
+func TestAKeyWithNothingUnderItStillGoes(t *testing.T) {
+	// The trailing newline goes with the key when the key is the last line;
+	// that is what this has always done, and the caller writes the file back
+	// through writeIfChanged either way.
+	for _, c := range []struct{ name, in, want string }{
+		{"nothing after it", "other: 1\nslash_commands:\n", "other: 1"},
+		{"blank lines after it", "slash_commands:\n\n\nother: 1\n", "other: 1\n"},
+		{"another key after it", "slash_commands:\nother: 1\n", "other: 1\n"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := dropEmptyYAMLKey(c.in, "slash_commands:"); got != c.want {
+				t.Errorf("got:\n%q\nwant:\n%q", got, c.want)
+			}
+		})
+	}
+}
+
+// The shape every YAML serializer writes: a sequence at the key's own indent.
+// Its entries are the key's, and reading them as a stray list dropped the key
+// on install — before any uninstall (#2724).
+func TestASequenceAtTheKeysOwnIndentBelongsToIt(t *testing.T) {
+	in := "other: 1\nslash_commands:\n- command: \"mine\"\n  recipe_path: /m\n"
+	if got := dropEmptyYAMLKey(in, "slash_commands:"); got != in {
+		t.Errorf("the key was dropped from under its own entries:\n%s", got)
+	}
+}
+
+// And the whole round trip through the writers, at every indent a person may
+// have used. What goes in must come back out byte for byte.
+func TestGooseCommandRoundTripsAtEveryIndent(t *testing.T) {
+	for _, c := range []struct{ name, indent string }{
+		{"a sequence in the first column", ""},
+		{"one space", " "},
+		{"two spaces", "  "},
+		{"three spaces", "   "},
+		{"four spaces", "    "},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(gooseConfigDir(), "config.yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			before := "other: 1\nslash_commands:\n" +
+				c.indent + "- command: \"mine\"\n" +
+				c.indent + "  recipe_path: /m\n"
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := installGooseCommand("/opt/deja", false); err != nil {
+				t.Fatal(err)
+			}
+			wired, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(wired), `- command: "deja"`) {
+				t.Fatalf("the command was not written:\n%s", wired)
+			}
+			if !strings.Contains(string(wired), `- command: "mine"`) {
+				t.Errorf("the reader's own entry did not survive the install:\n%s", wired)
+			}
+			// One list, one indent: an entry spliced in at another width is a
+			// file no YAML parser will read.
+			for _, line := range strings.Split(string(wired), "\n") {
+				if strings.HasPrefix(strings.TrimLeft(line, " \t"), "- command:") &&
+					line[:len(line)-len(strings.TrimLeft(line, " \t"))] != c.indent {
+					t.Errorf("an entry was written at another indent than the list:\n%s", wired)
+					break
+				}
+			}
+
+			if _, err := installGooseCommand("/opt/deja", true); err != nil {
+				t.Fatal(err)
+			}
+			back, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(back) != before {
+				t.Errorf("the config did not come back:\nwas:\n%q\nnow:\n%q", before, back)
+			}
+		})
+	}
+}
+
+// A config with windows line endings is read line by line like any other, and
+// every line ended in a carriage return, so nothing matched: a second install
+// wrote a second key, and uninstall left the empty one this file exists to
+// prevent (#2724).
+func TestGooseCommandSurvivesWindowsLineEndings(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(gooseConfigDir(), "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("other: 1\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := installGooseCommand("/opt/deja", false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wired, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(wired), "slash_commands:"); n != 1 {
+		t.Errorf("%d slash_commands keys after two installs:\n%s", n, wired)
+	}
+	if _, err := installGooseCommand("/opt/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(back), "slash_commands:") {
+		t.Errorf("an empty key was left behind, which goose reads as null:\n%q", back)
+	}
+}

--- a/cmd/deja/install_goose_command.go
+++ b/cmd/deja/install_goose_command.go
@@ -40,6 +40,42 @@ func indentLines(s, pad string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+// gooseSlashCommandsBlock returns the text after the slash_commands key, for
+// reading the indent its entries are written at.
+func gooseSlashCommandsBlock(s string) string {
+	i := strings.Index("\n"+s, "\nslash_commands:\n")
+	if i < 0 {
+		return ""
+	}
+	return s[i+len("\nslash_commands:\n")-1:]
+}
+
+// gooseListIndent is the indent the entries of a list are written at, and
+// whether there is a list to read one from. Distinct from yamlBlockIndent
+// because "" is an answer here: a sequence in the first column is what every
+// YAML serializer writes, and an entry spliced in at two spaces beside it is a
+// file no parser will read (#2724).
+func gooseListIndent(block string) (string, bool) {
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "- ") {
+			return "", false
+		}
+		return line[:len(line)-len(strings.TrimLeft(line, " \t"))], true
+	}
+	return "", false
+}
+
+// normaliseGooseNewlines is what installGoose does to the same file for the
+// same reason: a CRLF config read line by line leaves every line ending in \r,
+// so nothing matches and the writer added a second key on every run.
+func normaliseGooseNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
+}
+
 // removeGooseSlashCommand takes our entry out of the slash_commands list and
 // leaves every other entry, and the key itself, where they were.
 func removeGooseSlashCommand(s string) string {
@@ -53,9 +89,13 @@ func removeGooseSlashCommand(s string) string {
 			out = append(out, lines[i])
 			continue
 		}
+		dash := yamlIndentWidth(lines[i])
 		i++
-		// The entry's remaining keys are indented further than its dash.
-		for i < len(lines) && strings.HasPrefix(strings.TrimRight(lines[i], " "), "    ") {
+		// The entry's remaining keys are indented further than its dash — its
+		// dash, not four spaces: a list written at four had its neighbours'
+		// lines eaten as if they were ours, and uninstall came back with the
+		// key and every entry gone (#2724).
+		for i < len(lines) && strings.TrimSpace(lines[i]) != "" && yamlIndentWidth(lines[i]) > dash {
 			i++
 		}
 		i--
@@ -78,7 +118,14 @@ func dropEmptyYAMLKey(s, key string) string {
 		for j < len(lines) && strings.TrimSpace(lines[j]) == "" {
 			j++
 		}
-		if j < len(lines) && strings.HasPrefix(lines[j], "  ") {
+		// Nested is "indented further than the key", not "starts with two
+		// spaces": one space is valid YAML and is not two, so a config written
+		// that way had its key dropped and its entries left behind as a stray
+		// list — which goose then cannot read at all (#2724). A tab is not
+		// legal YAML indentation, and is treated as indentation here anyway,
+		// because leaving a file alone is the safe answer for one this cannot
+		// have written.
+		if j < len(lines) && yamlLineBelongsTo(lines[j], lines[i]) {
 			out = append(out, lines[i])
 			continue
 		}
@@ -116,9 +163,16 @@ func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 		}
 	}
 
-	next := removeGooseSlashCommand(string(old))
+	next := removeGooseSlashCommand(normaliseGooseNewlines(string(old)))
 	if !uninstall {
-		entry := fmt.Sprintf("  - command: \"deja\"\n    recipe_path: %s\n", yamlQuote(recipe))
+		// At the indent the list already uses, the way the extensions writer
+		// does: a two-space entry spliced into a list written at one, three or
+		// four is a file no YAML parser will read (#2724).
+		pad, ok := gooseListIndent(gooseSlashCommandsBlock(next))
+		if !ok {
+			pad = "  "
+		}
+		entry := fmt.Sprintf("%s- command: \"deja\"\n%s  recipe_path: %s\n", pad, pad, yamlQuote(recipe))
 		if i := strings.Index("\n"+next, "\nslash_commands:\n"); i >= 0 {
 			at := i + len("\nslash_commands:\n") - 1
 			next = next[:at] + entry + next[at:]
@@ -154,4 +208,28 @@ func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 		}
 	}
 	return installResult{Path: path, Action: a}, nil
+}
+
+// yamlLineBelongsTo reports whether a line is part of the block under a key.
+//
+// Indented further is the ordinary shape. A sequence at the key's own indent is
+// the other one, and it is what every YAML serializer writes —
+// `slash_commands:` followed by `- command: mine` in the first column is a key
+// with an entry, not an empty key beside a stray list, and reading it as the
+// second dropped the key and left the entries orphaned (#2724).
+func yamlLineBelongsTo(line, key string) bool {
+	switch {
+	case yamlIndentWidth(line) > yamlIndentWidth(key):
+		return true
+	case yamlIndentWidth(line) == yamlIndentWidth(key):
+		return strings.HasPrefix(strings.TrimLeft(line, " \t"), "- ")
+	}
+	return false
+}
+
+// yamlIndentWidth is how far a line is indented, counting spaces and tabs
+// alike. YAML forbids tabs, so this is not reading a shape deja writes — it is
+// refusing to mistake one for the top level.
+func yamlIndentWidth(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " \t"))
 }


### PR DESCRIPTION
`deja uninstall goose` on a config whose entries are indented with one space
dropped the `slash_commands:` key and left the entries behind as a stray list —
a file goose cannot read. "Has entries" was `HasPrefix(line, "  ")`, and one
space is valid YAML and is not two.

It compares indent widths now. Four spaces worked by accident before; one and
three did not.
