### PR TITLE
fix(install): say the entry is off whichever way the host spells it

### DIFF
--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -52,3 +52,44 @@ func TestAnEntryThatIsOnSaysNothingAboutASwitch(t *testing.T) {
 		}
 	}
 }
+
+// opencode.jsonc is written by a second writer that rewrites deja's entry as
+// one line, so a switch the reader had set went out with the old line and the
+// entry came back on with install reporting success (#2757).
+func TestTheOpencodeJSONCWriterKeepsASwitchTheReaderSet(t *testing.T) {
+	for _, sw := range []string{`"enabled":false`, `"disabled":true`} {
+		t.Run(sw, func(t *testing.T) {
+			old := "{\n  \"mcp\": {\n    \"deja\": {\"type\":\"local\",\"command\":[\"/old/deja\",\"mcp\"]," + sw + "}\n  }\n}\n"
+			next, note, err := updateOpencodeJSONC([]byte(old), "/new/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(next), sw) {
+				t.Errorf("the switch was dropped:\n%s", next)
+			}
+			if !strings.Contains(string(next), "/new/deja") {
+				t.Errorf("the entry was not updated:\n%s", next)
+			}
+			if !strings.Contains(note, "switched off") {
+				t.Errorf("the reader is not told the entry is off: %q", note)
+			}
+		})
+	}
+}
+
+// An entry that is on keeps its shape and says nothing.
+func TestTheOpencodeJSONCWriterSaysNothingAboutAnEntryThatIsOn(t *testing.T) {
+	for _, on := range []string{"", `,"enabled":true`, `,"disabled":false`} {
+		old := "{\n  \"mcp\": {\n    \"deja\": {\"type\":\"local\",\"command\":[\"/old/deja\",\"mcp\"]" + on + "}\n  }\n}\n"
+		next, note, err := updateOpencodeJSONC([]byte(old), "/new/deja", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(note, "switched off") {
+			t.Errorf("%q: an entry that is on was reported as off: %q", on, note)
+		}
+		if strings.Contains(string(next), "\"enabled\":false") || strings.Contains(string(next), "\"disabled\":true") {
+			t.Errorf("%q: an entry that is on was written off:\n%s", on, next)
+		}
+	}
+}

--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line that says deja was left switched off was keyed to one spelling.
+// opencode writes `enabled: false`, and a config carrying that reported a
+// clean install for wiring that will never run (#2757).
+func TestAnEntrySwitchedOffIsReportedWhicheverWayItIsSpelt(t *testing.T) {
+	for _, off := range []map[string]any{
+		{"disabled": true},
+		{"enabled": false},
+	} {
+		name := "disabled"
+		if _, ok := off["enabled"]; ok {
+			name = "enabled false"
+		}
+		t.Run(name, func(t *testing.T) {
+			prev := map[string]any{"command": "/old/deja", "args": []any{"mcp"}}
+			for k, v := range off {
+				prev[k] = v
+			}
+			merged, note := mergeDejaEntry(prev, map[string]any{"command": "/new/deja", "args": []string{"mcp"}})
+			for k, v := range off {
+				if merged[k] != v {
+					t.Errorf("the switch was not carried through: %v", merged)
+				}
+			}
+			if !strings.Contains(note, "switched off") {
+				t.Errorf("the reader is not told the entry is off: %q", note)
+			}
+		})
+	}
+}
+
+// And an entry that is on says nothing, whichever way that is spelt.
+func TestAnEntryThatIsOnSaysNothingAboutASwitch(t *testing.T) {
+	for _, on := range []map[string]any{
+		{},
+		{"disabled": false},
+		{"enabled": true},
+	} {
+		prev := map[string]any{"command": "/old/deja", "args": []any{"mcp"}}
+		for k, v := range on {
+			prev[k] = v
+		}
+		_, note := mergeDejaEntry(prev, map[string]any{"command": "/new/deja", "args": []string{"mcp"}})
+		if strings.Contains(note, "switched off") {
+			t.Errorf("%v: an entry that is on was reported as off: %q", on, note)
+		}
+	}
+}

--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -93,3 +93,49 @@ func TestTheOpencodeJSONCWriterSaysNothingAboutAnEntryThatIsOn(t *testing.T) {
 		}
 	}
 }
+
+// The switch is read out of the entry, not out of the reader's words about it
+// and not out of a block nested inside it: both switched a running server off
+// and said deja had left it as it was.
+func TestTheOpencodeJSONCWriterReadsTheEntrysOwnSwitch(t *testing.T) {
+	for _, entry := range []string{
+		`"deja": {"type":"local","command":["/old/deja","mcp"]} // "enabled": false when I travel`,
+		`"deja": {"type":"local","command":["/old/deja","mcp"]} /* "disabled": true once */`,
+		`"deja": {"type":"local","command":["/old/deja","mcp"],"options":{"enabled":false},"enabled":true}`,
+		`"deja": {"type":"local","command":["/old/deja","mcp"],"enabled":"false"}`,
+		// A comment inside the entry, at the depth its own keys sit at.
+		"\"deja\": {\"type\":\"local\", // \"enabled\": false when I travel\n      \"command\":[\"/old/deja\",\"mcp\"]}",
+		"\"deja\": {\"type\":\"local\", /* \"disabled\": true once */ \"command\":[\"/old/deja\",\"mcp\"]}",
+	} {
+		old := "{\n  \"mcp\": {\n    " + entry + "\n  }\n}\n"
+		next, note, err := updateOpencodeJSONC([]byte(old), "/new/deja", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(next), `"enabled":false`) || strings.Contains(string(next), `"disabled":true`) {
+			t.Errorf("%s\n  was switched off:\n%s", entry, next)
+		}
+		if strings.Contains(note, "switched off") {
+			t.Errorf("%s\n  was reported off: %q", entry, note)
+		}
+	}
+}
+
+// deja's own switched-off entry is not a stranger's on the next install: the
+// note compares against what deja writes, switch and all.
+func TestASwitchedOffEntryOfDejasIsNotReportedReplacedEveryRun(t *testing.T) {
+	old := []byte("{\n  \"mcp\": {\n    \"deja\": {\"type\":\"local\",\"command\":[\"/bin/deja\",\"mcp\"],\"enabled\":false}\n  }\n}\n")
+	next, note, err := updateOpencodeJSONC(old, "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "replaced") {
+		t.Errorf("deja's own entry was reported as somebody else's: %q", note)
+	}
+	if !strings.Contains(note, "switched off") {
+		t.Errorf("the entry is still off and nothing says so: %q", note)
+	}
+	if string(next) != string(old) {
+		t.Errorf("a repeat install rewrote the entry:\n%s", next)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2913,13 +2913,19 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		note := ""
 		entryLine := line
 		if !uninstall {
-			note = replacedJSONCLineNote(dropped, line)
 			// opencode's other writer rewrites deja's entry as one line, so a
 			// switch the reader had set was dropped with the rest of it: the
 			// entry came back on and install said nothing (#2757). Carry it
 			// through and say so, the way the merge does.
-			if off := jsoncEntrySwitch(strings.Join(dropped, " ")); off != "" {
+			off := jsoncEntrySwitch(strings.Join(dropped, "\n"))
+			if off != "" {
 				entryLine = strings.TrimSuffix(line, "}") + "," + off + "}"
+			}
+			// Against what is about to be written, not against the line
+			// without the switch: otherwise deja's own switched-off entry
+			// never matches itself and every repeat install says "replaced".
+			note = replacedJSONCLineNote(dropped, entryLine)
+			if off != "" {
 				if note != "" {
 					note += "; "
 				}
@@ -3001,21 +3007,49 @@ func replacedJSONCLineNote(dropped []string, line string) string {
 // Text rather than JSON, for the same reason jsoncEntryCommand is: the block
 // may carry comments and trailing commas.
 func jsoncEntrySwitch(text string) string {
+	// The reader's comments come out first: a line reading
+	// `// "enabled": false when I travel` is a note about the entry, not the
+	// entry, and reading it switched off a server that was running.
+	code := stripJSONComments(text)
 	for _, sw := range []struct{ key, off string }{
 		{"enabled", "false"},
 		{"disabled", "true"},
 	} {
-		i := strings.Index(text, `"`+sw.key+`"`)
-		if i < 0 {
-			continue
-		}
-		rest := strings.TrimSpace(text[i+len(sw.key)+2:])
-		if !strings.HasPrefix(rest, ":") {
-			continue
-		}
-		rest = strings.TrimSpace(rest[1:])
-		if strings.HasPrefix(rest, sw.off) {
+		if at := jsoncEntryKeyValue(code, sw.key); strings.HasPrefix(at, sw.off) {
 			return `"` + sw.key + `":` + sw.off
+		}
+	}
+	return ""
+}
+
+// jsoncEntryKeyValue returns what follows `"key":` in the entry's own object,
+// or empty when the key is not there. Its own: a nested block carries its own
+// settings, and taking the first match anywhere let `"options":{"enabled":
+// false}` switch off an entry that says it is on.
+func jsoncEntryKeyValue(code, key string) string {
+	depth, inString, escaped := 0, false, false
+	for i := 0; i < len(code); i++ {
+		switch c := code[i]; {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"' && !inString:
+			inString = true
+			// The entry is `"deja": { … }`, so its own keys sit one brace in.
+			if depth == 1 && strings.HasPrefix(code[i:], `"`+key+`"`) {
+				rest := strings.TrimSpace(code[i+len(key)+2:])
+				if strings.HasPrefix(rest, ":") {
+					return strings.TrimSpace(rest[1:])
+				}
+			}
+		case c == '"':
+			inString = false
+		case inString:
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
 		}
 	}
 	return ""

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2289,16 +2289,32 @@ func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
 	if _, ok := out["command"]; ok {
 		delete(out, "transport")
 	}
-	if disabled, _ := out["disabled"].(bool); disabled {
+	if entrySwitchedOff(out) {
 		// Switching it back on silently would undo a decision deja was not
 		// asked to revisit; leaving it off without a word looks like a install
 		// that worked.
 		if note != "" {
 			note += "; "
 		}
-		note += "left the entry disabled, the way it was — deja will not answer until you turn it back on"
+		note += "left the entry switched off, the way it was — deja will not answer until you turn it back on"
 	}
 	return out, note
+}
+
+// entrySwitchedOff reports whether the reader has turned this entry off.
+//
+// One switch, two spellings: most hosts write `disabled: true`, opencode
+// writes `enabled: false`. The note was keyed to the first, so a config
+// carrying the second reported a clean install for wiring that will never run
+// (#2757).
+func entrySwitchedOff(entry map[string]any) bool {
+	if off, ok := entry["disabled"].(bool); ok && off {
+		return true
+	}
+	if on, ok := entry["enabled"].(bool); ok && !on {
+		return true
+	}
+	return false
 }
 
 // sameEntry compares an entry read out of a config with the one deja is about

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2911,8 +2911,20 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 			}
 		}
 		note := ""
+		entryLine := line
 		if !uninstall {
 			note = replacedJSONCLineNote(dropped, line)
+			// opencode's other writer rewrites deja's entry as one line, so a
+			// switch the reader had set was dropped with the rest of it: the
+			// entry came back on and install said nothing (#2757). Carry it
+			// through and say so, the way the merge does.
+			if off := jsoncEntrySwitch(strings.Join(dropped, " ")); off != "" {
+				entryLine = strings.TrimSuffix(line, "}") + "," + off + "}"
+				if note != "" {
+					note += "; "
+				}
+				note += "left the entry switched off, the way it was — deja will not answer until you turn it back on"
+			}
 		}
 		if !uninstall {
 			// Ours goes first, carrying its own comma. Written last it needed
@@ -2923,7 +2935,7 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 			// else's line needed — not on an opening brace, not after a
 			// trailing comment, not inside a block comment (#1695) — stop
 			// applying at all.
-			entry := line
+			entry := entryLine
 			at := len(body)
 			if i := jsoncFirstCodeLine(body); i >= 0 {
 				entry += ","
@@ -2980,6 +2992,33 @@ func replacedJSONCLineNote(dropped []string, line string) string {
 		return "replaced the deja entry that was already here"
 	}
 	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
+}
+
+// jsoncEntrySwitch reads an off switch out of the entry text, and returns it
+// the way it will be written back — `"enabled":false` or `"disabled":true`.
+// Empty when the entry is on.
+//
+// Text rather than JSON, for the same reason jsoncEntryCommand is: the block
+// may carry comments and trailing commas.
+func jsoncEntrySwitch(text string) string {
+	for _, sw := range []struct{ key, off string }{
+		{"enabled", "false"},
+		{"disabled", "true"},
+	} {
+		i := strings.Index(text, `"`+sw.key+`"`)
+		if i < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(text[i+len(sw.key)+2:])
+		if !strings.HasPrefix(rest, ":") {
+			continue
+		}
+		rest = strings.TrimSpace(rest[1:])
+		if strings.HasPrefix(rest, sw.off) {
+			return `"` + sw.key + `":` + sw.off
+		}
+	}
+	return ""
 }
 
 // jsoncEntryCommand pulls the command out of an entry deja did not write. It

--- a/cmd/deja/jsonc_install_test.go
+++ b/cmd/deja/jsonc_install_test.go
@@ -236,7 +236,7 @@ func TestACommentedConfigKeepsTheFieldsOnDejasOwnEntry(t *testing.T) {
 	if !strings.Contains(got, `"disabled": true`) {
 		t.Errorf("a disabled entry was silently switched on:\n%s", got)
 	}
-	if !strings.Contains(out, "left the entry disabled") {
+	if !strings.Contains(out, "left the entry switched off") {
 		t.Errorf("nothing said the entry is still off:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #2757.

The note that says deja was left switched off was keyed to `disabled: true`. opencode writes `enabled: false`, so a config carrying that reported a clean install for wiring that will never run. One helper reads both spellings, and the sentence no longer names one of them.