### PR TITLE
fix: markers fire on words, not on any substring

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
@@ -727,11 +728,10 @@ func blankOpeningNow(low string) string {
 		at := i + j
 		opens := true
 		for k := at - 1; k >= 0; k-- {
-			r := rune(out[k])
-			if r == ' ' || r == '\t' || r == '*' || r == '#' {
+			if out[k] == ' ' || out[k] == '\t' || out[k] == '*' || out[k] == '#' {
 				continue
 			}
-			opens = !isWordByte(out[k])
+			opens = !endsWord(out[:k+1])
 			break
 		}
 		if opens {
@@ -741,17 +741,20 @@ func blankOpeningNow(low string) string {
 	}
 }
 
-// isWordByte says whether a byte belongs to a word rather than to punctuation.
-// Cyrillic is multi-byte, and every continuation byte is >= 0x80, so this reads
-// "part of a word" for them too.
-func isWordByte(b byte) bool {
-	switch {
-	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
-		return true
-	case b >= 0x80:
-		return true
+// endsWord says whether text ends inside a word rather than at punctuation.
+//
+// This read the last byte and called anything >= 0x80 part of a word, on the
+// grounds that Cyrillic is multi-byte. So is Russian punctuation: «», the em
+// dash, the ellipsis. A line reading «Теперь SQL — два SELECT» has its state
+// word preceded by a guillemet, which the byte test called a letter, so the
+// word did not read as opening a clause and a plan was promoted as an outcome —
+// the exact case blankOpeningNow exists to catch (#2734).
+func endsWord(text string) bool {
+	r, size := utf8.DecodeLastRuneInString(text)
+	if size == 0 || r == utf8.RuneError {
+		return false
 	}
-	return false
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 // CarriesDecisionExcept is the same, ignoring markers the asker used. A marker
@@ -768,7 +771,7 @@ func CarriesDecisionExcept(text string, asked []string) bool {
 	}
 	low = blankOpeningNow(low)
 	for _, d := range decisionMarkers {
-		if !strings.Contains(low, d) {
+		if !marksLine(low, d) {
 			continue
 		}
 		skip := false
@@ -785,6 +788,42 @@ func CarriesDecisionExcept(text string, asked []string) bool {
 	return false
 }
 
+// marksLine reports whether a marker fires on a line, which it does only where
+// it begins a word.
+//
+// Markers were plain substrings, so they fired inside longer words that mean
+// something else or the opposite: "released" inside "[Unreleased]", "decision:"
+// inside "reviewDecision:", "solution" inside "pollution", "fixed" inside
+// "unfixed". Measured on 85k assistant lines from a real store, 82 promoted
+// lines were promoted on nothing else (#2734).
+//
+// The end of the word is deliberately left open. Half the markers are Russian
+// verbs whose inflections are how they are actually written — "решили",
+// "исправили", "заработала" — and pinning the tail would drop the forms the
+// list was extended for.
+func marksLine(low, marker string) bool {
+	if marker == "" {
+		return false
+	}
+	// The first rune, not the first byte: every Cyrillic marker starts with a
+	// multi-byte one, and reading a single byte of it decoded as an error and
+	// took the boundary rule out of play for half the list.
+	if first, _ := utf8.DecodeRuneInString(marker); !unicode.IsLetter(first) && !unicode.IsDigit(first) {
+		return strings.Contains(low, marker)
+	}
+	for i := 0; ; {
+		j := strings.Index(low[i:], marker)
+		if j < 0 {
+			return false
+		}
+		at := i + j
+		if at == 0 || !endsWord(low[:at]) {
+			return true
+		}
+		i = at + 1
+	}
+}
+
 // selectConclusions keeps assistant messages that carry a decision marker,
 // plus the final message (the outcome), in transcript order. Conversational
 // sessions where nothing matches keep everything — the filter only kicks in
@@ -798,7 +837,7 @@ func selectConclusions(ms []model.Message) []model.Message {
 		low := strings.ToLower(m.Text)
 		marked := false
 		for _, d := range decisionMarkers {
-			if strings.Contains(low, d) {
+			if marksLine(low, d) {
 				marked = true
 				break
 			}

--- a/internal/digest/marker_boundary_test.go
+++ b/internal/digest/marker_boundary_test.go
@@ -1,0 +1,35 @@
+package digest
+
+import "testing"
+
+// A marker fires where it begins a word. As a plain substring it fired inside
+// longer words meaning something else, or the opposite (#2734).
+func TestMarkersDoNotFireInsideAnotherWord(t *testing.T) {
+	inside := []string{
+		"Заметки живут в теле релиза, в CHANGELOG.md пустой [Unreleased] блок.",
+		"`reviewDecision: REVIEW_REQUIRED` — сам себя одобрить не могу.",
+		"Path resolves correctly, so the pollution is in the writer, not the path.",
+		"The one genuinely-unfixed item is the NFD form of the accented name.",
+		// Both halves of the list, not just the ASCII one: "оказалось" sits
+		// inside "показалось", which is the opposite claim.
+		"мне показалось, что тест флэйковый, но я не проверял",
+	}
+	for _, line := range inside {
+		if CarriesDecision(line) {
+			t.Errorf("a marker fired inside another word: %q", line)
+		}
+	}
+
+	// The tail stays open: half the markers are Russian verbs, and the
+	// inflections are how they are written.
+	inflected := []string{
+		"решили оставить один индекс на все харнессы",
+		"исправили в том же коммите, тест краснеет на откате",
+		"вторая нода заработала после смены keepalive",
+	}
+	for _, line := range inflected {
+		if !CarriesDecision(line) {
+			t.Errorf("an inflected marker stopped firing: %q", line)
+		}
+	}
+}

--- a/internal/digest/opening_now_test.go
+++ b/internal/digest/opening_now_test.go
@@ -1,0 +1,31 @@
+package digest
+
+import "testing"
+
+// "теперь" opening a clause starts a plan; in the middle of one it reports a
+// state. Which it is was decided by the byte before it, and every byte >= 0x80
+// counted as a letter — so Russian punctuation, which is also multi-byte, hid
+// the opening and the plan was promoted as an outcome (#2734).
+func TestPunctuationDoesNotHideAnOpeningNow(t *testing.T) {
+	plans := []string{
+		"— Теперь пишу SQL и проверяю выборку.",
+		"«Теперь пишу SQL и проверяю выборку».",
+		"…Теперь пишу SQL и проверяю выборку.",
+	}
+	for _, line := range plans {
+		if CarriesDecision(line) {
+			t.Errorf("a plan promoted as a conclusion: %q", line)
+		}
+	}
+
+	// Mid-sentence it still reports where something ended up.
+	states := []string{
+		"прод-пины теперь ложатся на deploy/prod, а не на общий кластер",
+		"дамп теперь на двух нодах, обе отвечают",
+	}
+	for _, line := range states {
+		if !CarriesDecision(line) {
+			t.Errorf("an outcome read as a plan: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
The rest of #2734: markers matched as plain substrings.

Two defects, both measured on 85k assistant lines from a real store, promotions counted before and after each step:

**Punctuation read as letters.** `isWordByte` called every byte >= 0x80 part of a word, on the grounds that Cyrillic is multi-byte. So is Russian punctuation — «», the em dash, the ellipsis. `blankOpeningNow` uses that test to tell a plan ("Теперь пишу SQL") from a state ("пины теперь ложатся на prod"), so a plan behind a guillemet was promoted as an outcome — the exact case that function exists to catch. 5772 promotions to 5583.

**Markers fired inside longer words.** "released" inside `[Unreleased]`, "decision:" inside `reviewDecision:`, "solution" inside "pollution", "fixed" inside "unfixed", "оказалось" inside "показалось". A marker now has to begin a word. 5583 to 5455.

The tail is deliberately left open: half the list is Russian verbs whose inflections are how they are written ("решили", "исправили", "заработала"), and pinning it would drop the forms the list was extended for. Mutation-checked, including that one.

One trap worth naming, since it cost me a wrong measurement first: `marker[:1]` is the first *byte*, which for every Cyrillic marker decodes as an error — so a boundary rule written that way silently skips half the list while looking correct in ASCII tests. There is a mutation for that case now.