### PR TITLE
fix(how): count the sessions the policy hid, not their commands

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -180,7 +180,10 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 // hid, and an agent told nothing exists invents something.
 func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, int, error) {
 	pol := policy.Load()
-	hidden := 0
+	// Sessions, not records: the sentence this feeds says "matching sessions",
+	// and one withheld session that ran a command five times was reported as
+	// five (#1641, the shape #1639 fixed for friction).
+	hidden := map[string]bool{}
 	// The other rule that takes sessions out of an answer. It is applied inside
 	// retrieval, and this screen reads the record log instead of ranking, so it
 	// was not applied here at all: a tree the reader asked deja to stay out of
@@ -190,7 +193,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
 		if !pol.Allows(activation, meta.Project) {
-			hidden++
+			hidden[meta.Harness+":"+meta.ID] = true
 			return
 		}
 		if pol.Ignored(meta.Path, meta.Project) {
@@ -236,7 +239,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 	})
 	if err != nil {
-		return nil, hidden, len(ignored), fmt.Errorf("read: %w", err)
+		return nil, len(hidden), len(ignored), fmt.Errorf("read: %w", err)
 	}
 	out := make([]howEntry, 0, len(byCmd))
 	for _, e := range byCmd {
@@ -254,7 +257,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 		return out[i].Command < out[j].Command
 	})
-	return out, hidden, len(ignored), nil
+	return out, len(hidden), len(ignored), nil
 }
 
 func pluralRuns(n int) string {

--- a/cmd/deja/how_hidden_count_test.go
+++ b/cmd/deja/how_hidden_count_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// howEntries counted withheld records and the sentence it feeds says sessions,
+// so one hidden session that ran a command five times was reported as five
+// (#1641, the shape #1639 fixed for friction). The CLI and the MCP how tool
+// both pass that number on.
+func TestHowCountsWithheldSessionsNotRecords(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, `{"type":"assistant","timestamp":"2026-07-10T10:0`+string(rune('0'+i))+`:00Z","sessionId":"bbbb0002-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`)
+	}
+	if err := os.WriteFile(filepath.Join(store, "bbbb0002.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	out, err := captureRun(t, "how", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "hides 1 matching session") {
+		t.Errorf("the store holds one session; the note says otherwise:\n%s", out)
+	}
+	if strings.Contains(out, "hides 5") {
+		t.Errorf("record count reported as sessions:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #1641. Follow-on from #1639, which fixed the same shape in friction.

`howEntries` incremented a counter per withheld record while the sentence it feeds says "matching sessions", so one hidden session that ran a command five times was reported as five. Both callers pass that number on: the CLI and the MCP `how` tool.