### PR TITLE
fix: write into an mcp block that opens and closes on one line

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -2737,6 +2738,10 @@ func jsoncBraceDelta(code string) int {
 	return depth
 }
 
+// emptyJSONCBlockRE matches an "mcp" block with nothing in it, however the
+// reader spaced the braces.
+var emptyJSONCBlockRE = regexp.MustCompile(`"mcp"\s*:\s*\{\s*\}`)
+
 func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string, error) {
 	line := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
 	s := string(old)
@@ -2748,6 +2753,7 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 	}
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	start, end := -1, -1
+	sameLine := false
 	inBlock := false
 	for i, l := range lines {
 		code, next, _ := jsoncCodeOf(l, inBlock)
@@ -2755,6 +2761,15 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		if strings.Contains(code, `"mcp"`) && strings.Contains(code, "{") {
 			start = i
 			depth := jsoncBraceDelta(code)
+			if depth <= 0 {
+				// The block opens and closes on the line that names it. There
+				// are no lines between the braces to insert between, and the
+				// general path below wrote the entry after the block instead —
+				// outside it, and leaving a file no parser would read (#2742).
+				sameLine = true
+				end = i
+				break
+			}
 			block := inBlock
 			for j := i + 1; j < len(lines); j++ {
 				c, nb, _ := jsoncCodeOf(lines[j], block)
@@ -2767,6 +2782,24 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 			}
 			break
 		}
+	}
+	if sameLine && !uninstall {
+		code, _, _ := jsoncCodeOf(lines[start], false)
+		// Only an empty one. A block with entries already on that line is a
+		// shape this text path cannot edit safely, and the refusal below says
+		// so rather than guessing where the commas go.
+		if !emptyJSONCBlockRE.MatchString(code) {
+			return nil, "", fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
+		}
+		indent := lines[start][:len(lines[start])-len(strings.TrimLeft(lines[start], " \t"))]
+		at := strings.LastIndex(lines[start], "{")
+		head := lines[start][:at+1]
+		tail := lines[start][at+1:]
+		tail = strings.Replace(tail, "}", "", 1)
+		out := append([]string{}, lines[:start]...)
+		out = append(out, head, line, indent+"}"+tail)
+		out = append(out, lines[start+1:]...)
+		return []byte(strings.Join(out, "\n") + "\n"), "", nil
 	}
 	if start >= 0 && end > start {
 		// The lines this drops are the entry that was already here. Naming what

--- a/cmd/deja/jsonc_empty_block_test.go
+++ b/cmd/deja/jsonc_empty_block_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Writing into a commented config whose mcp block is empty must leave a file a
+// parser still reads. A comma after the only entry made it invalid JSON, and
+// every later run then refused, blaming the reader's comment for deja's byte
+// (#2742).
+func TestJSONCEmptyBlockStaysParseable(t *testing.T) {
+	seed := "{ // hi\n  \"mcp\": {}\n}\n"
+	out, _, err := updateOpencodeJSONC([]byte(seed), "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "deja") {
+		t.Fatalf("the entry was not written:\n%s", got)
+	}
+	if !strings.Contains(got, "// hi") {
+		t.Errorf("the reader's comment was lost:\n%s", got)
+	}
+	// Strip the line comments the way a jsonc reader would, then parse.
+	var body []string
+	for _, l := range strings.Split(got, "\n") {
+		if i := strings.Index(l, "//"); i >= 0 {
+			l = l[:i]
+		}
+		body = append(body, l)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(strings.Join(body, "\n")), &root); err != nil {
+		t.Fatalf("deja left the config unparseable (%v):\n%s", err, got)
+	}
+	mcp, _ := root["mcp"].(map[string]any)
+	if _, ok := mcp["deja"]; !ok {
+		t.Errorf("the entry is not in the mcp block:\n%s", got)
+	}
+}


### PR DESCRIPTION
First of the divergences in #2742, and the one that leaves the config broken. Does not close the issue — the other three are untouched.

The reported symptom was a dangling comma. What actually happens on main is different, so the test is written against the real behaviour:

    { // hi
      "mcp": {}
        "deja": {"type":"local","command":["/bin/deja","mcp"]}
    }

`"mcp": {}` opens and closes on the line that names it, so there are no lines between the braces. The text path inserted after the block instead — outside it — and the result is not JSON, so every later run of that target refuses and blames the reader's comment for deja's byte.

Now that shape is recognised and the line is expanded into three, keeping the reader's comment and whatever else sits after the closing brace. Only when the block is empty: one already holding entries on that line is a shape this path cannot edit safely, and it takes the existing refusal rather than guessing where the commas go.

The test parses the result the way a jsonc reader would and checks deja is inside the block, not merely present. It fails on main.