### PR TITLE
fix(hermes): deja's entry is a direct child of its block

### DIFF
--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -128,26 +128,48 @@ func doctorAutoRecall(w io.Writer) {
 // both nest ours under a key: a plain "deja appears in the file" check would
 // pass on a disabled entry.
 func doctorGooseWired(path string) bool {
-	return yamlHasNestedKey(path, "deja:")
+	return yamlHasChildKey(path, "extensions:", "deja:")
 }
 
 func doctorHermesWired(path string) bool {
-	return yamlHasKey(path, "mcp_servers:") && yamlHasNestedKey(path, "deja:")
+	return yamlHasChildKey(path, "mcp_servers:", "deja:")
 }
 
-// yamlHasNestedKey is yamlHasKey for a key that has to sit under something.
+// yamlHasChildKey reports whether a key sits directly under a top-level parent.
+//
 // The indent is whatever the reader wrote the block at, and asking for exactly
 // two called a goose deja had just wired at four unwired — while the writer
-// itself follows the block (#2614, #2727). Nested, not top level: `deja:` in
-// the first column is not an entry in anybody's server list.
-func yamlHasNestedKey(path, key string) bool {
+// itself follows the block (#2614, #2727). "Anywhere below the top level" was
+// the other end of the same mistake: `deja:` in another server's env, or in a
+// comment-shaped example under `notes:`, then read as a wired server (#2730).
+func yamlHasChildKey(path, parent, key string) bool {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(string(b), "\n") {
-		trimmed := strings.TrimRight(line, " \t\r")
-		if strings.TrimSpace(trimmed) == key && yamlIndentWidth(trimmed) > 0 {
+	lines := strings.Split(string(b), "\n")
+	inBlock := false
+	child := -1
+	for _, raw := range lines {
+		line := strings.TrimRight(raw, " \t\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.TrimSpace(line) == parent && yamlIndentWidth(line) == 0 {
+			inBlock, child = true, -1
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		if yamlIndentWidth(line) == 0 {
+			inBlock = false
+			continue
+		}
+		if child < 0 {
+			child = yamlIndentWidth(line)
+		}
+		if strings.TrimSpace(line) == key && yamlIndentWidth(line) == child {
 			return true
 		}
 	}

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -150,7 +150,12 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 	}
 	next := removeHermesMCPBlock(lfText(old))
 	if !uninstall {
-		entry := "  deja:\n    command: " + yamlQuote(exe) + "\n    args:\n      - mcp\n    enabled: true\n"
+		pad, ok := hermesBlockIndent(next)
+		if !ok {
+			pad = "  "
+		}
+		entry := pad + "deja:\n" + pad + pad + "command: " + yamlQuote(exe) + "\n" +
+			pad + pad + "args:\n" + pad + pad + pad + "- mcp\n" + pad + pad + "enabled: true\n"
 		if i := strings.Index(next, "\nmcp_servers:\n"); i >= 0 {
 			at := i + len("\nmcp_servers:\n")
 			next = next[:at] + entry + next[at:]
@@ -171,7 +176,10 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 			forgetBlockAdded(path, "mcp_servers")
 		}
 	}
-	a, werr := writeIfChanged(path, old, []byte(next))
+	// The file's own final newline, the way both goose writers keep it: this
+	// was the only writer that did not, so a config whose deja block ended it
+	// came back without one (#2606, #2730).
+	a, werr := writeIfChanged(path, old, []byte(keepTrailingNewline(lfText(old), next)))
 	return installResult{Path: path, Action: a}, werr
 }
 
@@ -180,16 +188,30 @@ func installHermesMCP(exe string, uninstall bool) (installResult, error) {
 func removeHermesMCPBlock(s string) string {
 	lines := strings.Split(s, "\n")
 	var out []string
+	// Inside `mcp_servers:` and at its own child indent — nothing else. Reading
+	// `deja:` at any depth emptied a server of somebody else's whose env holds
+	// a key by that name, which is a config deja broke while claiming to
+	// uninstall itself (#2730).
+	inBlock := false
+	child := -1
 	for i := 0; i < len(lines); i++ {
-		// The indent deja's own key was written at: a block is whatever width
-		// the reader used, and reading it as exactly two left the server wired
-		// on every config written at one or four (#2727). The writer has asked
-		// since #2614; this is the other half.
-		if strings.TrimSpace(lines[i]) != "deja:" || yamlIndentWidth(lines[i]) == 0 {
-			out = append(out, lines[i])
+		line := lines[i]
+		if strings.TrimSpace(line) == "mcp_servers:" && yamlIndentWidth(line) == 0 {
+			inBlock, child = true, -1
+			out = append(out, line)
 			continue
 		}
-		pad := yamlIndentWidth(lines[i])
+		if inBlock && strings.TrimSpace(line) != "" && yamlIndentWidth(line) == 0 {
+			inBlock, child = false, -1
+		}
+		if inBlock && child < 0 && strings.TrimSpace(line) != "" {
+			child = yamlIndentWidth(line)
+		}
+		if !inBlock || strings.TrimSpace(line) != "deja:" || yamlIndentWidth(line) != child {
+			out = append(out, line)
+			continue
+		}
+		pad := yamlIndentWidth(line)
 		i++
 		for i < len(lines) {
 			if strings.TrimSpace(lines[i]) == "" {
@@ -215,6 +237,31 @@ func removeHermesMCPBlock(s string) string {
 		i--
 	}
 	return strings.Join(out, "\n")
+}
+
+// hermesBlockIndent is the indent the servers under `mcp_servers:` are written
+// at, and whether there is a block to read one from. deja wrote its own entry
+// at two whatever the file used, so on a config indented at three or four the
+// entry landed shallower than its siblings — and the uninstall that reads
+// "indented further than deja's key" then took those siblings with it (#2730).
+func hermesBlockIndent(s string) (string, bool) {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "mcp_servers:" || yamlIndentWidth(line) != 0 {
+			continue
+		}
+		for _, next := range lines[i+1:] {
+			if strings.TrimSpace(next) == "" {
+				continue
+			}
+			if yamlIndentWidth(next) == 0 {
+				return "", false
+			}
+			return next[:len(next)-len(strings.TrimLeft(next, " \t"))], true
+		}
+		return "", false
+	}
+	return "", false
 }
 
 // setHermesPluginEnabled adds or removes deja from plugins.enabled, touching

--- a/cmd/deja/yaml_indent_readers_test.go
+++ b/cmd/deja/yaml_indent_readers_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 // The writers ask what indent a block uses; these two readers assumed two
@@ -119,5 +121,92 @@ func TestHermesUninstallTakesTheCommentsInsideItsBlock(t *testing.T) {
 	}
 	if !strings.Contains(got, "the reader's note") {
 		t.Errorf("the reader's own comment went with it:\n%s", got)
+	}
+}
+
+// deja's entry is a direct child of the block it belongs to. Reading `deja:`
+// at any depth emptied a server of somebody else's whose env holds a key by
+// that name — deja breaking a config while claiming to remove itself (#2730).
+func TestHermesUninstallLeavesAForeignKeyByThatNameAlone(t *testing.T) {
+	in := "mcp_servers:\n" +
+		"  other:\n    cmd: /o\n    env:\n      deja:\n        HOME: /x\n    enabled: true\n" +
+		"  third:\n    cmd: /t\n"
+	if got := removeHermesMCPBlock(in); got != in {
+		t.Errorf("a config with no deja server was rewritten:\nwant:\n%s\ngot:\n%s", in, got)
+	}
+}
+
+// And what doctor calls wired: the same key, in the same places.
+func TestDoctorDoesNotReadAMentionAsAWiredServer(t *testing.T) {
+	for _, c := range []struct{ name, body string }{
+		{"under another server's env", "mcp_servers:\n  other:\n    env:\n      deja:\n        x: 1\n"},
+		{"in an example under notes", "mcp_servers:\n  a:\n    cmd: /a\nnotes:\n  examples:\n    deja:\n      how: to wire it\n"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(c.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if doctorHermesWired(path) {
+				t.Errorf("hermes was called wired by a mention:\n%s", c.body)
+			}
+			if doctorGooseWired(path) {
+				t.Errorf("goose was called wired by a mention:\n%s", c.body)
+			}
+		})
+	}
+}
+
+// The writer wrote its entry at two spaces whatever the file used, so on a
+// config indented at three or four deja's entry landed shallower than its
+// siblings — and the uninstall then took those siblings with it (#2730).
+func TestHermesRoundTripsAtEveryIndent(t *testing.T) {
+	for _, c := range []struct{ name, indent string }{
+		{"one space", " "},
+		{"two spaces", "  "},
+		{"three spaces", "   "},
+		{"four spaces", "    "},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tmp := hermeticEnv(t)
+			t.Setenv("DEJA_HERMES_ROOT", filepath.Join(tmp, "hermes"))
+			path := filepath.Join(sources.HermesHome(), "config.yaml")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			before := "# hermes config\nmcp_servers:\n" +
+				c.indent + "before:\n" + c.indent + c.indent + "cmd: /b\n" +
+				c.indent + "after:\n" + c.indent + c.indent + "cmd: /a\n"
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := installHermesMCP("/opt/deja", false); err != nil {
+				t.Fatal(err)
+			}
+			wired, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range []string{"before:", "after:", "deja:", "/opt/deja"} {
+				if !strings.Contains(string(wired), want) {
+					t.Fatalf("%q is missing after the install:\n%s", want, wired)
+				}
+			}
+			if !strings.Contains(string(wired), c.indent+"deja:") {
+				t.Errorf("deja's entry was not written at the block's indent:\n%s", wired)
+			}
+
+			if _, err := installHermesMCP("/opt/deja", true); err != nil {
+				t.Fatal(err)
+			}
+			back, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(back) != before {
+				t.Errorf("the config did not come back:\nwas:\n%q\nnow:\n%q", before, back)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#2727 taught these readers to take the indent from the file, and two of them
then read too much: `deja uninstall hermes` emptied the env of a server that
happened to hold a key by that name, and doctor called a config wired because
`deja:` appeared under `notes:`.

Both are scoped to a direct child of `mcp_servers:` / `extensions:` now, at
that block's own indent. The writer takes the block's indent too, which is what
was destroying foreign servers on a four-space file, and hermes keeps the
file's final newline like the other writers.
