### PR TITLE
fix(install): opencode reads its config by content, and an inline block is opened

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2842,8 +2842,13 @@ func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end
 // to decide which side of it the entry belongs on, and refusing is the honest
 // answer for a shape nobody writes.
 func openInlineBlock(lines []string, key string) ([]string, bool) {
+	inBlock := false
 	for i, l := range lines {
-		code, _, _ := jsoncCodeOf(l, false)
+		// The comment state carries between lines: read on its own, a line
+		// inside a /* … */ looks like code, and splitting it rewrote a block
+		// the reader had commented out.
+		code, next, _ := jsoncCodeOf(l, inBlock)
+		inBlock = next
 		if !strings.Contains(code, `"`+key+`"`) || !strings.Contains(code, "{") {
 			continue
 		}
@@ -2856,10 +2861,15 @@ func openInlineBlock(lines []string, key string) ([]string, bool) {
 			if open < 0 {
 				return lines, false
 			}
-			rest := strings.TrimSpace(l[open+1:])
-			if rest == "" {
+			// What a parser reads, not what the line holds: a comment after the
+			// opening brace — `"mcp": { // my servers` — is not a server on
+			// the opening line, and refusing it took an ordinary shape away
+			// from exactly the readers #1664 was opened for.
+			codeOpen := braceOutsideString(code, '{')
+			if codeOpen < 0 || strings.TrimSpace(code[codeOpen+1:]) == "" {
 				return lines, true
 			}
+			rest := strings.TrimSpace(l[open+1:])
 			if strings.TrimSpace(code) != strings.TrimSpace(l) {
 				return lines, false
 			}
@@ -2990,7 +3000,10 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 	lines, canOpen := openInlineBlock(lines, "mcp")
 	if !canOpen {
 		if uninstall {
-			return []byte(strings.Join(lines, "\n") + "\n"), "", nil
+			// The file as it was, byte for byte: this is a config deja has
+			// just declined to edit, and rejoining the lines wrote the split
+			// back out — and gave a file with no trailing newline one.
+			return old, "", nil
 		}
 		return nil, "", fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
 	}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2841,32 +2841,87 @@ func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end
 // already held. A line carrying a comment is left alone: the split would have
 // to decide which side of it the entry belongs on, and refusing is the honest
 // answer for a shape nobody writes.
-func openInlineBlock(lines []string, key string) []string {
+func openInlineBlock(lines []string, key string) ([]string, bool) {
 	for i, l := range lines {
 		code, _, _ := jsoncCodeOf(l, false)
 		if !strings.Contains(code, `"`+key+`"`) || !strings.Contains(code, "{") {
 			continue
 		}
-		if jsoncBraceDelta(code) > 0 || strings.TrimSpace(code) != strings.TrimSpace(l) {
-			// Either it already spans lines, or the line holds a comment.
-			return lines
+		if jsoncBraceDelta(code) > 0 {
+			// The block spans lines, but its first server may sit on the
+			// opening line — `"mcp": { "a": {…}` — and then the lines between
+			// the ends hold nothing, so deja's entry went in with no comma
+			// after the reader's and the file stopped parsing.
+			open := braceOutsideString(l, '{')
+			if open < 0 {
+				return lines, false
+			}
+			rest := strings.TrimSpace(l[open+1:])
+			if rest == "" {
+				return lines, true
+			}
+			if strings.TrimSpace(code) != strings.TrimSpace(l) {
+				return lines, false
+			}
+			indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
+			out := append([]string{}, lines[:i]...)
+			out = append(out, l[:open+1], indent+"  "+rest)
+			return append(out, lines[i+1:]...), true
+		}
+		if strings.TrimSpace(code) != strings.TrimSpace(l) {
+			// A comment on the line the block opens and closes on. Splitting
+			// it would have to decide which side of the comment the entry
+			// belongs on, and there is no answer that keeps the reader's
+			// meaning — so the caller refuses rather than writing past the
+			// block, which is what a silent pass-through did (#2777).
+			return lines, false
 		}
 		open := braceOutsideString(l, '{')
-		close := braceOutsideString(l, '}')
-		if open < 0 || close < open {
-			return lines
+		end := matchingBrace(l, open)
+		if open < 0 || end < 0 {
+			return lines, false
 		}
 		indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
-		inner := strings.TrimSpace(l[open+1 : close])
+		inner := strings.TrimSpace(l[open+1 : end])
 		out := append([]string{}, lines[:i]...)
 		out = append(out, l[:open+1])
 		if inner != "" {
 			out = append(out, indent+"  "+inner)
 		}
-		out = append(out, indent+l[close:])
-		return append(out, lines[i+1:]...)
+		out = append(out, indent+l[end:])
+		return append(out, lines[i+1:]...), true
 	}
-	return lines
+	return lines, true
+}
+
+// matchingBrace is the `}` that closes the `{` at open, counting depth and
+// skipping strings. Taking the first structural `}` instead split a non-empty
+// inline block inside its first server: it still parsed, but it left the
+// reader's file reindented into something that reads as broken.
+func matchingBrace(line string, open int) int {
+	if open < 0 || open >= len(line) || line[open] != '{' {
+		return -1
+	}
+	depth, inString, escaped := 0, false, false
+	for i := open; i < len(line); i++ {
+		switch c := line[i]; {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // braceOutsideString is the index of the first brace of that kind a parser
@@ -2932,7 +2987,13 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 	// the insert landed after its closing brace and the config stopped
 	// parsing (#2777). `"mcp": {}` is what a config nobody has added a server
 	// to looks like.
-	lines = openInlineBlock(lines, "mcp")
+	lines, canOpen := openInlineBlock(lines, "mcp")
+	if !canOpen {
+		if uninstall {
+			return []byte(strings.Join(lines, "\n") + "\n"), "", nil
+		}
+		return nil, "", fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
+	}
 	start, end := -1, -1
 	inBlock := false
 	for i, l := range lines {
@@ -3027,6 +3088,12 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		return nil, "", fmt.Errorf("opencode config has an \"mcp\" block deja could not edit without risking it — add the deja server by hand")
 	}
 	insert := len(lines) - 1
+	// The block is spliced in above the file's closing brace, so the file has
+	// to have one of its own on that line. On a config written as a single
+	// line the splice put the new block *before* the object (#2777).
+	if insert < 1 || strings.TrimSpace(stripJSONComments(lines[insert])) != "}" {
+		return nil, "", fmt.Errorf("opencode config is not laid out in a way deja can add to — add the deja server by hand")
+	}
 	comma := ""
 	for i := insert - 1; i >= 0; i-- {
 		trim := strings.TrimSpace(lines[i])

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2672,7 +2672,10 @@ func installOpencode(exe string, uninstall bool) (installResult, error) {
 	}
 	var next []byte
 	var note string
-	if strings.HasSuffix(path, ".jsonc") {
+	// The content, not the name: opencode reads either file as JSONC, and
+	// picking the writer by extension meant the same commented config was
+	// edited as text under one name and refused under the other (#1664).
+	if strings.HasSuffix(path, ".jsonc") || configIsJSONC(old) {
 		next, note, err = updateOpencodeJSONC(old, exe, uninstall)
 	} else {
 		next, note, err = updateOpencodeJSON(old, path, exe, uninstall)
@@ -2833,6 +2836,59 @@ func jsoncCodeOf(line string, inBlock bool) (code string, stillInBlock bool, end
 	return strings.TrimSpace(b.String()), inBlock, end
 }
 
+// openInlineBlock rewrites `"key": { … }` written on one line into the
+// multi-line shape the rest of this writer reads, keeping whatever the line
+// already held. A line carrying a comment is left alone: the split would have
+// to decide which side of it the entry belongs on, and refusing is the honest
+// answer for a shape nobody writes.
+func openInlineBlock(lines []string, key string) []string {
+	for i, l := range lines {
+		code, _, _ := jsoncCodeOf(l, false)
+		if !strings.Contains(code, `"`+key+`"`) || !strings.Contains(code, "{") {
+			continue
+		}
+		if jsoncBraceDelta(code) > 0 || strings.TrimSpace(code) != strings.TrimSpace(l) {
+			// Either it already spans lines, or the line holds a comment.
+			return lines
+		}
+		open := braceOutsideString(l, '{')
+		close := braceOutsideString(l, '}')
+		if open < 0 || close < open {
+			return lines
+		}
+		indent := l[:len(l)-len(strings.TrimLeft(l, " \t"))]
+		inner := strings.TrimSpace(l[open+1 : close])
+		out := append([]string{}, lines[:i]...)
+		out = append(out, l[:open+1])
+		if inner != "" {
+			out = append(out, indent+"  "+inner)
+		}
+		out = append(out, indent+l[close:])
+		return append(out, lines[i+1:]...)
+	}
+	return lines
+}
+
+// braceOutsideString is the index of the first brace of that kind a parser
+// would read as structure — a path holding one is ordinary (#2475).
+func braceOutsideString(line string, want byte) int {
+	inString, escaped := false, false
+	for i := 0; i < len(line); i++ {
+		switch c := line[i]; {
+		case escaped:
+			escaped = false
+		case c == '\\' && inString:
+			escaped = true
+		case c == '"':
+			inString = !inString
+		case inString:
+		case c == want:
+			return i
+		}
+	}
+	return -1
+}
+
 // jsoncBraceDelta counts the braces of one line's code that a parser reads as
 // structure. Comments are already out — jsoncCodeOf strips them, and keeps
 // string contents because the `"deja"` match and the comma offset both need
@@ -2872,6 +2928,11 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		return []byte("{\n  \"mcp\": {\n" + line + "\n  }\n}\n"), "", nil
 	}
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	// A block that opens and closes on one line has no end line to find, so
+	// the insert landed after its closing brace and the config stopped
+	// parsing (#2777). `"mcp": {}` is what a config nobody has added a server
+	// to looks like.
+	lines = openInlineBlock(lines, "mcp")
 	start, end := -1, -1
 	inBlock := false
 	for i, l := range lines {

--- a/cmd/deja/opencode_comments_test.go
+++ b/cmd/deja/opencode_comments_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// opencode's config is JSONC whatever it is called: the text writer was picked
+// by the file's extension, so the same content in `opencode.json` was decoded
+// strictly and the target refused — the reader who annotated their config
+// could not install deja at all (#1664, the half #1663 left).
+func TestOpencodeReadsTheContentNotTheExtension(t *testing.T) {
+	for _, name := range []string{"opencode.json", "opencode.jsonc"} {
+		t.Run(name, func(t *testing.T) {
+			hermeticEnv(t)
+			dir := filepath.Join(opencodeConfigHome(), "opencode")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, name)
+			before := "{\n  // the theme is deliberate\n  \"theme\": \"opencode\",\n  \"mcp\": {}\n}\n"
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := captureRun(t, "install", "opencode", "--no-index"); err != nil {
+				t.Fatalf("a commented config was refused: %v", err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(b), "// the theme is deliberate") {
+				t.Errorf("the comment was dropped:\n%s", b)
+			}
+			if !strings.Contains(string(b), `"deja"`) {
+				t.Errorf("the entry was not written:\n%s", b)
+			}
+
+			// And out again, leaving the reader's file as it was.
+			if _, err := captureRun(t, "uninstall", "opencode"); err != nil {
+				t.Fatal(err)
+			}
+			b, err = os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), `"deja"`) {
+				t.Errorf("the entry survived the uninstall:\n%s", b)
+			}
+			if !strings.Contains(string(b), "// the theme is deliberate") {
+				t.Errorf("the comment was dropped on the way out:\n%s", b)
+			}
+		})
+	}
+}
+
+// A block written inline has no end line to find, so the entry landed after
+// its closing brace and the config stopped parsing — with install reporting
+// success (#2777). An empty inline block is what a config nobody has added a
+// server to looks like.
+func TestOpencodeOpensAnInlineBlockRatherThanWritingPastIt(t *testing.T) {
+	for _, before := range []string{
+		"{\n  \"theme\": \"opencode\",\n  \"mcp\": {}\n}\n",
+		"{\n  \"mcp\": {\"other\": {\"type\":\"local\",\"command\":[\"x\"]}}\n}\n",
+		"{\n  // annotated\n  \"mcp\": {}\n}\n",
+	} {
+		t.Run(strings.TrimSpace(strings.SplitN(before, "\n", 3)[1]), func(t *testing.T) {
+			hermeticEnv(t)
+			dir := filepath.Join(opencodeConfigHome(), "opencode")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "opencode.jsonc")
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := captureRun(t, "install", "opencode", "--no-index"); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var probe map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &probe); err != nil {
+				t.Fatalf("the config no longer parses: %v\n%s", err, b)
+			}
+			mcp, _ := probe["mcp"].(map[string]any)
+			if _, ok := mcp["deja"]; !ok {
+				t.Errorf("the entry is not in the block:\n%s", b)
+			}
+			if strings.Contains(before, "other") {
+				if _, ok := mcp["other"]; !ok {
+					t.Errorf("the reader's own server was dropped:\n%s", b)
+				}
+			}
+		})
+	}
+}

--- a/cmd/deja/opencode_comments_test.go
+++ b/cmd/deja/opencode_comments_test.go
@@ -66,6 +66,8 @@ func TestOpencodeOpensAnInlineBlockRatherThanWritingPastIt(t *testing.T) {
 	for _, before := range []string{
 		"{\n  \"theme\": \"opencode\",\n  \"mcp\": {}\n}\n",
 		"{\n  \"mcp\": {\"other\": {\"type\":\"local\",\"command\":[\"x\"]}}\n}\n",
+		// The block spans lines, but its first server sits on the opening one.
+		"{\n  \"mcp\": { \"other\": {\"type\":\"local\",\"command\":[\"x\"]}\n  }\n}\n",
 		"{\n  // annotated\n  \"mcp\": {}\n}\n",
 	} {
 		t.Run(strings.TrimSpace(strings.SplitN(before, "\n", 3)[1]), func(t *testing.T) {
@@ -99,5 +101,72 @@ func TestOpencodeOpensAnInlineBlockRatherThanWritingPastIt(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The shapes the writer cannot edit are refused, and the file is left exactly
+// as it was. Writing past a block it could not open is what made a config
+// unreadable while install reported success (#2777).
+func TestOpencodeLeavesAConfigItCannotEditAlone(t *testing.T) {
+	for _, before := range []string{
+		// A comment on the line the block opens and closes on: there is no
+		// side of it the entry can go without changing what the reader wrote.
+		"{\n  \"mcp\": {} // mine\n}\n",
+		"{\n  \"mcp\": /* mine */ {}\n}\n",
+		// A whole config on one line: the block would be spliced above the
+		// object rather than inside it.
+		"{\"theme\": \"x\"} // mine\n",
+		"{} // mine\n",
+	} {
+		t.Run(strings.TrimSpace(before), func(t *testing.T) {
+			hermeticEnv(t)
+			dir := filepath.Join(opencodeConfigHome(), "opencode")
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "opencode.json")
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := captureRun(t, "install", "opencode", "--no-index"); err == nil {
+				t.Error("a config deja cannot edit was reported as installed")
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != before {
+				t.Errorf("the config was written to anyway:\n%s", b)
+			}
+		})
+	}
+}
+
+// An inline block with servers in it keeps its shape: the split has to fall on
+// the brace that closes the block, not on the first one in the line.
+func TestOpencodeSplitsAnInlineBlockAtItsOwnBrace(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(opencodeConfigHome(), "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "opencode.jsonc")
+	before := "{\n  \"mcp\": {\"a\": {\"type\":\"local\",\"command\":[\"x\"]}}\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "opencode", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &probe); err != nil {
+		t.Fatalf("the config no longer parses: %v\n%s", err, b)
+	}
+	if strings.Contains(string(b), "}}") {
+		t.Errorf("the split fell inside the reader's own server:\n%s", b)
 	}
 }

--- a/cmd/deja/opencode_comments_test.go
+++ b/cmd/deja/opencode_comments_test.go
@@ -68,6 +68,8 @@ func TestOpencodeOpensAnInlineBlockRatherThanWritingPastIt(t *testing.T) {
 		"{\n  \"mcp\": {\"other\": {\"type\":\"local\",\"command\":[\"x\"]}}\n}\n",
 		// The block spans lines, but its first server sits on the opening one.
 		"{\n  \"mcp\": { \"other\": {\"type\":\"local\",\"command\":[\"x\"]}\n  }\n}\n",
+		// A comment after the opening brace is not a server on that line.
+		"{\n  \"mcp\": { // my servers\n    \"other\": {\"type\":\"local\",\"command\":[\"x\"]}\n  }\n}\n",
 		"{\n  // annotated\n  \"mcp\": {}\n}\n",
 	} {
 		t.Run(strings.TrimSpace(strings.SplitN(before, "\n", 3)[1]), func(t *testing.T) {
@@ -168,5 +170,32 @@ func TestOpencodeSplitsAnInlineBlockAtItsOwnBrace(t *testing.T) {
 	}
 	if strings.Contains(string(b), "}}") {
 		t.Errorf("the split fell inside the reader's own server:\n%s", b)
+	}
+}
+
+// A config deja declines to edit is not written to on the way out either: the
+// uninstall path rejoined the lines it had split while deciding, so a block
+// commented out with /* … */ came back reshaped by a run that refused to
+// touch it.
+func TestUninstallLeavesAConfigItCannotEditByteIdentical(t *testing.T) {
+	hermeticEnv(t)
+	dir := filepath.Join(opencodeConfigHome(), "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "opencode.jsonc")
+	before := "{\n  /* off\n  \"mcp\": {},\n  */\n  \"theme\": \"x\"\n}"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "uninstall", "opencode"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != before {
+		t.Errorf("a config the uninstall did not edit was rewritten:\n%q\nwant\n%q", b, before)
 	}
 }


### PR DESCRIPTION
Closes #1664 and #2777.

#1664: five targets refused a config with a `//` comment in it. Four were fixed by the JSONC writer (#2739, #2743, #2747); opencode was the one left, because its text writer was picked by the file's *extension* — so the same commented content was edited in `opencode.jsonc` and refused in `opencode.json`. It goes by content now.

#2777, found while checking that: a block written inline as `"mcp": {}` has no end line to find, so deja's entry landed after the closing brace and the config stopped parsing, with install reporting success. An empty inline block is what a config nobody has added a server to looks like. `openInlineBlock` opens it first, keeping whatever the line already held; a line carrying a comment is left to today's refusal rather than guessing which side of it the entry belongs on.