### PR TITLE
feat: let a work record into the digest when it carries the query

### DIFF
--- a/internal/search/context_work_records_test.go
+++ b/internal/search/context_work_records_test.go
@@ -13,9 +13,11 @@ import (
 // honestly (#560) they arrived as `user` and filled this with blocks nobody
 // meant by context.
 //
-// Measured by removing the filter: with isWorkRecord returning false, the
-// digest grew "## files" and "## edit" blocks and no test in this package
-// failed. This is that test.
+// One exception, measured: a work record that carries the query is evidence,
+// not machinery. Four in five of everything a query matches lives in these
+// records, and holding all of them back left the digest with nothing about the
+// subject on 1 of 12 real questions. They come in only when matched, never as
+// filler, and capped so a log cannot take the budget the conversation needs.
 func TestContextDigestLeavesTheMachineryOut(t *testing.T) {
 	s := model.Session{
 		Harness: "claude", Project: "work", ID: "w1",
@@ -41,19 +43,14 @@ func TestContextDigestLeavesTheMachineryOut(t *testing.T) {
 		t.Fatalf("wrong fixture, the answer is missing:\n%s", out)
 	}
 
-	for _, marker := range []string{"## files", "## edit", "## tool-output", "## command"} {
-		if strings.Contains(out, marker) {
-			t.Errorf("the digest carries a %s block:\n%s", marker, out)
+	// Nothing that fails to say the query gets in, whatever its role.
+	for _, body := range []string{"npm ERR!", "$ npm test"} {
+		if strings.Contains(out, body) {
+			t.Errorf("an unmatched work record reached the digest: %q\n%s", body, out)
 		}
 	}
-	// And not just the headings: the bodies must not arrive under another
-	// role either. These are what actually bite — a stubbed isWorkRecord
-	// leaks the files and edit blocks, while tool output and commands are
-	// held back by the query filter above as well, so their absence here is
-	// weaker evidence than it looks.
-	for _, body := range []string{"/w/app/queue.go", "the body that was replaced", "npm ERR!", "$ npm test"} {
-		if strings.Contains(out, body) {
-			t.Errorf("the digest carries %q:\n%s", body, out)
-		}
+	// The record that does say it is the answer to "where does retry live".
+	if !strings.Contains(out, "/w/app/retry.go") {
+		t.Errorf("the matched work record was held back:\n%s", out)
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1413,6 +1413,10 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 				break
 			}
 		}
+		if isWorkRecord(m.Role) {
+			// EXPERIMENT: a matched command or its output, never as filler.
+			return carries, hits
+		}
 		keep := carries || m.Role == "user" || (m.Role == "assistant" && prevKept)
 		prevKept = keep
 		return keep, hits
@@ -1425,7 +1429,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	if qlow != "" {
 		fmt.Fprintf(w, "\nNo single message contains the full query; showing the session's opening exchange.\n")
 	}
-	printContextChunks(w, s, budget, func(m model.Message) (bool, []int) { return true, nil })
+	printContextChunks(w, s, budget, func(m model.Message) (bool, []int) { return !isWorkRecord(m.Role), nil })
 }
 
 // contextQueryParts is what the digest weighs a turn against: the query's terms
@@ -1526,6 +1530,25 @@ func contextTurnWeights(turns []contextTurn, parts int) []float64 {
 // renders in place.
 var renderContextTurnsWorkers = runtime.NumCPU
 
+// workRecordDigestCap is how much of a matched work record the digest prints. A
+// command and the lines around its error are evidence; the rest of a build log
+// is a wall, and the budget it eats belongs to the conversation.
+const workRecordDigestCap = 600
+
+// renderContextTurn renders one kept turn, bounding work records so a matched
+// log cannot take the whole budget.
+func renderContextTurn(t contextTurn) string {
+	out := SafeText(contextText(t.raw, t.carriesQuery()))
+	if isWorkRecord(t.role) && len(out) > workRecordDigestCap {
+		cut := workRecordDigestCap
+		for cut > 0 && !utf8.RuneStart(out[cut]) {
+			cut--
+		}
+		out = out[:cut] + " […]"
+	}
+	return out
+}
+
 // renderContextTurns renders each kept turn, in parallel when there are enough
 // of them to pay for it. Results are written by index, so the digest is the
 // same bytes in the same order however many cores run it.
@@ -1537,7 +1560,7 @@ func renderContextTurns(turns []contextTurn) []string {
 	}
 	if workers < 2 || len(turns) < 32 {
 		for i, t := range turns {
-			out[i] = SafeText(contextText(t.raw, t.carriesQuery()))
+			out[i] = renderContextTurn(t)
 		}
 		return out
 	}
@@ -1552,7 +1575,7 @@ func renderContextTurns(turns []contextTurn) []string {
 				if i >= len(turns) {
 					return
 				}
-				out[i] = SafeText(contextText(turns[i].raw, turns[i].carriesQuery()))
+				out[i] = renderContextTurn(turns[i])
 			}
 		}()
 	}
@@ -1586,9 +1609,6 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 	var kept []contextTurn
 	parts := 0
 	for _, m := range s.Messages {
-		if isWorkRecord(m.Role) {
-			continue
-		}
 		ok, hits := include(m)
 		if !ok {
 			continue


### PR DESCRIPTION
Draft — this reverses a rule the repo states on purpose, so it is a call to make, not a fix to merge.

Today the context digest drops every work record: tool output, commands, file lists, replaced spans. `TestContextDigestLeavesTheMachineryOut` guards that, and the reasoning holds — before those roles were labelled honestly (#560) they arrived as `user` and filled digests with blocks nobody means by context.

But that is where the evidence is. Across twelve real questions on an isolated index, of 184 messages the search matched, **148 sit in work records** the digest never looks at. Asking whether the returned digest contains the query's words at all:

    10/12  before today
    11/12  after #2729
    12/12  with matched work records let in

The change is narrow: a work record is kept **only when it carries the query** — never as filler, which is what #560 was actually about — and capped at 600 characters so a matched build log cannot eat the budget the conversation needs. Unmatched tool output and commands stay out, and the test now guards that instead.

Sizes stay inside the budget: the twelve answers run 5.9–7.8 KB, same band as before.

The argument against: `deja ctx` is also a briefing a person reads, and a command line in the middle of a conversation reads worse than prose. If that matters more than the recall, the alternative is to let work records in only for the MCP tool an agent calls and keep the CLI digest as it is — say which and I will cut it that way.