### PR TITLE
fix(help): fit the usage page to the terminal reading it

### DIFF
--- a/cmd/deja/help_role_values_test.go
+++ b/cmd/deja/help_role_values_test.go
@@ -42,6 +42,10 @@ func roleStore(t *testing.T) string {
 // ordinary results by design, so the flag is the only way to them and help is
 // where someone looks for the flag (#1096).
 func TestHelpNamesEveryRoleThatMatches(t *testing.T) {
+	// The page is reflowed to the terminal since #1661, and a narrow COLUMNS
+	// in the environment would split the line this reads.
+	t.Setenv("COLUMNS", "")
+
 	roleStore(t)
 
 	// Each role has to actually reach a record of its own kind, or the help

--- a/cmd/deja/help_width.go
+++ b/cmd/deja/help_width.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+)
+
+// wrapUsage lays the help page out for the terminal reading it.
+//
+// The page is written at its natural width — a usage line names every flag its
+// command takes, and that is the point of it — but nothing consulted the
+// screen, so twelve of eighty-four lines wrapped on a default 80-column
+// terminal and the wrap fell wherever the width happened to land, inside a
+// bracketed group as often as not (#1661).
+//
+// A width of zero is a reader with no screen — a pipe, a file — and gets the
+// text exactly as written, the rule printableWidth already sets.
+func wrapUsage(text string, width int) string {
+	if width <= 0 {
+		return text
+	}
+	var out []string
+	for _, line := range strings.Split(text, "\n") {
+		out = append(out, wrapUsageLine(line, width)...)
+	}
+	return strings.Join(out, "\n")
+}
+
+// wrapUsageLine breaks one line at the spaces between its groups, never inside
+// one: `[--before 2026-01-01]` is a single thing to read, and a wrap through
+// the middle of it costs the reader the flag and its example both.
+func wrapUsageLine(line string, width int) []string {
+	if len([]rune(line)) <= width {
+		return []string{line}
+	}
+	indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+	fields := usageGroups(strings.TrimLeft(line, " "))
+	// The continuation sits under the command rather than under the margin, so
+	// a wrapped line still reads as one usage line.
+	hanging := indent + "    "
+	var out []string
+	cur := indent
+	for _, f := range fields {
+		next := cur
+		if len(strings.TrimSpace(next)) > 0 {
+			next += " "
+		}
+		next += f
+		if len([]rune(next)) <= width {
+			cur = next
+			continue
+		}
+		if len(strings.TrimSpace(cur)) > 0 {
+			out = append(out, cur)
+			cur = hanging
+		}
+		if len([]rune(cur+f)) <= width {
+			cur += f
+			continue
+		}
+		// A group wider than the terminal on its own — the parenthesised
+		// sentence after a hook command. Keeping it whole would put the line
+		// back over the width this exists to respect, so it breaks at its own
+		// spaces, which is where a sentence can be broken.
+		for _, word := range strings.Fields(f) {
+			try := cur
+			if strings.TrimSpace(try) != "" {
+				try += " "
+			}
+			try += word
+			if len([]rune(try)) > width && strings.TrimSpace(cur) != "" {
+				out = append(out, cur)
+				cur = hanging + word
+				continue
+			}
+			cur = try
+		}
+	}
+	if strings.TrimSpace(cur) != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+// usageGroups splits a usage line into the pieces a wrap may fall between: a
+// word, or a bracketed or parenthesised group with everything inside it.
+func usageGroups(s string) []string {
+	var out []string
+	depth := 0
+	start := -1
+	for i := 0; i < len(s); i++ {
+		switch c := s[i]; {
+		case c == '[' || c == '(':
+			if depth == 0 && start < 0 {
+				start = i
+			}
+			depth++
+		case c == ']' || c == ')':
+			if depth > 0 {
+				depth--
+			}
+		case c == ' ' && depth == 0:
+			if start >= 0 {
+				out = append(out, s[start:i])
+				start = -1
+			}
+		default:
+			if start < 0 {
+				start = i
+			}
+		}
+	}
+	if start >= 0 {
+		out = append(out, s[start:])
+	}
+	return out
+}

--- a/cmd/deja/help_width_test.go
+++ b/cmd/deja/help_width_test.go
@@ -69,3 +69,20 @@ func TestASingleCommandsHelpFitsToo(t *testing.T) {
 		}
 	}
 }
+
+// The wiring, not just the wrapper: `deja help` and `deja <cmd> --help` are
+// the two surfaces that have to ask the terminal how wide it is.
+func TestBothHelpSurfacesAreWrappedForTheTerminal(t *testing.T) {
+	t.Setenv("COLUMNS", "80")
+	for _, args := range [][]string{{"help"}, {"last", "--help"}} {
+		out, err := captureRun(t, args...)
+		if err != nil {
+			t.Fatalf("%v: %v", args, err)
+		}
+		for _, line := range strings.Split(out, "\n") {
+			if len([]rune(line)) > 80 {
+				t.Errorf("%v printed a line %d wide:\n%s", args, len([]rune(line)), line)
+			}
+		}
+	}
+}

--- a/cmd/deja/help_width_test.go
+++ b/cmd/deja/help_width_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The help page is one hand-written string 148 columns wide, and nothing in it
+// consults the terminal: twelve of its eighty-four lines wrap on a default
+// 80-column one, and `deja last --help` quotes the widest of them (#1661).
+func TestHelpFitsAnOrdinaryTerminal(t *testing.T) {
+	for _, width := range []int{80, 100, 120} {
+		wrapped := wrapUsage(usageText(), width)
+		for _, line := range strings.Split(wrapped, "\n") {
+			if len([]rune(line)) > width {
+				t.Errorf("at %d columns a line is %d wide:\n%s", width, len([]rune(line)), line)
+			}
+		}
+	}
+}
+
+// A wrapped usage line stays readable: the flags land under the command with a
+// hanging indent, and a bracketed group is never split down the middle.
+func TestAWrappedUsageLineKeepsItsGroupsWhole(t *testing.T) {
+	line := "  deja last [n] [--json] [--project name] [--harness name] [--from macro] [--since 7d] [--before 2026-01-01] [--path p] [--tool t] [--full] [--stats]"
+	out := wrapUsage(line, 80)
+	rows := strings.Split(out, "\n")
+	if len(rows) < 2 {
+		t.Fatalf("the widest line in the page was not wrapped:\n%s", out)
+	}
+	if !strings.HasPrefix(rows[0], "  deja last ") {
+		t.Errorf("the command left its own line: %q", rows[0])
+	}
+	for _, r := range rows[1:] {
+		if !strings.HasPrefix(r, "      ") {
+			t.Errorf("a continuation is not indented under the command: %q", r)
+		}
+	}
+	for _, r := range rows {
+		if strings.Count(r, "[") != strings.Count(r, "]") {
+			t.Errorf("a bracketed group was split across lines: %q", r)
+		}
+	}
+	// Nothing is lost or reordered: the words come back in the same order.
+	if strings.Join(strings.Fields(out), " ") != strings.Join(strings.Fields(line), " ") {
+		t.Errorf("wrapping changed the line:\n%s\n%s", line, out)
+	}
+}
+
+// A terminal deja cannot measure — a pipe, a file — gets the page as written.
+func TestAPipeGetsThePageAsWritten(t *testing.T) {
+	if got := wrapUsage(usageText(), 0); got != usageText() {
+		t.Error("the page was reflowed for a reader with no screen to fit it to")
+	}
+}
+
+// `deja last --help` quotes the widest line on the page, so it is the one that
+// wrapped worst.
+func TestASingleCommandsHelpFitsToo(t *testing.T) {
+	for _, name := range []string{"last", "search", "install", "sync"} {
+		h := helpForCommand(name)
+		if h == "" {
+			t.Fatalf("no help for %q", name)
+		}
+		for _, line := range strings.Split(wrapUsage(h, 80), "\n") {
+			if len([]rune(line)) > 80 {
+				t.Errorf("%s --help has a line %d wide:\n%s", name, len([]rune(line)), line)
+			}
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -240,7 +240,10 @@ func run(args []string) error {
 	warnBrokenPolicy(args[0], os.Stderr)
 	if wantsHelp(args[1:]) {
 		if h := helpForCommand(args[0]); h != "" {
-			fmt.Print(h)
+			// The same width the page itself respects: `deja last --help`
+			// quotes the widest line in it, so a single command's help was
+			// the one most likely to wrap (#1661).
+			fmt.Print(wrapUsage(h, printableWidth(os.Stdout)))
 			return nil
 		}
 	}
@@ -3439,7 +3442,7 @@ var helpHidden = map[string]bool{
 }
 
 func printUsage() {
-	fmt.Print(usageText())
+	fmt.Print(wrapUsage(usageText(), printableWidth(os.Stdout)))
 }
 
 // usageText renders the usage block so `--help` on a single command can quote


### PR DESCRIPTION
Closes #1661, on the first of the three options: reflow at print time, leave the text as written.

The page is one hand-written string 148 columns wide and nothing consulted the terminal, so twelve of its eighty-four lines wrapped at 80 columns — and the wrap fell wherever the width landed, inside `[--before 2026-01-01]` as often as between groups. `deja last --help` quotes the widest line, so single-command help was worst.

`wrapUsage` breaks between groups with a hanging indent, never inside one, and falls back to word breaks only for a parenthesised sentence wider than the screen on its own. A pipe still gets the page exactly as written — the rule `printableWidth` already sets.