### PR TITLE
fix(how): count the sessions the policy hid, not their commands

### DIFF
--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -52,3 +52,44 @@ func TestAnEntryThatIsOnSaysNothingAboutASwitch(t *testing.T) {
 		}
 	}
 }
+
+// opencode.jsonc is written by a second writer that rewrites deja's entry as
+// one line, so a switch the reader had set went out with the old line and the
+// entry came back on with install reporting success (#2757).
+func TestTheOpencodeJSONCWriterKeepsASwitchTheReaderSet(t *testing.T) {
+	for _, sw := range []string{`"enabled":false`, `"disabled":true`} {
+		t.Run(sw, func(t *testing.T) {
+			old := "{\n  \"mcp\": {\n    \"deja\": {\"type\":\"local\",\"command\":[\"/old/deja\",\"mcp\"]," + sw + "}\n  }\n}\n"
+			next, note, err := updateOpencodeJSONC([]byte(old), "/new/deja", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(next), sw) {
+				t.Errorf("the switch was dropped:\n%s", next)
+			}
+			if !strings.Contains(string(next), "/new/deja") {
+				t.Errorf("the entry was not updated:\n%s", next)
+			}
+			if !strings.Contains(note, "switched off") {
+				t.Errorf("the reader is not told the entry is off: %q", note)
+			}
+		})
+	}
+}
+
+// An entry that is on keeps its shape and says nothing.
+func TestTheOpencodeJSONCWriterSaysNothingAboutAnEntryThatIsOn(t *testing.T) {
+	for _, on := range []string{"", `,"enabled":true`, `,"disabled":false`} {
+		old := "{\n  \"mcp\": {\n    \"deja\": {\"type\":\"local\",\"command\":[\"/old/deja\",\"mcp\"]" + on + "}\n  }\n}\n"
+		next, note, err := updateOpencodeJSONC([]byte(old), "/new/deja", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(note, "switched off") {
+			t.Errorf("%q: an entry that is on was reported as off: %q", on, note)
+		}
+		if strings.Contains(string(next), "\"enabled\":false") || strings.Contains(string(next), "\"disabled\":true") {
+			t.Errorf("%q: an entry that is on was written off:\n%s", on, next)
+		}
+	}
+}

--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line that says deja was left switched off was keyed to one spelling.
+// opencode writes `enabled: false`, and a config carrying that reported a
+// clean install for wiring that will never run (#2757).
+func TestAnEntrySwitchedOffIsReportedWhicheverWayItIsSpelt(t *testing.T) {
+	for _, off := range []map[string]any{
+		{"disabled": true},
+		{"enabled": false},
+	} {
+		name := "disabled"
+		if _, ok := off["enabled"]; ok {
+			name = "enabled false"
+		}
+		t.Run(name, func(t *testing.T) {
+			prev := map[string]any{"command": "/old/deja", "args": []any{"mcp"}}
+			for k, v := range off {
+				prev[k] = v
+			}
+			merged, note := mergeDejaEntry(prev, map[string]any{"command": "/new/deja", "args": []string{"mcp"}})
+			for k, v := range off {
+				if merged[k] != v {
+					t.Errorf("the switch was not carried through: %v", merged)
+				}
+			}
+			if !strings.Contains(note, "switched off") {
+				t.Errorf("the reader is not told the entry is off: %q", note)
+			}
+		})
+	}
+}
+
+// And an entry that is on says nothing, whichever way that is spelt.
+func TestAnEntryThatIsOnSaysNothingAboutASwitch(t *testing.T) {
+	for _, on := range []map[string]any{
+		{},
+		{"disabled": false},
+		{"enabled": true},
+	} {
+		prev := map[string]any{"command": "/old/deja", "args": []any{"mcp"}}
+		for k, v := range on {
+			prev[k] = v
+		}
+		_, note := mergeDejaEntry(prev, map[string]any{"command": "/new/deja", "args": []string{"mcp"}})
+		if strings.Contains(note, "switched off") {
+			t.Errorf("%v: an entry that is on was reported as off: %q", on, note)
+		}
+	}
+}

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -180,7 +180,10 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 // hid, and an agent told nothing exists invents something.
 func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, int, error) {
 	pol := policy.Load()
-	hidden := 0
+	// Sessions, not records: the sentence this feeds says "matching sessions",
+	// and one withheld session that ran a command five times was reported as
+	// five (#1641, the shape #1639 fixed for friction).
+	hidden := map[string]bool{}
 	// The other rule that takes sessions out of an answer. It is applied inside
 	// retrieval, and this screen reads the record log instead of ranking, so it
 	// was not applied here at all: a tree the reader asked deja to stay out of
@@ -190,7 +193,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
 		if !pol.Allows(activation, meta.Project) {
-			hidden++
+			hidden[meta.Harness+":"+meta.ID] = true
 			return
 		}
 		if pol.Ignored(meta.Path, meta.Project) {
@@ -236,7 +239,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 	})
 	if err != nil {
-		return nil, hidden, len(ignored), fmt.Errorf("read: %w", err)
+		return nil, len(hidden), len(ignored), fmt.Errorf("read: %w", err)
 	}
 	out := make([]howEntry, 0, len(byCmd))
 	for _, e := range byCmd {
@@ -254,7 +257,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 		return out[i].Command < out[j].Command
 	})
-	return out, hidden, len(ignored), nil
+	return out, len(hidden), len(ignored), nil
 }
 
 func pluralRuns(n int) string {

--- a/cmd/deja/how_hidden_count_test.go
+++ b/cmd/deja/how_hidden_count_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// howEntries counted withheld records and the sentence it feeds says sessions,
+// so one hidden session that ran a command five times was reported as five
+// (#1641, the shape #1639 fixed for friction). The CLI and the MCP how tool
+// both pass that number on.
+func TestHowCountsWithheldSessionsNotRecords(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, `{"type":"assistant","timestamp":"2026-07-10T10:0`+string(rune('0'+i))+`:00Z","sessionId":"bbbb0002-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`)
+	}
+	if err := os.WriteFile(filepath.Join(store, "bbbb0002.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	out, err := captureRun(t, "how", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "hides 1 matching session") {
+		t.Errorf("the store holds one session; the note says otherwise:\n%s", out)
+	}
+	if strings.Contains(out, "hides 5") {
+		t.Errorf("record count reported as sessions:\n%s", out)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2289,16 +2289,32 @@ func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
 	if _, ok := out["command"]; ok {
 		delete(out, "transport")
 	}
-	if disabled, _ := out["disabled"].(bool); disabled {
+	if entrySwitchedOff(out) {
 		// Switching it back on silently would undo a decision deja was not
 		// asked to revisit; leaving it off without a word looks like a install
 		// that worked.
 		if note != "" {
 			note += "; "
 		}
-		note += "left the entry disabled, the way it was — deja will not answer until you turn it back on"
+		note += "left the entry switched off, the way it was — deja will not answer until you turn it back on"
 	}
 	return out, note
+}
+
+// entrySwitchedOff reports whether the reader has turned this entry off.
+//
+// One switch, two spellings: most hosts write `disabled: true`, opencode
+// writes `enabled: false`. The note was keyed to the first, so a config
+// carrying the second reported a clean install for wiring that will never run
+// (#2757).
+func entrySwitchedOff(entry map[string]any) bool {
+	if off, ok := entry["disabled"].(bool); ok && off {
+		return true
+	}
+	if on, ok := entry["enabled"].(bool); ok && !on {
+		return true
+	}
+	return false
 }
 
 // sameEntry compares an entry read out of a config with the one deja is about

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2911,8 +2911,20 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 			}
 		}
 		note := ""
+		entryLine := line
 		if !uninstall {
 			note = replacedJSONCLineNote(dropped, line)
+			// opencode's other writer rewrites deja's entry as one line, so a
+			// switch the reader had set was dropped with the rest of it: the
+			// entry came back on and install said nothing (#2757). Carry it
+			// through and say so, the way the merge does.
+			if off := jsoncEntrySwitch(strings.Join(dropped, " ")); off != "" {
+				entryLine = strings.TrimSuffix(line, "}") + "," + off + "}"
+				if note != "" {
+					note += "; "
+				}
+				note += "left the entry switched off, the way it was — deja will not answer until you turn it back on"
+			}
 		}
 		if !uninstall {
 			// Ours goes first, carrying its own comma. Written last it needed
@@ -2923,7 +2935,7 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 			// else's line needed — not on an opening brace, not after a
 			// trailing comment, not inside a block comment (#1695) — stop
 			// applying at all.
-			entry := line
+			entry := entryLine
 			at := len(body)
 			if i := jsoncFirstCodeLine(body); i >= 0 {
 				entry += ","
@@ -2980,6 +2992,33 @@ func replacedJSONCLineNote(dropped []string, line string) string {
 		return "replaced the deja entry that was already here"
 	}
 	return fmt.Sprintf("replaced the deja entry that was already here, which ran %s", safeForStatusline(was, 200))
+}
+
+// jsoncEntrySwitch reads an off switch out of the entry text, and returns it
+// the way it will be written back — `"enabled":false` or `"disabled":true`.
+// Empty when the entry is on.
+//
+// Text rather than JSON, for the same reason jsoncEntryCommand is: the block
+// may carry comments and trailing commas.
+func jsoncEntrySwitch(text string) string {
+	for _, sw := range []struct{ key, off string }{
+		{"enabled", "false"},
+		{"disabled", "true"},
+	} {
+		i := strings.Index(text, `"`+sw.key+`"`)
+		if i < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(text[i+len(sw.key)+2:])
+		if !strings.HasPrefix(rest, ":") {
+			continue
+		}
+		rest = strings.TrimSpace(rest[1:])
+		if strings.HasPrefix(rest, sw.off) {
+			return `"` + sw.key + `":` + sw.off
+		}
+	}
+	return ""
 }
 
 // jsoncEntryCommand pulls the command out of an entry deja did not write. It

--- a/cmd/deja/jsonc_install_test.go
+++ b/cmd/deja/jsonc_install_test.go
@@ -236,7 +236,7 @@ func TestACommentedConfigKeepsTheFieldsOnDejasOwnEntry(t *testing.T) {
 	if !strings.Contains(got, `"disabled": true`) {
 		t.Errorf("a disabled entry was silently switched on:\n%s", got)
 	}
-	if !strings.Contains(out, "left the entry disabled") {
+	if !strings.Contains(out, "left the entry switched off") {
 		t.Errorf("nothing said the entry is still off:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #1641. Follow-on from #1639, which fixed the same shape in friction.

`howEntries` incremented a counter per withheld record, and the sentence it feeds says "matching sessions" — so one hidden session that ran a command five times was reported as five. Both callers pass that number on: the CLI and the MCP `how` tool.