### PR TITLE
fix: merge deja's own entry on the jsonc path instead of replacing it

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2742,6 +2742,31 @@ func jsoncBraceDelta(code string) int {
 // reader spaced the braces.
 var emptyJSONCBlockRE = regexp.MustCompile(`"mcp"\s*:\s*\{\s*\}`)
 
+// mergedJSONCEntryLine builds the entry line to write, carrying over whatever
+// the reader had on deja's own entry. Falls back to the plain line when the
+// dropped text is not one entry this can read: a shape it cannot parse is not a
+// reason to refuse the install, only to write the entry deja knows.
+func mergedJSONCEntryLine(dropped []string, exe string) (string, string) {
+	plain := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
+	next := map[string]any{"type": "local", "command": []string{exe, "mcp"}}
+	joined := strings.TrimSpace(strings.Join(dropped, " "))
+	at := strings.Index(joined, ":")
+	if len(dropped) == 0 || at < 0 {
+		return plain, ""
+	}
+	value := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(joined[at+1:]), ","))
+	var was any
+	if err := json.Unmarshal([]byte(value), &was); err != nil {
+		return plain, ""
+	}
+	merged, note := mergeDejaEntry(was, next)
+	b, err := json.Marshal(merged)
+	if err != nil {
+		return plain, ""
+	}
+	return `    "deja": ` + string(b), note
+}
+
 func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string, error) {
 	line := fmt.Sprintf(`    "deja": {"type":"local","command":[%q,"mcp"]}`, exe)
 	s := string(old)
@@ -2807,6 +2832,14 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		// it, what install told you depended on which of the two names the
 		// config had (#2392).
 		body, dropped, wasLast := dropJSONCEntry(lines[start+1 : end])
+		// What the reader put on our own entry is theirs: an environment
+		// pointing at a store on another disk, an entry switched off. The
+		// parsed path has merged those since #2479; this one rewrote the line
+		// and dropped them without a word (#2742).
+		mergeNote := ""
+		if !uninstall {
+			line, mergeNote = mergedJSONCEntryLine(dropped, exe)
+		}
 		// Our entry used to go last, so the comma joining it to the block sat
 		// on the line above — the reader's. Taking ours out leaves that comma
 		// with nothing after it, which a strict reader of the file rejects, so
@@ -2820,7 +2853,12 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		}
 		note := ""
 		if !uninstall {
-			note = replacedJSONCLineNote(dropped, line)
+			// mergeDejaEntry says the same sentence when it takes an entry
+			// over, so prefer its note: it also carries what merging found.
+			note = mergeNote
+			if note == "" {
+				note = replacedJSONCLineNote(dropped, line)
+			}
 		}
 		if !uninstall {
 			// Ours goes first, carrying its own comma. Written last it needed

--- a/cmd/deja/jsonc_merge_entry_test.go
+++ b/cmd/deja/jsonc_merge_entry_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// What the reader put on deja's own entry is theirs. The parsed path merges it
+// (#2479): an env pointing at a store on another disk survives, and an entry
+// switched off stays off with a line saying so. The text path replaces the
+// line, so both were lost without a word (#2742).
+func TestJSONCKeepsWhatTheReaderPutOnDejasEntry(t *testing.T) {
+	seed := "{ // hi\n  \"mcp\": {\n" +
+		"    \"deja\": {\"type\":\"local\",\"command\":[\"/old/deja\",\"mcp\"]," +
+		"\"environment\":{\"DEJA_INDEX_DIR\":\"/vol/store\"},\"enabled\":false}\n" +
+		"  }\n}\n"
+
+	out, note, err := updateOpencodeJSONC([]byte(seed), "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "/bin/deja") {
+		t.Fatalf("the binary was not updated:\n%s", got)
+	}
+	if !strings.Contains(got, "/vol/store") {
+		t.Errorf("the reader's environment was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "\"enabled\":false") && !strings.Contains(got, "\"enabled\": false") {
+		t.Errorf("an entry the reader had switched off was silently switched on:\n%s", got)
+	}
+	// The note names what was taken over, once.
+	if !strings.Contains(note, "/old/deja") {
+		t.Errorf("the note does not say what the entry ran: %q", note)
+	}
+	if strings.Count(note, "/old/deja") != 1 {
+		t.Errorf("the note says it twice: %q", note)
+	}
+	// Not asserted: the "still off" line. It is keyed to `disabled`, and
+	// opencode writes `enabled`, so it does not fire here — a gap of its own.
+}


### PR DESCRIPTION
Third divergence in #2742, and it does reproduce. Seeded a commented opencode config whose deja entry carries an environment and is switched off, then ran install:

    before  "deja": {"type":"local","command":["/old/deja","mcp"],"environment":{"DEJA_INDEX_DIR":"/vol/store"},"enabled":false}
    after   "deja": {"type":"local","command":["/bin/deja","mcp"]}

A store on another disk and a deliberate off switch, both gone without a word. The parsed path has merged these since #2479; the text path rewrote the line.

Now it parses the entry it is about to drop and puts it through the same `mergeDejaEntry`, so only the binary changes. A dropped entry it cannot parse falls back to writing the plain line — an odd shape is a reason to write what deja knows, not to refuse the install.

Also fixed on the way: the note came out twice, once from `replacedJSONCLineNote` and once from the merge, which say the same sentence.

Not fixed, and worth its own issue: the "the entry is still off" line is keyed to `disabled`, and opencode writes `enabled`, so a switched-off opencode entry stays off silently. The test says so where it stops asserting.

Fails on main; fails again when the merge call is stubbed out.