### PR TITLE
fix: take out a hook line deja wrote for a subcommand it no longer has

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1335,6 +1335,67 @@ const (
 	hookWrapsDejas
 )
 
+// retiredDejaHook reports whether a command line is deja's own, calling a hook
+// this build no longer has: `<binary> hook-something` and nothing else.
+//
+// The writers recognise the subcommand they are installing and nothing else, so
+// a line deja wrote under a name that has since gone was invisible to them. It
+// sat beside the new one and ran on every session start forever, and since the
+// build has no such command it did nothing but cost a process (#2719).
+//
+// Deja's own line only. A wrapper someone built around a hook is theirs, and so
+// is a line with anything else on it.
+func retiredDejaHook(existing any) bool {
+	s, ok := existing.(string)
+	if !ok {
+		return false
+	}
+	fields := strings.Fields(s)
+	if len(fields) != 2 || !strings.HasPrefix(fields[1], "hook-") {
+		return false
+	}
+	// The whole field has to be the name and nothing else. A reader's line can
+	// end in a redirect — deja hook-context>>/tmp/deja.log — which splits the
+	// same way and is theirs to keep.
+	for _, r := range fields[1] {
+		if (r < 'a' || r > 'z') && r != '-' {
+			return false
+		}
+	}
+	if !isDejaBinaryToken(fields[0]) {
+		return false
+	}
+	if hookNames[fields[1]] {
+		return false
+	}
+	// A name that merely extends one of ours is not ours: `hook-context-extra`
+	// is somebody else's subcommand that happens to start like deja's, and
+	// TestALongerSubcommandIsNotOurs has held that line since before this.
+	for name := range hookNames {
+		if strings.HasPrefix(fields[1], name) {
+			return false
+		}
+	}
+	return true
+}
+
+// hookNames is every hook subcommand this build has. Written out rather than
+// derived from the dispatch table, which cannot be read from here without an
+// initialisation cycle; TestHookNamesMatchTheDispatchTable is what keeps the
+// two from drifting, the same arrangement helpHidden uses.
+var hookNames = map[string]bool{
+	"hook-antigravity":  true,
+	"hook-context":      true,
+	"hook-goose":        true,
+	"hook-goose-prompt": true,
+	"hook-plan":         true,
+	"hook-precompact":   true,
+	"hook-prompt":       true,
+	"hook-refresh":      true,
+	"hook-tool":         true,
+	"hook-tool-after":   true,
+}
+
 func hookCommandKindOf(existing any, cmd string) hookCommandKind {
 	s, ok := existing.(string)
 	if !ok || s == "" {
@@ -1442,6 +1503,12 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 			h, _ := hAny.(map[string]any)
 			kind := hookNotDejas
 			if h != nil && h["type"] == "command" {
+				// A line of ours calling a hook this build dropped is not a
+				// third-party entry to leave alone; it is ours to take out.
+				if retiredDejaHook(h["command"]) {
+					removed = true
+					continue
+				}
 				kind = hookCommandKindOf(h["command"], cmd)
 			}
 			if kind == hookWrapsDejas {

--- a/cmd/deja/retired_hook_test.go
+++ b/cmd/deja/retired_hook_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// hookNames is written out because the dispatch table cannot be read from
+// install.go without an initialisation cycle. This is what stops the two from
+// drifting: a hook added or retired without touching the list fails here.
+func TestHookNamesMatchTheDispatchTable(t *testing.T) {
+	for name := range commands {
+		if !strings.HasPrefix(name, "hook-") {
+			continue
+		}
+		if !hookNames[name] {
+			t.Errorf("%s is a hook this build has and hookNames does not list it", name)
+		}
+	}
+	for name := range hookNames {
+		if _, ok := commands[name]; !ok {
+			t.Errorf("hookNames lists %s, which this build does not have", name)
+		}
+	}
+}
+
+// A line deja wrote under a hook name that has since gone sat beside the new
+// one and ran on every session start, doing nothing but costing a process.
+func TestInstallRemovesItsOwnRetiredHookLine(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"hooks":{"SessionStart":[{"hooks":[` +
+		`{"type":"command","command":"/old/bin/deja hook-session"},` +
+		`{"type":"command","command":"/usr/bin/env myown-wrapper deja hook-session"}` +
+		`]}]}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := captureRun(t, "install", "claude-auto", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if strings.Contains(got, "/old/bin/deja hook-session") {
+		t.Errorf("deja's own retired hook line survived the repair:\n%s", got)
+	}
+	// Somebody else's wrapper is theirs, whatever it calls.
+	if !strings.Contains(got, "myown-wrapper") {
+		t.Errorf("a line deja did not write was removed:\n%s", got)
+	}
+	// And the repair still wired what this build does have.
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "hook-context") {
+		t.Errorf("the current session-start hook was not written:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #2719.

The hook writers recognise the subcommand they are installing and nothing else, so a line an older deja wrote under a name that has since gone was invisible to the repair. It sat beside the new entry and ran on every session start, doing nothing but costing a process.

Deja's own line only — `<binary> <hook-name>` and nothing more. Three guards, each of which a test in the repo already wanted:

- a redirect keeps the line: `deja hook-context>>/tmp/deja.log` splits into two fields the same way and is the reader's.
- a wrapper keeps the line: anything else on it makes it theirs.
- a name that merely extends one of ours keeps the line: `hook-context-extra` is somebody else's subcommand, which `TestALongerSubcommandIsNotOurs` has held since before this.

The list of hook names is written out in install.go rather than read from the dispatch table, which cannot be reached from there without an initialisation cycle. `TestHookNamesMatchTheDispatchTable` compares the two in both directions, the same arrangement `helpHidden` uses.

Scope worth stating: the sweep happens while writing each event, so it reaches a stale line under an event this build still writes — which is where deja's own lines are. A line under an event deja no longer writes at all would not be visited.

The test fails when the check is stubbed out.