### PR TITLE
fix(install): the text writer writes the entry its caller would have written

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1246,7 +1246,7 @@ func installClaude(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if configIsJSONC(old) {
-		return writeJSONCEntry(path, old, "mcpServers", exe, uninstall)
+		return writeJSONCEntry(path, old, "mcpServers", mcpServerEntry(exe), uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
@@ -2608,7 +2608,8 @@ func installMCPJSON(path, exe string, uninstall bool) (installResult, error) {
 		// A comment is not a broken file, and refusing the target over one is
 		// how somebody who annotated their config could not install deja at
 		// all (#1664).
-		return writeJSONCEntry(path, old, "mcpServers", exe, uninstall)
+		command, args := mcpCommandArgs(exe)
+		return writeJSONCEntry(path, old, "mcpServers", map[string]any{"command": command, "args": args}, uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -121,7 +121,12 @@ func jsoncEntryText(entry map[string]any) (string, error) {
 	return string(b), nil
 }
 
-// writeJSONCEntry is the install path for a config that carries comments.
+// writeJSONCEntry is the install path for a config edited as text.
+//
+// want is the entry the caller would have written through the parsed path, so
+// the two paths put the same thing in the file: claude's entry carries a
+// `type`, and building the entry here instead meant a commented .claude.json
+// got one without it.
 //
 // What to write is decided the same way as for a config without them — the
 // same block reader, the same merge onto an entry that is already there, the
@@ -129,7 +134,7 @@ func jsoncEntryText(entry map[string]any) (string, error) {
 // key order and formatting stay where they are. Deciding it twice is what left
 // this path dropping an env block, flipping `disabled`, writing a second entry
 // beside one under another name, and saying none of it (#2740).
-func writeJSONCEntry(path string, old []byte, blockKey, exe string, uninstall bool) (installResult, error) {
+func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]any, uninstall bool) (installResult, error) {
 	text := string(old)
 	var root map[string]any
 	if err := json.Unmarshal([]byte(stripJSONComments(text)), &root); err != nil {
@@ -176,9 +181,8 @@ func writeJSONCEntry(path string, old []byte, blockKey, exe string, uninstall bo
 		}
 		next, err = jsoncSetEntry(text, blockKey, key, "", true, blockWasAdded(path, blockKey))
 	} else {
-		command, args := mcpCommandArgs(exe)
 		var merged map[string]any
-		merged, note = mergeDejaEntry(m[key], map[string]any{"command": command, "args": args})
+		merged, note = mergeDejaEntry(m[key], want)
 		note = withOtherDejaEntries(note, m, key)
 		var entry string
 		entry, err = jsoncEntryText(merged)

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -72,7 +72,7 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 		if uninstall {
 			return text, nil
 		}
-		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  },", blockKey, id, entry)
+		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  }%s", blockKey, id, entry, rootComma(text, open))
 		return text[:open+1] + insert + text[open+1:], nil
 	}
 	found := zedFindKey(text, block.valueOpen+1, id)
@@ -109,6 +109,20 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 		return text[:cut[0]] + text[cut[1]:], nil
 	}
 	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
+}
+
+// rootComma is the comma after a block inserted at the top of an object, or
+// nothing when that object holds no other key.
+//
+// Unconditional, it wrote `{"mcpServers": {…},}` into a config whose only line
+// was a comment — not JSON, so every later run refused the target with a
+// message pointing at the reader's own comment. The same shape #2740 fixed one
+// level down, for a block with no entries in it.
+func rootComma(text string, open int) string {
+	if strings.TrimSpace(stripJSONComments(text[open+1:])) == "}" {
+		return ""
+	}
+	return ","
 }
 
 // jsoncEntryText renders an entry the way the writers build it, so the text
@@ -213,7 +227,7 @@ func jsoncSetFlag(text, blockKey, key string, value bool) (string, error) {
 	}
 	block := zedFindKey(text, open+1, blockKey)
 	if block == nil {
-		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  },", blockKey, key, rendered)
+		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  }%s", blockKey, key, rendered, rootComma(text, open))
 		return text[:open+1] + insert + text[open+1:], nil
 	}
 	if at := jsoncScalarValue(text, block, key); at != nil {

--- a/cmd/deja/jsonc_entry_shape_test.go
+++ b/cmd/deja/jsonc_entry_shape_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The text path built the entry itself instead of taking the one its caller
+// would have written, so a commented ~/.claude.json got an entry without the
+// `type` every other claude entry carries — two writers for one file, agreeing
+// on everything but what they write.
+func TestBothWritersPutTheSameEntryInClaudesConfig(t *testing.T) {
+	entryFor := func(t *testing.T, before string) map[string]any {
+		t.Helper()
+		hermeticEnv(t)
+		path := sources.ClaudeJSONPath()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureRun(t, "install", "claude-code", "--no-index"); err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var root map[string]any
+		if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+			t.Fatalf("the config no longer parses: %v\n%s", err, b)
+		}
+		servers, _ := root["mcpServers"].(map[string]any)
+		entry, ok := servers["deja"].(map[string]any)
+		if !ok {
+			t.Fatalf("no deja entry:\n%s", b)
+		}
+		return entry
+	}
+
+	plain := entryFor(t, "{\n  \"mcpServers\": {}\n}\n")
+	commented := entryFor(t, "{\n  // mine\n  \"mcpServers\": {}\n}\n")
+
+	for _, key := range []string{"type", "command", "args"} {
+		if !sameEntry(plain[key], commented[key]) {
+			t.Errorf("%s: the commented config got %#v, the plain one %#v", key, commented[key], plain[key])
+		}
+	}
+	if commented["type"] != "stdio" {
+		t.Errorf("the entry claude reads carries no transport: %#v", commented)
+	}
+}
+
+// And the writers that do not want a type still do not get one.
+func TestTheGenericWriterKeepsItsOwnEntryShape(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\n  // mine\n  \"mcpServers\": {}\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `"type"`) {
+		t.Errorf("cursor's entry gained a transport it does not use:\n%s", b)
+	}
+}

--- a/cmd/deja/jsonc_entry_shape_test.go
+++ b/cmd/deja/jsonc_entry_shape_test.go
@@ -78,3 +78,57 @@ func TestTheGenericWriterKeepsItsOwnEntryShape(t *testing.T) {
 		t.Errorf("cursor's entry gained a transport it does not use:\n%s", b)
 	}
 }
+
+// The block is written at the top of the object with a comma after it, and a
+// config whose only line is a comment has no other key for that comma to
+// separate: the file stopped being JSON, and every later run refused the
+// target with a message pointing at the reader's own comment. The same shape
+// #2740 fixed one level down.
+func TestABlockWrittenIntoAnEmptyObjectCarriesNoStrayComma(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // mine\n}\n",
+		"{\n  /* mine */\n}\n",
+		"{}\n",
+	} {
+		t.Run(strings.TrimSpace(before), func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.CursorCLIHome(), "mcp.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var probe map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &probe); err != nil {
+				t.Fatalf("the config no longer parses: %v\n%s", err, b)
+			}
+			// And the run that comes after it still works, which is what the
+			// stray comma took away.
+			if _, err := captureRun(t, "install", "cursor", "--no-index"); err != nil {
+				t.Fatalf("the second run was refused: %v", err)
+			}
+		})
+	}
+}
+
+// The same insert in the flag writer, which puts gemini's hook switch in.
+func TestAFlagBlockWrittenIntoAnEmptyObjectCarriesNoStrayComma(t *testing.T) {
+	for _, before := range []string{"{\n  // mine\n}\n", "{}\n"} {
+		got, err := jsoncSetFlag(before, "hooksConfig", "enabled", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var probe map[string]any
+		if err := json.Unmarshal([]byte(stripJSONComments(got)), &probe); err != nil {
+			t.Errorf("%q: the config no longer parses: %v\n%s", before, err, got)
+		}
+	}
+}


### PR DESCRIPTION
Found while looking at #1665: routing every JSON config through the text writer to keep key order surfaced this, and it is a live defect on its own.

`writeJSONCEntry` built the entry itself — command and args — while `installClaude` writes `{type, command, args}`. So a `~/.claude.json` with a comment in it got an entry with no `type`, and the same file without the comment got one. The entry is now the caller's, so both paths put the same thing in the file.

#1665 itself stays open: routing the plain-JSON writers through the text path breaks six tests — the gemini hook switch stops being idempotent, and three uninstall paths change shape — so it wants its own iteration rather than riding along here. Noted on the issue.