### PR TITLE
fix: do not recall a bullet of a document as a session's decision

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -207,6 +207,52 @@ var shareStopwords = map[string]bool{
 	"это": true, "у": true, "с": true, "по": true, "а": true, "но": true,
 }
 
+// IsDocumentItem reports whether a line is one item of a document the agent
+// wrote rather than something it said about the work.
+//
+// A message can be a draft, a spec, a checklist — a text produced during the
+// session rather than a statement about it. Measured on a real store, the
+// session-start block recalled "- Keep responses concise by default; caveman
+// mode active: lite." to a later agent as a past decision; it is one bullet of
+// a 130-line specification the agent had just written. The prose around such a
+// document still describes the work and is left alone, and so is a short list
+// inside an ordinary reply — this asks that the message be mostly structure.
+func IsDocumentItem(message, line string) bool {
+	if !isStructureLine(line) {
+		return false
+	}
+	lines, marked := 0, 0
+	for _, l := range strings.Split(message, "\n") {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		lines++
+		if isStructureLine(l) {
+			marked++
+		}
+	}
+	return lines >= documentLines && marked*10 >= lines*documentShare
+}
+
+// documentLines is how long a message must be before its shape says anything.
+// A four-line reply with three bullets is a normal answer.
+const documentLines = 20
+
+// documentShare is how much of it must be structure, in tenths.
+const documentShare = 8
+
+func isStructureLine(l string) bool {
+	t := strings.TrimSpace(l)
+	if t == "" {
+		return false
+	}
+	switch t[0] {
+	case '-', '*', '#', '|', '+':
+		return true
+	}
+	return false
+}
+
 func looksLikeListingDump(line string) bool {
 	fields := strings.Fields(line)
 	if len(fields) < 8 {

--- a/internal/digest/document_item_test.go
+++ b/internal/digest/document_item_test.go
@@ -1,0 +1,43 @@
+package digest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A specification the agent wrote during the session is not a statement about
+// the session. One of its bullets was being recalled to a later agent as a past
+// decision.
+func TestDocumentItemIsNotWhatTheSessionConcluded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("## Goal\n")
+	b.WriteString("- Consolidate scattered AI work into one workspace\n")
+	b.WriteString("## Constraints & Preferences\n")
+	for i := range 30 {
+		fmt.Fprintf(&b, "- rule %d: keep responses concise by default\n", i)
+	}
+	spec := b.String()
+
+	if !IsDocumentItem(spec, "- rule 7: keep responses concise by default") {
+		t.Error("a bullet of a thirty-line specification was taken for a conclusion")
+	}
+	// The prose in the same message still describes the work.
+	if IsDocumentItem(spec, "Ниже — черновик правил, это будущий источник правды") {
+		t.Error("the prose introducing the document was dropped with it")
+	}
+
+	// An ordinary reply that happens to list three things is not a document.
+	reply := "Починил. Причина была в трёх местах:\n- gate\n- cache\n- hook\nПроверил на реальном сторе."
+	if IsDocumentItem(reply, "- gate") {
+		t.Error("a short list inside a normal answer was treated as a document")
+	}
+	// And a table row in a long table is structure like any other.
+	var tb strings.Builder
+	for i := range 25 {
+		fmt.Fprintf(&tb, "| bench%d | six fixed queries against a real index | median |\n", i)
+	}
+	if !IsDocumentItem(tb.String(), "| bench3 | six fixed queries against a real index | median |") {
+		t.Error("a row of a long table was taken for a conclusion")
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -546,6 +546,11 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		// shard later" and "we moved the shard to the region" are the same line
 		// to all of them. These markers are what the session-start digest
 		// already uses to tell one from the other.
+		// One bullet of a document the agent wrote is not what the session
+		// concluded, however well it matches (#2740).
+		if digest.IsDocumentItem(m.Text, line) {
+			continue
+		}
 		if digest.CarriesDecision(line) {
 			hits++
 		}


### PR DESCRIPTION
Closes #2740.

`matchedLines` picks the densest line of a message. A specification or rules draft the agent wrote during the session is dense in every line, so it kept winning — and "- Keep responses concise by default; caveman mode active: lite." reached a later agent as something a past session concluded.

The rule is structural, not another word list: a list item, heading or table row is skipped when the message it sits in is at least twenty lines and at least eight tenths structure. Prose in the same message is untouched, so the sentence introducing a draft still describes the work, and a three-bullet list inside a normal reply is not a document.

Found by reading a sample of what the markers promote (#2734): six of twenty-four lines were not conclusions, and three of those six — two guidance bullets and a benchmark table row — are this.

Evidence is the unit test and the sample reading; I have not measured an end-to-end change in block content, so I am not claiming one. The test fails when the shape check is stubbed out.