### PR TITLE
fix(install): ask every Roo host before writing the first one

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2489,12 +2489,14 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a, Note: note}, err
 }
 
-// firstDirThatIsThere is the directory a write would actually land in: the
-// settings directory itself once it exists, and otherwise the nearest parent
-// that does, since install creates what is missing under it.
-func firstDirThatIsThere(dir string) string {
+// firstDirThatTakesAWrite is the directory a write would actually land in: the
+// config's own directory once it exists, and otherwise the nearest parent that
+// does, since install creates what is missing under it. os.Stat rather than a
+// Lstat: the write follows a symlinked directory, so the question has to
+// follow it too.
+func firstDirThatTakesAWrite(dir string) string {
 	for {
-		if isRealDir(dir) {
+		if fi, err := os.Stat(dir); err == nil && fi.IsDir() {
 			return dir
 		}
 		parent := filepath.Dir(dir)
@@ -2503,6 +2505,40 @@ func firstDirThatIsThere(dir string) string {
 		}
 		dir = parent
 	}
+}
+
+// mcpConfigReadable asks only whether the config can be read and parsed —
+// deliberately not whether its block is a shape deja edits. On the way out,
+// a block deja never wrote is left alone and reported unchanged (#2399), so
+// naming it as a host deja gave up on would be wrong.
+func mcpConfigReadable(path string) error {
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(old)) == 0 {
+		return nil
+	}
+	_, err = parseConfigRoot(path, old)
+	return err
+}
+
+// parseConfigRoot decodes a config the writers edit, comments and all. It
+// returns a nil root only for an empty file; `null` is an error, since it
+// decodes into a nil map without one and the writer then assigns into it.
+func parseConfigRoot(path string, old []byte) (map[string]any, error) {
+	text := string(old)
+	if configIsJSONC(old) {
+		text = stripJSONComments(text)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(text), &root); err != nil {
+		return nil, configParseError(path, err)
+	}
+	if root == nil {
+		return nil, configParseError(path, errors.New("the file holds null, not an object"))
+	}
+	return root, nil
 }
 
 // mcpEntryWritable asks whether installMCPJSON could write its entry into this
@@ -2520,19 +2556,13 @@ func mcpEntryWritable(path, blockKey string) error {
 	if len(bytes.TrimSpace(old)) == 0 {
 		return nil
 	}
-	text := string(old)
 	jsonc := configIsJSONC(old)
-	if jsonc {
-		text = stripJSONComments(text)
-	}
-	var root map[string]any
-	if err := json.Unmarshal([]byte(text), &root); err != nil {
-		return configParseError(path, err)
+	root, err := parseConfigRoot(path, old)
+	if err != nil {
+		return err
 	}
 	if root == nil {
-		// `null` decodes into a nil map without an error, and the writer then
-		// assigns into it.
-		return configParseError(path, errors.New("the file holds null, not an object"))
+		return nil
 	}
 	if jsonc {
 		// The text writer inserts rather than replaces, so a key holding

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2489,6 +2489,22 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a, Note: note}, err
 }
 
+// firstDirThatIsThere is the directory a write would actually land in: the
+// settings directory itself once it exists, and otherwise the nearest parent
+// that does, since install creates what is missing under it.
+func firstDirThatIsThere(dir string) string {
+	for {
+		if isRealDir(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return dir
+		}
+		dir = parent
+	}
+}
+
 // mcpEntryWritable asks whether installMCPJSON could write its entry into this
 // config, without writing anything.
 //
@@ -2501,12 +2517,36 @@ func mcpEntryWritable(path, blockKey string) error {
 	if err != nil {
 		return err
 	}
-	if len(bytes.TrimSpace(old)) == 0 || configIsJSONC(old) {
+	if len(bytes.TrimSpace(old)) == 0 {
 		return nil
 	}
+	text := string(old)
+	jsonc := configIsJSONC(old)
+	if jsonc {
+		text = stripJSONComments(text)
+	}
 	var root map[string]any
-	if err := json.Unmarshal(old, &root); err != nil {
+	if err := json.Unmarshal([]byte(text), &root); err != nil {
 		return configParseError(path, err)
+	}
+	if root == nil {
+		// `null` decodes into a nil map without an error, and the writer then
+		// assigns into it.
+		return configParseError(path, errors.New("the file holds null, not an object"))
+	}
+	if jsonc {
+		// The text writer inserts rather than replaces, so a key holding
+		// anything but an object would end up in the file twice with the
+		// reader's value winning — writeJSONCEntry refuses those, and so must
+		// this (#2740). It also needs a top-level object to insert into.
+		if v, present := root[blockKey]; present {
+			if _, isObject := v.(map[string]any); !isObject {
+				return fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, blockKey)
+			}
+		}
+		if zedTopLevelOpen(string(old)) < 0 {
+			return fmt.Errorf("%s: does not look like a settings object; add %q by hand", path, blockKey)
+		}
 	}
 	_, _, err = mcpBlock(root, blockKey, path)
 	return err

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2561,9 +2561,6 @@ func mcpEntryWritable(path, blockKey string) error {
 	if err != nil {
 		return err
 	}
-	if root == nil {
-		return nil
-	}
 	if jsonc {
 		// The text writer inserts rather than replaces, so a key holding
 		// anything but an object would end up in the file twice with the

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2489,6 +2489,29 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	return installResult{Path: path, Action: a, Note: note}, err
 }
 
+// mcpEntryWritable asks whether installMCPJSON could write its entry into this
+// config, without writing anything.
+//
+// It has to accept exactly what the writer accepts: a comment is not a broken
+// file (#1664), so a JSONC config passes here and is edited as text. What it
+// catches is the config the writer would refuse — one that does not parse, or
+// whose block is something other than an object.
+func mcpEntryWritable(path, blockKey string) error {
+	old, err := readConfig(path)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(old)) == 0 || configIsJSONC(old) {
+		return nil
+	}
+	var root map[string]any
+	if err := json.Unmarshal(old, &root); err != nil {
+		return configParseError(path, err)
+	}
+	_, _, err = mcpBlock(root, blockKey, path)
+	return err
+}
+
 func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 	old, err := readConfig(path)
 	if err != nil {

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -29,6 +29,19 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 	paths := rooMCPSettingsPaths()
 	var last installResult
 	wrote := false
+	if !uninstall {
+		// One settings file per host, written in turn: a refusal on the second
+		// host used to leave the first one wired with a .bak beside it while
+		// the run reported the target refused (#2750). Ask every host first.
+		for _, p := range paths {
+			if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
+				continue
+			}
+			if err := mcpEntryWritable(p, "mcpServers"); err != nil {
+				return installResult{}, err
+			}
+		}
+	}
 	for _, p := range paths {
 		// Only hosts Roo has actually run in: creating the directory would
 		// leave settings behind for an editor that is not installed.
@@ -37,6 +50,12 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 		}
 		res, err := installMCPJSON(p, exe, uninstall)
 		if err != nil {
+			// On the way out, a host deja cannot read is one it cannot take
+			// its entry out of — and refusing there would leave the hosts it
+			// can read wired, which is what the run was asked to undo.
+			if uninstall {
+				continue
+			}
 			return installResult{}, err
 		}
 		last = res

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -30,7 +30,8 @@ func rooMCPSettingsPaths() []string {
 func installRoo(exe string, uninstall bool) (installResult, error) {
 	paths := rooMCPSettingsPaths()
 	var last installResult
-	var skipped []string
+	var unread, unwritable []string
+	skip := map[string]bool{}
 	wrote := false
 	seen := 0
 	for _, p := range paths {
@@ -40,36 +41,48 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 			continue
 		}
 		seen++
-		err := mcpEntryWritable(p, "mcpServers")
-		if err == nil && !uninstall {
-			// Reading the settings is not enough: the snapshot and the write
-			// both land in the host's settings directory, so a directory deja
-			// cannot write is the same half-install shape one host later.
-			if dir := firstDirThatIsThere(filepath.Dir(p)); !dirWritable(dir) {
-				err = fmt.Errorf("%s: deja cannot write in that directory — check its permissions", shortHome(dir))
-			}
+		// Reading the settings is not the whole question: the snapshot and the
+		// config both land in the host's settings directory, so a directory
+		// deja cannot write is the same half-install shape one host later.
+		dir := firstDirThatTakesAWrite(filepath.Dir(p))
+		readErr := mcpConfigReadable(p)
+		writeErr := error(nil)
+		if !dirWritable(dir) {
+			writeErr = fmt.Errorf("%s: deja cannot write in that directory — check its permissions", shortHome(dir))
 		}
-		if err == nil {
+		if !uninstall {
+			// One settings file per host, written in turn: a refusal on the
+			// second host used to leave the first one wired with a .bak beside
+			// it while the run reported the target refused (#2750). Every host
+			// is asked before any is written — including the shapes the writer
+			// refuses, which are install's business alone.
+			for _, err := range []error{readErr, writeErr, mcpEntryWritable(p, "mcpServers")} {
+				if err != nil {
+					return installResult{}, err
+				}
+			}
 			continue
 		}
-		// One settings file per host, written in turn: a refusal on the second
-		// host used to leave the first one wired with a .bak beside it while
-		// the run reported the target refused (#2750). Every host is asked
-		// before any is written.
-		if !uninstall {
-			return installResult{}, err
+		// On the way out, a host deja cannot read or write is one it cannot
+		// take its entry out of — and refusing there would leave the hosts it
+		// can wired, which is what the run was asked to undo. Named, so the
+		// reader knows which one still has deja in it. A shape deja does not
+		// edit is not named here: installMCPJSON leaves a block it never wrote
+		// alone and reports it unchanged (#2399).
+		switch {
+		case readErr != nil:
+			unread = append(unread, shortHome(p))
+			skip[p] = true
+		case writeErr != nil:
+			unwritable = append(unwritable, shortHome(p))
+			skip[p] = true
 		}
-		// On the way out, a host deja cannot read is one it cannot take its
-		// entry out of — and refusing there would leave the hosts it can read
-		// wired, which is what the run was asked to undo. Named, so the reader
-		// knows which one still has deja in it.
-		skipped = append(skipped, shortHome(p))
 	}
 	for _, p := range paths {
 		if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
 			continue
 		}
-		if uninstall && mcpEntryWritable(p, "mcpServers") != nil {
+		if skip[p] {
 			continue
 		}
 		res, err := installMCPJSON(p, exe, uninstall)
@@ -81,11 +94,10 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 			wrote = true
 		}
 	}
-	if len(skipped) > 0 {
-		// A host that was there and could not be read is not "no host found":
-		// deja is still wired in it, and saying nothing would leave the reader
+	if note := rooLeftNote(unread, unwritable); note != "" {
+		// A host that was there and was skipped is not "no host found": deja
+		// is still wired in it, and saying nothing would leave the reader
 		// thinking the uninstall was complete.
-		note := "left " + strings.Join(skipped, ", ") + " — deja could not read " + pluralWhich(len(skipped))
 		if last.Path == "" {
 			return installResult{Action: note}, nil
 		}
@@ -119,4 +131,18 @@ func rooFirstRoot() string {
 		}
 	}
 	return filepath.Join(os.DevNull, "roo")
+}
+
+// rooLeftNote names the hosts an uninstall did not clean, and why. Two
+// reasons, two strings: a file deja could not read at all, and one it read but
+// cannot write where it sits.
+func rooLeftNote(unread, unwritable []string) string {
+	var parts []string
+	if len(unread) > 0 {
+		parts = append(parts, "left "+strings.Join(unread, ", ")+" — deja could not read "+pluralWhich(len(unread)))
+	}
+	if len(unwritable) > 0 {
+		parts = append(parts, "left "+strings.Join(unwritable, ", ")+" — deja cannot write "+pluralWhich(len(unwritable)))
+	}
+	return strings.Join(parts, "; ")
 }

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -50,6 +50,16 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 		if !dirWritable(dir) {
 			writeErr = fmt.Errorf("%s: deja cannot write in that directory — check its permissions", shortHome(dir))
 		}
+		if uninstall && writeErr != nil {
+			// Only a host there is something to take out of. A settings file
+			// with no deja in it is not written on the way out either, so a
+			// directory that refuses the write changes nothing there and
+			// naming it would send the reader after a file that is already
+			// the way they want it.
+			if old, err := readConfig(p); err != nil || !mentionsDeja(old) {
+				writeErr = nil
+			}
+		}
 		if !uninstall {
 			// One settings file per host, written in turn: a refusal on the
 			// second host used to leave the first one wired with a .bak beside

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -28,34 +30,50 @@ func rooMCPSettingsPaths() []string {
 func installRoo(exe string, uninstall bool) (installResult, error) {
 	paths := rooMCPSettingsPaths()
 	var last installResult
+	var skipped []string
 	wrote := false
-	if !uninstall {
-		// One settings file per host, written in turn: a refusal on the second
-		// host used to leave the first one wired with a .bak beside it while
-		// the run reported the target refused (#2750). Ask every host first.
-		for _, p := range paths {
-			if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
-				continue
-			}
-			if err := mcpEntryWritable(p, "mcpServers"); err != nil {
-				return installResult{}, err
-			}
-		}
-	}
+	seen := 0
 	for _, p := range paths {
 		// Only hosts Roo has actually run in: creating the directory would
 		// leave settings behind for an editor that is not installed.
 		if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
 			continue
 		}
+		seen++
+		err := mcpEntryWritable(p, "mcpServers")
+		if err == nil && !uninstall {
+			// Reading the settings is not enough: the snapshot and the write
+			// both land in the host's settings directory, so a directory deja
+			// cannot write is the same half-install shape one host later.
+			if dir := firstDirThatIsThere(filepath.Dir(p)); !dirWritable(dir) {
+				err = fmt.Errorf("%s: deja cannot write in that directory — check its permissions", shortHome(dir))
+			}
+		}
+		if err == nil {
+			continue
+		}
+		// One settings file per host, written in turn: a refusal on the second
+		// host used to leave the first one wired with a .bak beside it while
+		// the run reported the target refused (#2750). Every host is asked
+		// before any is written.
+		if !uninstall {
+			return installResult{}, err
+		}
+		// On the way out, a host deja cannot read is one it cannot take its
+		// entry out of — and refusing there would leave the hosts it can read
+		// wired, which is what the run was asked to undo. Named, so the reader
+		// knows which one still has deja in it.
+		skipped = append(skipped, shortHome(p))
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(filepath.Dir(filepath.Dir(p))); err != nil {
+			continue
+		}
+		if uninstall && mcpEntryWritable(p, "mcpServers") != nil {
+			continue
+		}
 		res, err := installMCPJSON(p, exe, uninstall)
 		if err != nil {
-			// On the way out, a host deja cannot read is one it cannot take
-			// its entry out of — and refusing there would leave the hosts it
-			// can read wired, which is what the run was asked to undo.
-			if uninstall {
-				continue
-			}
 			return installResult{}, err
 		}
 		last = res
@@ -63,7 +81,18 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 			wrote = true
 		}
 	}
-	if !wrote && last.Path == "" {
+	if len(skipped) > 0 {
+		// A host that was there and could not be read is not "no host found":
+		// deja is still wired in it, and saying nothing would leave the reader
+		// thinking the uninstall was complete.
+		note := "left " + strings.Join(skipped, ", ") + " — deja could not read " + pluralWhich(len(skipped))
+		if last.Path == "" {
+			return installResult{Action: note}, nil
+		}
+		last.Note = joinNotes(last.Note, note)
+		return last, nil
+	}
+	if !wrote && last.Path == "" && seen == 0 {
 		// No host has ever run Roo here, so there is no settings file to write
 		// into and creating one would leave configuration for an editor that is
 		// not installed. Say that, rather than "unchanged roo", which names a

--- a/cmd/deja/install_roo_hosts_test.go
+++ b/cmd/deja/install_roo_hosts_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// rooHost lays out one VS Code host the way sources.RooRoots expects it, with
+// the given settings file in place.
+func rooHost(t *testing.T, dir, settings string) string {
+	t.Helper()
+	root := filepath.Join(dir, "globalStorage", "rooveterinaryinc.roo-cline")
+	if err := os.MkdirAll(filepath.Join(root, "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if settings != "" {
+		if err := os.WriteFile(filepath.Join(root, "settings", "mcp_settings.json"), []byte(settings), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// roo wires one settings file per host, so a refusal on the second host left
+// the first one written with a .bak beside it while the run reported the
+// target refused (#2750).
+func TestRooWritesNoHostWhenOneOfThemWillRefuse(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	bad := rooHost(t, filepath.Join(dir, "b"), "{ this is not json ]\n")
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, bad}, string(os.PathListSeparator)))
+
+	first := filepath.Join(good, "settings", "mcp_settings.json")
+	before, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err == nil {
+		t.Fatal("a target that cannot finish reported itself installed")
+	}
+	after, rerr := os.ReadFile(first)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the first host was written before the refusal:\n%s", after)
+	}
+	if _, err := os.Stat(first + ".bak"); err == nil {
+		t.Errorf("a snapshot was left beside a file that was never changed")
+	}
+}
+
+// The check has to accept what the writer accepts: installMCPJSON takes a
+// settings file with comments in it, so refusing one here would keep somebody
+// who annotated their config from installing at all (#1664).
+func TestRooTakesACommentedHostTheWriterCanEdit(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	host := rooHost(t, filepath.Join(dir, "a"), "{\n  // mine\n  \"mcpServers\": {}\n}\n")
+	t.Setenv("DEJA_ROO_ROOTS", host)
+
+	path := filepath.Join(host, "settings", "mcp_settings.json")
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+		t.Fatalf("a commented host was refused: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "// mine") {
+		t.Errorf("the comment was dropped:\n%s", b)
+	}
+	if !strings.Contains(string(b), "\"deja\"") {
+		t.Errorf("the entry was not written:\n%s", b)
+	}
+}
+
+// A settings file whose mcpServers is not an object is what installMCPJSON
+// refuses, and it has to be refused before the other host is written.
+func TestRooRefusesABlockTheWriterCannotUseBeforeWriting(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	bad := rooHost(t, filepath.Join(dir, "b"), "{\"mcpServers\": [1, 2]}\n")
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, bad}, string(os.PathListSeparator)))
+
+	first := filepath.Join(good, "settings", "mcp_settings.json")
+	before, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err == nil {
+		t.Fatal("a block the writer cannot use was accepted")
+	}
+	after, rerr := os.ReadFile(first)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the first host was written before the refusal:\n%s", after)
+	}
+}
+
+// On the way out there is nothing to refuse over: uninstall takes deja out of
+// the hosts it can read and leaves the rest alone, the way #2399 has it for a
+// block deja never wrote.
+func TestUninstallRooTakesDejaOutOfTheHostsItCanRead(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	t.Setenv("DEJA_ROO_ROOTS", good)
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	bad := rooHost(t, filepath.Join(dir, "b"), "{ not json ]\n")
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, bad}, string(os.PathListSeparator)))
+
+	if _, err := captureRun(t, "uninstall", "roo"); err != nil {
+		t.Fatalf("uninstall refused over a host it was not asked to edit: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(good, "settings", "mcp_settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "\"deja\"") {
+		t.Errorf("deja was left in a host that could be read:\n%s", b)
+	}
+}

--- a/cmd/deja/install_roo_hosts_test.go
+++ b/cmd/deja/install_roo_hosts_test.go
@@ -335,3 +335,42 @@ func TestUninstallRooDoesNotNameAHostItNeverTouched(t *testing.T) {
 		})
 	}
 }
+
+// The write reason is for a host there is something to take out of. A host
+// with no deja in its settings — or none at all — is not written on the way
+// out either, so a directory that refuses the write changes nothing there.
+func TestUninstallRooDoesNotNameAHostWithNothingOfDejaInIt(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop a write here")
+	}
+	for _, other := range []string{"", "{\n  \"mcpServers\": {\"mine\": {\"command\": \"x\"}}\n}\n"} {
+		name := "no settings file"
+		if other != "" {
+			name = "someone else's server"
+		}
+		t.Run(name, func(t *testing.T) {
+			hermeticEnv(t)
+			dir := t.TempDir()
+			a := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+			t.Setenv("DEJA_ROO_ROOTS", a)
+			if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+				t.Fatal(err)
+			}
+			b := rooHost(t, filepath.Join(dir, "b"), other)
+			closed := filepath.Join(b, "settings")
+			if err := os.Chmod(closed, 0o555); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(closed, 0o755) })
+			t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{a, b}, string(os.PathListSeparator)))
+
+			out, err := captureRun(t, "uninstall", "roo")
+			if err != nil {
+				t.Fatalf("uninstall refused over a host with nothing of deja's in it: %v", err)
+			}
+			if strings.Contains(out, "cannot write") {
+				t.Errorf("a host with nothing to remove was named as one deja gave up on:\n%s", out)
+			}
+		})
+	}
+}

--- a/cmd/deja/install_roo_hosts_test.go
+++ b/cmd/deja/install_roo_hosts_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -127,5 +128,106 @@ func TestUninstallRooTakesDejaOutOfTheHostsItCanRead(t *testing.T) {
 	}
 	if strings.Contains(string(b), "\"deja\"") {
 		t.Errorf("deja was left in a host that could be read:\n%s", b)
+	}
+}
+
+// The JSONC writer refuses more than the parsed one does, and the check has to
+// refuse the same shapes: a commented host whose block is not an object, or
+// whose top level is not an object at all, used to pass the check and refuse
+// one host too late.
+func TestRooAsksTheJSONCWriterWhatItWouldRefuse(t *testing.T) {
+	for _, bad := range []string{
+		"{\n  // mine\n  \"mcpServers\": [1, 2]\n}\n",
+		"{\n  // mine\n  \"mcpServers\": null\n}\n",
+		"// mine\n[1, 2]\n",
+		"// mine\n5\n",
+		"// mine\nnull\n",
+		"null\n",
+	} {
+		t.Run(strings.TrimSpace(bad), func(t *testing.T) {
+			hermeticEnv(t)
+			dir := t.TempDir()
+			good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+			other := rooHost(t, filepath.Join(dir, "b"), bad)
+			t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, other}, string(os.PathListSeparator)))
+
+			first := filepath.Join(good, "settings", "mcp_settings.json")
+			before, err := os.ReadFile(first)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := captureRun(t, "install", "roo", "--no-index"); err == nil {
+				t.Fatal("a host the writer would refuse was accepted")
+			}
+			after, rerr := os.ReadFile(first)
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			if string(after) != string(before) {
+				t.Errorf("the first host was written before the refusal:\n%s", after)
+			}
+			if _, err := os.Stat(first + ".bak"); err == nil {
+				t.Errorf("a snapshot was left beside a file that was never changed")
+			}
+		})
+	}
+}
+
+// Reading the settings is not the whole question: the snapshot and the write
+// both land in the host's settings directory.
+func TestRooAsksWhetherItCanWriteTheHostAtAll(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop a write here")
+	}
+	hermeticEnv(t)
+	dir := t.TempDir()
+	good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	other := rooHost(t, filepath.Join(dir, "b"), "{\n  \"mcpServers\": {}\n}\n")
+	closed := filepath.Join(other, "settings")
+	if err := os.Chmod(closed, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(closed, 0o755) })
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, other}, string(os.PathListSeparator)))
+
+	first := filepath.Join(good, "settings", "mcp_settings.json")
+	before, err := os.ReadFile(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err == nil {
+		t.Fatal("a host deja cannot write was accepted")
+	}
+	after, rerr := os.ReadFile(first)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the first host was written before the refusal:\n%s", after)
+	}
+}
+
+// A host that is there and cannot be read still has deja in it, so the run
+// says so rather than reporting no host at all.
+func TestUninstallRooNamesTheHostItCouldNotRead(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	good := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	t.Setenv("DEJA_ROO_ROOTS", good)
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	bad := rooHost(t, filepath.Join(dir, "b"), "{ not json ]\n")
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{good, bad}, string(os.PathListSeparator)))
+
+	out, err := captureRun(t, "uninstall", "roo")
+	if err != nil {
+		t.Fatalf("uninstall refused over a host it was not asked to edit: %v", err)
+	}
+	if strings.Contains(out, "no Roo host found") {
+		t.Errorf("a host that is there was reported as no host at all:\n%s", out)
+	}
+	if !strings.Contains(out, "could not read") {
+		t.Errorf("the host deja could not read is not named:\n%s", out)
 	}
 }

--- a/cmd/deja/install_roo_hosts_test.go
+++ b/cmd/deja/install_roo_hosts_test.go
@@ -231,3 +231,107 @@ func TestUninstallRooNamesTheHostItCouldNotRead(t *testing.T) {
 		t.Errorf("the host deja could not read is not named:\n%s", out)
 	}
 }
+
+// The write follows a symlinked settings directory, so the question of whether
+// the host takes a write has to follow it too: a Lstat walked past the link,
+// answered about the host root, and refused a host that installs fine.
+func TestRooFollowsASymlinkedSettingsDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop a write here")
+	}
+	hermeticEnv(t)
+	dir := t.TempDir()
+	host := rooHost(t, filepath.Join(dir, "a"), "")
+	elsewhere := filepath.Join(dir, "elsewhere")
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := filepath.Join(host, "settings")
+	if err := os.RemoveAll(settings); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, settings); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(host, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(host, 0o755) })
+	t.Setenv("DEJA_ROO_ROOTS", host)
+
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+		t.Fatalf("a host whose settings directory is a writable symlink was refused: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(elsewhere, "mcp_settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "\"deja\"") {
+		t.Errorf("the entry was not written:\n%s", b)
+	}
+}
+
+// A host deja cannot write is skipped on the way out rather than aborting the
+// run: the loop used to stop at the first one and leave every later host wired.
+func TestUninstallRooCleansTheHostsItCanAndNamesTheRest(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop a write here")
+	}
+	hermeticEnv(t)
+	dir := t.TempDir()
+	a := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+	b := rooHost(t, filepath.Join(dir, "b"), "{\n  \"mcpServers\": {}\n}\n")
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{a, b}, string(os.PathListSeparator)))
+	if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	closed := filepath.Join(a, "settings")
+	if err := os.Chmod(closed, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(closed, 0o755) })
+
+	out, err := captureRun(t, "uninstall", "roo")
+	if err != nil {
+		t.Fatalf("uninstall stopped at the host it could not write: %v", err)
+	}
+	if !strings.Contains(out, "cannot write") {
+		t.Errorf("the host deja could not write is not named:\n%s", out)
+	}
+	left, rerr := os.ReadFile(filepath.Join(b, "settings", "mcp_settings.json"))
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if strings.Contains(string(left), "\"deja\"") {
+		t.Errorf("a host deja could clean was left wired:\n%s", left)
+	}
+}
+
+// A block deja never wrote is left alone and reported unchanged (#2399), so it
+// is not a host the uninstall gave up on and must not be named as one.
+func TestUninstallRooDoesNotNameAHostItNeverTouched(t *testing.T) {
+	hermeticEnv(t)
+	for _, shape := range []string{
+		"{\"mcpServers\": [1, 2]}\n",
+		"{\n  // mine\n  \"mcpServers\": [1, 2]\n}\n",
+	} {
+		t.Run(strings.TrimSpace(shape), func(t *testing.T) {
+			dir := t.TempDir()
+			a := rooHost(t, filepath.Join(dir, "a"), "{\n  \"mcpServers\": {}\n}\n")
+			t.Setenv("DEJA_ROO_ROOTS", a)
+			if _, err := captureRun(t, "install", "roo", "--no-index"); err != nil {
+				t.Fatal(err)
+			}
+			b := rooHost(t, filepath.Join(dir, "b"), shape)
+			t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{a, b}, string(os.PathListSeparator)))
+
+			out, err := captureRun(t, "uninstall", "roo")
+			if err != nil {
+				t.Fatalf("uninstall refused over a block it never wrote: %v", err)
+			}
+			if strings.Contains(out, "could not read") || strings.Contains(out, "cannot write") {
+				t.Errorf("a host deja never touched was named as one it gave up on:\n%s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #2750.

roo writes one MCP settings file per VS Code host. A refusal on the second host left the first one written with a `.bak` beside it while the run reported the target refused.

The new `mcpEntryWritable` asks what `installMCPJSON` would accept — a commented config passes, since that path edits it as text, and only a config that does not parse or whose block is not an object is refused — and every host is asked before any is written. On the way out a host deja cannot read is skipped rather than refused: refusing there left the hosts it can read still wired.