### PR TITLE
fix(mcp): the how tool prints the CLI's answer instead of its own copy

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -144,25 +144,47 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "no command on this machine mentions %q\n", strings.Join(terms, " "))
 		return nil
 	}
+	writeHowEntries(stdout, entries, limit, func(c string) string {
+		// The command itself, kept the way a person would copy it, folded onto
+		// one line so a newline in it cannot forge a row of deja's (#1863).
+		return search.SafeCommand(c)
+	}, " · last ")
+	// The cap said nothing, so eight of thirteen ways to run the tests read as
+	// thirteen — the misread the search screen already avoids (#1632). On
+	// stderr, where search puts the same line: stdout stays the list.
+	if note := howCapNote(len(entries), limit); note != "" {
+		fmt.Fprintf(os.Stderr, "deja: %s\n", note)
+	}
+	return nil
+}
+
+// writeHowEntries is the answer both surfaces print. The MCP tool used to
+// build its own copy of this loop, so what the CLI learned to say the agent
+// never heard — and the cap note was the drift showing (#1634). The two
+// differences that are real stay parameters: how a command is made safe to
+// show, and the separator before the date.
+func writeHowEntries(w io.Writer, entries []howEntry, limit int, safe func(string) string, lastSep string) {
 	for i, e := range entries {
 		if i >= limit {
 			break
 		}
 		when := ""
 		if !e.Last.IsZero() {
-			when = " · last " + e.Last.Local().Format("2006-01-02")
+			when = lastSep + e.Last.Local().Format("2006-01-02")
 		}
-		fmt.Fprintf(stdout, "%s\n", search.SafeCommand(e.Command))
-		fmt.Fprintf(stdout, "  ran %s in %s%s%s\n",
+		fmt.Fprintf(w, "%s\n", safe(e.Command))
+		fmt.Fprintf(w, "  ran %s in %s%s%s\n",
 			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when, e.failureNote())
 	}
-	// The cap said nothing, so eight of thirteen ways to run the tests read as
-	// thirteen — the misread the search screen already avoids (#1632). On
-	// stderr, where search puts the same line: stdout stays the list.
-	if len(entries) > limit {
-		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", limit, len(entries))
+}
+
+// howCapNote is the sentence that says the list was cut, or empty when it was
+// not. One sentence, so the agent and the reader are told the same thing.
+func howCapNote(found, limit int) string {
+	if found <= limit {
+		return ""
 	}
-	return nil
+	return fmt.Sprintf("showing %d of %d — raise --limit for the rest", limit, found)
 }
 
 // howEntries groups the commands that mention every term, so the same

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -144,15 +144,11 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "no command on this machine mentions %q\n", strings.Join(terms, " "))
 		return nil
 	}
-	writeHowEntries(stdout, entries, limit, func(c string) string {
-		// The command itself, kept the way a person would copy it, folded onto
-		// one line so a newline in it cannot forge a row of deja's (#1863).
-		return search.SafeCommand(c)
-	}, " · last ")
+	writeHowEntries(stdout, entries, limit, " · last ")
 	// The cap said nothing, so eight of thirteen ways to run the tests read as
 	// thirteen — the misread the search screen already avoids (#1632). On
 	// stderr, where search puts the same line: stdout stays the list.
-	if note := howCapNote(len(entries), limit); note != "" {
+	if note := howCapNote(len(entries), limit, "raise --limit for the rest"); note != "" {
 		fmt.Fprintf(os.Stderr, "deja: %s\n", note)
 	}
 	return nil
@@ -160,10 +156,9 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 
 // writeHowEntries is the answer both surfaces print. The MCP tool used to
 // build its own copy of this loop, so what the CLI learned to say the agent
-// never heard — and the cap note was the drift showing (#1634). The two
-// differences that are real stay parameters: how a command is made safe to
-// show, and the separator before the date.
-func writeHowEntries(w io.Writer, entries []howEntry, limit int, safe func(string) string, lastSep string) {
+// never heard — and the cap note was the drift showing (#1634). The one
+// difference that is real stays a parameter: the separator before the date.
+func writeHowEntries(w io.Writer, entries []howEntry, limit int, lastSep string) {
 	for i, e := range entries {
 		if i >= limit {
 			break
@@ -172,19 +167,23 @@ func writeHowEntries(w io.Writer, entries []howEntry, limit int, safe func(strin
 		if !e.Last.IsZero() {
 			when = lastSep + e.Last.Local().Format("2006-01-02")
 		}
-		fmt.Fprintf(w, "%s\n", safe(e.Command))
+		// The command itself, kept the way a person would copy it, folded onto
+		// one line so a newline in it cannot forge a row of deja's (#1863).
+		fmt.Fprintf(w, "%s\n", search.SafeCommand(e.Command))
 		fmt.Fprintf(w, "  ran %s in %s%s%s\n",
 			pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when, e.failureNote())
 	}
 }
 
 // howCapNote is the sentence that says the list was cut, or empty when it was
-// not. One sentence, so the agent and the reader are told the same thing.
-func howCapNote(found, limit int) string {
+// not. One sentence, so the agent and the reader are told the same thing —
+// except for how to see the rest, which is a flag at a terminal and another
+// call over MCP, where there is no flag to raise.
+func howCapNote(found, limit int, raise string) string {
 	if found <= limit {
 		return ""
 	}
-	return fmt.Sprintf("showing %d of %d — raise --limit for the rest", limit, found)
+	return fmt.Sprintf("showing %d of %d — %s", limit, found, raise)
 }
 
 // howEntries groups the commands that mention every term, so the same

--- a/cmd/deja/how_mcp_cap_test.go
+++ b/cmd/deja/how_mcp_cap_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The MCP how tool cut the list at its limit and said nothing, so an agent
+// asking how the tests are run here got eight of thirteen with no way to know
+// there were more — and no way to ask a follow-up. The CLI has said so since
+// #1632; the tool reimplemented the answer instead of sharing it (#1634).
+func TestTheMCPHowToolSaysWhenItCutTheList(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 13; i++ {
+		id := "0000000" + string(rune('a'+i)) + "-1111-4000-8000-d6e7f8a9b0c1"
+		line := `{"type":"assistant","timestamp":"2026-07-0` + string(rune('1'+i%9)) + `T10:00:00Z","sessionId":"` + id + `","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./... -run Case` + string(rune('a'+i)) + `"}}]}}`
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "how", json.RawMessage(`{"what":"go test","limit":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(text, "go test"); n < 3 {
+		t.Fatalf("expected three entries:\n%s", text)
+	}
+	if !strings.Contains(text, "3 of 13") {
+		t.Errorf("the cut is silent — nothing says how many there were:\n%s", text)
+	}
+
+	// The control: an uncut list says nothing extra.
+	text, err = callMCPTool(dir, "how", json.RawMessage(`{"what":"go test","limit":20}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, " of 13") {
+		t.Errorf("a list that was not cut says it was:\n%s", text)
+	}
+}

--- a/cmd/deja/how_mcp_cap_test.go
+++ b/cmd/deja/how_mcp_cap_test.go
@@ -42,6 +42,13 @@ func TestTheMCPHowToolSaysWhenItCutTheList(t *testing.T) {
 	if !strings.Contains(text, "3 of 13") {
 		t.Errorf("the cut is silent — nothing says how many there were:\n%s", text)
 	}
+	// An agent passes limit as a field; there is no flag for it to raise.
+	if strings.Contains(text, "--limit") {
+		t.Errorf("the agent is told to raise a flag it cannot pass:\n%s", text)
+	}
+	if !strings.Contains(text, "call again with a higher limit") {
+		t.Errorf("the agent is not told how to see the rest:\n%s", text)
+	}
 
 	// The control: an uncut list says nothing extra.
 	text, err = callMCPTool(dir, "how", json.RawMessage(`{"what":"go test","limit":20}`))

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -475,19 +475,17 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			limit = 8
 		}
 		var hb strings.Builder
-		for i, e := range entries {
-			if i >= limit {
-				break
-			}
-			when := ""
-			if !e.Last.IsZero() {
-				when = ", last " + e.Last.Local().Format("2006-01-02")
-			}
-			// The same note the CLI prints: the agent reading this is the
-			// one most likely to run the command back without looking.
-			fmt.Fprintf(&hb, "%s\n  ran %s in %s%s%s\n", commandListingLine(e.Command), pluralRuns(e.Runs), pluralSessions(len(e.Sessions)), when, e.failureNote())
+		// The same lines the CLI prints, from the same writer: this tool used
+		// to keep its own copy of the loop, so a note the CLI learned never
+		// reached the agent (#1634).
+		writeHowEntries(&hb, entries, limit, commandListingLine, ", last ")
+		out := strings.TrimRight(hb.String(), "\n")
+		if note := howCapNote(len(entries), limit); note != "" {
+			// The agent cannot ask a follow-up of its own, so the cut has to
+			// travel with the answer rather than to a terminal it never sees.
+			out += "\n\n" + note
 		}
-		return strings.TrimRight(hb.String(), "\n"), nil
+		return out, nil
 	case "remember":
 		var a struct {
 			Text    string   `json:"text"`

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -478,9 +478,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// The same lines the CLI prints, from the same writer: this tool used
 		// to keep its own copy of the loop, so a note the CLI learned never
 		// reached the agent (#1634).
-		writeHowEntries(&hb, entries, limit, commandListingLine, ", last ")
+		writeHowEntries(&hb, entries, limit, ", last ")
 		out := strings.TrimRight(hb.String(), "\n")
-		if note := howCapNote(len(entries), limit); note != "" {
+		if note := howCapNote(len(entries), limit, "call again with a higher limit for the rest"); note != "" {
 			// The agent cannot ask a follow-up of its own, so the cut has to
 			// travel with the answer rather than to a terminal it never sees.
 			out += "\n\n" + note


### PR DESCRIPTION
Closes #1634. Stacked on #2760.

The MCP `how` tool kept its own copy of the listing loop, so what the CLI learned to say the agent never heard — the cap note from #1632 being the drift showing. Both surfaces now write through one `writeHowEntries`, with the two real differences as parameters (how a command is made safe to show, and the separator before the date), and share one `howCapNote`. The agent gets the cut as part of the answer, since it has no terminal to read a stderr line from.