### PR TITLE
fix(install): refuse a config deja cannot read instead of writing over it

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -707,6 +707,11 @@ func restoreReplacedFile(path string, ours func([]byte) bool) (bool, error) {
 	if ours(b) {
 		return false, os.Remove(bak)
 	}
+	// The one write that does not go through writeIfChanged: a file deja
+	// cannot read is not one to put the snapshot back over (#2751).
+	if _, err := readConfig(path); err != nil {
+		return false, err
+	}
 	if err := os.WriteFile(path, b, 0o644); err != nil {
 		return false, err
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -161,9 +161,6 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	}
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
-		if err == nil {
-			err = configWasReadable(r.Path)
-		}
 		if err != nil {
 			note(t, err)
 			continue
@@ -1075,34 +1072,28 @@ func matchFinalNewline(old, next []byte) []byte {
 	return bytes.TrimSuffix(next, []byte("\r"))
 }
 
-// configWasReadable refuses a target whose config could not be read.
+// readConfig reads a config a writer is about to edit.
 //
-// The writers read the old config with `old, _ := os.ReadFile`, and an
-// unreadable file is empty to all of them. writeIfChanged refuses before it
-// writes over one, but a writer that decides there is nothing to do never gets
-// that far: `uninstall cursor` found no entry to remove and reported the target
-// unwired while its config still named deja (#2751).
-func configWasReadable(path string) error {
-	if path == "" {
-		return nil
+// Every writer used to read it with `old, _ := os.ReadFile`, so a file that
+// exists but cannot be read was empty to all of them and deja wrote a config
+// holding only deja over it. A file that is not there is still empty — that is
+// the ordinary first install — but anything else is the reader's config, and
+// deja cannot edit what it cannot read (#2751).
+func readConfig(path string) ([]byte, error) {
+	b, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	return f.Close()
+	return b, nil
 }
 
 func writeIfChanged(path string, old, next []byte) (string, error) {
-	// Every writer reads the old config with `old, _ := os.ReadFile`, so a
-	// file that exists but cannot be read arrived here as an empty one and was
-	// written over with a config holding deja and nothing else. backupOnce
-	// used to catch it by reading the file itself — but it takes one snapshot
-	// per file and returns early once a `.bak` is beside it, which is the
-	// ordinary state after any earlier install (#2751).
+	// The last guard for a file deja could not read: the writers go through
+	// readConfig now, but this also covers the ones that write a file they
+	// never read. An unreadable config used to be an empty one here, and
+	// backupOnce hid it — it takes one snapshot per file and returns early
+	// once a `.bak` is beside it, which is the ordinary state after any
+	// earlier install (#2751).
 	if f, err := os.Open(path); err == nil {
 		_ = f.Close()
 	} else if !os.IsNotExist(err) {
@@ -1246,7 +1237,10 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 
 func installClaude(exe string, uninstall bool) (installResult, error) {
 	path := sources.ClaudeJSONPath()
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -1332,7 +1326,10 @@ var claudeHookWiring = []struct{ Event, Sub, Matcher string }{
 
 func installClaudeHook(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
@@ -1580,7 +1577,10 @@ func combinedStatusline(existing, exe string) string {
 // ccstatusline or their own script) — printing how to combine instead.
 func installStatusline(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
@@ -1670,7 +1670,10 @@ type tomlMCPBlock struct {
 }
 
 func installTOML(path, block string, uninstall bool) (installResult, error) {
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	text := lfText(old)
 	blocks := tomlMCPBlocks(text)
 	hasDeja := false
@@ -2362,7 +2365,10 @@ func installCursor(exe string, uninstall bool) (installResult, error) {
 // mcpServers shape: entries carry a type and an enabled-tools list.
 func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.Home(), ".copilot", "mcp-config.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -2420,7 +2426,10 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 // servers under mcp.servers, not the common mcpServers root.
 func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -2481,7 +2490,10 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 }
 
 func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
@@ -2548,10 +2560,12 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 			path = filepath.Join(dir, "opencode.jsonc")
 		}
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var next []byte
 	var note string
-	var err error
 	if strings.HasSuffix(path, ".jsonc") {
 		next, note, err = updateOpencodeJSONC(old, exe, uninstall)
 	} else {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -161,6 +161,9 @@ func runInstall(dir string, args []string, uninstall bool) error {
 	}
 	for _, t := range targets {
 		r, err := installTarget(t, exe, uninstall)
+		if err == nil {
+			err = configWasReadable(r.Path)
+		}
 		if err != nil {
 			note(t, err)
 			continue
@@ -1072,7 +1075,39 @@ func matchFinalNewline(old, next []byte) []byte {
 	return bytes.TrimSuffix(next, []byte("\r"))
 }
 
+// configWasReadable refuses a target whose config could not be read.
+//
+// The writers read the old config with `old, _ := os.ReadFile`, and an
+// unreadable file is empty to all of them. writeIfChanged refuses before it
+// writes over one, but a writer that decides there is nothing to do never gets
+// that far: `uninstall cursor` found no entry to remove and reported the target
+// unwired while its config still named deja (#2751).
+func configWasReadable(path string) error {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return f.Close()
+}
+
 func writeIfChanged(path string, old, next []byte) (string, error) {
+	// Every writer reads the old config with `old, _ := os.ReadFile`, so a
+	// file that exists but cannot be read arrived here as an empty one and was
+	// written over with a config holding deja and nothing else. backupOnce
+	// used to catch it by reading the file itself — but it takes one snapshot
+	// per file and returns early once a `.bak` is beside it, which is the
+	// ordinary state after any earlier install (#2751).
+	if f, err := os.Open(path); err == nil {
+		_ = f.Close()
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
 	// Before the comparison, not after: a CRLF config converted afterwards
 	// would differ from `old` on every run, so each repeat install would
 	// rewrite the file and report it changed.

--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -130,8 +130,11 @@ func refreshAiderContext(dir string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	old, _ := os.ReadFile(path)
-	_, err := writeIfChanged(path, old, []byte(body))
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
+	_, err = writeIfChanged(path, old, []byte(body))
 	return err
 }
 

--- a/cmd/deja/install_antigravity.go
+++ b/cmd/deja/install_antigravity.go
@@ -46,12 +46,18 @@ func installAntigravityPlugin(exe string, uninstall bool) (installResult, error)
 	}
 	manifest = append(manifest, '\n')
 	manifestPath := filepath.Join(dir, "plugin.json")
-	oldManifest, _ := os.ReadFile(manifestPath)
+	oldManifest, err := readConfig(manifestPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeIfChanged(manifestPath, oldManifest, manifest); err != nil {
 		return installResult{}, err
 	}
 	hooksPath := filepath.Join(dir, "hooks.json")
-	oldHooks, _ := os.ReadFile(hooksPath)
+	oldHooks, err := readConfig(hooksPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	next, err := json.MarshalIndent(map[string]any{
 		"deja-recall": map[string]any{
 			"PreInvocation": []any{map[string]any{

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -39,7 +39,10 @@ func installCodexHooks(exe string, uninstall bool) (installResult, error) {
 	// codex home gets its hooks written where codex actually reads them. Every
 	// other codex path already goes through it (e.g. doctor.go). See #850.
 	path := filepath.Join(sources.CodexHome(), "hooks.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
@@ -153,7 +156,10 @@ func installOpencodePlugin(exe string, uninstall bool) (installResult, error) {
 		}
 		return installResult{Path: path, Action: "removed"}, nil
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	next := []byte(opencodePluginJS(exe))
 	a, err := writeIfChanged(path, old, next)
 	return installResult{Path: path, Action: a}, err
@@ -333,7 +339,10 @@ func installSettingsHookCmd(path, event, matcher string, timeout int, cmd string
 // no longer uses. Without it a generator fix ships and the old, dead entry
 // keeps firing next to the new one for everyone who installed before.
 func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd string, uninstall bool, retire map[string]bool) (installResult, error) {
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	// A settings file carrying comments cannot be rewritten without losing
 	// them, and a hook entry is an element in an event array rather than a key
@@ -465,7 +474,10 @@ const kimiHookMarker = "# deja: auto-recall (managed by `deja install kimi-auto`
 // this look like a harness that cannot take context at all.
 func installKimiAuto(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.KimiConfigDir(), "config.toml")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	s := strings.TrimRight(removeKimiHookBlock(lfText(old)), "\n")
 	if !uninstall {
 		block := kimiHookMarker + "\n[[hooks]]\nevent = \"UserPromptSubmit\"\ncommand = " +

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -38,7 +38,10 @@ func installClineAuto(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return installResult{}, err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(path, old, []byte(clinePluginJS(exe)))
 	if err != nil {
 		return installResult{}, err
@@ -52,7 +55,10 @@ func installClineAuto(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(skill, 0o755); err != nil {
 		return installResult{}, err
 	}
-	oldSkill, _ := os.ReadFile(filepath.Join(skill, "SKILL.md"))
+	oldSkill, err := readConfig(filepath.Join(skill, "SKILL.md"))
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeGuidanceFile(filepath.Join(skill, "SKILL.md"), oldSkill, []byte(skillFile(skillBody))); err != nil {
 		return installResult{}, err
 	}

--- a/cmd/deja/install_command_files.go
+++ b/cmd/deja/install_command_files.go
@@ -138,7 +138,10 @@ func installCommandFile(harness, exe string, uninstall bool) (installResult, err
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return installResult{}, err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(path, old, []byte(commandFileText(harness, exe)))
 	return installResult{Path: path, Action: a}, err
 }

--- a/cmd/deja/install_commands.go
+++ b/cmd/deja/install_commands.go
@@ -26,7 +26,10 @@ func installClaudeCommands(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return installResult{}, err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(path, old, []byte(claudeCommandMD(exe)))
 	if err != nil {
 		return installResult{}, err

--- a/cmd/deja/install_cursor.go
+++ b/cmd/deja/install_cursor.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"path/filepath"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -19,7 +18,10 @@ import (
 // with both installed still gets one injection, not two.
 func installCursorHooks(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.CursorCLIHome(), "hooks.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}

--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -339,13 +339,19 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 	if err := os.MkdirAll(filepath.Dir(cmdPath), 0o755); err != nil {
 		return installResult{}, err
 	}
-	oldCmd, _ := os.ReadFile(cmdPath)
+	oldCmd, err := readConfig(cmdPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeIfChanged(cmdPath, oldCmd, []byte(dshCommandJS(exe))); err != nil {
 		return installResult{}, err
 	}
 	if withAuto {
 		autoPath := dshAutoPath()
-		oldAuto, _ := os.ReadFile(autoPath)
+		oldAuto, err := readConfig(autoPath)
+		if err != nil {
+			return installResult{}, err
+		}
 		if _, err := writeIfChanged(autoPath, oldAuto, []byte(dshAutoJS(exe))); err != nil {
 			return installResult{}, err
 		}

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -53,7 +53,10 @@ func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	manifestPath := filepath.Join(dir, "gemini-extension.json")
-	oldManifest, _ := os.ReadFile(manifestPath)
+	oldManifest, err := readConfig(manifestPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeIfChanged(manifestPath, oldManifest, append(manifest, '\n')); err != nil {
 		return installResult{}, err
 	}
@@ -85,7 +88,10 @@ func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	hooksPath := filepath.Join(dir, "hooks", "hooks.json")
-	oldHooks, _ := os.ReadFile(hooksPath)
+	oldHooks, err := readConfig(hooksPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(hooksPath, oldHooks, append(hooks, '\n'))
 	if err != nil {
 		return installResult{}, err
@@ -117,7 +123,10 @@ func geminiHooksEnabled() bool {
 // loaded and its hooks are never run.
 func enableGeminiHooks() error {
 	path := filepath.Join(sources.GeminiHome(), "settings.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -295,7 +295,10 @@ func writeGooseHook() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
 	_, werr := writeIfChanged(path, old, body)
 	return werr
 }
@@ -364,7 +367,10 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
 	_, err = writeIfChanged(path, old, []byte(out.String()))
 	return err
 }
@@ -398,8 +404,11 @@ func refreshGooseHintsFor(cwd string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	old, _ := os.ReadFile(path)
-	_, err := writeIfChanged(path, old, []byte(body))
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
+	_, err = writeIfChanged(path, old, []byte(body))
 	return err
 }
 

--- a/cmd/deja/install_goose_command.go
+++ b/cmd/deja/install_goose_command.go
@@ -157,7 +157,10 @@ func installGooseCommand(exe string, uninstall bool) (installResult, error) {
 		if err := os.MkdirAll(filepath.Dir(recipe), 0o755); err != nil {
 			return installResult{}, err
 		}
-		oldRecipe, _ := os.ReadFile(recipe)
+		oldRecipe, err := readConfig(recipe)
+		if err != nil {
+			return installResult{}, err
+		}
 		if _, err := writeIfChanged(recipe, oldRecipe, []byte(gooseRecipe(exe))); err != nil {
 			return installResult{}, err
 		}

--- a/cmd/deja/install_grok.go
+++ b/cmd/deja/install_grok.go
@@ -21,8 +21,8 @@ import (
 // integration that looked installed and did nothing.
 func installGrokUserSettings(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.GrokHome(), "user-settings.json")
-	old, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
+	old, err := readConfig(path)
+	if err != nil {
 		return installResult{}, err
 	}
 	// Round-tripping through a map keeps every key this CLI version has that

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -32,12 +32,18 @@ func installHermesPlugin(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	manifestPath := filepath.Join(dir, "plugin.yaml")
-	oldManifest, _ := os.ReadFile(manifestPath)
+	oldManifest, err := readConfig(manifestPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeIfChanged(manifestPath, oldManifest, []byte(hermesPluginManifest)); err != nil {
 		return installResult{}, err
 	}
 	codePath := filepath.Join(dir, "__init__.py")
-	oldCode, _ := os.ReadFile(codePath)
+	oldCode, err := readConfig(codePath)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(codePath, oldCode, []byte(hermesPluginPy(exe)))
 	if err != nil {
 		return installResult{}, err

--- a/cmd/deja/install_omp_auto.go
+++ b/cmd/deja/install_omp_auto.go
@@ -44,7 +44,10 @@ func installOmpAuto(exe string, uninstall bool) (installResult, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return installResult{}, err
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(path, old, []byte(ompExtensionJS(exe)))
 	return installResult{Path: path, Action: a}, err
 }

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -44,12 +44,18 @@ func installOpenClawHooks(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	docPath := filepath.Join(dir, "HOOK.md")
-	oldDoc, _ := os.ReadFile(docPath)
+	oldDoc, err := readConfig(docPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	if _, err := writeIfChanged(docPath, oldDoc, []byte(openclawHookDoc())); err != nil {
 		return installResult{}, err
 	}
 	handlerPath := filepath.Join(dir, "handler.js")
-	oldHandler, _ := os.ReadFile(handlerPath)
+	oldHandler, err := readConfig(handlerPath)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(handlerPath, oldHandler, []byte(openclawHandlerJS(exe)))
 	if err != nil {
 		return installResult{}, err
@@ -64,7 +70,10 @@ func installOpenClawHooks(exe string, uninstall bool) (installResult, error) {
 // both, the pack is discovered and listed as ready but never invoked.
 func setOpenClawHookEnabled(on bool) (string, error) {
 	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return "", err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		if !on {

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -44,13 +44,19 @@ func installOpenClawPlugin(exe string, uninstall bool) (installResult, error) {
 		{"openclaw.plugin.json", openclawPluginManifest()},
 	} {
 		path := filepath.Join(dir, f.name)
-		old, _ := os.ReadFile(path)
+		old, err := readConfig(path)
+		if err != nil {
+			return installResult{}, err
+		}
 		if _, err := writeIfChanged(path, old, []byte(f.body)); err != nil {
 			return installResult{}, err
 		}
 	}
 	entry := filepath.Join(dir, "index.mjs")
-	old, _ := os.ReadFile(entry)
+	old, err := readConfig(entry)
+	if err != nil {
+		return installResult{}, err
+	}
 	a, err := writeIfChanged(entry, old, []byte(openclawPluginJS(exe)))
 	if err != nil {
 		return installResult{}, err
@@ -65,7 +71,10 @@ func installOpenClawPlugin(exe string, uninstall bool) (installResult, error) {
 // leaving every other plugin — and the user's allow list — untouched.
 func setOpenClawPluginEnabled(on bool) (string, error) {
 	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return "", err
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		if !on {

--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -31,7 +31,10 @@ func installPiExtension(exe string, uninstall bool) (installResult, error) {
 		}
 		return installResult{Path: path, Action: "removed"}, nil
 	}
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	next := []byte(piExtensionTS(exe))
 	a, err := writeIfChanged(path, old, next)
 	return installResult{Path: path, Action: a}, err

--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -50,7 +50,10 @@ func syncAutoPlistPath() string {
 
 func installSyncTimerLaunchd(exe string, uninstall bool) (installResult, error) {
 	path := syncAutoPlistPath()
-	old, _ := os.ReadFile(path)
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
+	}
 	if uninstall {
 		if len(old) > 0 {
 			_, _ = runLaunchctl("unload", path)
@@ -109,8 +112,14 @@ func installSyncTimerSystemd(exe string, uninstall bool) (installResult, error) 
 	dir := syncAutoUnitDir()
 	service := filepath.Join(dir, "deja-sync.service")
 	timer := filepath.Join(dir, "deja-sync.timer")
-	oldService, _ := os.ReadFile(service)
-	oldTimer, _ := os.ReadFile(timer)
+	oldService, err := readConfig(service)
+	if err != nil {
+		return installResult{}, err
+	}
+	oldTimer, err := readConfig(timer)
+	if err != nil {
+		return installResult{}, err
+	}
 	if uninstall {
 		if len(oldTimer) > 0 {
 			_, _ = runSystemctl("--user", "disable", "--now", "deja-sync.timer")

--- a/cmd/deja/install_sync_timer.go
+++ b/cmd/deja/install_sync_timer.go
@@ -50,15 +50,19 @@ func syncAutoPlistPath() string {
 
 func installSyncTimerLaunchd(exe string, uninstall bool) (installResult, error) {
 	path := syncAutoPlistPath()
-	old, err := readConfig(path)
-	if err != nil {
-		return installResult{}, err
-	}
 	if uninstall {
-		if len(old) > 0 {
+		// Removal never reads the unit: it unloads the job and deletes the
+		// file by path, so a plist deja cannot read is still one it can take
+		// out — and refusing here left a launchd job loaded against a binary
+		// the user was removing (#2751).
+		if _, err := os.Stat(path); err == nil {
 			_, _ = runLaunchctl("unload", path)
 		}
 		return installResult{Path: path, Action: removeOurUnit(path)}, nil
+	}
+	old, err := readConfig(path)
+	if err != nil {
+		return installResult{}, err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return installResult{}, err
@@ -112,6 +116,15 @@ func installSyncTimerSystemd(exe string, uninstall bool) (installResult, error) 
 	dir := syncAutoUnitDir()
 	service := filepath.Join(dir, "deja-sync.service")
 	timer := filepath.Join(dir, "deja-sync.timer")
+	if uninstall {
+		// As above: the units come out by path, so an unreadable one is no
+		// reason to leave a timer running (#2751).
+		if _, err := os.Stat(timer); err == nil {
+			_, _ = runSystemctl("--user", "disable", "--now", "deja-sync.timer")
+		}
+		removeOurUnit(service)
+		return installResult{Path: timer, Action: removeOurUnit(timer)}, nil
+	}
 	oldService, err := readConfig(service)
 	if err != nil {
 		return installResult{}, err
@@ -119,13 +132,6 @@ func installSyncTimerSystemd(exe string, uninstall bool) (installResult, error) 
 	oldTimer, err := readConfig(timer)
 	if err != nil {
 		return installResult{}, err
-	}
-	if uninstall {
-		if len(oldTimer) > 0 {
-			_, _ = runSystemctl("--user", "disable", "--now", "deja-sync.timer")
-		}
-		removeOurUnit(service)
-		return installResult{Path: timer, Action: removeOurUnit(timer)}, nil
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return installResult{}, err

--- a/cmd/deja/install_unreadable_test.go
+++ b/cmd/deja/install_unreadable_test.go
@@ -133,3 +133,34 @@ func TestAMultiFileTargetIsRefusedOnTheFileItCannotRead(t *testing.T) {
 		t.Errorf("the config was written over:\n%s", after)
 	}
 }
+
+// The sync timer's unit is read only to decide whether the job is loaded; the
+// removal itself is by path. Refusing to read it left a launchd job running
+// against a binary the user was removing.
+func TestUninstallTakesOutASyncUnitItCannotRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("chmod does not take a file's read away here")
+	}
+	hermeticEnv(t)
+	if _, err := captureRun(t, "install", "sync-timer", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	unit := syncAutoPlistPath()
+	if runtime.GOOS != "darwin" {
+		unit = filepath.Join(syncAutoUnitDir(), "deja-sync.timer")
+	}
+	if _, err := os.Stat(unit); err != nil {
+		t.Skipf("no unit written here: %v", err)
+	}
+	if err := os.Chmod(unit, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unit, 0o644) })
+
+	if _, err := captureRun(t, "uninstall", "sync-timer"); err != nil {
+		t.Fatalf("uninstall refused a unit it only had to remove: %v", err)
+	}
+	if _, err := os.Stat(unit); !os.IsNotExist(err) {
+		t.Errorf("the unit survived the uninstall")
+	}
+}

--- a/cmd/deja/install_unreadable_test.go
+++ b/cmd/deja/install_unreadable_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -16,8 +17,8 @@ import (
 // earlier install, and then the user's config went with nothing left of it
 // (#2751).
 func TestAConfigThatCannotBeReadIsNotOverwritten(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root reads it anyway")
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("chmod does not take a file's read away here")
 	}
 	hermeticEnv(t)
 	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
@@ -59,8 +60,8 @@ func TestAConfigThatCannotBeReadIsNotOverwritten(t *testing.T) {
 // And the same on the way out: what cannot be read cannot be edited down to
 // "the file without deja in it" either.
 func TestUninstallDoesNotWriteOverAConfigItCannotRead(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("root reads it anyway")
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("chmod does not take a file's read away here")
 	}
 	hermeticEnv(t)
 	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
@@ -81,6 +82,8 @@ func TestUninstallDoesNotWriteOverAConfigItCannotRead(t *testing.T) {
 
 	if _, err := captureRun(t, "uninstall", "cursor"); err == nil {
 		t.Error("a config deja could not read was reported as unwired")
+	} else if !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal does not name the config: %v", err)
 	}
 	if err := os.Chmod(path, 0o644); err != nil {
 		t.Fatal(err)
@@ -91,5 +94,42 @@ func TestUninstallDoesNotWriteOverAConfigItCannotRead(t *testing.T) {
 	}
 	if string(after) != string(before) {
 		t.Errorf("the config was written over on the way out:\n%s", after)
+	}
+}
+
+// A target that wires more than one file has to be refused on the file that
+// cannot be read, not on whichever one it happens to report: `uninstall
+// claude-auto` read no entry to remove from an unreadable ~/.claude.json and
+// said the target was unwired while the file still named deja.
+func TestAMultiFileTargetIsRefusedOnTheFileItCannotRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("chmod does not take a file's read away here")
+	}
+	hermeticEnv(t)
+	if _, err := captureRun(t, "install", "claude-auto", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	path := sources.ClaudeJSONPath()
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	if _, err := captureRun(t, "uninstall", "claude-auto"); err == nil {
+		t.Error("a target was reported unwired while a config it could not read still names deja")
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	after, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the config was written over:\n%s", after)
 	}
 }

--- a/cmd/deja/install_unreadable_test.go
+++ b/cmd/deja/install_unreadable_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The writers read the old config with `old, _ := os.ReadFile`, so a file that
+// exists but cannot be read looked exactly like one that is not there and deja
+// wrote a fresh config over it. backupOnce caught that by accident — until a
+// `.bak` was already beside the file, which is the ordinary state after any
+// earlier install, and then the user's config went with nothing left of it
+// (#2751).
+func TestAConfigThatCannotBeReadIsNotOverwritten(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads it anyway")
+	}
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mine := "{\"mcpServers\":{\"mine\":{\"command\":\"x\"}}}\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A snapshot from an earlier install: backupOnce takes one per file per
+	// run, so with this here it never reads the config at all.
+	if err := os.WriteFile(path+".bak", []byte("older\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, err := captureRun(t, "install", "cursor", "--no-index")
+	if err == nil {
+		t.Error("a config deja could not read was reported as installed")
+	} else if !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal does not name the config: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(b) != mine {
+		t.Errorf("the config deja could not read was written over:\n%s", b)
+	}
+}
+
+// And the same on the way out: what cannot be read cannot be edited down to
+// "the file without deja in it" either.
+func TestUninstallDoesNotWriteOverAConfigItCannotRead(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads it anyway")
+	}
+	hermeticEnv(t)
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path+".bak", []byte("older\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	if _, err := captureRun(t, "uninstall", "cursor"); err == nil {
+		t.Error("a config deja could not read was reported as unwired")
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	after, rerr := os.ReadFile(path)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the config was written over on the way out:\n%s", after)
+	}
+}


### PR DESCRIPTION
Closes #2751.

Every writer reads the old config with `old, _ := os.ReadFile`, so a file that exists but cannot be read is empty to all of them. `backupOnce` caught that by accident — until a `.bak` is already beside the file, which is the ordinary state after any earlier install. Then `install cursor` reported "created" and replaced the user's servers with deja's entry, with no snapshot of what was there.

Two guards: `writeIfChanged` refuses before it writes over such a file, and the install loop refuses a target whose config it could not read at all — a writer that decides there is nothing to do never reaches the first one, so `uninstall cursor` used to report the target unwired while its config still named deja.