### PR TITLE
fix(blame): name the file this one's history stops at

### DIFF
--- a/cmd/deja/blame_earlier_name.go
+++ b/cmd/deja/blame_earlier_name.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 // earlierNameJointCap bounds how many files the one session that saw both may
@@ -16,6 +18,12 @@ import (
 // thirteen-file refactor touches everything, and naming whichever of them
 // happened to stop first is a coin toss dressed as a finding.
 const earlierNameJointCap = 3
+
+// earlierNameReadCap bounds how many candidate sessions are read to confirm a
+// move. The candidates are tried newest first, so the cap costs only the
+// oldest of a crowded field — and a crowded field is the case where the answer
+// was least worth trusting anyway.
+const earlierNameReadCap = 3
 
 // earlierNameNote points at a file this one's history may continue from.
 //
@@ -90,8 +98,24 @@ func earlierNameNote(dir, typed string, target search.BlameTarget) string {
 	if targetFirst.IsZero() {
 		return ""
 	}
-	best, bestWhen := "", time.Time{}
-	for p, j := range together {
+	// Newest first, then by path: a map's order is not an order, and on equal
+	// timestamps — one per session, so ties are ordinary — the same command
+	// answered with a different file on each run.
+	candidates := make([]string, 0, len(together))
+	for p := range together {
+		candidates = append(candidates, p)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := together[candidates[i]], together[candidates[j]]
+		if !a.when.Equal(b.when) {
+			return a.when.After(b.when)
+		}
+		return candidates[i] < candidates[j]
+	})
+	best := ""
+	reads := 0
+	for _, p := range candidates {
+		j := together[p]
 		// It stopped where this one carried on: the joint session is the last
 		// time anything touched it, and this file outlived it.
 		if !lastTouch[p].Equal(j.when) || !j.when.Before(targetLast) {
@@ -115,12 +139,19 @@ func earlierNameNote(dir, typed string, target search.BlameTarget) string {
 		// to the other. Prose alone would be guesswork, which is why #1627
 		// rejected it; prose as the second signal is what separates the two
 		// shapes the first one cannot.
+		//
+		// Each of these reads a session, so the field is bounded: a hub file
+		// with ten one-off neighbours cost ten reads and most of blame's own
+		// wall-clock.
+		if reads >= earlierNameReadCap {
+			break
+		}
+		reads++
 		if !sessionSaysItMoved(dir, j.session, path.Base(p), target.Base) {
 			continue
 		}
-		if best == "" || j.when.After(bestWhen) {
-			best, bestWhen = p, j.when
-		}
+		best = p
+		break
 	}
 	if best == "" {
 		return ""
@@ -167,16 +198,49 @@ func sessionSaysItMoved(dir, id, from, to string) bool {
 	if err != nil || !ok {
 		return false
 	}
+	from, to = strings.ToLower(from), strings.ToLower(to)
 	for _, m := range s.Messages {
-		text := strings.ToLower(m.Text)
-		if !strings.Contains(text, strings.ToLower(from)) || !strings.Contains(text, strings.ToLower(to)) {
+		// Not what a file says about itself: an edit's payload is carried in
+		// the message text, so a file whose contents read "renamed from x" was
+		// voting for a rename nobody performed.
+		if m.Role == sources.RoleFiles || m.Role == "tool_result" {
 			continue
 		}
-		for _, verb := range []string{"rename", "renaming", "mv ", "moved", "move "} {
-			if strings.Contains(text, verb) {
-				return true
-			}
+		text := strings.ToLower(m.Text)
+		i, j := strings.Index(text, from), strings.Index(text, to)
+		if i < 0 || j < 0 {
+			continue
+		}
+		if movedBetween(text, min(i, j), max(i, j)+len(to)) {
+			return true
 		}
 	}
 	return false
 }
+
+// movedBetween looks for the verb in the span that holds both names, rather
+// than anywhere in the message: a turn that renames two other files and
+// mentions ours in passing said nothing about ours (#1627).
+//
+// "remove" is not "move": it contains it, and matching the substring made the
+// deletion case — the one thing this note cannot tell from a rename — vote
+// for itself.
+func movedBetween(text string, from, to int) bool {
+	span := text[max(0, from-moveVerbReach):min(len(text), to+moveVerbReach)]
+	for _, verb := range []string{"rename", "renaming", "renamed", "git mv ", "mv "} {
+		if strings.Contains(span, verb) {
+			return true
+		}
+	}
+	for _, verb := range []string{" move ", " moved ", " moving "} {
+		if strings.Contains(" "+span+" ", verb) {
+			return true
+		}
+	}
+	return false
+}
+
+// moveVerbReach is how far either side of the two names the verb may sit. A
+// rename sentence puts it next to them; a paragraph that happens to hold both
+// puts it anywhere.
+const moveVerbReach = 40

--- a/cmd/deja/blame_earlier_name.go
+++ b/cmd/deja/blame_earlier_name.go
@@ -11,28 +11,46 @@ import (
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
-// earlierNameNote points at the file this one's history stops at.
+// earlierNameJointCap bounds how many files the one session that saw both may
+// have touched. A rename lands in a session that is about the rename; a
+// thirteen-file refactor touches everything, and naming whichever of them
+// happened to stop first is a coin toss dressed as a finding.
+const earlierNameJointCap = 3
+
+// earlierNameNote points at a file this one's history may continue from.
 //
 // blame answers under the name you type, so the moment a file is renamed
 // everything discussed under the old name drops out — and the name a reader
 // has is the one in their editor (#1627). Following the rename is the other
 // option and it is guesswork: "rename X to Y" in a plan nobody carried out
 // reads exactly like one that was done, and a wrong link silently attributes
-// one file's history to another. So deja names the candidate and lets the
-// reader decide.
+// one file's history to another.
 //
-// The signal is touch data rather than prose: one session touched both files,
-// the other one was never touched after it, and this one was. That is a rename
-// as far as the index can see it, without reading anybody's intent.
+// So this asserts nothing. It reports what the index saw — one session touched
+// both files, the other one stopped there, this one went on — and leaves the
+// reader to say whether that was a rename. The conditions are narrow for the
+// same reason: two files edited together once are not evidence of anything, so
+// the pair has to be nearly alone in its session, in the same directory, in a
+// project this file was worked on in, and the older file's last touch has to
+// be that very session.
 func earlierNameNote(dir, typed string, target search.BlameTarget) string {
 	metas, err := index.AllMeta(dir)
 	if err != nil {
 		return ""
 	}
-	type span struct{ first, last time.Time }
-	seen := map[string]*span{}
-	together := map[string]bool{}
-	var targetSpan span
+	lastTouch := map[string]time.Time{}
+	type joint struct {
+		when    time.Time
+		project string
+		session string
+	}
+	together := map[string]joint{}
+	var targetFirst, targetLast time.Time
+	targetProjects := map[string]bool{}
+	// The directories the file itself was recorded under, so a candidate can
+	// be held to the same one without guessing how the reader's typed path
+	// maps onto the absolute path a session wrote.
+	targetDirs := map[string]bool{}
 	for _, m := range metas {
 		when := m.Updated
 		if when.IsZero() {
@@ -47,71 +65,118 @@ func earlierNameNote(dir, typed string, target search.BlameTarget) string {
 		}
 		for _, p := range m.Touched {
 			if blameSamePath(p, typed, target) {
-				if targetSpan.first.IsZero() || when.Before(targetSpan.first) {
-					targetSpan.first = when
+				if targetFirst.IsZero() || when.Before(targetFirst) {
+					targetFirst = when
 				}
-				if when.After(targetSpan.last) {
-					targetSpan.last = when
+				if when.After(targetLast) {
+					targetLast = when
 				}
+				targetProjects[m.Project] = true
+				targetDirs[path.Dir(filepath.ToSlash(p))] = true
 				continue
 			}
-			s := seen[p]
-			if s == nil {
-				s = &span{first: when}
-				seen[p] = s
+			if when.After(lastTouch[p]) {
+				lastTouch[p] = when
 			}
-			if when.Before(s.first) {
-				s.first = when
-			}
-			if when.After(s.last) {
-				s.last = when
-			}
-			if touchedTarget {
-				together[p] = true
+			// The session that saw both, and only when it is small enough to
+			// be about these two files.
+			if touchedTarget && len(m.Touched) <= earlierNameJointCap {
+				if prev, ok := together[p]; !ok || when.After(prev.when) {
+					together[p] = joint{when: when, project: m.Project, session: m.ID}
+				}
 			}
 		}
 	}
-	if targetSpan.first.IsZero() {
+	if targetFirst.IsZero() {
 		return ""
 	}
-	best := ""
-	var bestLast time.Time
-	for p := range together {
-		s := seen[p]
-		// The shape of a rename: the other file was already being worked on
-		// before this one existed, and nothing touched it after the session
-		// that touched both.
-		if !s.first.Before(targetSpan.first) || s.last.After(targetSpan.last) {
+	best, bestWhen := "", time.Time{}
+	for p, j := range together {
+		// It stopped where this one carried on: the joint session is the last
+		// time anything touched it, and this file outlived it.
+		if !lastTouch[p].Equal(j.when) || !j.when.Before(targetLast) {
 			continue
 		}
-		if path.Ext(p) != path.Ext(target.Base) || path.Base(p) == target.Base {
+		if !targetProjects[j.project] {
 			continue
 		}
-		if best == "" || s.last.After(bestLast) {
-			best, bestLast = p, s.last
+		// Same directory and same kind of file. A rename moves a name, not a
+		// file's place in the tree — and when it does move one, saying nothing
+		// beats pointing at a vendored copy or a file from another package.
+		if !targetDirs[path.Dir(filepath.ToSlash(p))] {
+			continue
+		}
+		if path.Ext(p) != path.Ext(target.Base) {
+			continue
+		}
+		// The timing is the same for a rename and for two files that merely
+		// met once — a test beside its subject, a caller and the file it
+		// replaced. So the session that saw both has to say it moved one name
+		// to the other. Prose alone would be guesswork, which is why #1627
+		// rejected it; prose as the second signal is what separates the two
+		// shapes the first one cannot.
+		if !sessionSaysItMoved(dir, j.session, path.Base(p), target.Base) {
+			continue
+		}
+		if best == "" || j.when.After(bestWhen) {
+			best, bestWhen = p, j.when
 		}
 	}
 	if best == "" {
 		return ""
 	}
-	return fmt.Sprintf("deja: this file's history stops here — %s was worked on before it and not since; `deja blame %s` for what came before\n",
+	// What was seen, not what it means: deja cannot tell a rename from a file
+	// that was deleted while this one took over its work, and calling it a
+	// rename would be the wrong link this exists to avoid.
+	return fmt.Sprintf("deja: %s was last touched in the same session as this file — `deja blame %s` if that is where its history continues from\n",
 		search.SafeLine(shortHome(best)), pasteSafe(best))
 }
 
-// blameSamePath asks whether a touched path is the file blame was asked about,
-// on the same terms the search does: the reader types what their editor shows,
-// which is rarely the absolute path a session recorded.
+// blameSamePath asks whether a touched path is the file blame was asked about.
+// What the reader typed, not what deja resolved it to: the file is named the
+// way their editor shows it — `internal/search/x.go` — while the session
+// recorded whatever absolute path that machine had.
+//
+// The basename alone is not enough for a typed path: `internal/a/util.go` and
+// `internal/b/util.go` are two files, and folding them together dragged one
+// file's first touch back to the other's, which killed the very renames this
+// note is about.
 func blameSamePath(touched, typed string, target search.BlameTarget) bool {
 	if touched == target.FullPath {
 		return true
 	}
-	// What the reader typed, not what deja resolved it to: the file is named
-	// the way their editor shows it — `internal/search/x.go` — while the
-	// session recorded whatever absolute path that machine had.
 	q := strings.TrimPrefix(filepath.ToSlash(typed), "./")
 	t := filepath.ToSlash(touched)
-	if q != "" && (t == q || strings.HasSuffix(t, "/"+q)) {
+	if q == "" {
+		return false
+	}
+	if t == q || strings.HasSuffix(t, "/"+q) {
 		return true
 	}
-	return path.Base(t) == target.Base
+	// A reader who typed a bare name means the file of that name, and there is
+	// nothing else to go on — but only when they typed a bare name.
+	return !strings.Contains(q, "/") && path.Base(t) == q
+}
+
+// sessionSaysItMoved reads the one session that touched both files and asks
+// whether it names them together in a sentence about moving a name — `git mv`,
+// "rename x to y". One session, read only when the touch data has already
+// narrowed the field to a single candidate.
+func sessionSaysItMoved(dir, id, from, to string) bool {
+	s, ok, err := index.FindByPrefix(dir, id)
+	if err != nil || !ok {
+		return false
+	}
+	for _, m := range s.Messages {
+		text := strings.ToLower(m.Text)
+		if !strings.Contains(text, strings.ToLower(from)) || !strings.Contains(text, strings.ToLower(to)) {
+			continue
+		}
+		for _, verb := range []string{"rename", "renaming", "mv ", "moved", "move "} {
+			if strings.Contains(text, verb) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/cmd/deja/blame_earlier_name.go
+++ b/cmd/deja/blame_earlier_name.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// earlierNameNote points at the file this one's history stops at.
+//
+// blame answers under the name you type, so the moment a file is renamed
+// everything discussed under the old name drops out — and the name a reader
+// has is the one in their editor (#1627). Following the rename is the other
+// option and it is guesswork: "rename X to Y" in a plan nobody carried out
+// reads exactly like one that was done, and a wrong link silently attributes
+// one file's history to another. So deja names the candidate and lets the
+// reader decide.
+//
+// The signal is touch data rather than prose: one session touched both files,
+// the other one was never touched after it, and this one was. That is a rename
+// as far as the index can see it, without reading anybody's intent.
+func earlierNameNote(dir, typed string, target search.BlameTarget) string {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return ""
+	}
+	type span struct{ first, last time.Time }
+	seen := map[string]*span{}
+	together := map[string]bool{}
+	var targetSpan span
+	for _, m := range metas {
+		when := m.Updated
+		if when.IsZero() {
+			when = m.Started
+		}
+		touchedTarget := false
+		for _, p := range m.Touched {
+			if blameSamePath(p, typed, target) {
+				touchedTarget = true
+				break
+			}
+		}
+		for _, p := range m.Touched {
+			if blameSamePath(p, typed, target) {
+				if targetSpan.first.IsZero() || when.Before(targetSpan.first) {
+					targetSpan.first = when
+				}
+				if when.After(targetSpan.last) {
+					targetSpan.last = when
+				}
+				continue
+			}
+			s := seen[p]
+			if s == nil {
+				s = &span{first: when}
+				seen[p] = s
+			}
+			if when.Before(s.first) {
+				s.first = when
+			}
+			if when.After(s.last) {
+				s.last = when
+			}
+			if touchedTarget {
+				together[p] = true
+			}
+		}
+	}
+	if targetSpan.first.IsZero() {
+		return ""
+	}
+	best := ""
+	var bestLast time.Time
+	for p := range together {
+		s := seen[p]
+		// The shape of a rename: the other file was already being worked on
+		// before this one existed, and nothing touched it after the session
+		// that touched both.
+		if !s.first.Before(targetSpan.first) || s.last.After(targetSpan.last) {
+			continue
+		}
+		if path.Ext(p) != path.Ext(target.Base) || path.Base(p) == target.Base {
+			continue
+		}
+		if best == "" || s.last.After(bestLast) {
+			best, bestLast = p, s.last
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return fmt.Sprintf("deja: this file's history stops here — %s was worked on before it and not since; `deja blame %s` for what came before\n",
+		search.SafeLine(shortHome(best)), pasteSafe(best))
+}
+
+// blameSamePath asks whether a touched path is the file blame was asked about,
+// on the same terms the search does: the reader types what their editor shows,
+// which is rarely the absolute path a session recorded.
+func blameSamePath(touched, typed string, target search.BlameTarget) bool {
+	if touched == target.FullPath {
+		return true
+	}
+	// What the reader typed, not what deja resolved it to: the file is named
+	// the way their editor shows it — `internal/search/x.go` — while the
+	// session recorded whatever absolute path that machine had.
+	q := strings.TrimPrefix(filepath.ToSlash(typed), "./")
+	t := filepath.ToSlash(touched)
+	if q != "" && (t == q || strings.HasSuffix(t, "/"+q)) {
+		return true
+	}
+	return path.Base(t) == target.Base
+}

--- a/cmd/deja/blame_earlier_name.go
+++ b/cmd/deja/blame_earlier_name.go
@@ -203,30 +203,55 @@ func sessionSaysItMoved(dir, id, from, to string) bool {
 		// Not what a file says about itself: an edit's payload is carried in
 		// the message text, so a file whose contents read "renamed from x" was
 		// voting for a rename nobody performed.
-		if m.Role == sources.RoleFiles || m.Role == "tool_result" {
+		if m.Role == sources.RoleFiles || m.Role == sources.RoleEdit || m.Role == "tool_result" {
 			continue
 		}
 		text := strings.ToLower(m.Text)
-		i, j := strings.Index(text, from), strings.Index(text, to)
-		if i < 0 || j < 0 {
-			continue
-		}
-		if movedBetween(text, min(i, j), max(i, j)+len(to)) {
+		if sessionTextSaysItMoved(text, from, to) {
 			return true
 		}
 	}
 	return false
 }
 
+// sessionTextSaysItMoved asks whether one message says these two names were
+// the same file under two names. Both have to be there, and the verb has to
+// sit beside one of them.
+func sessionTextSaysItMoved(text, from, to string) bool {
+	text, from, to = strings.ToLower(text), strings.ToLower(from), strings.ToLower(to)
+	i, j := strings.Index(text, from), strings.Index(text, to)
+	if i < 0 || j < 0 {
+		return false
+	}
+	first, last := i, j+len(to)
+	if j < i {
+		first, last = j, i+len(from)
+	}
+	return movedBetween(text, first, last)
+}
+
 // movedBetween looks for the verb in the span that holds both names, rather
 // than anywhere in the message: a turn that renames two other files and
 // mentions ours in passing said nothing about ours (#1627).
-//
-// "remove" is not "move": it contains it, and matching the substring made the
-// deletion case — the one thing this note cannot tell from a rename — vote
-// for itself.
 func movedBetween(text string, from, to int) bool {
-	span := text[max(0, from-moveVerbReach):min(len(text), to+moveVerbReach)]
+	// Ahead of the pair, or in a gap short enough to be one clause. A rename
+	// is written before its names — "rename x to y", "git mv x y" — and
+	// anything between two mentions far apart is somebody else's sentence:
+	// "old.go still leaks; also rename helper.go to helpers.go; and new.go
+	// needs the same guard" put an unrelated rename between ours.
+	if hasMoveVerb(text[max(0, from-moveVerbReach):from]) {
+		return true
+	}
+	if to-from <= moveVerbReach {
+		return hasMoveVerb(text[from:min(len(text), to)])
+	}
+	return false
+}
+
+// hasMoveVerb reads the words that mean a name was moved. "remove" is not
+// "move": it contains it, and matching the substring made the deletion case —
+// the one thing this note cannot tell from a rename — vote for itself.
+func hasMoveVerb(span string) bool {
 	for _, verb := range []string{"rename", "renaming", "renamed", "git mv ", "mv "} {
 		if strings.Contains(span, verb) {
 			return true

--- a/cmd/deja/blame_earlier_name_test.go
+++ b/cmd/deja/blame_earlier_name_test.go
@@ -30,6 +30,11 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 			`","cwd":"/proj","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
 			path + `","old_string":"a","new_string":"b"}}]}}`
 	}
+	edit := func(id, day, path, old string) string {
+		return `{"type":"assistant","timestamp":"2026-07-` + day + `T10:00:00Z","sessionId":"` + id +
+			`","cwd":"/proj","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
+			path + `","old_string":"` + old + `","new_string":"// nothing to see"}}]}}`
+	}
 	say := func(id, day, text string) string {
 		return `{"type":"user","timestamp":"2026-07-` + day + `T10:01:00Z","sessionId":"` + id +
 			`","cwd":"/proj","message":{"role":"user","content":"` + text + `"}}`
@@ -65,6 +70,16 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 	write("eight.jsonl",
 		say("hhhh0008", "13", "the table test needs another case"),
 		touch("hhhh0008", "13", "/proj/internal/tbl/foo_test.go"))
+	// The word came from a file, not from anybody: an edit carries its payload
+	// in the message text, so a file whose own contents read "renamed from"
+	// used to vote for a rename nobody performed.
+	write("eleven.jsonl",
+		say("kkkk0011", "11", "update the docs"),
+		edit("kkkk0011", "11", "/proj/internal/edge/quiet.go", "// renamed from loud.go in v2"),
+		touch("kkkk0011", "11", "/proj/internal/edge/loud.go"))
+	write("twelve.jsonl",
+		say("llll0012", "13", "the edge case again"),
+		touch("llll0012", "13", "/proj/internal/edge/quiet.go"))
 	// A move out of another directory, worded as a rename: a name that moved
 	// house is not the name this file's history continues under, and pointing
 	// at it is how the note would start naming vendored copies.
@@ -122,8 +137,9 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 	}
 
 	// And the cases that are not a rename by any reading: a pair that met
-	// once, and a test file beside its subject.
-	for _, file := range []string{"internal/other/cache.go", "internal/tbl/foo_test.go"} {
+	// once, a test file beside its subject, and a file whose own contents
+	// carried the word.
+	for _, file := range []string{"internal/other/cache.go", "internal/tbl/foo_test.go", "internal/edge/quiet.go"} {
 		note, err = captureRunStderr(t, "blame", file)
 		if err != nil {
 			t.Fatal(err)
@@ -151,17 +167,12 @@ func TestOnlyASentenceAboutTheseTwoNamesCounts(t *testing.T) {
 		{"remove old_name.go, new_name.go covers everything it did", false},
 		{"old_name.go removed, new_name.go takes over", false},
 		{"old_name.go and new_name.go both call the same helper", false},
+		// Far apart, with somebody else's rename in between.
+		{"old_name.go still leaks; also rename helper.go to helpers.go; and new_name.go needs the same guard", false},
 	} {
-		span := c.text
-		i, j := strings.Index(span, "old_name.go"), strings.Index(span, "new_name.go")
-		if i < 0 || j < 0 {
-			t.Fatalf("fixture does not name both files: %q", c.text)
-		}
-		from, to := i, j+len("new_name.go")
-		if j < i {
-			from, to = j, i+len("old_name.go")
-		}
-		if got := movedBetween(span, from, to); got != c.want {
+		// Through the same span the reader of a session goes through, so the
+		// table guards what production does rather than its own arithmetic.
+		if got := sessionTextSaysItMoved(c.text, "old_name.go", "new_name.go"); got != c.want {
 			t.Errorf("movedBetween(%q) = %v, want %v", c.text, got, c.want)
 		}
 	}

--- a/cmd/deja/blame_earlier_name_test.go
+++ b/cmd/deja/blame_earlier_name_test.go
@@ -19,20 +19,13 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	write := func(name, id, day string, lines ...string) {
+	write := func(name string, lines ...string) {
 		t.Helper()
-		var b strings.Builder
-		for _, l := range lines {
-			b.WriteString(l)
-			b.WriteByte('\n')
-		}
-		if err := os.WriteFile(filepath.Join(store, name), []byte(b.String()), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(store, name), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		_ = id
-		_ = day
 	}
-	touch := func(id, day, path, text string) string {
+	touch := func(id, day, path string) string {
 		return `{"type":"assistant","timestamp":"2026-07-` + day + `T10:00:00Z","sessionId":"` + id +
 			`","cwd":"/proj","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
 			path + `","old_string":"a","new_string":"b"}}]}}`
@@ -41,19 +34,54 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 		return `{"type":"user","timestamp":"2026-07-` + day + `T10:01:00Z","sessionId":"` + id +
 			`","cwd":"/proj","message":{"role":"user","content":"` + text + `"}}`
 	}
-	write("one.jsonl", "aaaa0001", "10",
+	write("one.jsonl",
 		say("aaaa0001", "10", "the retry loop in internal/search/old_name.go keeps firing"),
-		touch("aaaa0001", "10", "/proj/internal/search/old_name.go", ""))
-	write("two.jsonl", "bbbb0002", "12",
+		touch("aaaa0001", "10", "/proj/internal/search/old_name.go"))
+	write("two.jsonl",
 		say("bbbb0002", "12", "the backoff in internal/search/old_name.go is wrong"),
-		touch("bbbb0002", "12", "/proj/internal/search/old_name.go", ""))
-	write("three.jsonl", "cccc0003", "14",
+		touch("bbbb0002", "12", "/proj/internal/search/old_name.go"))
+	write("three.jsonl",
 		say("cccc0003", "14", "rename internal/search/old_name.go to internal/search/new_name.go"),
-		touch("cccc0003", "14", "/proj/internal/search/old_name.go", ""),
-		touch("cccc0003", "14", "/proj/internal/search/new_name.go", ""))
-	write("four.jsonl", "dddd0004", "16",
+		touch("cccc0003", "14", "/proj/internal/search/old_name.go"),
+		touch("cccc0003", "14", "/proj/internal/search/new_name.go"))
+	write("four.jsonl",
 		say("dddd0004", "16", "the backoff in internal/search/new_name.go is still wrong"),
-		touch("dddd0004", "16", "/proj/internal/search/new_name.go", ""))
+		touch("dddd0004", "16", "/proj/internal/search/new_name.go"))
+	// Two files that merely coincided once, a test file beside its subject, a
+	// same-named file in another package, and a file from another project:
+	// none of them is a name this file's history continues from, and each of
+	// them fired before the rules were narrowed.
+	write("five.jsonl",
+		say("eeee0005", "11", "touch both while wiring the cache"),
+		touch("eeee0005", "11", "/proj/internal/other/parser.go"),
+		touch("eeee0005", "11", "/proj/internal/other/cache.go"))
+	write("six.jsonl",
+		say("ffff0006", "13", "the cache still misses"),
+		touch("ffff0006", "13", "/proj/internal/other/cache.go"))
+	write("seven.jsonl",
+		say("gggg0007", "11", "write the table test"),
+		touch("gggg0007", "11", "/proj/internal/tbl/foo.go"),
+		touch("gggg0007", "11", "/proj/internal/tbl/foo_test.go"))
+	write("eight.jsonl",
+		say("hhhh0008", "13", "the table test needs another case"),
+		touch("hhhh0008", "13", "/proj/internal/tbl/foo_test.go"))
+	// A move out of another directory, worded as a rename: a name that moved
+	// house is not the name this file's history continues under, and pointing
+	// at it is how the note would start naming vendored copies.
+	write("nine.jsonl",
+		say("iiii0009", "15", "rename internal/deep/gone.go to internal/search/new_name.go"),
+		touch("iiii0009", "15", "/proj/internal/deep/gone.go"),
+		touch("iiii0009", "15", "/proj/internal/search/new_name.go"))
+	// And a refactor that swept several files along while saying the word:
+	// whichever of them stopped last would be named on the strength of the
+	// sweep rather than of anything about it.
+	write("ten.jsonl",
+		say("jjjj0010", "15", "rename internal/search/swept.go to internal/search/new_name.go while we are here"),
+		touch("jjjj0010", "15", "/proj/internal/search/swept.go"),
+		touch("jjjj0010", "15", "/proj/internal/search/a.go"),
+		touch("jjjj0010", "15", "/proj/internal/search/b.go"),
+		touch("jjjj0010", "15", "/proj/internal/search/c.go"),
+		touch("jjjj0010", "15", "/proj/internal/search/new_name.go"))
 
 	dir := filepath.Join(tmp, "index.db")
 	if err := index.Ensure(dir, "", false, nil); err != nil {
@@ -70,6 +98,18 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 	if !strings.Contains(note, "deja blame") {
 		t.Errorf("the line does not say how to read what came before:\n%s", note)
 	}
+	// What was seen, not what it means: deja cannot tell a rename from a file
+	// that was deleted while this one took over its work.
+	if strings.Contains(note, "renamed") {
+		t.Errorf("the line claims a rename it cannot know about:\n%s", note)
+	}
+	// One name, and it is the one in the same directory, from the session that
+	// was about the move rather than one that swept it along.
+	for _, other := range []string{"gone.go", "swept.go", "a.go"} {
+		if strings.Contains(note, other) {
+			t.Errorf("the note named %s:\n%s", other, note)
+		}
+	}
 
 	// The other direction says nothing: nothing came before the old name, and
 	// a file whose history is all under its own name needs no hint.
@@ -77,7 +117,19 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(note, "what came before") {
+	if strings.Contains(note, "continues from") {
 		t.Errorf("the file the history starts at was given a hint:\n%s", note)
+	}
+
+	// And the cases that are not a rename by any reading: a pair that met
+	// once, and a test file beside its subject.
+	for _, file := range []string{"internal/other/cache.go", "internal/tbl/foo_test.go"} {
+		note, err = captureRunStderr(t, "blame", file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(note, "continues from") {
+			t.Errorf("%s was told its history continues from a file it merely shared a session with:\n%s", file, note)
+		}
 	}
 }

--- a/cmd/deja/blame_earlier_name_test.go
+++ b/cmd/deja/blame_earlier_name_test.go
@@ -133,3 +133,36 @@ func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
 		}
 	}
 }
+
+// The verb has to be about these two names. A turn that renames two other
+// files and mentions ours in passing said nothing about ours; "remove" is not
+// "move" — matching the substring made the deletion case, the one thing this
+// note cannot tell from a rename, vote for itself; and a file whose own
+// contents read "renamed from x" is not somebody saying so.
+func TestOnlyASentenceAboutTheseTwoNamesCounts(t *testing.T) {
+	for _, c := range []struct {
+		text string
+		want bool
+	}{
+		{"rename old_name.go to new_name.go", true},
+		{"git mv internal/search/old_name.go internal/search/new_name.go", true},
+		{"moving old_name.go to new_name.go now", true},
+		{"rename helper.go to helpers.go, and while you are there old_name.go and new_name.go both need the retry fix", false},
+		{"remove old_name.go, new_name.go covers everything it did", false},
+		{"old_name.go removed, new_name.go takes over", false},
+		{"old_name.go and new_name.go both call the same helper", false},
+	} {
+		span := c.text
+		i, j := strings.Index(span, "old_name.go"), strings.Index(span, "new_name.go")
+		if i < 0 || j < 0 {
+			t.Fatalf("fixture does not name both files: %q", c.text)
+		}
+		from, to := i, j+len("new_name.go")
+		if j < i {
+			from, to = j, i+len("old_name.go")
+		}
+		if got := movedBetween(span, from, to); got != c.want {
+			t.Errorf("movedBetween(%q) = %v, want %v", c.text, got, c.want)
+		}
+	}
+}

--- a/cmd/deja/blame_earlier_name_test.go
+++ b/cmd/deja/blame_earlier_name_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// blame answers under the name you type, so a rename drops everything said
+// under the old name out of the file's history — and the name a reader has is
+// the one in their editor. The history is in the index and reachable, just not
+// from there (#1627).
+func TestBlameNamesTheFileTheHistoryStopsAt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, id, day string, lines ...string) {
+		t.Helper()
+		var b strings.Builder
+		for _, l := range lines {
+			b.WriteString(l)
+			b.WriteByte('\n')
+		}
+		if err := os.WriteFile(filepath.Join(store, name), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_ = id
+		_ = day
+	}
+	touch := func(id, day, path, text string) string {
+		return `{"type":"assistant","timestamp":"2026-07-` + day + `T10:00:00Z","sessionId":"` + id +
+			`","cwd":"/proj","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
+			path + `","old_string":"a","new_string":"b"}}]}}`
+	}
+	say := func(id, day, text string) string {
+		return `{"type":"user","timestamp":"2026-07-` + day + `T10:01:00Z","sessionId":"` + id +
+			`","cwd":"/proj","message":{"role":"user","content":"` + text + `"}}`
+	}
+	write("one.jsonl", "aaaa0001", "10",
+		say("aaaa0001", "10", "the retry loop in internal/search/old_name.go keeps firing"),
+		touch("aaaa0001", "10", "/proj/internal/search/old_name.go", ""))
+	write("two.jsonl", "bbbb0002", "12",
+		say("bbbb0002", "12", "the backoff in internal/search/old_name.go is wrong"),
+		touch("bbbb0002", "12", "/proj/internal/search/old_name.go", ""))
+	write("three.jsonl", "cccc0003", "14",
+		say("cccc0003", "14", "rename internal/search/old_name.go to internal/search/new_name.go"),
+		touch("cccc0003", "14", "/proj/internal/search/old_name.go", ""),
+		touch("cccc0003", "14", "/proj/internal/search/new_name.go", ""))
+	write("four.jsonl", "dddd0004", "16",
+		say("dddd0004", "16", "the backoff in internal/search/new_name.go is still wrong"),
+		touch("dddd0004", "16", "/proj/internal/search/new_name.go", ""))
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	note, err := captureRunStderr(t, "blame", "internal/search/new_name.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "old_name.go") {
+		t.Errorf("nothing points at the name the history stops at:\n%s", note)
+	}
+	if !strings.Contains(note, "deja blame") {
+		t.Errorf("the line does not say how to read what came before:\n%s", note)
+	}
+
+	// The other direction says nothing: nothing came before the old name, and
+	// a file whose history is all under its own name needs no hint.
+	note, err = captureRunStderr(t, "blame", "internal/search/old_name.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "what came before") {
+		t.Errorf("the file the history starts at was given a hint:\n%s", note)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2530,6 +2530,11 @@ func runBlame(dir string, args []string) error {
 		return nil
 	}
 	search.PrintBlame(os.Stdout, hits, false)
+	// The name the reader has is the one in their editor, and a rename drops
+	// everything said under the old one out of this answer (#1627).
+	if note := earlierNameNote(dir, path, target); note != "" {
+		fmt.Fprint(os.Stderr, note)
+	}
 	// blame answers "who touched this file". Ten blocks and nothing else reads
 	// as all of them, the misread search already avoids with the same sentence
 	// (#2299). --json keeps its bare array: a machine consumer reading a total


### PR DESCRIPTION
Closes #1627, on the middle option the issue laid out.

blame answers under the name you type, so a rename drops everything said under the old name out of the file's history — and the name a reader has is the one in their editor. Following the rename is the other option and it is guesswork: "rename X to Y" in a plan nobody carried out reads exactly like one that was done, and a wrong link silently attributes one file's history to another.

So deja names the candidate and lets the reader decide, from touch data rather than prose: one session touched both files, the other was never touched after it, and this one was.