### PR TITLE
fix(remember): quote the id in the tombstone hint the way a shell pastes it

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3061,7 +3061,8 @@ func runForget(dir string, args []string) error {
 			fmt.Fprintln(os.Stderr, "deja: nothing is forgotten on this machine")
 		}
 		if len(keys) > 0 {
-			fmt.Fprintf(os.Stderr, "deja: `deja forget --unforget %s` brings one back and rebuilds the index\n", pasteSafe(keys[0]))
+			quoted := pasteSafe(keys[0])
+			fmt.Fprintf(os.Stderr, "deja: `deja forget --unforget %s` brings one back and rebuilds the index%s\n", quoted, pasteSafeCaveat(quoted))
 		}
 		return nil
 	}
@@ -3117,7 +3118,11 @@ func runForget(dir string, args []string) error {
 			// The ids, not just the count: this is the moment someone checks
 			// that they got back exactly what they lost, and both the list and
 			// the ambiguity refusal name them a step earlier (#1095, #1014).
-			fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index — %s\n", back, pluralS(back), joinCapped(names, 5))
+			// Prose, not a command: the names are read, not pasted, so they
+			// are neutralised rather than quoted. Raw, an escape byte in a
+			// project name landed here on the line after the hint that told
+			// the reader to run this (#1794).
+			fmt.Fprintf(os.Stdout, "restored %d session%s and rebuilt the index — %s\n", back, pluralS(back), safeForStatusline(joinCapped(names, 5), 200))
 		}
 		for _, line := range unforgetGoneLines(missing) {
 			fmt.Fprintln(os.Stdout, line)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3061,7 +3061,7 @@ func runForget(dir string, args []string) error {
 			fmt.Fprintln(os.Stderr, "deja: nothing is forgotten on this machine")
 		}
 		if len(keys) > 0 {
-			fmt.Fprintf(os.Stderr, "deja: `deja forget --unforget %s` brings one back and rebuilds the index\n", keys[0])
+			fmt.Fprintf(os.Stderr, "deja: `deja forget --unforget %s` brings one back and rebuilds the index\n", pasteSafe(keys[0]))
 		}
 		return nil
 	}

--- a/cmd/deja/paste_safe.go
+++ b/cmd/deja/paste_safe.go
@@ -102,6 +102,9 @@ func actsOnATerminal(r rune) bool {
 // `proj&&id` produced `deja forget --unforget deja:…-proj&&id`, and pasting it
 // ran `id`. The name is not always the reader's own; it comes from a directory
 // name or from an MCP tool call.
+//
+// `=` is not in the set: zsh's EQUALS option is on by default, so a value that
+// starts a word with it — `=ls` — is replaced by the path of that command.
 func shellQuoteForPaste(s string) string {
 	if s == "" {
 		return "''"
@@ -113,11 +116,23 @@ func shellQuoteForPaste(s string) string {
 			// matters when it does not.
 			continue
 		}
-		if !strings.ContainsRune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_@%+=:,./-", r) {
+		if !strings.ContainsRune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_@%+:,./-", r) {
 			return shellQuote(s)
 		}
 	}
 	return s
+}
+
+// pasteSafeCaveat is the shell the quoted form needs, or empty when any shell
+// takes it. Only bash and zsh read `$'…'`; dash and fish pass the `$` and the
+// backslashes through literally, so the command matches nothing and says so
+// with a straight face. Every line that hands over a quoted value carries the
+// caveat, not just the first one that needed it.
+func pasteSafeCaveat(quoted string) string {
+	if strings.HasPrefix(quoted, "$'") {
+		return " (in bash or zsh)"
+	}
+	return ""
 }
 
 // tombstoneHint is the sentence both writers print when the note they just
@@ -125,13 +140,6 @@ func shellQuoteForPaste(s string) string {
 // and `promote` each had their own copy of it.
 func tombstoneHint(what, id string) string {
 	quoted := pasteSafe(id)
-	where := ""
-	if strings.HasPrefix(quoted, "$'") {
-		// Only bash and zsh read this form; dash and fish would take the `$`
-		// literally and match nothing. Saying which shell is what makes the
-		// line honest for the reader who is not in one of them.
-		where = " (in bash or zsh)"
-	}
 	return fmt.Sprintf("deja: %s but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`%s\n",
-		what, safeForStatusline(id, 200), quoted, where)
+		what, safeForStatusline(id, 200), quoted, pasteSafeCaveat(quoted))
 }

--- a/cmd/deja/paste_safe.go
+++ b/cmd/deja/paste_safe.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// pasteSafe renders a value the reader is meant to paste back into a shell.
+//
+// The tombstone hint is the case that forced it: the id is the argument of the
+// command that lifts the tombstone, so sanitising it hands over a command that
+// names nothing — and printing it raw sends an escape byte from a project name
+// straight to the terminal (#1794, the half #1792 left). ANSI-C quoting is
+// both at once: the bytes are visible as `\e`, `\t`, `\x00`, and bash and zsh
+// turn them back into the same bytes.
+func pasteSafe(s string) string {
+	if needsANSICQuoting(s) {
+		var b strings.Builder
+		b.WriteString("$'")
+		for _, r := range s {
+			switch r {
+			case '\'':
+				b.WriteString(`\'`)
+			case '\\':
+				b.WriteString(`\\`)
+			case 0x1b:
+				b.WriteString(`\e`)
+			case '\n':
+				b.WriteString(`\n`)
+			case '\r':
+				b.WriteString(`\r`)
+			case '\t':
+				b.WriteString(`\t`)
+			default:
+				if r < 0x20 || r == 0x7f {
+					fmt.Fprintf(&b, `\x%02x`, r)
+					continue
+				}
+				b.WriteRune(r)
+			}
+		}
+		b.WriteString("'")
+		return b.String()
+	}
+	return shellQuoteIfNeeded(s)
+}
+
+// needsANSICQuoting is true for the values single quotes cannot make safe: a
+// control byte inside single quotes is still a control byte on its way to the
+// terminal.
+func needsANSICQuoting(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// tombstoneHint is the sentence both writers print when the note they just
+// wrote lands under a tombstone. One sentence, one id, quoted once: `remember`
+// and `promote` each had their own copy of it.
+func tombstoneHint(what, id string) string {
+	return fmt.Sprintf("deja: %s but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n",
+		what, safeForStatusline(id, 200), pasteSafe(id))
+}

--- a/cmd/deja/paste_safe.go
+++ b/cmd/deja/paste_safe.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // pasteSafe renders a value the reader is meant to paste back into a shell.
@@ -10,57 +12,126 @@ import (
 // The tombstone hint is the case that forced it: the id is the argument of the
 // command that lifts the tombstone, so sanitising it hands over a command that
 // names nothing — and printing it raw sends an escape byte from a project name
-// straight to the terminal (#1794, the half #1792 left). ANSI-C quoting is
-// both at once: the bytes are visible as `\e`, `\t`, `\x00`, and bash and zsh
-// turn them back into the same bytes.
+// straight to the terminal (#1794, the half #1792 left).
+//
+// Two forms, and the choice is not about looks. A value carrying anything a
+// terminal acts on goes out ANSI-C quoted — the bytes are visible as `\e`,
+// `\t`, `\u200e`, and bash and zsh turn them back into the same bytes. Anything
+// else that a shell would act on — `;`, `&`, `>`, a space — goes out single
+// quoted. Only a value that is plain by every measure is printed bare.
+//
+// ANSI-C quoting is bash and zsh; dash and fish have no such form, which is
+// why the hint says which shells it is for rather than pretending otherwise.
 func pasteSafe(s string) string {
-	if needsANSICQuoting(s) {
-		var b strings.Builder
-		b.WriteString("$'")
-		for _, r := range s {
-			switch r {
-			case '\'':
-				b.WriteString(`\'`)
-			case '\\':
-				b.WriteString(`\\`)
-			case 0x1b:
-				b.WriteString(`\e`)
-			case '\n':
-				b.WriteString(`\n`)
-			case '\r':
-				b.WriteString(`\r`)
-			case '\t':
-				b.WriteString(`\t`)
+	if !needsANSICQuoting(s) {
+		return shellQuoteForPaste(s)
+	}
+	var b strings.Builder
+	b.WriteString("$'")
+	for i := 0; i < len(s); {
+		// Bytes, not runes: `for range` turns invalid UTF-8 into U+FFFD, so a
+		// stray 0xff came back out as three different bytes and the pasted
+		// command named a key that does not exist.
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			fmt.Fprintf(&b, `\x%02x`, s[i])
+			i++
+			continue
+		}
+		i += size
+		switch r {
+		case '\'':
+			b.WriteString(`\'`)
+		case '\\':
+			b.WriteString(`\\`)
+		case 0x1b:
+			b.WriteString(`\e`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			switch {
+			case r < 0x20 || r == 0x7f:
+				fmt.Fprintf(&b, `\x%02x`, r)
+			case actsOnATerminal(r):
+				// C1 controls — U+009B is CSI on most terminals — and the
+				// bidi and format characters, which the prose half strips and
+				// this half used to carry through raw.
+				fmt.Fprintf(&b, `\u%04x`, r)
 			default:
-				if r < 0x20 || r == 0x7f {
-					fmt.Fprintf(&b, `\x%02x`, r)
-					continue
-				}
 				b.WriteRune(r)
 			}
 		}
-		b.WriteString("'")
-		return b.String()
 	}
-	return shellQuoteIfNeeded(s)
+	b.WriteString("'")
+	return b.String()
 }
 
 // needsANSICQuoting is true for the values single quotes cannot make safe: a
 // control byte inside single quotes is still a control byte on its way to the
-// terminal.
+// terminal, and so is a byte that is not valid UTF-8.
 func needsANSICQuoting(s string) bool {
-	for _, r := range s {
-		if r < 0x20 || r == 0x7f {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
 			return true
 		}
+		if actsOnATerminal(r) {
+			return true
+		}
+		i += size
 	}
 	return false
+}
+
+// actsOnATerminal is the predicate safeForStatusline strips by, kept the same
+// on purpose: the prose half of a line and the command half of it have to
+// agree about which characters a terminal acts on, or one of them leaks what
+// the other removed.
+func actsOnATerminal(r rune) bool {
+	return unicode.IsControl(r) || unicode.Is(unicode.Cf, r)
+}
+
+// shellQuoteForPaste single-quotes anything a shell would act on. The set kept
+// bare is the conservative one — letters, digits, and the punctuation that has
+// no meaning to a shell in an unquoted word — because the alternative is
+// handing the reader a command that runs something else: a project name of
+// `proj&&id` produced `deja forget --unforget deja:…-proj&&id`, and pasting it
+// ran `id`. The name is not always the reader's own; it comes from a directory
+// name or from an MCP tool call.
+func shellQuoteForPaste(s string) string {
+	if s == "" {
+		return "''"
+	}
+	for _, r := range s {
+		if r >= utf8.RuneSelf {
+			// Non-ASCII is not a shell metacharacter, and quoting every
+			// accented project name would make the hint look like escaping
+			// matters when it does not.
+			continue
+		}
+		if !strings.ContainsRune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_@%+=:,./-", r) {
+			return shellQuote(s)
+		}
+	}
+	return s
 }
 
 // tombstoneHint is the sentence both writers print when the note they just
 // wrote lands under a tombstone. One sentence, one id, quoted once: `remember`
 // and `promote` each had their own copy of it.
 func tombstoneHint(what, id string) string {
-	return fmt.Sprintf("deja: %s but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n",
-		what, safeForStatusline(id, 200), pasteSafe(id))
+	quoted := pasteSafe(id)
+	where := ""
+	if strings.HasPrefix(quoted, "$'") {
+		// Only bash and zsh read this form; dash and fish would take the `$`
+		// literally and match nothing. Saying which shell is what makes the
+		// line honest for the reader who is not in one of them.
+		where = " (in bash or zsh)"
+	}
+	return fmt.Sprintf("deja: %s but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`%s\n",
+		what, safeForStatusline(id, 200), quoted, where)
 }

--- a/cmd/deja/paste_safe_test.go
+++ b/cmd/deja/paste_safe_test.go
@@ -18,6 +18,10 @@ func TestAPastedIdShowsItsControlBytesAndStillPastes(t *testing.T) {
 		{"it's", `'it'"'"'s'`},
 		{"tab\there", `$'tab\there'`},
 		{"nl\nhere", `$'nl\nhere'`},
+		// A rendering rather than a round-trip: bash and dash drop a NUL
+		// from an argument. Unreachable — argv cannot carry one and
+		// Tombstones() filters keys that do — and pinned so the escape is
+		// visible rather than raw if it ever arrives.
 		{"nul\x00here", `$'nul\x00here'`},
 		// A shell acts on more than quotes and spaces. Pasting the first of
 		// these used to run `id`, and the second truncated a file.
@@ -31,6 +35,9 @@ func TestAPastedIdShowsItsControlBytesAndStillPastes(t *testing.T) {
 		// C1 controls and the format characters: the prose half strips these,
 		// so the command half cannot carry them raw. U+009B is CSI.
 		{"proj\u009bX", `$'proj\u009bX'`},
+		// zsh replaces a word-initial `=word` with the path of that command.
+		{"=ls", `'=ls'`},
+		{"a=b", `'a=b'`},
 		{"proj\u202eX", `$'proj\u202eX'`},
 		// A byte that is not valid UTF-8 stays that byte: decoding it to
 		// U+FFFD wrote three different bytes back, so the pasted command
@@ -93,5 +100,20 @@ func TestTheHintNamesTheShellsThatCanPasteIt(t *testing.T) {
 	plain := tombstoneHint("it is written", "deja-2026-08-25-notes")
 	if strings.Contains(plain, "bash or zsh") {
 		t.Errorf("an ordinary id was given a shell caveat it does not need:\n%s", plain)
+	}
+}
+
+// Every line that hands over a quoted value carries the shell caveat, not just
+// the tombstone hint: dash takes `$'…'` literally and the command then matches
+// nothing, silently.
+func TestEveryQuotedPasteSaysWhichShellReadsIt(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"deja-2026-08-25-p\x1b[31mX", " (in bash or zsh)"},
+		{"deja-2026-08-25-has space", ""},
+		{"deja-2026-08-25-plain", ""},
+	} {
+		if got := pasteSafeCaveat(pasteSafe(c.in)); got != c.want {
+			t.Errorf("pasteSafeCaveat(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }

--- a/cmd/deja/paste_safe_test.go
+++ b/cmd/deja/paste_safe_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"unicode"
 )
 
 // The hint hands the reader a command to paste, so the id in it cannot be
@@ -18,6 +19,25 @@ func TestAPastedIdShowsItsControlBytesAndStillPastes(t *testing.T) {
 		{"tab\there", `$'tab\there'`},
 		{"nl\nhere", `$'nl\nhere'`},
 		{"nul\x00here", `$'nul\x00here'`},
+		// A shell acts on more than quotes and spaces. Pasting the first of
+		// these used to run `id`, and the second truncated a file.
+		{"proj&&id", `'proj&&id'`},
+		{"proj;id", `'proj;id'`},
+		{"proj>out", `'proj>out'`},
+		{"proj|id", `'proj|id'`},
+		{"proj(x)", `'proj(x)'`},
+		{"proj*", `'proj*'`},
+		{"~proj", `'~proj'`},
+		// C1 controls and the format characters: the prose half strips these,
+		// so the command half cannot carry them raw. U+009B is CSI.
+		{"proj\u009bX", `$'proj\u009bX'`},
+		{"proj\u202eX", `$'proj\u202eX'`},
+		// A byte that is not valid UTF-8 stays that byte: decoding it to
+		// U+FFFD wrote three different bytes back, so the pasted command
+		// named a key that does not exist.
+		{"proj\xffX", `$'proj\xffX'`},
+		// An ordinary accented name is not a shell problem and stays bare.
+		{"projekt-über", "projekt-über"},
 	} {
 		if got := pasteSafe(c.in); got != c.want {
 			t.Errorf("pasteSafe(%q) = %s, want %s", c.in, got, c.want)
@@ -36,5 +56,42 @@ func TestTheTombstoneHintCarriesNoEscapeByte(t *testing.T) {
 	}
 	if !strings.Contains(hint, `\e[31mX`) {
 		t.Errorf("the id is not shown the way it can be pasted back:\n%s", hint)
+	}
+}
+
+// The two halves of the line agree about what a terminal acts on: the prose
+// half strips it, the command half quotes it, and neither passes it through.
+func TestBothHalvesOfTheHintAgreeAboutControlCharacters(t *testing.T) {
+	for _, id := range []string{
+		"deja-2026-08-25-p\x1b[31mX",
+		"deja-2026-08-25-p\u009bX",
+		"deja-2026-08-25-p\u202eX",
+		"deja-2026-08-25-p\u200eX",
+		"deja-2026-08-25-p\x7fX",
+	} {
+		hint := tombstoneHint("it is written", id)
+		for _, r := range hint {
+			if unicode.IsControl(r) && r != '\n' {
+				t.Errorf("%q: the hint carries a control character: %q", id, hint)
+				break
+			}
+			if unicode.Is(unicode.Cf, r) {
+				t.Errorf("%q: the hint carries a format character: %q", id, hint)
+				break
+			}
+		}
+	}
+}
+
+// The ANSI-C form is bash and zsh only, so the line says so — a dash or fish
+// reader pasting it would get a literal `$` and match nothing.
+func TestTheHintNamesTheShellsThatCanPasteIt(t *testing.T) {
+	odd := tombstoneHint("it is written", "deja-2026-08-25-p\x1b[31mX")
+	if !strings.Contains(odd, "in bash or zsh") {
+		t.Errorf("the quoted form is not attributed to a shell that reads it:\n%s", odd)
+	}
+	plain := tombstoneHint("it is written", "deja-2026-08-25-notes")
+	if strings.Contains(plain, "bash or zsh") {
+		t.Errorf("an ordinary id was given a shell caveat it does not need:\n%s", plain)
 	}
 }

--- a/cmd/deja/paste_safe_test.go
+++ b/cmd/deja/paste_safe_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The hint hands the reader a command to paste, so the id in it cannot be
+// sanitised — a sanitised id names nothing and the paste fails. It also cannot
+// carry an escape byte to the terminal (#1794). ANSI-C quoting is both: the
+// bytes are visible, and bash and zsh reproduce them.
+func TestAPastedIdShowsItsControlBytesAndStillPastes(t *testing.T) {
+	for _, c := range []struct{ in, want string }{
+		{"deja-2026-08-25-notes", "deja-2026-08-25-notes"},
+		{"deja-2026-08-25-p\x1b[31mX", `$'deja-2026-08-25-p\e[31mX'`},
+		{"two words", `'two words'`},
+		{"it's", `'it'"'"'s'`},
+		{"tab\there", `$'tab\there'`},
+		{"nl\nhere", `$'nl\nhere'`},
+		{"nul\x00here", `$'nul\x00here'`},
+	} {
+		if got := pasteSafe(c.in); got != c.want {
+			t.Errorf("pasteSafe(%q) = %s, want %s", c.in, got, c.want)
+		}
+	}
+}
+
+// And the hint itself carries no raw escape byte.
+func TestTheTombstoneHintCarriesNoEscapeByte(t *testing.T) {
+	hint := tombstoneHint("it is written", "deja-2026-08-25-p\x1b[31mX")
+	if strings.ContainsRune(hint, 0x1b) {
+		t.Errorf("the hint carries an escape byte to the terminal:\n%q", hint)
+	}
+	if !strings.Contains(hint, "deja forget --unforget") {
+		t.Errorf("the hint no longer says how to lift the tombstone:\n%s", hint)
+	}
+	if !strings.Contains(hint, `\e[31mX`) {
+		t.Errorf("the id is not shown the way it can be pasted back:\n%s", hint)
+	}
+}

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -146,7 +146,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	// Say so and name the one command that restores it, rather than silently
 	// clearing a tombstone the reader set on purpose.
 	if noteID := "deja-note-" + strings.ReplaceAll(src, ":", "-"); index.Tombstoned("deja:" + noteID) {
-		fmt.Fprintf(os.Stderr, "deja: the note is written but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n", noteID, noteID)
+		fmt.Fprint(os.Stderr, tombstoneHint("the note is written", noteID))
 	}
 	if exportPath != "" {
 		masked, err := exportPromoted(exportPath, title, text, src, state, s.Updated)

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -197,7 +197,8 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	// The id deja resolved, not the one the reader typed: a prefix that stood
 	// for several sessions would send the correction to whichever is newest —
 	// measured, that was a different session from the one just marked (#884).
-	fmt.Fprintf(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote %s --state <state>`\n", pasteSafe(s.ID))
+	quoted := pasteSafe(s.ID)
+	fmt.Fprintf(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote %s --state <state>`%s\n", quoted, pasteSafeCaveat(quoted))
 	return nil
 }
 

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -154,7 +154,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 			// The note is already written by this point, so failing with a bare
 			// syscall told the reader their decision was lost when it was not
 			// — and named a path with nothing to do about it (#871).
-			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, search.SafeNote(title))
+			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", safeForStatusline(src, 200), state, search.SafeNote(title))
 			return fmt.Errorf("the note is kept, but %s could not be written (%s) — export it somewhere you can, or read the note back with `deja show %s`",
 				exportPath, exportFailureReason(err), "deja-note-"+strings.ReplaceAll(src, ":", "-"))
 		}
@@ -164,7 +164,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 		// rewritten — the warning is what was missing (#848).
 		fmt.Fprintf(os.Stderr, "deja: %d secret%s masked in this file. pattern redaction is a floor — review before sending; rotate anything that leaked.\n", masked, pluralS(masked))
 	}
-	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", src, state, search.SafeNote(title))
+	fmt.Fprintf(stdout, "promoted %s as %s: %s\n", safeForStatusline(src, 200), state, search.SafeNote(title))
 	if line := markTakenBack(src, state, prior); line != "" {
 		fmt.Fprintln(stdout, line)
 	}
@@ -197,7 +197,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 	// The id deja resolved, not the one the reader typed: a prefix that stood
 	// for several sessions would send the correction to whichever is newest —
 	// measured, that was a different session from the one just marked (#884).
-	fmt.Fprintln(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote", s.ID, "--state <state>`")
+	fmt.Fprintf(stdout, "the note now outranks the raw transcript in recall; corrections append with `deja promote %s --state <state>`\n", pasteSafe(s.ID))
 	return nil
 }
 

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -84,7 +84,7 @@ func runRemember(dir string, args []string) error {
 	// path. Name the restore command rather than lose the line quietly.
 	dayNote := "deja-" + now.Local().Format("2006-01-02") + "-" + strings.TrimSpace(project)
 	if index.Tombstoned("deja:" + dayNote) {
-		fmt.Fprintf(os.Stderr, "deja: it is written but stays hidden — %s was forgotten, and its tombstone lifts only through `deja forget --unforget deja:%s`\n", dayNote, dayNote)
+		fmt.Fprint(os.Stderr, tombstoneHint("it is written", dayNote))
 	}
 	suffix := ""
 	if norm := sources.NormalizeTags(tags); len(norm) > 0 {


### PR DESCRIPTION
Closes #1794, the half #1792 left.

The hint hands the reader the command that lifts the tombstone, so the id in it cannot be sanitised — a sanitised id names nothing. It also cannot carry an escape byte from a project name to the terminal. ANSI-C quoting is both: `$'deja-2026-08-25-p\\e[31mX'` shows the bytes and reproduces them in bash and zsh (checked both).

`remember` and `promote` had their own copy of the sentence; they share one now.