### PR TITLE
fix: a list marker needs a space after it

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -246,9 +246,21 @@ func isStructureLine(l string) bool {
 	if t == "" {
 		return false
 	}
-	switch t[0] {
-	case '-', '*', '#', '|', '+':
+	if t[0] == '|' {
 		return true
+	}
+	// The marker has to be followed by a space, or it is not a marker: a line
+	// opening in bold — "**1. caffeinate in a separate terminal**" — starts
+	// with an asterisk and is a sentence, and "-> then the retry fires" starts
+	// with a dash. Both were counted as structure by the first version of this,
+	// which is how a real conclusion could be mistaken for a list item.
+	rest := strings.TrimLeft(t, "#")
+	if len(rest) < len(t) {
+		return rest == "" || strings.HasPrefix(rest, " ")
+	}
+	switch t[0] {
+	case '-', '*', '+':
+		return strings.HasPrefix(t[1:], " ")
 	}
 	return false
 }

--- a/internal/digest/document_item_test.go
+++ b/internal/digest/document_item_test.go
@@ -41,3 +41,34 @@ func TestDocumentItemIsNotWhatTheSessionConcluded(t *testing.T) {
 		t.Error("a row of a long table was taken for a conclusion")
 	}
 }
+
+// A marker with no space after it is not a marker. Found by reading what the
+// document rule still skipped: a bold sentence opens with an asterisk and a
+// pointer opens with a dash, and counting either as structure lets a real
+// conclusion be dropped as a list item.
+func TestBoldAndArrowsAreNotStructure(t *testing.T) {
+	var b strings.Builder
+	for i := range 30 {
+		fmt.Fprintf(&b, "- rule %d: something the document says\n", i)
+	}
+	doc := b.String()
+
+	for _, line := range []string{
+		"**1. caffeinate — in a separate terminal** so it survives the session",
+		"-> the retry fires only after the second failure",
+		"#2740 is the issue this came from",
+	} {
+		if IsDocumentItem(doc, line) {
+			t.Errorf("a sentence was taken for a list item: %q", line)
+		}
+	}
+	for _, line := range []string{
+		"- rule 3: something the document says",
+		"## Constraints",
+		"| bench | queries | median |",
+	} {
+		if !IsDocumentItem(doc, line) {
+			t.Errorf("real structure went unrecognised: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #2741, found by reading the three document items that fix still skipped rather than by adding a threshold.

All three turned out to be legitimate conclusions, which is the guard working. But one of them was:

    **1. caffeinate — в ОТДЕЛЬНОМ терминале** (не в этом, чтоб жил независимо от Claude-сессии)

That is a sentence in bold, and `isStructureLine` looked only at the first byte, so an asterisk made it a list item. Inside a document-shaped message it would have been dropped as structure — a real conclusion lost to a markdown character.

Now a marker counts only when a space follows it, and `#` only when the run of hashes is followed by one. Table pipes are unchanged. `-> arrows` and `#2740` stop being structure too.

The test fails when the space requirement is removed.