### PR TITLE
fix: gemini-auto no longer refuses a commented config it has already edited

### DIFF
--- a/cmd/deja/gemini_commented_settings_test.go
+++ b/cmd/deja/gemini_commented_settings_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The MCP entry goes into a commented gemini config through the text path, and
+// this used to refuse the same file afterwards for having comments — after it
+// had been edited (#2744).
+func TestGeminiHooksReadPastComments(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.GeminiHome(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Already on: nothing to write, and no complaint about the comment.
+	on := "{ // mine\n  \"hooksConfig\": {\"enabled\": true}\n}\n"
+	if err := os.WriteFile(path, []byte(on), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := enableGeminiHooks(); err != nil {
+		t.Errorf("refused a commented config that already has hooks on: %v", err)
+	}
+	b, _ := os.ReadFile(path)
+	if string(b) != on {
+		t.Errorf("rewrote a file it had nothing to change:\n%s", b)
+	}
+
+	// Not on: still a refusal, but one that says what to switch on rather than
+	// quoting a parser at the reader's own comment.
+	off := "{ // mine\n  \"hooksConfig\": {\"enabled\": false}\n}\n"
+	if err := os.WriteFile(path, []byte(off), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := enableGeminiHooks()
+	if err == nil {
+		t.Fatal("silently rewrote a commented config")
+	}
+	if !strings.Contains(err.Error(), "by hand") || !strings.Contains(err.Error(), "hooksConfig") {
+		t.Errorf("the refusal does not say what to do: %v", err)
+	}
+	if b, _ := os.ReadFile(path); string(b) != off {
+		t.Errorf("the file changed on the refusing path:\n%s", b)
+	}
+}

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -122,7 +123,22 @@ func enableGeminiHooks() error {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
-		return fmt.Errorf("gemini settings: %w", err)
+		// The MCP entry went in through the text path, which keeps comments,
+		// and then this refused the same file for having them — after it had
+		// been edited, with a .bak left beside it (#2744). Read past them: if
+		// hooks are already on there is nothing to write, and if they are not,
+		// say what to switch on rather than quoting a parser at somebody about
+		// their own comment.
+		var stripped map[string]any
+		if json.Unmarshal(jsoncStripped(old), &stripped) != nil {
+			return fmt.Errorf("gemini settings: %w", err)
+		}
+		if cfg, _ := stripped["hooksConfig"].(map[string]any); cfg != nil {
+			if on, ok := cfg["enabled"].(bool); ok && on {
+				return nil
+			}
+		}
+		return fmt.Errorf("gemini settings has comments deja will not rewrite — set \"hooksConfig\": {\"enabled\": true} in %s by hand", path)
 	}
 	cfg, _ := root["hooksConfig"].(map[string]any)
 	if cfg == nil {
@@ -139,4 +155,17 @@ func enableGeminiHooks() error {
 	}
 	_, err = writeIfChanged(path, old, append(next, '\n'))
 	return err
+}
+
+// jsoncStripped blanks the comments out of a config so it can be read as JSON,
+// leaving the bytes around them where they were.
+func jsoncStripped(b []byte) []byte {
+	lines := strings.Split(string(b), "\n")
+	inBlock := false
+	for i, l := range lines {
+		code, next, _ := jsoncCodeOf(l, inBlock)
+		inBlock = next
+		lines[i] = code
+	}
+	return []byte(strings.Join(lines, "\n"))
 }


### PR DESCRIPTION
First half of #2744 — the part that is worse than a plain refusal. Does not close it: the other targets listed there still refuse.

`installMCPJSON` writes the entry through the text path, which keeps comments. `enableGeminiHooks` then read the same `~/.gemini/settings.json` with a strict `json.Unmarshal` and failed on the comment, so the target reported failure with the file already edited and a `.bak` beside it.

It now reads past the comments:

- hooks already on — nothing to write, no complaint, and the file is not touched.
- hooks off — still a refusal, since rewriting the file would strip the reader's comments, but one that names the key to set and the path to set it in rather than quoting a parser about their own comment.

The test covers both, and checks the file is byte-identical on each path.