### PR TITLE
fix(install): the switch writer edits only what it can read

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -624,10 +624,12 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		// without the tools: its own `gemini mcp list` said "No MCP servers
 		// configured" on a machine that had just run `deja install --auto`.
 		// grok-auto pairs them the same way.
-		if _, err := installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall); err != nil {
+		// Same file, same reason as qwen-auto: whichever half may refuse goes
+		// first (#2745).
+		if _, err := installGeminiAuto(exe, uninstall); err != nil {
 			return installResult{}, err
 		}
-		return installGeminiAuto(exe, uninstall)
+		return installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
 	case "antigravity":
 		return installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall)
 	case "antigravity-auto":
@@ -642,10 +644,14 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "qwen-auto":
-		if _, err := installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall); err != nil {
+		// The hook first: it lives in the same file as the MCP entry, and a
+		// refusal after the entry was written left the target reported as
+		// refused with half its wiring in the file and a .bak beside it
+		// (#2745, the shape #2744 was about).
+		if _, err := installQwenAuto(exe, uninstall); err != nil {
 			return installResult{}, err
 		}
-		return installQwenAuto(exe, uninstall)
+		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "kimi":
 		return installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall)
 	case "kimi-auto":

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -335,10 +335,29 @@ func installSettingsHookCmd(path, event, matcher string, timeout int, cmd string
 func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd string, uninstall bool, retire map[string]bool) (installResult, error) {
 	old, _ := os.ReadFile(path)
 	var root map[string]any
-	if len(bytes.TrimSpace(old)) == 0 {
+	// A settings file carrying comments cannot be rewritten without losing
+	// them, and a hook entry is an element in an event array rather than a key
+	// in an object, so the text path the MCP writers take does not reach here
+	// (#2744). What it can do is answer honestly: read the file with its
+	// comments blanked, and when there is nothing of deja's to change, say
+	// unchanged rather than refuse a file it was never going to touch.
+	jsonc := configIsJSONC(old)
+	source := old
+	if jsonc {
+		source = []byte(stripJSONComments(string(old)))
+	}
+	if len(bytes.TrimSpace(source)) == 0 {
 		root = map[string]any{}
-	} else if err := json.Unmarshal(old, &root); err != nil {
+	} else if err := json.Unmarshal(source, &root); err != nil {
 		return installResult{}, configParseError(path, err)
+	}
+	before := ""
+	if jsonc {
+		b, err := json.Marshal(root)
+		if err != nil {
+			return installResult{}, err
+		}
+		before = string(b)
 	}
 	hooks, _ := root["hooks"].(map[string]any)
 	if hooks == nil {
@@ -409,6 +428,18 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 	}
 	if len(hooks) == 0 {
 		delete(root, "hooks")
+	}
+	if jsonc {
+		after, err := json.Marshal(root)
+		if err != nil {
+			return installResult{}, err
+		}
+		if string(after) == before {
+			// Nothing of deja's here either way: leave the reader's comments
+			// where they are and report the truth.
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		return installResult{}, fmt.Errorf("%s: deja cannot edit hooks in a file that carries comments — add or remove the hook by hand, or take the comments out", path)
 	}
 	next, err := marshalConfigLike(old, root)
 	if err != nil {

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -105,7 +105,7 @@ func geminiHooksEnabled() bool {
 		return false
 	}
 	var root map[string]any
-	if err := json.Unmarshal(b, &root); err != nil {
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
 		return false
 	}
 	cfg, _ := root["hooksConfig"].(map[string]any)
@@ -121,6 +121,11 @@ func enableGeminiHooks() error {
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// The same file the MCP entry went into a moment ago. Refusing it here
+		// left the target reported as refused with half its wiring written and
+		// a .bak beside it (#2744).
+		return enableGeminiHooksJSONC(path, old)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return fmt.Errorf("gemini settings: %w", err)
 	}
@@ -138,5 +143,38 @@ func enableGeminiHooks() error {
 		return err
 	}
 	_, err = writeIfChanged(path, old, append(next, '\n'))
+	return err
+}
+
+// enableGeminiHooksJSONC is enableGeminiHooks for a settings file carrying
+// comments: the same decision, read from the file with its comments blanked,
+// and the switch written by text so everything else stays put.
+func enableGeminiHooksJSONC(path string, old []byte) error {
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(old))), &root); err != nil {
+		return fmt.Errorf("gemini settings: %w", err)
+	}
+	cfg, _ := root["hooksConfig"].(map[string]any)
+	if enabled, ok := cfg["enabled"].(bool); ok && enabled {
+		return nil
+	}
+	// A key holding something else — a list, a string, null. zedFindKey does
+	// not match those either, so the write would fall through to inserting a
+	// second `hooksConfig` and the reader's value would win (#2745, the shape
+	// #2740 closed for entries).
+	if v, present := root["hooksConfig"]; present && cfg == nil {
+		_ = v
+		return fmt.Errorf("gemini settings: %q is not an object deja can edit — left as it was", "hooksConfig")
+	}
+	if v, present := cfg["enabled"]; present {
+		if _, ok := v.(bool); !ok {
+			return fmt.Errorf("gemini settings: %q is not a switch deja can turn on — left as it was", "hooksConfig.enabled")
+		}
+	}
+	next, err := jsoncSetFlag(string(old), "hooksConfig", "enabled", true)
+	if err != nil {
+		return fmt.Errorf("gemini settings: %w", err)
+	}
+	_, err = writeIfChanged(path, old, []byte(next))
 	return err
 }

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -190,3 +190,109 @@ func writeJSONCEntry(path string, old []byte, blockKey, exe string, uninstall bo
 	a, werr := writeIfChanged(path, old, []byte(next))
 	return installResult{Path: path, Action: a, Note: note}, werr
 }
+
+// jsoncSetFlag turns a boolean setting on inside a block, in a config that
+// carries comments. The switch is one key deep — `hooksConfig.enabled` — and
+// it lives in the same file the MCP entry does, so refusing it there meant a
+// target that wrote half its wiring and then reported itself refused (#2744).
+func jsoncSetFlag(text, blockKey, key string, value bool) (string, error) {
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return "", fmt.Errorf("does not look like a settings object; set %q by hand", blockKey+"."+key)
+	}
+	rendered := "false"
+	if value {
+		rendered = "true"
+	}
+	block := zedFindKey(text, open+1, blockKey)
+	if block == nil {
+		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  },", blockKey, key, rendered)
+		return text[:open+1] + insert + text[open+1:], nil
+	}
+	if at := jsoncScalarValue(text, block, key); at != nil {
+		return text[:at[0]] + rendered + text[at[1]:], nil
+	}
+	tail := ""
+	if rest := text[block.valueOpen+1:]; rest != "" && rest[0] != '\n' && rest[0] != '}' {
+		tail = "\n   "
+	}
+	comma := ","
+	if strings.TrimSpace(stripJSONComments(text[block.valueOpen+1:block.valueEnd-1])) == "" {
+		comma, tail = "", "\n  "
+	}
+	insert := fmt.Sprintf("\n    %q: %s%s%s", key, rendered, comma, tail)
+	return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
+}
+
+// jsoncScalarValue is where a scalar setting's value sits inside a block, or
+// nil when the block does not have that key. Scalars, because zedFindKey looks
+// for an object and a switch is a bare `true`.
+func jsoncScalarValue(text string, block *zedSpan, key string) *[2]int {
+	want := `"` + key + `"`
+	depth := 0
+	for i := block.valueOpen + 1; i < block.valueEnd-1; i++ {
+		if j := zedSkipComment(text, i); j != i {
+			i = j - 1
+			continue
+		}
+		switch text[i] {
+		case '"':
+			end := zedStringEnd(text, i)
+			if end < 0 {
+				return nil
+			}
+			if depth == 0 && text[i:end] == want && jsoncIsKey(text, end) {
+				v := end
+				for v < len(text) && (text[v] == ' ' || text[v] == '\t' || text[v] == '\n' || text[v] == ':') {
+					v++
+				}
+				// A scalar, and only a scalar: an object or a list under this
+				// key would be spliced through the middle, leaving a file no
+				// parser reads and an install that said it worked (#2745).
+				if v >= block.valueEnd-1 || text[v] == '{' || text[v] == '[' {
+					return nil
+				}
+				stop := v
+				for stop < block.valueEnd-1 && text[stop] != ',' && text[stop] != '}' && text[stop] != '\n' {
+					// A comment after the value belongs to the reader, not to
+					// the value.
+					if text[stop] == '/' && zedSkipComment(text, stop) != stop {
+						break
+					}
+					stop++
+				}
+				for stop > v && (text[stop-1] == ' ' || text[stop-1] == '\t') {
+					stop--
+				}
+				span := [2]int{v, stop}
+				return &span
+			}
+			i = end - 1
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		}
+	}
+	return nil
+}
+
+// jsoncIsKey reports whether the string that ends at `end` is a key rather
+// than a value. A string value equal to the key's name is not the key, and
+// writing over it left `{"label": "enabled"true}` behind (#2745).
+func jsoncIsKey(text string, end int) bool {
+	for i := end; i < len(text); i++ {
+		if j := zedSkipComment(text, i); j != i {
+			i = j - 1
+			continue
+		}
+		switch text[i] {
+		case ' ', '\t', '\n', '\r':
+		case ':':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}

--- a/cmd/deja/jsonc_hooks_test.go
+++ b/cmd/deja/jsonc_hooks_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// gemini-auto wrote its MCP entry through the text path and then refused the
+// same file with a strict decode, so the target reported itself refused with
+// half its wiring written and a .bak beside it — worse than the plain refusal
+// it replaced (#2744).
+func TestGeminiAutoTakesACommentedSettingsFile(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.GeminiHome(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // my theme\n  \"theme\": \"dark\"\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := captureRun(t, "install", "gemini-auto", "--no-index"); err != nil {
+		t.Fatalf("a comment refused the target: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "// my theme") || !strings.Contains(got, `"theme": "dark"`) {
+		t.Errorf("the reader's file did not survive:\n%s", got)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(got)), &root); err != nil {
+		t.Fatalf("what deja wrote is not JSON: %v\n%s", err, got)
+	}
+	if _, ok := root["mcpServers"].(map[string]any)["deja"]; !ok {
+		t.Errorf("the server was not written:\n%s", got)
+	}
+	cfg, _ := root["hooksConfig"].(map[string]any)
+	if enabled, _ := cfg["enabled"].(bool); !enabled {
+		t.Errorf("the hook switch was not turned on:\n%s", got)
+	}
+}
+
+// The switch on a file that already has it, and on one whose block is written
+// at another shape: deja reads what is there rather than writing a second key.
+func TestTheGeminiHookSwitchReadsWhatIsThere(t *testing.T) {
+	for _, c := range []struct {
+		name, before string
+		wantWrite    bool
+	}{
+		{"already on", "{\n  // c\n  \"hooksConfig\": {\"enabled\": true}\n}\n", false},
+		{"turned off by hand", "{\n  // c\n  \"hooksConfig\": {\"enabled\": false}\n}\n", true},
+		{"a block with other keys", "{\n  // c\n  \"hooksConfig\": {\"timeout\": 5}\n}\n", true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.GeminiHome(), "settings.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(c.before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := enableGeminiHooks(); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := string(b)
+			if !strings.Contains(got, "// c") {
+				t.Errorf("the comment was dropped:\n%s", got)
+			}
+			var root map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(got)), &root); err != nil {
+				t.Fatalf("not JSON after the switch: %v\n%s", err, got)
+			}
+			cfg, _ := root["hooksConfig"].(map[string]any)
+			if enabled, _ := cfg["enabled"].(bool); !enabled {
+				t.Errorf("the switch is not on:\n%s", got)
+			}
+			if !c.wantWrite && got != c.before {
+				t.Errorf("a file that was already right was rewritten:\n%s", got)
+			}
+			if c.name == "a block with other keys" {
+				if _, ok := cfg["timeout"]; !ok {
+					t.Errorf("the reader's own key in that block was dropped:\n%s", got)
+				}
+			}
+		})
+	}
+}
+
+// And the hook writers that cannot edit a commented file say so, without
+// touching it — and say nothing at all when there was nothing of deja's in it
+// to change.
+func TestASettingsHookOnACommentedFileIsHonest(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.QwenConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // mine\n  \"theme\": \"dark\"\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Removing a hook that is not there changes nothing, so there is nothing
+	// to refuse.
+	r, err := installSettingsHook(path, "BeforeAgent", "", 10000, "/opt/deja", true)
+	if err != nil {
+		t.Fatalf("removing a hook that is not there was refused: %v", err)
+	}
+	if r.Action != "unchanged" {
+		t.Errorf("action is %q, want unchanged", r.Action)
+	}
+
+	// Writing one cannot be done without losing the comments, and says so.
+	if _, err := installSettingsHook(path, "UserPromptSubmit", "", 60000, "/opt/deja", false); err == nil {
+		t.Error("a hook was written into a file deja cannot rewrite")
+	} else if !strings.Contains(err.Error(), "carries comments") {
+		t.Errorf("the refusal does not say why: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != before {
+		t.Errorf("the file was touched anyway:\n%s", b)
+	}
+}
+
+// The shapes that made the flag writer splice through the middle of a value,
+// each one leaving a file no parser reads while install said it worked
+// (#2745).
+func TestTheFlagWriterRefusesWhatItCannotEdit(t *testing.T) {
+	for _, c := range []struct{ name, in string }{
+		{"a string value that reads like the key", `{"hooksConfig": {"label": "enabled", "timeout": 5}}`},
+		{"a value that is an object", `{"hooksConfig": {"enabled": {"deep": true}}}`},
+		{"a value that is a list", `{"hooksConfig": {"enabled": [1, 2]}}`},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := jsoncSetFlag(c.in, "hooksConfig", "enabled", true)
+			if err != nil {
+				return // refusing is an answer
+			}
+			var v any
+			if e := json.Unmarshal([]byte(stripJSONComments(out)), &v); e != nil {
+				t.Errorf("what it wrote is not JSON: %v\n%s", e, out)
+			}
+		})
+	}
+}
+
+// A block holding something else gets no second key of its own name: the
+// reader's value would win and the switch would read back off (#2745).
+func TestTheGeminiSwitchRefusesABlockItCannotEdit(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // c\n  \"hooksConfig\": null\n}\n",
+		"{\n  // c\n  \"hooksConfig\": [1]\n}\n",
+		"{\n  // c\n  \"hooksConfig\": {\"enabled\": [1]}\n}\n",
+	} {
+		hermeticEnv(t)
+		path := filepath.Join(sources.GeminiHome(), "settings.json")
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := enableGeminiHooks(); err == nil {
+			b, _ := os.ReadFile(path)
+			t.Errorf("a block deja cannot edit was accepted:\n%s", b)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(b) != before {
+			t.Errorf("the file was written anyway:\n%s", b)
+		}
+	}
+}
+
+// A comment after the value is the reader's, and the only byte the text path
+// was still eating.
+func TestTheFlagWriterKeepsACommentAfterTheValue(t *testing.T) {
+	in := "{\n  \"hooksConfig\": {\n    \"enabled\": false // off on purpose\n  }\n}\n"
+	out, err := jsoncSetFlag(in, "hooksConfig", "enabled", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "// off on purpose") {
+		t.Errorf("the comment was eaten:\n%s", out)
+	}
+	if !strings.Contains(out, "\"enabled\": true") {
+		t.Errorf("the switch was not turned on:\n%s", out)
+	}
+}
+
+// And the half-write: the hook half of a target goes first when it shares a
+// file with the MCP entry, so a refusal leaves the file as it was (#2745).
+func TestQwenAutoDoesNotWriteHalfItsWiringIntoACommentedFile(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.QwenConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // mine\n  \"theme\": \"dark\"\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "qwen-auto", "--no-index"); err == nil {
+		t.Fatal("a hook deja cannot write was reported as installed")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != before {
+		t.Errorf("the file was written before the refusal:\n%s", b)
+	}
+	if _, err := os.Stat(path + ".bak"); err == nil {
+		t.Errorf("a snapshot was left beside a file that was never changed")
+	}
+}


### PR DESCRIPTION
`gemini-auto` wrote its MCP entry through the text path and then refused the
same file with a strict decode: the target reported itself refused with half
its wiring written and a `.bak` beside it.

Both halves take the commented file now. Writing the switch by text needed
three guards, each of which was producing an unreadable file while install said
it worked: a string value that reads like the key is not the key, a value that
is not a scalar is refused rather than spliced through, and a `null` block is
refused rather than shadowed by a second key of the same name.

qwen-auto and gemini-auto also run the hook half first, since it shares a file
with the entry, so a refusal leaves the file exactly as it was.
