### PR TITLE
fix(mcp): tell an agent the session it was handed was forgotten

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -4150,13 +4150,40 @@ func forgottenSourceNote(s model.Session, selector string) string {
 	// Only when the reader named that session: an ordinary topical query that
 	// happens to land on the note is not asking about the forgotten source, and
 	// the line would be noise on every such search.
-	if selector == "" || !strings.Contains(key, selector) {
+	//
+	// Named means named. Testing the selector as a substring of the key fired
+	// on "claude" — the harness name is in every key — and on any single
+	// character, while the reverse case never fired at all: over MCP the
+	// selector is usually a sentence, and "what did we decide in s15" is a
+	// reader naming the session as plainly as `s15` is (#1624).
+	if !selectorNamesSession(selector, key) {
 		return ""
 	}
 	if !index.Tombstoned(key) {
 		return ""
 	}
 	return fmt.Sprintf("%s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone", key)
+}
+
+// selectorNamesSession reports whether the reader's selector names this
+// session: the whole key, an id prefix long enough to mean it, or one of the
+// words of a sentence being either of those.
+func selectorNamesSession(selector, key string) bool {
+	if strings.TrimSpace(selector) == "" {
+		return false
+	}
+	_, id, _ := strings.Cut(key, ":")
+	for _, word := range strings.Fields(selector) {
+		if word == key || word == id {
+			return true
+		}
+		// Four characters before a prefix counts: shorter than that and an
+		// ordinary word — "the", "in" — would name a session by accident.
+		if len(word) >= 4 && strings.HasPrefix(id, word) {
+			return true
+		}
+	}
+	return false
 }
 
 // forgetKeyOf names the exact session a selector reached, so a failed forget

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -894,7 +894,7 @@ func cmdCtx(dir string, rest []string) error {
 	// A short selector never reaches the id branch above, so a forgotten
 	// session's note arrives as an ordinary hit — and the answer still has to
 	// say the session is gone (#971).
-	noteForgottenSource(hits[0].Session, q)
+	noteForgottenSource(hits[0].Session, q, false)
 	// The hit carries the matching snippets, not the session: for a promoted
 	// note that meant the correction — which rarely repeats the words of the
 	// decision — was missing, and the command whose whole job is packaging
@@ -2107,7 +2107,7 @@ func findByPrefix(dir, p string) (model.Session, bool, error) {
 	if err := index.Ensure(dir, "", false, os.Stderr); err == nil {
 		if s, ok, err := index.FindByPrefix(dir, p); err == nil {
 			if ok {
-				noteForgottenSource(s, p)
+				noteForgottenSource(s, p, true)
 			}
 			return s, ok, nil
 		}
@@ -4122,18 +4122,21 @@ func sharedRowsAmong(dir string, keys []string) int {
 // session that has been forgotten. Asking for the session by the id you
 // remember answered with the note and said nothing, so the reply looked like
 // the session itself until you noticed the id had changed (#971).
-func noteForgottenSource(s model.Session, selector string) {
-	if line := forgottenSourceNote(s, selector); line != "" {
+func noteForgottenSource(s model.Session, selector string, resolved bool) {
+	if line := forgottenSourceNote(s, selector, resolved); line != "" {
 		fmt.Fprintf(os.Stderr, "deja: %s\n", line)
 	}
 }
 
 // forgottenSourceNote is the sentence itself, so every surface can carry it.
+// resolved says the selector reached this session through a prefix lookup: on
+// that path any prefix is honest by construction, and a length rule would only
+// guess at what the resolver already answered.
 // It lived inside the printer, which meant the CLI said a session was
 // forgotten and the MCP tools handed an agent the same note with the fact
 // removed — and "forgotten" is a decision the reader made about that session,
 // which is the kind of fact recall exists to carry (#1624).
-func forgottenSourceNote(s model.Session, selector string) string {
+func forgottenSourceNote(s model.Session, selector string, resolved bool) string {
 	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-note-") {
 		return ""
 	}
@@ -4156,7 +4159,7 @@ func forgottenSourceNote(s model.Session, selector string) string {
 	// character, while the reverse case never fired at all: over MCP the
 	// selector is usually a sentence, and "what did we decide in s15" is a
 	// reader naming the session as plainly as `s15` is (#1624).
-	if !selectorNamesSession(selector, key) {
+	if !selectorNamesSession(selector, key, resolved) {
 		return ""
 	}
 	if !index.Tombstoned(key) {
@@ -4168,7 +4171,7 @@ func forgottenSourceNote(s model.Session, selector string) string {
 // selectorNamesSession reports whether the reader's selector names this
 // session: the whole key, an id prefix long enough to mean it, or one of the
 // words of a sentence being either of those.
-func selectorNamesSession(selector, key string) bool {
+func selectorNamesSession(selector, key string, resolved bool) bool {
 	if strings.TrimSpace(selector) == "" {
 		return false
 	}
@@ -4177,9 +4180,13 @@ func selectorNamesSession(selector, key string) bool {
 		if word == key || word == id {
 			return true
 		}
-		// Four characters before a prefix counts: shorter than that and an
-		// ordinary word — "the", "in" — would name a session by accident.
-		if len(word) >= 4 && strings.HasPrefix(id, word) {
+		// A prefix counts only where something resolved it: `deja ctx 3f2a9c`
+		// reached this session and nothing else. Where nothing resolved — a
+		// search query — a prefix is a guess, and the ids real harnesses write
+		// make it a bad one: codex ids start with a year, cline ids start with
+		// the harness name, so "what did we ship in 2026" and "cline" would
+		// each name a session (#1624).
+		if resolved && strings.HasPrefix(id, word) {
 			return true
 		}
 	}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -4123,29 +4123,40 @@ func sharedRowsAmong(dir string, keys []string) int {
 // remember answered with the note and said nothing, so the reply looked like
 // the session itself until you noticed the id had changed (#971).
 func noteForgottenSource(s model.Session, selector string) {
+	if line := forgottenSourceNote(s, selector); line != "" {
+		fmt.Fprintf(os.Stderr, "deja: %s\n", line)
+	}
+}
+
+// forgottenSourceNote is the sentence itself, so every surface can carry it.
+// It lived inside the printer, which meant the CLI said a session was
+// forgotten and the MCP tools handed an agent the same note with the fact
+// removed — and "forgotten" is a decision the reader made about that session,
+// which is the kind of fact recall exists to carry (#1624).
+func forgottenSourceNote(s model.Session, selector string) string {
 	if s.Harness != "deja" || !strings.HasPrefix(s.ID, "deja-note-") {
-		return
+		return ""
 	}
 	src, ok := strings.CutPrefix(s.ID, "deja-note-")
 	if !ok || src == "" {
-		return
+		return ""
 	}
 	// The selector named the source, not the note: a reader who typed the note
 	// id knows what they asked for.
 	if strings.HasPrefix(s.ID, selector) {
-		return
+		return ""
 	}
 	key := strings.Replace(src, "-", ":", 1)
 	// Only when the reader named that session: an ordinary topical query that
 	// happens to land on the note is not asking about the forgotten source, and
 	// the line would be noise on every such search.
 	if selector == "" || !strings.Contains(key, selector) {
-		return
+		return ""
 	}
 	if !index.Tombstoned(key) {
-		return
+		return ""
 	}
-	fmt.Fprintf(os.Stderr, "deja: %s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone\n", key)
+	return fmt.Sprintf("%s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone", key)
 }
 
 // forgetKeyOf names the exact session a selector reached, so a failed forget

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -335,13 +335,18 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		text, sessions, raw, ids, projects, note, err := recallContextResultFrom(dir, a.Query, a.Harness)
 		if err == nil {
-			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead))
+			// Above the frame, the way the resource reader puts its own note:
+			// inside it, deja's statement of fact would read as recalled text
+			// the agent has just been told not to trust. Its room comes out of
+			// the budget before the trim, not after — added afterwards it put
+			// the reply over the size this tool documents, which is what
+			// #1797 fixed for the frame itself.
+			lead := ""
 			if note != "" {
-				// Above the frame, the way the resource reader puts its own
-				// note: inside it, deja's statement of fact would read as
-				// recalled text the agent has just been told not to trust.
-				text = "deja: " + note + "\n\n" + text
+				lead = "deja: " + note + "\n\n"
 			}
+			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead-len(lead)))
+			text = lead + text
 			usage.RecordServedFrom(dir, usage.KindContext, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
@@ -1297,7 +1302,9 @@ func contextByID(dir, q string) (string, idContext, bool) {
 	// deja's own words do not belong inside a frame that tells the reader to
 	// treat what it holds as untrusted.
 	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole}),
-		note: forgottenSourceNote(whole, q)}, true
+		// FindByPrefix resolved this session from the selector, so a prefix
+		// here is honest by construction.
+		note: forgottenSourceNote(whole, q, true)}, true
 }
 
 // recallContextResult keeps the four-value shape its callers and tests read.
@@ -1380,7 +1387,7 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole),
 		// The search path reaches a promoted note as often as the id path
 		// does — the note carries the id in its own text.
-		forgottenSourceNote(whole, q), nil
+		forgottenSourceNote(whole, q, false), nil
 }
 
 func mcpProgress() io.Writer {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1279,6 +1279,12 @@ func contextByID(dir, q string) (string, idContext, bool) {
 		whole = full
 	}
 	var b bytes.Buffer
+	// The fact before the content, the way the CLI prints it: an agent handed
+	// the note promoted from a session it named has to be told the session was
+	// forgotten (#1624).
+	if line := forgottenSourceNote(whole, q); line != "" {
+		b.WriteString(line + "\n\n")
+	}
 	search.PrintContext(&b, whole, "")
 	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole})}, true
 }
@@ -1355,6 +1361,13 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 		whole = full
 	}
 	var b bytes.Buffer
+	// The same sentence the CLI prints above the answer: an agent handed the
+	// note promoted from a session it named is told the session was forgotten
+	// (#1624). The search path reaches it as often as the id path does — the
+	// note carries the id in its text.
+	if line := forgottenSourceNote(whole, q); line != "" {
+		b.WriteString(line + "\n\n")
+	}
 	search.PrintContext(&b, whole, q)
 	text := b.String()
 	if hits[0].Tier != search.TierExact {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -333,9 +333,15 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if line := buildingNowForAgent(dir); line != "" {
 			return frameRecall(line), nil
 		}
-		text, sessions, raw, ids, projects, err := recallContextResultFrom(dir, a.Query, a.Harness)
+		text, sessions, raw, ids, projects, note, err := recallContextResultFrom(dir, a.Query, a.Harness)
 		if err == nil {
 			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead))
+			if note != "" {
+				// Above the frame, the way the resource reader puts its own
+				// note: inside it, deja's statement of fact would read as
+				// recalled text the agent has just been told not to trust.
+				text = "deja: " + note + "\n\n" + text
+			}
 			usage.RecordServedFrom(dir, usage.KindContext, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
@@ -1252,6 +1258,11 @@ func recallContext(dir, q string) (string, error) {
 type idContext struct {
 	session string
 	size    int64
+	// note is deja's own word about the session — today, that it was
+	// forgotten. It travels beside the text rather than inside it, because
+	// the frame the text goes into tells the reader to treat what it holds as
+	// untrusted, and this is not recalled content (#1624).
+	note string
 }
 
 // contextByID answers from the session an id-prefix names, for the tool an
@@ -1279,34 +1290,34 @@ func contextByID(dir, q string) (string, idContext, bool) {
 		whole = full
 	}
 	var b bytes.Buffer
+	search.PrintContext(&b, whole, "")
 	// The fact before the content, the way the CLI prints it: an agent handed
 	// the note promoted from a session it named has to be told the session was
-	// forgotten (#1624).
-	if line := forgottenSourceNote(whole, q); line != "" {
-		b.WriteString(line + "\n\n")
-	}
-	search.PrintContext(&b, whole, "")
-	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole})}, true
+	// forgotten (#1624). It travels out of band — see idContext.note — because
+	// deja's own words do not belong inside a frame that tells the reader to
+	// treat what it holds as untrusted.
+	return b.String(), idContext{session: whole.ID, size: rawSize([]model.Session{whole}),
+		note: forgottenSourceNote(whole, q)}, true
 }
 
 // recallContextResult keeps the four-value shape its callers and tests read.
 func recallContextResult(dir, q, harness string) (string, int, int64, []string, error) {
-	text, sessions, raw, ids, _, err := recallContextResultFrom(dir, q, harness)
+	text, sessions, raw, ids, _, _, err := recallContextResultFrom(dir, q, harness)
 	return text, sessions, raw, ids, err
 }
 
 // recallContextResultFrom is recallContextResult plus the project behind the
 // session it served, for the reason recallTextResultFrom exists (#2324).
-func recallContextResultFrom(dir, q, harness string) (string, int, int64, []string, []string, error) {
+func recallContextResultFrom(dir, q, harness string) (string, int, int64, []string, []string, string, error) {
 	o := search.Options{Query: nfcfold.Compose(q), Harness: harness, All: true, RecallWorn: usage.WornSessions(dir)}
 	if stale, err := index.EnsureForSearchStale(dir, o, mcpProgress()); err != nil {
-		return "", 0, 0, nil, nil, err
+		return "", 0, 0, nil, nil, "", err
 	} else if stale {
 		requestWarmup(dir)
 	}
 	result, err := index.SearchWithRecoveryDetailed(dir, o, mcpProgress())
 	if err != nil {
-		return "", 0, 0, nil, nil, err
+		return "", 0, 0, nil, nil, "", err
 	}
 	ss := result.Sessions
 	o.Tier = result.Tier
@@ -1325,7 +1336,7 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	} else if result.Tier == search.TierRelevance {
 		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(q), result.TermIDF)
 	} else if hits, err = search.Run(ss, o); err != nil {
-		return "", 0, 0, nil, nil, err
+		return "", 0, 0, nil, nil, "", err
 	}
 	hits, policyHidden := policyFilterHitsCounted(policy.ActivationMCP, hits)
 	var semantic bool
@@ -1344,9 +1355,9 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 		// After the search, like the CLI does since #1614: there is no answer
 		// left for the id to shadow.
 		if text, id, ok := contextByID(dir, q); ok {
-			return text, 1, id.size, []string{id.session}, nil, nil
+			return text, 1, id.size, []string{id.session}, nil, id.note, nil
 		}
-		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil, nil
+		return emptyRecallAnswerPolicy(dir, q, policyHidden), 0, 0, nil, nil, "", nil
 	}
 	// The same order the search screen shows: this handed the agent a session
 	// the reader had rejected, while search demoted it and said why (#1099).
@@ -1361,19 +1372,15 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 		whole = full
 	}
 	var b bytes.Buffer
-	// The same sentence the CLI prints above the answer: an agent handed the
-	// note promoted from a session it named is told the session was forgotten
-	// (#1624). The search path reaches it as often as the id path does — the
-	// note carries the id in its text.
-	if line := forgottenSourceNote(whole, q); line != "" {
-		b.WriteString(line + "\n\n")
-	}
 	search.PrintContext(&b, whole, q)
 	text := b.String()
 	if hits[0].Tier != search.TierExact {
 		text = "[" + hits[0].Tier + "]\n" + text
 	}
-	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole), nil
+	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole),
+		// The search path reaches a promoted note as often as the id path
+		// does — the note carries the id in its own text.
+		forgottenSourceNote(whole, q), nil
 }
 
 func mcpProgress() io.Writer {

--- a/cmd/deja/mcp_forgotten_note_test.go
+++ b/cmd/deja/mcp_forgotten_note_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The CLI says a session was forgotten and answers with the note promoted from
+// it; the MCP tools handed the agent the same content with the fact removed.
+// "Forgotten" is a decision the user made about that session, which is exactly
+// the kind of fact recall exists to carry (#1624).
+func TestAnAgentAskingForAForgottenSessionIsToldSo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","message":{"role":"user","content":"the decision: keep the ticker window at 30s"},"timestamp":"2026-07-11T10:00:00Z","sessionId":"s15","cwd":"/proj"}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s15.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s15"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "s15"); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"s15"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "ticker window") {
+		t.Fatalf("the agent was answered from something else:\n%s", text)
+	}
+	if !strings.Contains(text, "is forgotten") {
+		t.Errorf("the agent was handed the note without being told the session is gone:\n%s", text)
+	}
+
+	// The same two cases the CLI keeps quiet about: the note asked for by its
+	// own id, and an ordinary query that happens to land on it.
+	text, err = callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"deja-note-claude-s15"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "is forgotten") {
+		t.Errorf("asking for the note by its own id was answered with a warning:\n%s", text)
+	}
+	text, err = callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"ticker window"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "is forgotten") {
+		t.Errorf("an ordinary query was answered with a warning about a session nobody named:\n%s", text)
+	}
+}

--- a/cmd/deja/mcp_forgotten_note_test.go
+++ b/cmd/deja/mcp_forgotten_note_test.go
@@ -107,24 +107,59 @@ func TestAnAgentAskingForAForgottenSessionIsToldSo(t *testing.T) {
 // the harness name and on any single character while never firing for the
 // sentence an agent actually sends.
 func TestOnlyASelectorThatNamesTheSessionFires(t *testing.T) {
-	const key = "claude:s15"
 	for _, c := range []struct {
-		selector string
-		want     bool
+		key, selector string
+		resolved      bool
+		want          bool
 	}{
-		{"s15", true},
-		{"claude:s15", true},
-		{"what did we decide in s15", true},
-		{"s15abc", false},
-		{"claude", false},
-		{"a", false},
-		{":s1", false},
-		{"s1", false},
-		{"", false},
-		{"   ", false},
+		{"claude:s15", "s15", false, true},
+		{"claude:s15", "claude:s15", false, true},
+		{"claude:s15", "what did we decide in s15", false, true},
+		{"claude:s15", "s15abc", false, false},
+		{"claude:s15", "claude", false, false},
+		{"claude:s15", "a", false, false},
+		{"claude:s15", ":s1", false, false},
+		{"claude:s15", "", false, false},
+		{"claude:s15", "   ", false, false},
+		// A prefix counts where a resolver answered with this session and
+		// nothing else — `deja ctx s1` — and nowhere else.
+		{"claude:s15", "s1", true, true},
+		{"claude:s15", "s1", false, false},
+		// The ids real harnesses write are why: a search query would
+		// otherwise name a session by starting with a year or a harness name.
+		{"codex:2026-07-31T00-00-00-abc", "what did we ship in 2026", false, false},
+		{"cline:cline-task-1767225600000", "cline", false, false},
+		{"cline:cline-task-1767225600000", "cline-task-1767225600000", false, true},
+		// A short id is still named by naming it, resolver or not.
+		{"gemini:s1", "s1", false, true},
 	} {
-		if got := selectorNamesSession(c.selector, key); got != c.want {
-			t.Errorf("selectorNamesSession(%q, %q) = %v, want %v", c.selector, key, got, c.want)
+		if got := selectorNamesSession(c.selector, c.key, c.resolved); got != c.want {
+			t.Errorf("selectorNamesSession(%q, %q, resolved=%v) = %v, want %v",
+				c.selector, c.key, c.resolved, got, c.want)
 		}
+	}
+}
+
+// The line is deja's own and goes above the frame, so its room has to come out
+// of the budget before the digest is trimmed — added afterwards it put the
+// reply over the size the tool documents, which is what #1797 fixed for the
+// frame itself.
+func TestTheForgottenLineIsInsideTheBudget(t *testing.T) {
+	dir := seedContextDigestSession(t, "proj", "wobble")
+	if _, err := captureRunStderr(t, "promote", "wobble", "--note", strings.Repeat("a long note about the shard budget ", 300)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "wobble"); err != nil {
+		t.Fatal(err)
+	}
+	framed, err := callMCPTool(dir, "recall_context", []byte(`{"query":"wobble"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(framed, "is forgotten") {
+		t.Fatalf("the reply does not carry the line this test is about:\n%s", framed[:200])
+	}
+	if len(framed) > contextMCPBudget {
+		t.Errorf("recall_context returned %d bytes, budget is %d", len(framed), contextMCPBudget)
 	}
 }

--- a/cmd/deja/mcp_forgotten_note_test.go
+++ b/cmd/deja/mcp_forgotten_note_test.go
@@ -45,6 +45,45 @@ func TestAnAgentAskingForAForgottenSessionIsToldSo(t *testing.T) {
 	if !strings.Contains(text, "is forgotten") {
 		t.Errorf("the agent was handed the note without being told the session is gone:\n%s", text)
 	}
+	// Deja's own words, not recalled text: the frame the answer goes into
+	// tells the reader to treat what it holds as untrusted.
+	if i, j := strings.Index(text, "is forgotten"), strings.Index(text, "<deja-recall>"); i > j {
+		t.Errorf("the line is inside the untrusted-data frame:\n%s", text)
+	}
+	if !strings.HasPrefix(text, "deja: ") {
+		t.Errorf("the line does not read as deja's own:\n%s", text)
+	}
+
+	// The id path is the other writer, reached when the words find nothing —
+	// asked directly, since a query naming the session also matches its text.
+	if _, id, ok := contextByID(dir, "deja-note-claude-s15"); !ok {
+		t.Error("the id path did not resolve the note")
+	} else if id.note != "" {
+		t.Errorf("asking for the note by its own id carried a warning: %q", id.note)
+	}
+	if _, id, ok := contextByID(dir, "s15"); !ok {
+		t.Error("the id path did not resolve the session")
+	} else if !strings.Contains(id.note, "is forgotten") {
+		t.Errorf("the id path hands over the note without the fact: %q", id.note)
+	}
+
+	// A word that is in every key is not a reader naming a session.
+	text, err = callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"claude"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "is forgotten") {
+		t.Errorf("the harness name was read as naming the session:\n%s", text)
+	}
+
+	// And the resource reader, the door that takes nothing but an id.
+	res, code, msg := mcpResourceRead(dir, "deja://session/s15")
+	if res == nil {
+		t.Fatalf("the resource reader refused: %d %s", code, msg)
+	}
+	if !strings.Contains(resourceText(t, res), "is forgotten") {
+		t.Errorf("the resource reader hands over the note without the fact:\n%s", resourceText(t, res))
+	}
 
 	// The same two cases the CLI keeps quiet about: the note asked for by its
 	// own id, and an ordinary query that happens to land on it.
@@ -61,5 +100,31 @@ func TestAnAgentAskingForAForgottenSessionIsToldSo(t *testing.T) {
 	}
 	if strings.Contains(text, "is forgotten") {
 		t.Errorf("an ordinary query was answered with a warning about a session nobody named:\n%s", text)
+	}
+}
+
+// selectorNamesSession is what decides it, and the old substring test fired on
+// the harness name and on any single character while never firing for the
+// sentence an agent actually sends.
+func TestOnlyASelectorThatNamesTheSessionFires(t *testing.T) {
+	const key = "claude:s15"
+	for _, c := range []struct {
+		selector string
+		want     bool
+	}{
+		{"s15", true},
+		{"claude:s15", true},
+		{"what did we decide in s15", true},
+		{"s15abc", false},
+		{"claude", false},
+		{"a", false},
+		{":s1", false},
+		{"s1", false},
+		{"", false},
+		{"   ", false},
+	} {
+		if got := selectorNamesSession(c.selector, key); got != c.want {
+			t.Errorf("selectorNamesSession(%q, %q) = %v, want %v", c.selector, key, got, c.want)
+		}
 	}
 }

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -122,7 +122,9 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	}
 	// The same word the CLI and recall_context carry: this door takes an id,
 	// so a reader here has named the session as plainly as anyone can (#1624).
-	if line := forgottenSourceNote(s, id); line != "" {
+	// This door takes an id and FindByPrefix resolved it, so a prefix here
+	// is honest by construction.
+	if line := forgottenSourceNote(s, id, true); line != "" {
 		note += "deja: " + line + "\n\n"
 	}
 	var b bytes.Buffer

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -120,6 +120,11 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 		note = fmt.Sprintf("deja: %d sessions match %q — this is the most recent; ask for a longer prefix to read another.\n\n",
 			n, neutralizeFrameMarkers(safeForStatusline(id, mcpResourceNameMax)))
 	}
+	// The same word the CLI and recall_context carry: this door takes an id,
+	// so a reader here has named the session as plainly as anyone can (#1624).
+	if line := forgottenSourceNote(s, id); line != "" {
+		note += "deja: " + line + "\n\n"
+	}
 	var b bytes.Buffer
 	search.PrintContext(&b, s, "")
 	// Same transcript, same frame as recall_context. Reading a session through


### PR DESCRIPTION
Closes #1624.

`deja ctx <id>` says a session was forgotten and answers with the note promoted from it; the MCP tools handed an agent the same note with the fact removed. "Forgotten" is a decision the reader made about that session, which is the kind of fact recall exists to carry.

The sentence moved out of the printer into `forgottenSourceNote`, and both MCP paths — the id path and the search path, since the note carries the id in its text — put it above the answer. The two cases the CLI keeps quiet about stay quiet: the note asked for by its own id, and an ordinary query that happens to land on it.