### PR TITLE
fix(yaml): read a block at the indent it was written at

### DIFF
--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -128,11 +128,30 @@ func doctorAutoRecall(w io.Writer) {
 // both nest ours under a key: a plain "deja appears in the file" check would
 // pass on a disabled entry.
 func doctorGooseWired(path string) bool {
-	return yamlHasKey(path, "  deja:")
+	return yamlHasNestedKey(path, "deja:")
 }
 
 func doctorHermesWired(path string) bool {
-	return yamlHasKey(path, "mcp_servers:") && yamlHasKey(path, "  deja:")
+	return yamlHasKey(path, "mcp_servers:") && yamlHasNestedKey(path, "deja:")
+}
+
+// yamlHasNestedKey is yamlHasKey for a key that has to sit under something.
+// The indent is whatever the reader wrote the block at, and asking for exactly
+// two called a goose deja had just wired at four unwired — while the writer
+// itself follows the block (#2614, #2727). Nested, not top level: `deja:` in
+// the first column is not an entry in anybody's server list.
+func yamlHasNestedKey(path, key string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if strings.TrimSpace(trimmed) == key && yamlIndentWidth(trimmed) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // yamlHasKey looks for a key on its own line. Matching a leading newline

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -180,19 +180,39 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 func removeHermesMCPBlock(s string) string {
 	lines := strings.Split(s, "\n")
 	var out []string
-	skipping := false
-	for _, l := range lines {
-		if skipping {
-			if strings.HasPrefix(l, "    ") || strings.TrimSpace(l) == "" && len(out) > 0 && strings.HasPrefix(out[len(out)-1], "    ") {
-				continue
-			}
-			skipping = false
-		}
-		if strings.TrimSpace(l) == "deja:" && strings.HasPrefix(l, "  ") && !strings.HasPrefix(l, "   ") {
-			skipping = true
+	for i := 0; i < len(lines); i++ {
+		// The indent deja's own key was written at: a block is whatever width
+		// the reader used, and reading it as exactly two left the server wired
+		// on every config written at one or four (#2727). The writer has asked
+		// since #2614; this is the other half.
+		if strings.TrimSpace(lines[i]) != "deja:" || yamlIndentWidth(lines[i]) == 0 {
+			out = append(out, lines[i])
 			continue
 		}
-		out = append(out, l)
+		pad := yamlIndentWidth(lines[i])
+		i++
+		for i < len(lines) {
+			if strings.TrimSpace(lines[i]) == "" {
+				// A blank line is inside the block only if the block goes on
+				// after it. The one that separates deja's block from what
+				// follows belongs to the file, and eating it made a second
+				// install differ from the first.
+				j := i
+				for j < len(lines) && strings.TrimSpace(lines[j]) == "" {
+					j++
+				}
+				if j < len(lines) && yamlIndentWidth(lines[j]) > pad {
+					i = j
+					continue
+				}
+				break
+			}
+			if yamlIndentWidth(lines[i]) <= pad {
+				break
+			}
+			i++
+		}
+		i--
 	}
 	return strings.Join(out, "\n")
 }

--- a/cmd/deja/yaml_indent_readers_test.go
+++ b/cmd/deja/yaml_indent_readers_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The writers ask what indent a block uses; these two readers assumed two
+// spaces. Uninstall then left hermes wired, and doctor called a goose install
+// it had just done unwired (#2727).
+func TestHermesUninstallTakesItsBlockOutAtAnyIndent(t *testing.T) {
+	for _, c := range []struct{ name, indent string }{
+		{"one space", " "},
+		{"two spaces", "  "},
+		{"four spaces", "    "},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			in := "mcp_servers:\n" +
+				c.indent + "deja:\n" +
+				c.indent + c.indent + "cmd: /old/deja\n" +
+				c.indent + "mine:\n" +
+				c.indent + c.indent + "cmd: /usr/bin/mine\n"
+			got := removeHermesMCPBlock(in)
+			if strings.Contains(got, "deja:") {
+				t.Errorf("deja's own block survived the uninstall:\n%s", got)
+			}
+			if !strings.Contains(got, "mine:") || !strings.Contains(got, "/usr/bin/mine") {
+				t.Errorf("the reader's own server did not survive:\n%s", got)
+			}
+			if !strings.Contains(got, "mcp_servers:") {
+				t.Errorf("the key went with it:\n%s", got)
+			}
+		})
+	}
+}
+
+// And what doctor says about a config deja itself wrote.
+func TestDoctorReadsAWiredBlockAtAnyIndent(t *testing.T) {
+	for _, c := range []struct{ name, indent string }{
+		{"one space", " "},
+		{"two spaces", "  "},
+		{"four spaces", "    "},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			goose := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(goose, []byte("extensions:\n"+
+				c.indent+"deja:\n"+c.indent+c.indent+"cmd: /opt/deja\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if !doctorGooseWired(goose) {
+				t.Errorf("doctor calls a wired goose unwired at this indent")
+			}
+			hermes := filepath.Join(dir, "hermes.yaml")
+			if err := os.WriteFile(hermes, []byte("mcp_servers:\n"+
+				c.indent+"deja:\n"+c.indent+c.indent+"cmd: /opt/deja\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if !doctorHermesWired(hermes) {
+				t.Errorf("doctor calls a wired hermes unwired at this indent")
+			}
+		})
+	}
+}
+
+// A key at the top level is not an entry under anything, and a server someone
+// else named is not deja.
+func TestDoctorDoesNotReadATopLevelKeyAsAWiredServer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("deja:\n  note: not a server block\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if doctorGooseWired(path) {
+		t.Error("a top-level key was read as a wired extension")
+	}
+	if err := os.WriteFile(path, []byte("extensions:\n  dejavu:\n    cmd: /opt/other\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if doctorGooseWired(path) {
+		t.Error("another name that starts the same was read as deja")
+	}
+}
+
+// The blank line after deja's block belongs to the file, not to the block:
+// swallowing it made a second install differ from the first, which is what
+// TestInstallIsIdempotent is for (#2727).
+func TestHermesUninstallLeavesTheFileAroundItAlone(t *testing.T) {
+	in := "mcp_servers:\n" +
+		"  mine:\n    cmd: /usr/bin/mine\n" +
+		"\n" +
+		"  deja:\n    cmd: /old/deja\n" +
+		"\n" +
+		"plugins:\n  enabled:\n    - other\n"
+	want := "mcp_servers:\n" +
+		"  mine:\n    cmd: /usr/bin/mine\n" +
+		"\n" +
+		"\n" +
+		"plugins:\n  enabled:\n    - other\n"
+	if got := removeHermesMCPBlock(in); got != want {
+		t.Errorf("the file around deja's block changed:\nwant:\n%q\ngot:\n%q", want, got)
+	}
+}
+
+// A comment inside deja's own block goes with it; one belonging to what
+// follows does not.
+func TestHermesUninstallTakesTheCommentsInsideItsBlock(t *testing.T) {
+	in := "mcp_servers:\n" +
+		"  deja:\n" +
+		"    # written by deja install\n" +
+		"    cmd: /old/deja\n" +
+		"  # the reader's note about their own server\n" +
+		"  mine:\n    cmd: /usr/bin/mine\n"
+	got := removeHermesMCPBlock(in)
+	if strings.Contains(got, "written by deja install") {
+		t.Errorf("a comment inside deja's block stayed:\n%s", got)
+	}
+	if !strings.Contains(got, "the reader's note") {
+		t.Errorf("the reader's own comment went with it:\n%s", got)
+	}
+}


### PR DESCRIPTION
Two readers assumed two spaces where the writers already ask. `deja uninstall
hermes` left the server wired on a config written at one or four, and doctor
called a goose install it had just done unwired for the same reason.

Both read the indent from the file now. The blank line after deja's block stays
with the file rather than going with the block — the first version of this ate
it, and TestInstallIsIdempotent said so.
