### PR TITLE
test: guard the jsonc refusal for an mcp key that is not an object

### DIFF
--- a/cmd/deja/jsonc_not_an_object_test.go
+++ b/cmd/deja/jsonc_not_an_object_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// An "mcp" key that is not an object cannot hold a server. Writing a second key
+// of the same name above it left both in the file; every reader takes the last,
+// which is the reader's, so deja was not wired and install said "updated"
+// anyway. The parsed path refuses this (#2399); the text path did not (#2742).
+func TestJSONCRefusesABlockThatIsNotAnObject(t *testing.T) {
+	for _, seed := range []string{
+		"{ // hi\n  \"mcp\": null\n}\n",
+		"{ // hi\n  \"mcp\": []\n}\n",
+		"{ // hi\n  \"mcp\": \"off\"\n}\n",
+	} {
+		out, _, err := updateOpencodeJSONC([]byte(seed), "/bin/deja", false)
+		if err == nil {
+			t.Errorf("install wrote into a config whose mcp key is not an object:\n%s", out)
+			continue
+		}
+		if !strings.Contains(err.Error(), "by hand") {
+			t.Errorf("the refusal does not say what to do: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Went to fix the second divergence in #2742 — "a block that is not an object gets a second key of the same name" — and it does not reproduce. `null`, `[]` and a string all take the existing refusal, which names what to do by hand.

So this is a test rather than a fix. It is worth having anyway: nothing covered that refusal, and stubbing the guard out makes this fail, so it holds the behaviour the issue was worried about.

Why the report says otherwise: only opencode has a text path at all (`.jsonc` files). The report described `mcpServers`, which is the parsed path, and that one has refused since #2399. Noted on the issue.