### PR TITLE
fix: say when install left an mcp entry switched off, in either spelling

### DIFF
--- a/cmd/deja/entry_switched_off_test.go
+++ b/cmd/deja/entry_switched_off_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// An entry the reader switched off stays off, which is right — and the note
+// says so, so nobody wires deja and then wonders why nothing recalls. That note
+// was keyed to `disabled`, and opencode, grok and openclaw all write `enabled`,
+// so on those files install reported success and said nothing (#2757).
+func TestMergeNamesAnEntryLeftSwitchedOff(t *testing.T) {
+	next := map[string]any{"type": "local", "command": []string{"/bin/deja", "mcp"}}
+
+	for _, off := range []map[string]any{
+		{"command": []any{"/old/deja", "mcp"}, "disabled": true},
+		{"command": []any{"/old/deja", "mcp"}, "enabled": false},
+	} {
+		merged, note := mergeDejaEntry(off, next)
+		if !strings.Contains(note, "turn it back on") {
+			t.Errorf("nothing said the entry is still off for %v: %q", off, note)
+		}
+		if _, ok := merged["disabled"]; ok {
+			if merged["disabled"] != true {
+				t.Errorf("switched the entry back on: %v", merged)
+			}
+		}
+		if v, ok := merged["enabled"]; ok && v != false {
+			t.Errorf("switched the entry back on: %v", merged)
+		}
+	}
+
+	// An entry that is on says nothing of the sort.
+	_, note := mergeDejaEntry(map[string]any{"command": []any{"/old/deja", "mcp"}, "enabled": true}, next)
+	if strings.Contains(note, "turn it back on") {
+		t.Errorf("called a live entry switched off: %q", note)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2257,6 +2257,23 @@ func commandListRunsMCP(words []any) bool {
 	return false
 }
 
+// entryIsOff reports whether the reader has switched an MCP entry off, in
+// either spelling the configs use. The note about leaving one off was keyed to
+// `disabled`, and opencode, grok and openclaw all write `enabled` — so on those
+// files install reported success on a config where deja will not run (#2757).
+//
+// Only an explicit off. An entry with neither key is on, which is what every
+// entry deja writes looks like.
+func entryIsOff(entry map[string]any) bool {
+	if off, ok := entry["disabled"].(bool); ok && off {
+		return true
+	}
+	if on, ok := entry["enabled"].(bool); ok && !on {
+		return true
+	}
+	return false
+}
+
 // mergeDejaEntry writes deja's wiring onto the entry that was already there.
 // deja owns the command, the args and the type; an env pointing at a store on
 // another disk, a timeout, a `disabled` the reader set — those are theirs, and
@@ -2287,14 +2304,14 @@ func mergeDejaEntry(prev any, entry map[string]any) (map[string]any, string) {
 	if _, ok := out["command"]; ok {
 		delete(out, "transport")
 	}
-	if disabled, _ := out["disabled"].(bool); disabled {
+	if entryIsOff(out) {
 		// Switching it back on silently would undo a decision deja was not
 		// asked to revisit; leaving it off without a word looks like a install
 		// that worked.
 		if note != "" {
 			note += "; "
 		}
-		note += "left the entry disabled, the way it was — deja will not answer until you turn it back on"
+		note += "left the entry switched off, the way it was — deja will not answer until you turn it back on"
 	}
 	return out, note
 }

--- a/cmd/deja/jsonc_merge_entry_test.go
+++ b/cmd/deja/jsonc_merge_entry_test.go
@@ -36,6 +36,9 @@ func TestJSONCKeepsWhatTheReaderPutOnDejasEntry(t *testing.T) {
 	if strings.Count(note, "/old/deja") != 1 {
 		t.Errorf("the note says it twice: %q", note)
 	}
-	// Not asserted: the "still off" line. It is keyed to `disabled`, and
-	// opencode writes `enabled`, so it does not fire here — a gap of its own.
+	// And the entry is off, so the note says so rather than reporting a plain
+	// success on a config where deja will not run (#2757).
+	if !strings.Contains(note, "turn it back on") {
+		t.Errorf("nothing said the entry is still off: %q", note)
+	}
 }


### PR DESCRIPTION
Reopens and fixes #2757.

`mergeDejaEntry` keeps an entry the reader switched off and prints a line saying so. That check read `disabled: true` only — opencode, grok and openclaw write `enabled: false`, so on those files install reported plain success on a config where deja will not answer.

`entryIsOff` now reads both spellings. Only an explicit off: an entry with neither key is on, which is what everything deja writes looks like. The note's wording moved from "disabled" to "switched off" since it now covers both.

Mutation-checked three ways: ignoring `enabled`, ignoring `disabled`, and treating `enabled: true` as off — each turns a test red.