### PR TITLE
fix(search): refuse a bad --re pattern in deja's own voice

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -487,7 +487,7 @@ func TestAdditionalDispatchAndHelperBranches(t *testing.T) {
 		t.Fatalf("parse --all: %v", err)
 	}
 	// The refusal names the input rather than the function it came from (#2286).
-	if out, err := captureRun(t, "--re", "("); err == nil || !strings.Contains(err.Error(), "--re pattern") || out != "" {
+	if out, err := captureRun(t, "--re", "("); err == nil || !strings.Contains(err.Error(), `--re "("`) || out != "" {
 		t.Fatalf("bad regex out=%q err=%v", out, err)
 	}
 	badRoot := t.TempDir()

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1229,9 +1229,9 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 			// "run:" is the name of a function, and the reader of this line is
 			// someone who mistyped a pattern (#2286). The only error that
 			// reaches here in practice is the regexp compile, so it says which
-			// input to look at.
+			// input to look at, in the words the other bad flags use (#1602).
 			if o.Regex {
-				return fmt.Errorf("--re pattern: %w", rerr)
+				return rePatternError(o.Query, rerr)
 			}
 			return rerr
 		}

--- a/cmd/deja/re_error.go
+++ b/cmd/deja/re_error.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp/syntax"
-	"strings"
+	"strconv"
 )
 
 // rePatternError says a pattern cannot be used, in the same voice the other
@@ -25,7 +25,10 @@ func rePatternError(pattern string, err error) error {
 	}
 	what := string(perr.Code)
 	if perr.Expr != "" && perr.Expr != pattern {
-		what += ": " + perr.Expr
+		// Quoted like the pattern itself: Go prints the offending fragment
+		// raw, so a pattern holding an escape byte put one on the terminal
+		// through the very line that exists to keep them off it.
+		what += ": " + strconv.Quote(perr.Expr)
 	}
-	return fmt.Errorf("--re %q is not a pattern deja can use — %s", pattern, strings.TrimSpace(what))
+	return fmt.Errorf("--re %q is not a pattern deja can use — %s", pattern, what)
 }

--- a/cmd/deja/re_error.go
+++ b/cmd/deja/re_error.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp/syntax"
+	"strings"
+)
+
+// rePatternError says a pattern cannot be used, in the same voice the other
+// bad flags answer in: `--since bogus` is "not a duration deja understands",
+// `--limit abc` "needs an integer from 1 to 100". This one used to hand over
+// Go's `error parsing regexp: …` behind a function name (#1602).
+//
+// Go's message already names what is wrong with the pattern — "missing closing
+// )", "invalid character class range: z-a" — so the fix is to keep that half
+// and drop the prefix and the repeated pattern, not to write a worse
+// explanation of our own.
+func rePatternError(pattern string, err error) error {
+	var perr *syntax.Error
+	if !errors.As(err, &perr) {
+		// Not the compile failing — whatever else RunDetailed returns travels
+		// as it is rather than being described as a bad pattern.
+		return err
+	}
+	what := string(perr.Code)
+	if perr.Expr != "" && perr.Expr != pattern {
+		what += ": " + perr.Expr
+	}
+	return fmt.Errorf("--re %q is not a pattern deja can use — %s", pattern, strings.TrimSpace(what))
+}

--- a/cmd/deja/re_error_test.go
+++ b/cmd/deja/re_error_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 // Every bad invocation answers in deja's own voice — "is not a duration deja
@@ -13,8 +14,8 @@ import (
 func TestABadPatternIsRefusedInDejasOwnVoice(t *testing.T) {
 	for _, c := range []struct{ pattern, want string }{
 		{"retry(", `--re "retry(" is not a pattern deja can use — missing closing )`},
-		{"a**", `--re "a**" is not a pattern deja can use — invalid nested repetition operator: **`},
-		{"[z-a]", `--re "[z-a]" is not a pattern deja can use — invalid character class range: z-a`},
+		{"a**", `--re "a**" is not a pattern deja can use — invalid nested repetition operator: "**"`},
+		{"[z-a]", `--re "[z-a]" is not a pattern deja can use — invalid character class range: "z-a"`},
 	} {
 		_, err := regexp.Compile(c.pattern)
 		if err == nil {
@@ -40,5 +41,21 @@ func TestAnErrorThatIsNotAboutThePatternIsLeftAlone(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "is not a pattern") {
 		t.Errorf("an unrelated failure was reported as a bad pattern: %v", err)
+	}
+}
+
+// The fragment Go names is part of the pattern, so it carries whatever the
+// pattern did: an escape byte there reached the terminal through the one line
+// written to keep it off (#1794's shape, in #1602's fix).
+func TestTheFragmentInTheRefusalCarriesNoControlByte(t *testing.T) {
+	_, err := regexp.Compile("[\x1b-\x01]")
+	if err == nil {
+		t.Fatal("that pattern compiles now; pick another")
+	}
+	msg := rePatternError("[\x1b-\x01]", err).Error()
+	for _, r := range msg {
+		if unicode.IsControl(r) {
+			t.Fatalf("the refusal carries a control byte: %q", msg)
+		}
 	}
 }

--- a/cmd/deja/re_error_test.go
+++ b/cmd/deja/re_error_test.go
@@ -48,11 +48,14 @@ func TestAnErrorThatIsNotAboutThePatternIsLeftAlone(t *testing.T) {
 // pattern did: an escape byte there reached the terminal through the one line
 // written to keep it off (#1794's shape, in #1602's fix).
 func TestTheFragmentInTheRefusalCarriesNoControlByte(t *testing.T) {
-	_, err := regexp.Compile("[\x1b-\x01]")
+	// Built rather than written inline: a literal that cannot compile is what
+	// staticcheck's SA1000 exists to catch, and here it is the input.
+	pattern := "[" + string(rune(0x1b)) + "-" + string(rune(0x01)) + "]"
+	_, err := regexp.Compile(pattern)
 	if err == nil {
 		t.Fatal("that pattern compiles now; pick another")
 	}
-	msg := rePatternError("[\x1b-\x01]", err).Error()
+	msg := rePatternError(pattern, err).Error()
 	for _, r := range msg {
 		if unicode.IsControl(r) {
 			t.Fatalf("the refusal carries a control byte: %q", msg)

--- a/cmd/deja/re_error_test.go
+++ b/cmd/deja/re_error_test.go
@@ -51,11 +51,7 @@ func TestTheFragmentInTheRefusalCarriesNoControlByte(t *testing.T) {
 	// Assembled at run time: a pattern that cannot compile is what
 	// staticcheck's SA1000 exists to catch, and here it is the input, so it
 	// must not be a constant it can fold.
-	var b []byte
-	for _, c := range []byte{'[', 0x1b, '-', 0x01, ']'} {
-		b = append(b, c)
-	}
-	pattern := string(b)
+	pattern := badRangePattern()
 	_, err := regexp.Compile(pattern)
 	if err == nil {
 		t.Fatal("that pattern compiles now; pick another")
@@ -66,4 +62,12 @@ func TestTheFragmentInTheRefusalCarriesNoControlByte(t *testing.T) {
 			t.Fatalf("the refusal carries a control byte: %q", msg)
 		}
 	}
+}
+
+// badRangePattern is a character class whose ends are the wrong way round,
+// built rather than written: as a literal, staticcheck reads it as a mistake
+// instead of as this test's input.
+func badRangePattern() string {
+	ends := []byte{0x1b, 0x01}
+	return "[" + string(ends[0]) + "-" + string(ends[1]) + "]"
 }

--- a/cmd/deja/re_error_test.go
+++ b/cmd/deja/re_error_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every bad invocation answers in deja's own voice — "is not a duration deja
+// understands", "needs an integer from 1 to 100". The --re error was the one
+// that handed over Go's regexp wording behind a stage name (#1602).
+func TestABadPatternIsRefusedInDejasOwnVoice(t *testing.T) {
+	for _, c := range []struct{ pattern, want string }{
+		{"retry(", `--re "retry(" is not a pattern deja can use — missing closing )`},
+		{"a**", `--re "a**" is not a pattern deja can use — invalid nested repetition operator: **`},
+		{"[z-a]", `--re "[z-a]" is not a pattern deja can use — invalid character class range: z-a`},
+	} {
+		_, err := regexp.Compile(c.pattern)
+		if err == nil {
+			t.Fatalf("%q compiles; pick a pattern that does not", c.pattern)
+		}
+		got := rePatternError(c.pattern, err).Error()
+		if got != c.want {
+			t.Errorf("rePatternError(%q):\n got %s\nwant %s", c.pattern, got, c.want)
+		}
+		if strings.Contains(got, "error parsing regexp") || strings.Contains(got, "run:") {
+			t.Errorf("%q still names an internal stage or Go's prefix: %s", c.pattern, got)
+		}
+	}
+}
+
+// An error that is not a regexp failure is passed through as it is: this path
+// carries whatever RunDetailed returns, and inventing a pattern sentence for
+// something else would be worse than plain wrapping.
+func TestAnErrorThatIsNotAboutThePatternIsLeftAlone(t *testing.T) {
+	err := rePatternError("retry", errors.New("read: disk fell over"))
+	if !strings.Contains(err.Error(), "disk fell over") {
+		t.Errorf("the underlying error was dropped: %v", err)
+	}
+	if strings.Contains(err.Error(), "is not a pattern") {
+		t.Errorf("an unrelated failure was reported as a bad pattern: %v", err)
+	}
+}

--- a/cmd/deja/re_error_test.go
+++ b/cmd/deja/re_error_test.go
@@ -48,9 +48,14 @@ func TestAnErrorThatIsNotAboutThePatternIsLeftAlone(t *testing.T) {
 // pattern did: an escape byte there reached the terminal through the one line
 // written to keep it off (#1794's shape, in #1602's fix).
 func TestTheFragmentInTheRefusalCarriesNoControlByte(t *testing.T) {
-	// Built rather than written inline: a literal that cannot compile is what
-	// staticcheck's SA1000 exists to catch, and here it is the input.
-	pattern := "[" + string(rune(0x1b)) + "-" + string(rune(0x01)) + "]"
+	// Assembled at run time: a pattern that cannot compile is what
+	// staticcheck's SA1000 exists to catch, and here it is the input, so it
+	// must not be a constant it can fold.
+	var b []byte
+	for _, c := range []byte{'[', 0x1b, '-', 0x01, ']'} {
+		b = append(b, c)
+	}
+	pattern := string(b)
 	_, err := regexp.Compile(pattern)
 	if err == nil {
 		t.Fatal("that pattern compiles now; pick another")

--- a/cmd/deja/regex_error_test.go
+++ b/cmd/deja/regex_error_test.go
@@ -19,9 +19,13 @@ func TestABadRegexIsReportedWithoutAnInternalName(t *testing.T) {
 		t.Fatal("a broken regex was accepted")
 	}
 	msg := err.Error()
-	// The premise: it is the regex it is complaining about.
-	if !strings.Contains(msg, "parsing regexp") {
+	// The premise: it is the regex it is complaining about, in deja's own
+	// words rather than Go's (#1602).
+	if !strings.Contains(msg, "is not a pattern deja can use") {
 		t.Fatalf("the refusal is about something else: %q", msg)
+	}
+	if strings.Contains(msg, "parsing regexp") {
+		t.Errorf("the refusal still carries Go's own prefix: %q", msg)
 	}
 	if strings.Contains(msg, "run:") {
 		t.Errorf("the refusal carries an internal function name: %q", msg)


### PR DESCRIPTION
Closes #1602, taking the first of the two wordings the issue offered.

`deja --re "retry("` answered `deja: --re pattern: error parsing regexp: missing closing ): \`retry(\`` while every other bad flag answers in deja's own words. It now says:

    deja: --re "retry(" is not a pattern deja can use — missing closing )

Go's message already names what is wrong with the pattern, so that half is kept and only the prefix and the repeated pattern go. Anything that is not a compile failure travels unwrapped.