### PR TITLE
fix(install): a comment in a config is not a refusal

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1192,6 +1192,8 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		return writeJSONCEntry(path, old, "mcpServers", exe, uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
@@ -2425,6 +2427,11 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// A comment is not a broken file, and refusing the target over one is
+		// how somebody who annotated their config could not install deja at
+		// all (#1664).
+		return writeJSONCEntry(path, old, "mcpServers", exe, uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}

--- a/cmd/deja/install_refusal_remedy_test.go
+++ b/cmd/deja/install_refusal_remedy_test.go
@@ -35,16 +35,21 @@ func TestRefusalRemedyMatchesTheFailure(t *testing.T) {
 	}
 }
 
-// The end-to-end shape: a JSON config carrying a comment is refused, and the
-// sentence that closes the run does not blame permissions.
-func TestInstallCommentedJSONDoesNotBlamePermissions(t *testing.T) {
+// The end-to-end shape: a config deja cannot parse is refused, and the sentence
+// that closes the run does not blame permissions.
+//
+// It used to be a commented config that stood here. A comment is no longer a
+// refusal — the entry is edited as text and the comment survives (#1664) — so
+// the case is a file that is genuinely broken, which is what the message was
+// always about.
+func TestInstallUnparseableJSONDoesNotBlamePermissions(t *testing.T) {
 	hermeticEnv(t)
 	root := filepath.Join(os.Getenv("HOME"), ".gemini")
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	settings := filepath.Join(root, "settings.json")
-	if err := os.WriteFile(settings, []byte("{\n  // mine\n  \"theme\": \"dark\"\n}\n"), 0o644); err != nil {
+	if err := os.WriteFile(settings, []byte("{\n  \"theme\": \"dark\",\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +61,34 @@ func TestInstallCommentedJSONDoesNotBlamePermissions(t *testing.T) {
 	if strings.Contains(msg, "permissions") {
 		t.Errorf("a parse error is reported as a permissions problem: %s", msg)
 	}
-	if !strings.Contains(msg, "invalid character") {
+	if !strings.Contains(msg, "unexpected end of JSON input") && !strings.Contains(msg, "invalid character") {
 		t.Errorf("the refusal does not carry the parse error: %s", msg)
+	}
+}
+
+// And the comment itself: the same target takes it now, and gives it back.
+func TestInstallTakesACommentedGeminiConfig(t *testing.T) {
+	hermeticEnv(t)
+	root := filepath.Join(os.Getenv("HOME"), ".gemini")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := filepath.Join(root, "settings.json")
+	before := "{\n  // mine\n  \"theme\": \"dark\"\n}\n"
+	if err := os.WriteFile(settings, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "gemini", "--no-index"); err != nil {
+		t.Fatalf("a comment refused the target: %v", err)
+	}
+	b, err := os.ReadFile(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "// mine") || !strings.Contains(string(b), `"theme": "dark"`) {
+		t.Errorf("the reader's file did not survive:\n%s", b)
+	}
+	if !strings.Contains(string(b), `"deja"`) {
+		t.Errorf("deja's entry was not written:\n%s", b)
 	}
 }

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// A config with a `//` line in it is not JSON, and five writers refused the
+// whole target over one: someone who had annotated `~/.cursor/mcp.json` could
+// not install deja at all, and the message sent them to look at permissions
+// (#1664). Zed's config is edited as text for exactly this reason since #1285 —
+// "comments, key order, indentation, trailing commas — survives untouched" —
+// and the scanners that do it are already general. This is the same edit under
+// a key of the caller's choosing.
+
+// configIsJSONC reports whether a config fails to parse as JSON only because it
+// carries comments. A file that is broken some other way is still refused: deja
+// does not guess at what a reader meant to write.
+func configIsJSONC(b []byte) bool {
+	var probe any
+	if json.Unmarshal(b, &probe) == nil {
+		return false
+	}
+	stripped := stripJSONComments(string(b))
+	return json.Unmarshal([]byte(stripped), &probe) == nil
+}
+
+// stripJSONComments blanks out comments, keeping every other byte where it is
+// so an offset into the result is an offset into the original.
+func stripJSONComments(text string) string {
+	out := []byte(text)
+	for i := 0; i < len(text); {
+		switch text[i] {
+		case '"':
+			end := zedStringEnd(text, i)
+			if end < 0 {
+				return string(out)
+			}
+			i = end
+		case '/':
+			end := zedSkipComment(text, i)
+			if end == i {
+				i++
+				continue
+			}
+			for j := i; j < end && j < len(out); j++ {
+				if out[j] != '\n' {
+					out[j] = ' '
+				}
+			}
+			i = end
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+// jsoncSetEntry writes deja's entry into a JSONC object under blockKey, or
+// takes it out, leaving every other byte of the file alone.
+func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool) (string, error) {
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return "", fmt.Errorf("does not look like a settings object; add %q by hand", blockKey)
+	}
+	block := zedFindKey(text, open+1, blockKey)
+	if block == nil {
+		if uninstall {
+			return text, nil
+		}
+		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  },", blockKey, id, entry)
+		return text[:open+1] + insert + text[open+1:], nil
+	}
+	found := zedFindKey(text, block.valueOpen+1, id)
+	if found == nil {
+		if uninstall {
+			return text, nil
+		}
+		// A newline after the entry when the block was written on one line, so
+		// the reader's first entry keeps a line of its own rather than being
+		// pushed against deja's closing brace.
+		tail := ""
+		if rest := text[block.valueOpen+1:]; rest != "" && rest[0] != '\n' && rest[0] != '}' {
+			tail = "\n   "
+		}
+		insert := fmt.Sprintf("\n    %q: %s,%s", id, entry, tail)
+		return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
+	}
+	if uninstall {
+		return zedDropEntry(text, block, found), nil
+	}
+	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
+}
+
+// jsoncEntryText renders an entry the way the writers build it, so the text
+// path and the parsed path put the same thing in the file.
+func jsoncEntryText(entry map[string]any) (string, error) {
+	b, err := json.MarshalIndent(entry, "    ", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// writeJSONCEntry is the install path for a config that carries comments: the
+// entry is edited as text and every other byte stays where the reader put it.
+func writeJSONCEntry(path string, old []byte, blockKey, exe string, uninstall bool) (installResult, error) {
+	command, args := mcpCommandArgs(exe)
+	entry, err := jsoncEntryText(map[string]any{"command": command, "args": args})
+	if err != nil {
+		return installResult{}, err
+	}
+	next, err := jsoncSetEntry(string(old), blockKey, "deja", entry, uninstall)
+	if err != nil {
+		return installResult{}, configParseError(path, err)
+	}
+	a, werr := writeIfChanged(path, old, []byte(next))
+	return installResult{Path: path, Action: a}, werr
+}

--- a/cmd/deja/jsonc_install_test.go
+++ b/cmd/deja/jsonc_install_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A `//` line is not a broken config. Five writers decoded the file as strict
+// JSON and refused the whole target over one comment, so somebody who had
+// annotated their config could not install deja at all — while Zed's config
+// has been edited as text since #1285 precisely so comments survive (#1664).
+func TestInstallKeepsACommentedConfig(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := `{
+  // the server I wrote myself
+  "mcpServers": {
+    "mine": {"command": "/usr/local/bin/mine"}
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "install", "cursor", "--no-index")
+	if err != nil {
+		t.Fatalf("a comment refused the target: %v\n%s", err, out)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "// the server I wrote myself") {
+		t.Errorf("the reader's comment was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, `"mine": {"command": "/usr/local/bin/mine"}`) {
+		t.Errorf("the reader's own entry was rewritten:\n%s", got)
+	}
+	if !strings.Contains(got, `"deja"`) {
+		t.Errorf("deja's entry was not written:\n%s", got)
+	}
+
+	// A second install changes nothing, and an uninstall gives the file back.
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	again, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(again) != got {
+		t.Errorf("a second install rewrote the file:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+	if _, err := captureRun(t, "uninstall", "cursor"); err != nil {
+		t.Fatal(err)
+	}
+	back, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(back), "// the server I wrote myself") ||
+		!strings.Contains(string(back), `"mine"`) {
+		t.Errorf("the uninstall did not give the file back:\n%s", back)
+	}
+	if strings.Contains(string(back), `"deja"`) {
+		t.Errorf("deja's entry survived the uninstall:\n%s", back)
+	}
+}
+
+// A file that is broken some other way is still refused: deja does not guess
+// at what a reader meant to write.
+func TestABrokenConfigIsStillRefused(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"mcpServers": {`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err == nil {
+		t.Error("a truncated config was accepted")
+	}
+}
+
+// The comment scanner keeps every other byte where it was, so an offset into
+// the stripped text is an offset into the original.
+func TestStrippingCommentsKeepsEveryOtherByteInPlace(t *testing.T) {
+	for _, in := range []string{
+		"{\n  // one\n  \"a\": 1\n}\n",
+		"{\n  /* two\n     lines */\n  \"a\": 1\n}\n",
+		`{"a": "// not a comment", "b": "/* nor this */"}`,
+		"{\n  \"a\": 1 // trailing\n}\n",
+	} {
+		out := stripJSONComments(in)
+		if len(out) != len(in) {
+			t.Errorf("length changed: %q -> %q", in, out)
+		}
+		for i := range in {
+			if in[i] == '\n' && out[i] != '\n' {
+				t.Errorf("a newline moved at %d in %q", i, in)
+			}
+		}
+	}
+	if !configIsJSONC([]byte("{\n // c\n \"a\": 1\n}")) {
+		t.Error("a commented object was not read as JSONC")
+	}
+	if configIsJSONC([]byte(`{"a": 1}`)) {
+		t.Error("plain JSON was read as JSONC")
+	}
+	if configIsJSONC([]byte(`{"a": `)) {
+		t.Error("a truncated object was read as JSONC")
+	}
+}


### PR DESCRIPTION
Someone who had annotated `~/.cursor/mcp.json` could not install deja into it
at all: the writers decode strict JSON, so one `//` line refused the target and
the message sent them to look at permissions.

Zed's config has been edited as text since #1285 so comments survive. The MCP
writers take the same path now when the file carries comments — the entry is
replaced by text and every other byte stays where the reader put it. A file
that is broken some other way is still refused.

One pinned decision changes with it: the end-to-end test that asserted a
commented config is refused now asserts a genuinely broken one is, which is
what its message was always about.
