### PR TITLE
fix(hooks): the receipt counts what the statusline counts

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -1139,15 +1139,40 @@ func limitHandoffTip(dir string) string {
 // serviceReceipt appends today's tally when there is one — the moment memory
 // lands is the moment to say what it has been doing all day.
 func serviceReceipt(dir string) string {
-	recalls, bytes, _ := usage.TodayWithInjections(dir)
-	if recalls < 2 || bytes == 0 {
+	// The same two counts the statusline prints, and the same names for them:
+	// what an agent asked for and got is a recall, and what deja sent unasked
+	// is memory arriving. Folding the second into the first made the receipt
+	// and the statusline disagree in one session, and the receipt is the one
+	// that rides into the model's context (#1575, following #1569).
+	n := usage.StatusCounters(dir)
+	served, bytes := n.Recalls, n.Bytes+n.Injected
+	if served+n.Injections < 2 || bytes == 0 {
 		return ""
 	}
-	raw := usage.TodayRaw(dir)
-	if raw/int64(bytes) < 2 {
-		return fmt.Sprintf(" · today: %d recall%s", recalls, pluralS(recalls))
+	var parts []string
+	if served > 0 {
+		parts = append(parts, fmt.Sprintf("%d recall%s", served, pluralS(served)))
 	}
-	return fmt.Sprintf(" · today: %d recall%s, %s distilled from %s", recalls, pluralS(recalls), humanBytes(int64(bytes)), humanBytes(raw))
+	if n.Injections > 0 {
+		parts = append(parts, fmt.Sprintf("memory arrived %s", timesToday(n.Injections)))
+	}
+	tail := ""
+	if n.RawToday/int64(bytes) >= 2 {
+		tail = fmt.Sprintf(", %s distilled from %s", humanBytes(int64(bytes)), humanBytes(n.RawToday))
+	}
+	return " · today: " + strings.Join(parts, ", ") + tail
+}
+
+// timesToday counts arrivals in words, so the receipt reads as a sentence
+// rather than a gauge: "memory arrived twice" beats "memory arrived 2 times".
+func timesToday(n int) string {
+	switch n {
+	case 1:
+		return "once"
+	case 2:
+		return "twice"
+	}
+	return fmt.Sprintf("%d times", n)
 }
 
 // staleReadOnlyNote is the one line for an index that is behind and cannot

--- a/cmd/deja/receipt_counts_test.go
+++ b/cmd/deja/receipt_counts_test.go
@@ -22,7 +22,7 @@ func TestTheReceiptCallsInjectionsWhatTheStatuslineCallsThem(t *testing.T) {
 	if strings.Contains(got, "recall") {
 		t.Errorf("injections are counted as recalls again: %q", got)
 	}
-	if !strings.Contains(got, "5") {
+	if !strings.Contains(got, "memory arrived 5 times") {
 		t.Errorf("the day the reader had is not in the receipt: %q", got)
 	}
 	n := usage.StatusCounters(dir)
@@ -58,7 +58,7 @@ func TestTheReceiptSeparatesWhatWasAskedForFromWhatArrived(t *testing.T) {
 	if !strings.Contains(got, "3 recalls") {
 		t.Errorf("the recalls are gone: %q", got)
 	}
-	if !strings.Contains(got, "2") {
+	if !strings.Contains(got, "memory arrived twice") {
 		t.Errorf("the injections are folded into the recalls: %q", got)
 	}
 }

--- a/cmd/deja/receipt_counts_test.go
+++ b/cmd/deja/receipt_counts_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// #1569 settled the daily counters on what an agent asked for and got, with
+// injections reported separately. The receipt — the one string that rides into
+// the model's context — was not part of that, so on a machine that lives on
+// auto-recall the statusline said "no agent recalls today" while the receipt
+// called the same five injections recalls (#1575).
+func TestTheReceiptCallsInjectionsWhatTheStatuslineCallsThem(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		usage.RecordDigest(dir, usage.KindHook, strings.Repeat("x", 400), 2, 4000)
+	}
+
+	got := serviceReceipt(dir)
+	if strings.Contains(got, "recall") {
+		t.Errorf("injections are counted as recalls again: %q", got)
+	}
+	if !strings.Contains(got, "5") {
+		t.Errorf("the day the reader had is not in the receipt: %q", got)
+	}
+	n := usage.StatusCounters(dir)
+	if n.Recalls != 0 {
+		t.Fatalf("the premise moved: the statusline counts %d recalls for a hook-only day", n.Recalls)
+	}
+}
+
+// A day an agent asked for memory itself still reads as recalls.
+func TestTheReceiptStillCountsWhatAnAgentAskedFor(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("x", 400), 2, 4000)
+	}
+
+	got := serviceReceipt(dir)
+	if !strings.Contains(got, "3 recalls") {
+		t.Errorf("what the agent asked for is no longer counted: %q", got)
+	}
+}
+
+// And a day with both says both, rather than folding one into the other.
+func TestTheReceiptSeparatesWhatWasAskedForFromWhatArrived(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		usage.RecordDigest(dir, usage.KindRecall, strings.Repeat("x", 400), 2, 4000)
+	}
+	for i := 0; i < 2; i++ {
+		usage.RecordDigest(dir, usage.KindHook, strings.Repeat("x", 400), 2, 4000)
+	}
+
+	got := serviceReceipt(dir)
+	if !strings.Contains(got, "3 recalls") {
+		t.Errorf("the recalls are gone: %q", got)
+	}
+	if !strings.Contains(got, "2") {
+		t.Errorf("the injections are folded into the recalls: %q", got)
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -296,6 +296,11 @@ type StatusNumbers struct {
 	Recalls  int
 	Bytes    int
 	Injected int
+	// Injections is how many times memory arrived unasked, where Injected is
+	// how much of it. The receipt counts events, not bytes, and used to fold
+	// them into Recalls — so the statusline said "no agent recalls today"
+	// while the receipt called the same five injections recalls (#1575).
+	Injections int
 	// This week, for the line the quiet days print.
 	WeekRecalls int
 	WeekBytes   int
@@ -335,6 +340,7 @@ func StatusCounters(indexDir string) StatusNumbers {
 				out.Bytes += e.Bytes
 			case injectedKind(e.Kind):
 				out.Injected += e.Bytes
+				out.Injections++
 			}
 		}
 		if !e.Time.Before(cut) && servedKind(e.Kind) {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -300,6 +300,11 @@ type StatusNumbers struct {
 	// how much of it. The receipt counts events, not bytes, and used to fold
 	// them into Recalls — so the statusline said "no agent recalls today"
 	// while the receipt called the same five injections recalls (#1575).
+	//
+	// Every injecting kind, which is a wider set than the field of the same
+	// name in stats --impact: that one is session starts, with tool lines and
+	// déjà vu moments counted beside it. Here they are arrivals, because the
+	// receipt is answering "how often did memory turn up today".
 	Injections int
 	// This week, for the line the quiet days print.
 	WeekRecalls int


### PR DESCRIPTION
Closes #1575, on the second of the two options: keep the signal for the people who see it most, and stop calling an injection a recall.

#1569 settled the daily counters on what an agent asked for and got, with injections reported separately. `serviceReceipt` was not part of it, so in one session the statusline said `no agent recalls today · 2.0 KB injected` while the receipt said `today: 5 recalls`. The receipt is the string that rides into the model's context.

It now reads ` · today: 3 recalls, memory arrived twice`, from the same counters the statusline uses.