### PR TITLE
fix(hooks): say when the receiver was lost with an unreadable payload

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -316,7 +316,7 @@ func runHookContext(dir string, plain bool) error {
 			// the projects behind its walls a forget of one of them could not
 			// reach the stored text (#2349).
 			if unreadable {
-				usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, out, 0, 0, policy.Load().Describe(policy.ActivationAuto), nil, from)
+				usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, out, input.SessionID, 0, 0, policy.Load().Describe(policy.ActivationAuto), nil, from)
 			} else {
 				usage.RecordDigestPolicyFrom(dir, usage.KindHook, out, input.SessionID, 0, 0, from, policy.Load().Describe(policy.ActivationAuto))
 			}
@@ -392,7 +392,7 @@ func runHookContext(dir string, plain bool) error {
 	digest = frameRecall(digest)
 	polName := policy.Load().Describe(policy.ActivationAuto)
 	if unreadable {
-		usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, digest, sessions, raw, polName, servedIDs, servedProjects)
+		usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs, servedProjects)
 	} else {
 		usage.RecordDigestPolicySessionsFrom(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs, servedProjects)
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -292,7 +292,12 @@ func runHookContext(dir string, plain bool) error {
 		SessionID string `json:"session_id"`
 		CWD       string `json:"cwd"`
 	}
-	_ = json.Unmarshal(readHookStdin(), &input)
+	// Best effort, as every hook is — but not silent about it. A payload deja
+	// cannot decode carries the session this injection went to, and losing it
+	// without a word left the audit log unable to tell that case from a host
+	// that sent nothing at all (#2161).
+	payload := readHookStdin()
+	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
 	// The harness tells us which project this is; deja read only the
 	// environment, so a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
@@ -310,7 +315,11 @@ func runHookContext(dir string, plain bool) error {
 			// The block is about the machine and names no project, so without
 			// the projects behind its walls a forget of one of them could not
 			// reach the stored text (#2349).
-			usage.RecordDigestPolicyFrom(dir, usage.KindHook, out, input.SessionID, 0, 0, from, policy.Load().Describe(policy.ActivationAuto))
+			if unreadable {
+				usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, out, 0, 0, policy.Load().Describe(policy.ActivationAuto), nil, from)
+			} else {
+				usage.RecordDigestPolicyFrom(dir, usage.KindHook, out, input.SessionID, 0, 0, from, policy.Load().Describe(policy.ActivationAuto))
+			}
 			if plain {
 				fmt.Fprintln(os.Stdout, out)
 				return nil
@@ -382,7 +391,11 @@ func runHookContext(dir string, plain bool) error {
 	}
 	digest = frameRecall(digest)
 	polName := policy.Load().Describe(policy.ActivationAuto)
-	usage.RecordDigestPolicySessionsFrom(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs, servedProjects)
+	if unreadable {
+		usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, digest, sessions, raw, polName, servedIDs, servedProjects)
+	} else {
+		usage.RecordDigestPolicySessionsFrom(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs, servedProjects)
+	}
 	// What this project was told, so the next session start can say something
 	// else. Without this the novelty ordering has nothing to read and every
 	// start serves the same three sessions (#2038).

--- a/cmd/deja/hook_payload_unread_test.go
+++ b/cmd/deja/hook_payload_unread_test.go
@@ -21,7 +21,13 @@ func TestAnUnreadablePayloadIsRecordedAsOne(t *testing.T) {
 		{"prose", "not a payload at all", "unreadable"},
 		{"truncated", `{"session_id":"ses1"`, "unreadable"},
 		{"binary", "\x00\x01\x02", "unreadable"},
+		{"a list", "[1, 2]", "unreadable"},
+		// These decode. A host that names no session is not a host deja could
+		// not read, and the row says so by saying nothing.
 		{"empty", "", ""},
+		{"whitespace", "   \n", ""},
+		{"empty object", "{}", ""},
+		{"null", "null", ""},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			skipWindowsEmptySessionID(t)
@@ -51,22 +57,92 @@ func TestAnUnreadablePayloadIsRecordedAsOne(t *testing.T) {
 			if err != nil {
 				t.Fatalf("nothing was written to the injection log: %v", err)
 			}
+			out, err := captureRun(t, "log", "5")
+			if err != nil {
+				t.Fatal(err)
+			}
 			if c.want == "" {
-				if strings.Contains(string(b), "unreadable") {
-					t.Errorf("a hook that was sent nothing reported a broken payload:\n%s", b)
+				if strings.Contains(string(b), "unreadable") || strings.Contains(out, "into: unknown") {
+					t.Errorf("a payload deja could read was reported as broken:\n%s\n%s", b, out)
 				}
 				return
 			}
 			if !strings.Contains(string(b), `"unreadable":true`) {
 				t.Errorf("the row does not say the payload could not be read:\n%s", b)
 			}
-			out, err := captureRun(t, "log", "5")
-			if err != nil {
-				t.Fatal(err)
-			}
 			if !strings.Contains(out, "into: unknown") {
 				t.Errorf("the log does not say the receiver is unknown:\n%s", out)
 			}
 		})
+	}
+}
+
+// A decode that fails on one field still read the others, so a payload that
+// names its session and mistypes something else keeps its receiver — the flag
+// is about the payload, not about the id.
+func TestAPayloadThatNamesItsSessionKeepsTheReceiver(t *testing.T) {
+	skipWindowsEmptySessionID(t)
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "halfterm", []string{
+		`{"type":"user","sessionId":"halfterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	// cwd is a number: the decode fails, after reading session_id.
+	withHookStdin(t, `{"session_id":"ses_half","cwd":123}`)
+	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
+		t.Fatalf("the hook injected nothing:\n%q", out)
+	}
+	out, err := captureRun(t, "log", "5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "into: ses_half") {
+		t.Errorf("a receiver the payload did name was thrown away:\n%s", out)
+	}
+}
+
+// --last carries the same answer as the list: the header is where #2301 put
+// the receiver, so it is where its absence has to be explained too.
+func TestTheLastHeaderSaysTheReceiverIsUnknown(t *testing.T) {
+	skipWindowsEmptySessionID(t)
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "lastterm", []string{
+		`{"type":"user","sessionId":"lastterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	withHookStdin(t, "not a payload at all")
+	if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
+		t.Fatalf("the hook injected nothing:\n%q", out)
+	}
+	out, err := captureRun(t, "log", "--last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "into: unknown") {
+		t.Errorf("the header does not explain the missing receiver:\n%s", out)
 	}
 }

--- a/cmd/deja/hook_payload_unread_test.go
+++ b/cmd/deja/hook_payload_unread_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// A hook fed something that is not a payload injects anyway — an agent that
+// asked for context gets it — but the receiver goes missing from the log that
+// exists to answer "to whom", and nothing told the two cases apart: a host that
+// sent nothing and a host whose payload deja could not read left the same row
+// (#2161).
+func TestAnUnreadablePayloadIsRecordedAsOne(t *testing.T) {
+	for _, c := range []struct{ name, payload, want string }{
+		{"prose", "not a payload at all", "unreadable"},
+		{"truncated", `{"session_id":"ses1"`, "unreadable"},
+		{"binary", "\x00\x01\x02", "unreadable"},
+		{"empty", "", ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			skipWindowsEmptySessionID(t)
+			withStatsStores(t)
+			claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+			old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+			writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "unreadterm", []string{
+				`{"type":"user","sessionId":"unreadterm","timestamp":"` + old +
+					`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+			})
+			if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+				t.Fatal(err)
+			}
+			cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+			if err := os.MkdirAll(cwd, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Chdir(cwd)
+			t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+			withHookStdin(t, c.payload)
+			if out := captureStdout(t, func() { runHookContextPlain(t) }); !strings.Contains(out, "transaction mode") {
+				t.Fatalf("the hook injected nothing, so there is no record to check:\n%q", out)
+			}
+
+			b, err := os.ReadFile(usage.SnapshotPath(index.DefaultDir()))
+			if err != nil {
+				t.Fatalf("nothing was written to the injection log: %v", err)
+			}
+			if c.want == "" {
+				if strings.Contains(string(b), "unreadable") {
+					t.Errorf("a hook that was sent nothing reported a broken payload:\n%s", b)
+				}
+				return
+			}
+			if !strings.Contains(string(b), `"unreadable":true`) {
+				t.Errorf("the row does not say the payload could not be read:\n%s", b)
+			}
+			out, err := captureRun(t, "log", "5")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out, "into: unknown") {
+				t.Errorf("the log does not say the receiver is unknown:\n%s", out)
+			}
+		})
+	}
+}

--- a/cmd/deja/hook_payload_unread_test.go
+++ b/cmd/deja/hook_payload_unread_test.go
@@ -111,6 +111,15 @@ func TestAPayloadThatNamesItsSessionKeepsTheReceiver(t *testing.T) {
 	if !strings.Contains(out, "into: ses_half") {
 		t.Errorf("a receiver the payload did name was thrown away:\n%s", out)
 	}
+	// The header is written by the other writer, and only it would show a
+	// receiver dropped there.
+	last, err := captureRun(t, "log", "--last")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(last, "into: ses_half") {
+		t.Errorf("the header dropped a receiver the list kept:\n%s", last)
+	}
 }
 
 // --last carries the same answer as the list: the header is where #2301 put

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -100,8 +100,14 @@ func runLogTo(w io.Writer, dir string, args []string) error {
 			sess = fmt.Sprintf(" · %d session%s", e.Sessions, pluralS(e.Sessions))
 		}
 		into := ""
-		if e.Into != "" {
+		switch {
+		case e.Into != "":
 			into = " · into: " + e.Into
+		case e.Unreadable:
+			// The injection happened and the session it went to was in a
+			// payload deja could not decode. Saying so is the difference from
+			// a host that sent nothing at all (#2161).
+			into = " · into: unknown (the host sent a payload deja could not read)"
 		}
 		fmt.Fprintf(w, "%s  %-14s %s%s%s%s\n", e.Time.Local().Format("2006-01-02 15:04"), e.Kind, humanBytes(int64(e.Bytes)), sess, into, mark)
 	}

--- a/cmd/deja/log.go
+++ b/cmd/deja/log.go
@@ -164,8 +164,13 @@ func snapshotTail(s usage.Snapshot) string {
 	if s.Policy != "" {
 		b.WriteString(" · policy: " + s.Policy)
 	}
-	if s.Into != "" {
+	switch {
+	case s.Into != "":
 		b.WriteString(" · into: " + s.Into)
+	case s.Unreadable:
+		// The list row says this; the header has to as well, or --last is
+		// back to the ambiguity #2301 added it to remove (#2161).
+		b.WriteString(" · into: unknown (the host sent a payload deja could not read)")
 	}
 	if len(s.Terms) > 0 {
 		b.WriteString(" · terms: " + strings.Join(s.Terms, ", "))

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -548,7 +548,10 @@ start on a checkout with no sessions of its own injects the environment block,
 which is about the machine rather than the project, so that event is `empty`
 and carries its `bytes`. `into` names the agent session an injection went to,
 as the harness names it, and is absent when the writer did not know one — an
-MCP recall answers a tool call, not a session start.
+MCP recall answers a tool call, not a session start. `unreadable` is true when
+a hook was sent a payload deja could not decode: the memory went out anyway, so
+the row exists, and the session it went to went with the payload. Without it
+that row is identical to one from a host that sent nothing at all.
 
 A line needs both `t` and `kind` to appear here at all: a half-written line, or
 one from something that is not deja, is skipped rather than shown with a missing
@@ -559,7 +562,8 @@ never disagree about whether something happened.
 injected digest itself. It carries `t` and `kind` as above, the `digest` text,
 `bytes`, and — each omitted when empty — `sessions`, the `policy` that allowed
 the injection, the `terms` behind a déjà vu firing, `into`, the agent session
-it went to, and `projects`, the projects the digest was built from. `projects`
+it went to, `unreadable` for an injection whose payload could not be decoded,
+and `projects`, the projects the digest was built from. `projects`
 is absent on records written before it existed and on injections whose writer
 does not know them. It is `null` when no digest has been recorded: one object is the
 shape, and that is how a missing one is spelled.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -550,8 +550,9 @@ and carries its `bytes`. `into` names the agent session an injection went to,
 as the harness names it, and is absent when the writer did not know one — an
 MCP recall answers a tool call, not a session start. `unreadable` is true when
 a hook was sent a payload deja could not decode: the memory went out anyway, so
-the row exists, and the session it went to went with the payload. Without it
-that row is identical to one from a host that sent nothing at all.
+the row exists, and without this it is identical to one from a host that sent
+nothing at all. It says nothing about `into` — a decode that fails on one field
+keeps the ones it read, so a payload that named its session carries both.
 
 A line needs both `t` and `kind` to appear here at all: a half-written line, or
 one from something that is not deja, is skipped rather than shown with a missing

--- a/internal/usage/log_json_contract_test.go
+++ b/internal/usage/log_json_contract_test.go
@@ -42,6 +42,11 @@ func TestLogJSONShapesAreStable(t *testing.T) {
 	assertShape(t, "Event", topLevelJSONKeys(Event{}), map[string]bool{
 		"t": true, "kind": true, "bytes": true, "sessions": true,
 		"empty": true, "raw": true, "ids": true, "into": true,
+		// "unreadable" is additive and optional: an injection whose host sent
+		// a payload deja could not decode has no receiver to name, and without
+		// this its row is identical to one from a host that sent nothing
+		// (#2161).
+		"unreadable": true,
 	})
 	// "into" is additive and optional: it names the agent session an injection
 	// went to, which the log never recorded. Without it the only measure of
@@ -53,5 +58,6 @@ func TestLogJSONShapesAreStable(t *testing.T) {
 	assertShape(t, "Snapshot", topLevelJSONKeys(Snapshot{}), map[string]bool{
 		"t": true, "kind": true, "sessions": true, "bytes": true,
 		"policy": true, "terms": true, "into": true, "projects": true, "digest": true,
+		"unreadable": true,
 	})
 }

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -202,13 +202,17 @@ func RecordDigestPolicySessionsFrom(indexDir, kind, digest, into string, session
 
 // RecordDigestPolicySessionsUnread is RecordDigestPolicySessionsFrom for a
 // hook whose payload could not be decoded. The memory goes out regardless — an
-// agent that asked for context gets it — and the row says the receiver is
-// unknown because the payload was unreadable, rather than looking exactly like
-// a row from a host that sent nothing (#2161).
-func RecordDigestPolicySessionsUnread(indexDir, kind, digest string, sessions int, raw int64, policyName string, ids, projects []string) {
+// agent that asked for context gets it — and the row says the payload was
+// unreadable rather than looking exactly like a row from a host that sent
+// nothing (#2161).
+//
+// into is still passed: a decode that fails on one field keeps the ones it
+// read, so a payload naming its session and mistyping something else has a
+// receiver worth recording.
+func RecordDigestPolicySessionsUnread(indexDir, kind, digest, into string, sessions int, raw int64, policyName string, ids, projects []string) {
 	at := time.Now().UTC()
-	recordFullAtUnread(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, "", at, true)
-	snapshotWriteAt(indexDir, kind, digest, "", sessions, policyName, nil, projects, at, true)
+	recordFullAtUnread(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at, true)
+	snapshotWriteAt(indexDir, kind, digest, into, sessions, policyName, nil, projects, at, true)
 }
 
 // SnapshotOnly stores the digest text without writing a counting event, for

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -36,9 +36,10 @@ type Snapshot struct {
 	// injections, which measures reporting rather than use.
 	Into string `json:"into,omitempty"`
 	// Unreadable marks an injection whose host sent a payload deja could not
-	// decode, so the session it went to went with it. The row is written
-	// either way — the memory did go out — and without this it is identical to
-	// a row from a host that sent nothing at all (#2161).
+	// decode. The row is written either way — the memory did go out — and
+	// without this it is identical to a row from a host that sent nothing at
+	// all (#2161). A decode that fails on one field keeps the ones it read, so
+	// this can stand beside a receiver rather than instead of one.
 	Unreadable bool `json:"unreadable,omitempty"`
 	// Projects names the projects the digest was built from. The trust policy
 	// answers for a project name with no index at all, so a record that names

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -35,6 +35,11 @@ type Snapshot struct {
 	// to say — measured on a real store, that sentence appears after 22 of 1218
 	// injections, which measures reporting rather than use.
 	Into string `json:"into,omitempty"`
+	// Unreadable marks an injection whose host sent a payload deja could not
+	// decode, so the session it went to went with it. The row is written
+	// either way — the memory did go out — and without this it is identical to
+	// a row from a host that sent nothing at all (#2161).
+	Unreadable bool `json:"unreadable,omitempty"`
 	// Projects names the projects the digest was built from. The trust policy
 	// answers for a project name with no index at all, so a record that names
 	// its own projects can be checked against a rule tightened after it was
@@ -195,6 +200,17 @@ func RecordDigestPolicySessionsFrom(indexDir, kind, digest, into string, session
 	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, projects, at)
 }
 
+// RecordDigestPolicySessionsUnread is RecordDigestPolicySessionsFrom for a
+// hook whose payload could not be decoded. The memory goes out regardless — an
+// agent that asked for context gets it — and the row says the receiver is
+// unknown because the payload was unreadable, rather than looking exactly like
+// a row from a host that sent nothing (#2161).
+func RecordDigestPolicySessionsUnread(indexDir, kind, digest string, sessions int, raw int64, policyName string, ids, projects []string) {
+	at := time.Now().UTC()
+	recordFullAtUnread(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, "", at, true)
+	snapshotWriteAt(indexDir, kind, digest, "", sessions, policyName, nil, projects, at, true)
+}
+
 // SnapshotOnly stores the digest text without writing a counting event, for
 // callers that already recorded one with extra fields.
 func SnapshotOnly(indexDir, kind, digest string, sessions int) {
@@ -264,6 +280,15 @@ func snapshotWriteInto(indexDir, kind, digest, into string, sessions int, policy
 // snapshotWriteIntoAt is snapshotWriteInto with the instant supplied, so a
 // caller writing both logs for one injection can stamp them alike (#2294).
 func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, policyName string, terms, projects []string, at time.Time) {
+	snapshotWriteAt(indexDir, kind, digest, into, sessions, policyName, terms, projects, at, false)
+}
+
+// snapshotWriteAt is snapshotWriteIntoAt for a caller that knows the payload
+// naming the receiver could not be read. The injection still happened, so the
+// row is written either way; what it carries is the difference between "no
+// session was named" and "the session was in a payload deja could not decode"
+// (#2161).
+func snapshotWriteAt(indexDir, kind, digest, into string, sessions int, policyName string, terms, projects []string, at time.Time, unreadable bool) {
 	if digest == "" {
 		return
 	}
@@ -273,7 +298,7 @@ func snapshotWriteIntoAt(indexDir, kind, digest, into string, sessions int, poli
 	}
 	b, err := marshalSnapshot(Snapshot{Time: at, Kind: kind, Sessions: sessions,
 		Bytes: len(digest), Policy: policyName, Terms: terms, Into: into,
-		Projects: projects, Digest: clipDigest(digest)})
+		Unreadable: unreadable, Projects: projects, Digest: clipDigest(digest)})
 	if err != nil {
 		return
 	}

--- a/internal/usage/unreadable_test.go
+++ b/internal/usage/unreadable_test.go
@@ -1,0 +1,63 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// An injection whose host sent a payload deja could not decode is recorded
+// either way — the memory did go out — and both writers carry the flag, so
+// neither surface reads like a row from a host that sent nothing (#2161).
+func TestAnUnreadablePayloadIsWrittenToBothLogs(t *testing.T) {
+	dir := t.TempDir()
+	RecordDigestPolicySessionsUnread(dir, KindHook, "a digest", "ses_half", 2, 4000, "local-only",
+		[]string{"claude:one"}, []string{"beta"})
+
+	events := read(Path(dir))
+	if len(events) != 1 {
+		t.Fatalf("want one event, got %d", len(events))
+	}
+	if !events[0].Unreadable {
+		t.Errorf("the event does not say the payload could not be read: %+v", events[0])
+	}
+	// The receiver a half-decoded payload did name is kept: the flag is about
+	// the payload, not about the id.
+	if events[0].Into != "ses_half" {
+		t.Errorf("the event dropped the receiver: %+v", events[0])
+	}
+
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &snap); err != nil {
+		t.Fatal(err)
+	}
+	if !snap.Unreadable {
+		t.Errorf("the snapshot does not say the payload could not be read:\n%s", b)
+	}
+	if snap.Into != "ses_half" || snap.Policy != "local-only" || len(snap.Projects) != 1 {
+		t.Errorf("the snapshot lost a field on the way: %+v", snap)
+	}
+}
+
+// The ordinary recorders leave the flag off, so an older row and a readable
+// one read the same.
+func TestAReadablePayloadIsNotFlagged(t *testing.T) {
+	dir := t.TempDir()
+	RecordDigestPolicySessionsFrom(dir, KindHook, "a digest", "ses1", 2, 4000, "local-only", nil, nil)
+	events := read(Path(dir))
+	if len(events) != 1 || events[0].Unreadable {
+		t.Errorf("a readable payload was flagged: %+v", events)
+	}
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "unreadable") {
+		t.Errorf("the snapshot carries the flag for a payload deja read:\n%s", b)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -109,9 +109,10 @@ type Event struct {
 	Into string `json:"into,omitempty"`
 	// Unreadable marks an injection whose host sent a payload deja could not
 	// decode. The memory still goes out — an agent that asked for context gets
-	// it — but the session it went to is lost with the payload, and without
-	// this the row is identical to one from a host that sent nothing at all
-	// (#2161).
+	// it — and without this the row is identical to one from a host that sent
+	// nothing at all (#2161). It says nothing about the receiver: a decode
+	// that fails on one field keeps the ones it read, so `into` can be there
+	// beside it.
 	Unreadable bool `json:"unreadable,omitempty"`
 }
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -107,6 +107,12 @@ type Event struct {
 	// only the newest could be named, through --last (#2307). It is the other
 	// direction from SessionIDs: what was served, and to whom.
 	Into string `json:"into,omitempty"`
+	// Unreadable marks an injection whose host sent a payload deja could not
+	// decode. The memory still goes out — an agent that asked for context gets
+	// it — but the session it went to is lost with the payload, and without
+	// this the row is identical to one from a host that sent nothing at all
+	// (#2161).
+	Unreadable bool `json:"unreadable,omitempty"`
 }
 
 type Summary struct {
@@ -226,6 +232,12 @@ func recordFull(indexDir, kind string, bytes, sessions int, empty bool, raw int6
 // time.Now() calls left the two logs disagreeing by microseconds about the same
 // injection, and nothing else joins them (#2294).
 func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string, into string, at time.Time) {
+	recordFullAtUnread(indexDir, kind, bytes, sessions, empty, raw, ids, into, at, false)
+}
+
+// recordFullAtUnread is recordFullAt for an injection whose receiver was in a
+// payload deja could not decode (#2161).
+func recordFullAtUnread(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string, into string, at time.Time, unreadable bool) {
 	p := Path(indexDir)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return
@@ -246,7 +258,7 @@ func recordFullAt(indexDir, kind string, bytes, sessions int, empty bool, raw in
 		return
 	}
 	defer func() { _ = f.Close() }()
-	b, err := json.Marshal(Event{Time: at, Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids, Into: into})
+	b, err := json.Marshal(Event{Time: at, Kind: kind, Bytes: bytes, Sessions: sessions, Empty: empty, RawBytes: raw, SessionIDs: ids, Into: into, Unreadable: unreadable})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Closes #2161.

A hook fed something that is not a payload injects anyway — an agent that asked for context gets it — but the session it went to was in that payload. The row it left was identical to one from a host that sent nothing at all, in the log that exists to answer "to whom".

The row now carries `unreadable`, and `deja log` says `into: unknown (the host sent a payload deja could not read)`. A host that sent nothing is still silent. Both JSON shapes gained the optional field, with the contract pin and docs updated.