### PR TITLE
fix: stop promoting CI status as what a session concluded

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -667,11 +667,19 @@ var decisionMarkers = []string{
 	"решили", "в итоге", "оказалось", "причина", "выяснилось", "вывод:", "мой вывод",
 	"выбрали", "остановились", "исправил", "починил", "заработало",
 	"не будем", "убрали", "переделали", "смержил", "выкатили",
-	// Mirrors of entries already in the English half: "works now", "passes
-	// now", "fixed". Measured over forty thousand assistant lines from a real
-	// store, Russian lines were marked 3.1% of the time against 4.3% for
-	// English, and these three phrases account for most of the gap.
-	"заработал", "готово", "зелёный",
+	// A mirror of "works now" and "fixed", added when Russian lines were the
+	// under-marked half. It went in beside "готово" and "зелёный"; those two
+	// are gone and this one stays, because the three were measured apart and
+	// only this one marks outcomes. Of the lines it alone marks, most read
+	// like "механизм наконец заработал полностью" or "SSH заработал 3/3 с
+	// keepalive" — what ended up working, which is the shape the list is for.
+	//
+	// "зелёный" alone marked 543 lines of 4901, and they were "CI зелёный, жду
+	// ревьюера", "PR #1566 зелёный целиком": the status chatter this list
+	// exists to see past, not what a session concluded. "готово" alone marked
+	// 221, mostly checklist ticks and table cells — and it fires inside
+	// "готового" and "полуготовое", where it means nothing at all (#2734).
+	"заработал",
 	// A decision is as often reported as the state something ended up in as by
 	// the act of deciding. Measured over 4000 assistant lines from a real
 	// store, the list above marks 4% of them, and lines like "прод-пины теперь
@@ -681,14 +689,6 @@ var decisionMarkers = []string{
 	// live questions turns into a pointer.
 	"теперь ", "стало ", "становится", "лежит в", "работает через",
 	"по умолчанию", "переехал", "now lives", "now goes", "by default",
-	// A decision is as often reported as the state something ended up in as by
-	// the act of deciding. Measured over 4000 assistant lines from a real
-	// store, the list above marks 4% of them, and lines like "прод-пины теперь
-	// ложатся на deploy/prod" or "бывшая ведущая становится ведомой" — plainly
-	// the outcome of a decision — were read as passing mentions. With these the
-	// share is 9%, the benchmark does not move, and one off-topic block of 58
-	// live questions turns into a pointer.
-
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather
@@ -698,12 +698,6 @@ var decisionMarkers = []string{
 func CarriesDecision(text string) bool {
 	return CarriesDecisionExcept(text, nil)
 }
-
-// CarriesDecisionExcept is the same, ignoring markers the asker used. A marker
-// that is also a word of the question makes the check circular: "в итоге" is
-// both, so a line matched on that phrase then counted as a conclusion because
-// of it. Measured on the benchmark, the question "по чему у нас в итоге
-// шардирование" promoted a session about something else entirely.
 
 // planAfterMarker are what follows a state word when the sentence is a plan
 // rather than an outcome: "теперь давай", "now let's". The state markers were
@@ -760,6 +754,11 @@ func isWordByte(b byte) bool {
 	return false
 }
 
+// CarriesDecisionExcept is the same, ignoring markers the asker used. A marker
+// that is also a word of the question makes the check circular: "в итоге" is
+// both, so a line matched on that phrase then counted as a conclusion because
+// of it. Measured on the benchmark, the question "по чему у нас в итоге
+// шардирование" promoted a session about something else entirely.
 func CarriesDecisionExcept(text string, asked []string) bool {
 	low := strings.ToLower(text)
 	for _, p := range planAfterMarker {

--- a/internal/digest/status_not_decision_test.go
+++ b/internal/digest/status_not_decision_test.go
@@ -1,0 +1,35 @@
+package digest
+
+import "testing"
+
+// The markers exist to see past status chatter at the few lines that say what a
+// session concluded. Two of them were chatter: measured on 85k assistant lines
+// from a real store, "зелёный" was the only marker on 543 of 4901 promoted
+// lines and "готово" on 221, and reading them they are CI runs and checklist
+// ticks (#2734).
+func TestGreenCIIsNotAConclusion(t *testing.T) {
+	chatter := []string{
+		"CI 12/12 зелёный, жду ревьюера.",
+		"CI зелёный на #1380 — все проверки прошли.",
+		"- ✓ упоминания в вебе — готово",
+		"первую попытку я построил копированием готового HOME",
+		"«полуготовое задание хуже повторного клика»",
+	}
+	for _, line := range chatter {
+		if CarriesDecision(line) {
+			t.Errorf("status chatter promoted as a conclusion: %q", line)
+		}
+	}
+
+	// What ended up working still counts. "заработал" went in beside those two
+	// and stays: of the lines it alone marks, most report an outcome.
+	settled := []string{
+		"Механизм наконец заработал полностью: настоящие HTTP-запросы, правильные ключи.",
+		"Direct SSH к se заработал 3/3 с keepalive-опциями.",
+	}
+	for _, line := range settled {
+		if !CarriesDecision(line) {
+			t.Errorf("an outcome read as a passing mention: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Measured for #2734, on 85k assistant lines from a real store.

The issue asked whether a higher marking rate is even good. It is not. Reading 40 marked English lines by hand, 21 were conclusions and 19 were status or plans — so the interesting number was never the rate, it was what got promoted.

Isolating each marker to the lines it *alone* marks:

    "зелёный"    543 of 4901   "CI 12/12 зелёный, жду ревьюера"
    "готово"     221 of 4901   "- ✓ упоминания в вебе — готово", table cells
    "заработал"   24 of 4901   "механизм наконец заработал полностью"

The first two are the status chatter the list exists to see past, and "готово" also fires inside "готового" and "полуготовое". "заработал" went in with them and is the one that holds up, so it stays.

Russian marking goes 8.4% to 6.7%, English unchanged at 6.2% — the gap the issue opened on closes by removing noise rather than adding markers.

Also in this diff, same function: a comment block that had been pasted twice, and `CarriesDecisionExcept`'s doc comment, which sat four declarations away from it.

Guard test mutation-checked three ways — putting either marker back, or dropping "заработал", turns it red.