### PR TITLE
fix(install): the JSONC path decides like the parsed one

### DIFF
--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // A config with a `//` line in it is not JSON, and five writers refused the
@@ -58,7 +59,7 @@ func stripJSONComments(text string) string {
 
 // jsoncSetEntry writes deja's entry into a JSONC object under blockKey, or
 // takes it out, leaving every other byte of the file alone.
-func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool) (string, error) {
+func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) (string, error) {
 	open := zedTopLevelOpen(text)
 	if open < 0 {
 		return "", fmt.Errorf("does not look like a settings object; add %q by hand", blockKey)
@@ -83,11 +84,26 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool) (string, er
 		if rest := text[block.valueOpen+1:]; rest != "" && rest[0] != '\n' && rest[0] != '}' {
 			tail = "\n   "
 		}
-		insert := fmt.Sprintf("\n    %q: %s,%s", id, entry, tail)
+		// And no comma into an empty block: `{"deja": {…},}` is not JSON, and
+		// the file was then refused on every later run with a message pointing
+		// at the reader's comment (#2740).
+		comma := ","
+		if strings.TrimSpace(stripJSONComments(text[block.valueOpen+1:block.valueEnd-1])) == "" {
+			comma, tail = "", "\n  "
+		}
+		insert := fmt.Sprintf("\n    %q: %s%s%s", id, entry, comma, tail)
 		return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
 	}
 	if uninstall {
-		return zedDropEntry(text, block, found), nil
+		if dropBlock {
+			return zedDropEntry(text, block, found), nil
+		}
+		// The entry alone. zedDropEntry takes the block with the last entry in
+		// it, which is right for a block deja created and wrong for one the
+		// reader wrote — the rule #2604 and #2583 settled for the other
+		// writers (#2740).
+		cut := zedEntrySpan(text, found)
+		return text[:cut[0]] + text[cut[1]:], nil
 	}
 	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
 }
@@ -102,18 +118,75 @@ func jsoncEntryText(entry map[string]any) (string, error) {
 	return string(b), nil
 }
 
-// writeJSONCEntry is the install path for a config that carries comments: the
-// entry is edited as text and every other byte stays where the reader put it.
+// writeJSONCEntry is the install path for a config that carries comments.
+//
+// What to write is decided the same way as for a config without them — the
+// same block reader, the same merge onto an entry that is already there, the
+// same notes — and only the writing is done by text, so the reader's comments,
+// key order and formatting stay where they are. Deciding it twice is what left
+// this path dropping an env block, flipping `disabled`, writing a second entry
+// beside one under another name, and saying none of it (#2740).
 func writeJSONCEntry(path string, old []byte, blockKey, exe string, uninstall bool) (installResult, error) {
-	command, args := mcpCommandArgs(exe)
-	entry, err := jsoncEntryText(map[string]any{"command": command, "args": args})
+	text := string(old)
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(text)), &root); err != nil {
+		return installResult{}, configParseError(path, err)
+	}
+	// A key that is there but holds something else — null, a list, a string.
+	// mcpBlock reads null as "no block", which is right where the writer can
+	// replace the value; here the write is a text insert, so it would leave a
+	// second key of the same name with the reader's value winning (#2740).
+	if v, present := root[blockKey]; present {
+		if _, isObject := v.(map[string]any); !isObject {
+			if uninstall {
+				return installResult{Path: path, Action: "unchanged"}, nil
+			}
+			return installResult{}, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, blockKey)
+		}
+	}
+	m, _, err := mcpBlock(root, blockKey, path)
 	if err != nil {
+		// A block that is not an object is a config deja does not understand,
+		// and writing a second key of the same name would leave the reader's
+		// value winning and deja unwired (#2399).
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
 		return installResult{}, err
 	}
-	next, err := jsoncSetEntry(string(old), blockKey, "deja", entry, uninstall)
+	if m == nil {
+		if uninstall {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		m = map[string]any{}
+		noteBlockAdded(path, blockKey)
+	}
+	key := dejaEntryKey(m)
+	var note string
+	var next string
+	if uninstall {
+		delete(m, key)
+		removeAdoptedDejaEntries(path, blockKey, m)
+		note = leftDejaEntriesNote(m)
+		if len(m) == 0 && blockWasAdded(path, blockKey) {
+			forgetBlockAdded(path, blockKey)
+		}
+		next, err = jsoncSetEntry(text, blockKey, key, "", true, blockWasAdded(path, blockKey))
+	} else {
+		command, args := mcpCommandArgs(exe)
+		var merged map[string]any
+		merged, note = mergeDejaEntry(m[key], map[string]any{"command": command, "args": args})
+		note = withOtherDejaEntries(note, m, key)
+		var entry string
+		entry, err = jsoncEntryText(merged)
+		if err != nil {
+			return installResult{}, err
+		}
+		next, err = jsoncSetEntry(text, blockKey, key, entry, false, false)
+	}
 	if err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	a, werr := writeIfChanged(path, old, []byte(next))
-	return installResult{Path: path, Action: a}, werr
+	return installResult{Path: path, Action: a, Note: note}, werr
 }

--- a/cmd/deja/jsonc_install_test.go
+++ b/cmd/deja/jsonc_install_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,20 +94,40 @@ func TestABrokenConfigIsStillRefused(t *testing.T) {
 }
 
 // The comment scanner keeps every other byte where it was, so an offset into
-// the stripped text is an offset into the original.
-func TestStrippingCommentsKeepsEveryOtherByteInPlace(t *testing.T) {
+// the stripped text is an offset into the original — and it leaves strings
+// alone, or a config holding an https:// URL loses the rest of that line and
+// is refused again (#2740).
+func TestStrippingCommentsBlanksCommentsAndNothingElse(t *testing.T) {
+	// The strings deja must not touch, byte for byte.
+	for _, in := range []string{
+		`{"url": "https://example.com/x", "a": 1}`,
+		`{"a": "// not a comment"}`,
+		`{"a": "/* nor this */"}`,
+	} {
+		if got := stripJSONComments(in); got != in {
+			t.Errorf("a string was blanked:\n%q\n%q", in, got)
+		}
+	}
+	// And the comments, which go without moving anything else.
 	for _, in := range []string{
 		"{\n  // one\n  \"a\": 1\n}\n",
-		"{\n  /* two\n     lines */\n  \"a\": 1\n}\n",
-		`{"a": "// not a comment", "b": "/* nor this */"}`,
+		"{\n  /* two */ \"a\": 1\n}\n",
 		"{\n  \"a\": 1 // trailing\n}\n",
+		"{\n  /* over\n     two lines */\n  \"a\": 1\n}\n",
 	} {
-		out := stripJSONComments(in)
-		if len(out) != len(in) {
-			t.Errorf("length changed: %q -> %q", in, out)
+		got := stripJSONComments(in)
+		if len(got) != len(in) {
+			t.Errorf("length changed: %q -> %q", in, got)
+		}
+		if strings.Contains(got, "//") || strings.Contains(got, "/*") {
+			t.Errorf("a comment survived: %q -> %q", in, got)
+		}
+		var v any
+		if err := json.Unmarshal([]byte(got), &v); err != nil {
+			t.Errorf("what is left is not JSON: %v\n%q", err, got)
 		}
 		for i := range in {
-			if in[i] == '\n' && out[i] != '\n' {
+			if in[i] == '\n' && got[i] != '\n' {
 				t.Errorf("a newline moved at %d in %q", i, in)
 			}
 		}
@@ -119,5 +140,132 @@ func TestStrippingCommentsKeepsEveryOtherByteInPlace(t *testing.T) {
 	}
 	if configIsJSONC([]byte(`{"a": `)) {
 		t.Error("a truncated object was read as JSONC")
+	}
+}
+
+// An empty block took a comma it had nothing to separate, which is not JSON —
+// and the file was then refused on every later run, with a message pointing at
+// the reader's comment rather than at deja's own byte (#2740).
+func TestAnEmptyBlockDoesNotGetADanglingComma(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // mine\n  \"mcpServers\": {}\n}\n",
+		"{\n  // mine\n  \"mcpServers\": {\n  }\n}\n",
+	} {
+		hermeticEnv(t)
+		path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var root map[string]any
+		if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+			t.Errorf("the file deja wrote is not JSON: %v\n%s", err, b)
+		}
+		// And a second run still reads it.
+		if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+			t.Errorf("the file deja wrote refused the next install: %v\n%s", err, b)
+		}
+	}
+}
+
+// A block that is not an object is a config deja does not understand. Writing
+// a second key of the same name leaves the reader's value winning and deja
+// unwired, with "updated" printed over it (#2740, the shape #2399 settled).
+func TestANonObjectBlockIsRefusedNotDuplicated(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // mine\n  \"mcpServers\": null\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err == nil {
+		b, _ := os.ReadFile(path)
+		t.Errorf("a block deja cannot edit was accepted:\n%s", b)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != before {
+		t.Errorf("the file was rewritten anyway:\n%s", b)
+	}
+}
+
+// The entry deja finds is merged onto, not replaced: an env pointing at a
+// store on another disk and a `disabled` the reader set are theirs (#2479).
+func TestACommentedConfigKeepsTheFieldsOnDejasOwnEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := `{
+  // mine
+  "mcpServers": {
+    "deja": {"command": "/old/deja", "args": ["mcp"], "env": {"DEJA_INDEX_DIR": "/big/disk"}, "disabled": true}
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "install", "cursor", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "/big/disk") {
+		t.Errorf("the reader's env was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, `"disabled": true`) {
+		t.Errorf("a disabled entry was silently switched on:\n%s", got)
+	}
+	if !strings.Contains(out, "left the entry disabled") {
+		t.Errorf("nothing said the entry is still off:\n%s", out)
+	}
+}
+
+// And an entry deja wrote under another name is the entry it takes over, not
+// one to write a second server beside (#2269, #2712).
+func TestACommentedConfigDoesNotGetASecondDejaEntry(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // mine\n  \"mcpServers\": {\n    \"deja-vu\": {\"command\": \"/old/bin/deja\", \"args\": [\"mcp\"]}\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file is not JSON: %v\n%s", err, b)
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	if len(servers) != 1 {
+		t.Errorf("%d servers after the install, want the one deja took over:\n%s", len(servers), b)
 	}
 }


### PR DESCRIPTION
#2739 gave the MCP writers a text path for commented configs, and that path
decided what to write on its own. Four things followed, all measured:

- an empty block took a comma it had nothing to separate, so the file stopped
  being JSON and every later run of that target refused — pointing at the
  reader's comment;
- a `null` block got a second key of the same name, with the reader's value
  winning and "updated" printed over it;
- deja's own entry was replaced rather than merged, dropping an `env` and
  switching a `disabled` back on;
- an entry under another name got a second one beside it, and none of the
  notes about any of this printed.

It decides with the parsed helpers now — `mcpBlock`, `dejaEntryKey`,
`mergeDejaEntry`, the notes, the block provenance — and only writes by text.
