### PR TITLE
fix: no trailing space where deja takes over an inline mcp brace

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2914,7 +2914,10 @@ func updateOpencodeJSONC(old []byte, exe string, uninstall bool) ([]byte, string
 		at := strings.LastIndex(lines[start], "{")
 		head := lines[start][:at+1]
 		tail := lines[start][at+1:]
-		tail = strings.Replace(tail, "}", "", 1)
+		// What is left of the line after the brace deja took over: a trailing
+		// comment stays, the spacing that used to sit between the two braces
+		// does not — "mcp": { } left a line ending in a space of deja's making.
+		tail = strings.TrimRight(strings.Replace(tail, "}", "", 1), " \t")
 		out := append([]string{}, lines[:start]...)
 		out = append(out, head, line, indent+"}"+tail)
 		out = append(out, lines[start+1:]...)

--- a/cmd/deja/jsonc_empty_block_test.go
+++ b/cmd/deja/jsonc_empty_block_test.go
@@ -40,3 +40,17 @@ func TestJSONCEmptyBlockStaysParseable(t *testing.T) {
 		t.Errorf("the entry is not in the mcp block:\n%s", got)
 	}
 }
+
+// The spacing between an inline block's braces is not deja's to leave behind:
+// "mcp": { } used to come back as a line ending in a space.
+func TestJSONCInlineBlockLeavesNoTrailingSpace(t *testing.T) {
+	out, _, err := updateOpencodeJSONC([]byte("{\n  \"mcp\": { }\n}\n"), "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range strings.Split(string(out), "\n") {
+		if l != strings.TrimRight(l, " \t") {
+			t.Errorf("a line ends in whitespace: %q\n%s", l, out)
+		}
+	}
+}


### PR DESCRIPTION
#2777 as filed does not reproduce — #2752 fixed the unparseable-config part a day earlier, and I ran the issue's own shape plus `"mcp": {},` with a key after it and `"mcp": { }` to confirm the entry lands inside the block.

What the repro did turn up: `"mcp": { }` came back as a line ending in a space. Deja takes the closing brace over and the spacing that sat between the two is left dangling. Not a parse problem, but it is deja's byte in somebody else's config, and it shows up in their next diff.

Guard asserts no line of the output ends in whitespace; mutation-checked.