### PR TITLE
fix(cli): with no home directory, write nothing where deja happens to run

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -68,6 +68,14 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	report := collectDoctorReport(lookup, dir)
 	var deepReport *index.DeepReport
 	if deep {
+		// doctor is what the no-home refusal sends the reader to, so it runs
+		// without one — but --deep takes the index lock before it reads, and
+		// with a relative index dir that left `.cache/deja/index.db.lock` in
+		// whatever directory they were standing in (#1692). There is no
+		// database at a path like that to verify anyway.
+		if !filepath.IsAbs(dir) {
+			return fmt.Errorf("doctor --deep cannot find your index — set HOME, or DEJA_INDEX_DIR to an absolute path")
+		}
 		dr, err := index.DeepVerify(dir)
 		if err != nil {
 			return fmt.Errorf("doctor: deep verify: %w", err)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -136,6 +136,20 @@ var worksWithNoHome = map[string]bool{
 	"install": true, "uninstall": true,
 }
 
+// dispatchKnows reports whether a word is a command deja runs, from either
+// half of the dispatcher: the map, and the switch above it that holds the five
+// commands taking their own argument parsing.
+func dispatchKnows(name string) bool {
+	if _, ok := commands[name]; ok {
+		return true
+	}
+	switch name {
+	case "show", "last", "search", "aider", "goose":
+		return true
+	}
+	return false
+}
+
 // homelessRefusal answers what to do when deja cannot find a home directory
 // and nothing else says where its index goes.
 //
@@ -155,7 +169,7 @@ func homelessRefusal(name string) (bool, error) {
 		// Only a name the dispatcher will actually take: `-v` is not a
 		// command, so allowlisting it let it through the guard, miss the map
 		// and land in the bare-query path — which builds an index (#1692).
-		if _, known := commands[name]; known || name == "install" || name == "uninstall" {
+		if _, known := commands[name]; known {
 			return false, nil
 		}
 	}
@@ -165,7 +179,7 @@ func homelessRefusal(name string) (bool, error) {
 	// The command's own name, or deja's: for a bare query the first word is
 	// the reader's, and "retry cannot find your home directory" reads as if
 	// `retry` were a command.
-	if _, known := commands[name]; !known {
+	if !dispatchKnows(name) {
 		name = "deja"
 	}
 	return true, fmt.Errorf("%s cannot find your home directory — set HOME, or DEJA_INDEX_DIR and XDG_CONFIG_HOME to absolute paths", name)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -129,7 +129,7 @@ func loadFileSources() []model.Session {
 // where every other message sends the reader to find out what deja can see;
 // and install carries #1690's own guard, whose advice is the right one for it.
 var worksWithNoHome = map[string]bool{
-	"version": true, "--version": true, "-v": true,
+	"version": true, "--version": true, "-version": true,
 	"help": true, "--help": true, "-h": true,
 	"completion": true, "update": true,
 	"doctor": true, "sources": true,
@@ -152,12 +152,20 @@ func homelessRefusal(name string) (bool, error) {
 		return false, nil
 	}
 	if worksWithNoHome[name] {
-		return false, nil
+		// Only a name the dispatcher will actually take: `-v` is not a
+		// command, so allowlisting it let it through the guard, miss the map
+		// and land in the bare-query path — which builds an index (#1692).
+		if _, known := commands[name]; known || name == "install" || name == "uninstall" {
+			return false, nil
+		}
 	}
 	if strings.HasPrefix(name, "hook-") || name == "statusline" || name == "warmup-status" {
 		return true, nil
 	}
-	if name == "" {
+	// The command's own name, or deja's: for a bare query the first word is
+	// the reader's, and "retry cannot find your home directory" reads as if
+	// `retry` were a command.
+	if _, known := commands[name]; !known {
 		name = "deja"
 	}
 	return true, fmt.Errorf("%s cannot find your home directory — set HOME, or DEJA_INDEX_DIR and XDG_CONFIG_HOME to absolute paths", name)

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -119,6 +119,23 @@ func loadFileSources() []model.Session {
 	return ss
 }
 
+// worksWithNoHome names the commands that never write under a home directory
+// they cannot find: they print, or they diagnose the very state the guard is
+// about, or they carry their own refusal.
+//
+// `version` and `help` write nothing at all and are what a packager runs;
+// `completion` is sourced from a shell rc file; `update` replaces the binary
+// and is how somebody gets out of a broken state; `doctor` and `sources` are
+// where every other message sends the reader to find out what deja can see;
+// and install carries #1690's own guard, whose advice is the right one for it.
+var worksWithNoHome = map[string]bool{
+	"version": true, "--version": true, "-v": true,
+	"help": true, "--help": true, "-h": true,
+	"completion": true, "update": true,
+	"doctor": true, "sources": true,
+	"install": true, "uninstall": true,
+}
+
 // homelessRefusal answers what to do when deja cannot find a home directory
 // and nothing else says where its index goes.
 //
@@ -127,14 +144,23 @@ func loadFileSources() []model.Session {
 // design of the hooks is to fail open and stay quiet (#1692). Either way
 // nothing is written, which is the part that matters — the index is a database,
 // and it was landing in whatever repository the agent was working in.
-func homelessRefusal(name, dir string) (error, bool) {
-	if filepath.IsAbs(dir) {
-		return nil, false
+func homelessRefusal(name string) (bool, error) {
+	// Both roots: the index answers to DEJA_INDEX_DIR, and the config
+	// directory to XDG_CONFIG_HOME, so one of them being absolute says
+	// nothing about the other.
+	if filepath.IsAbs(index.DefaultDir()) && filepath.IsAbs(xdgConfigHome()) {
+		return false, nil
+	}
+	if worksWithNoHome[name] {
+		return false, nil
 	}
 	if strings.HasPrefix(name, "hook-") || name == "statusline" || name == "warmup-status" {
-		return nil, true
+		return true, nil
 	}
-	return fmt.Errorf("%s cannot find your home directory — set HOME, or DEJA_INDEX_DIR to an absolute path", name), true
+	if name == "" {
+		name = "deja"
+	}
+	return true, fmt.Errorf("%s cannot find your home directory — set HOME, or DEJA_INDEX_DIR and XDG_CONFIG_HOME to absolute paths", name)
 }
 
 type command func(dir string, rest []string) error
@@ -244,6 +270,19 @@ var commands = map[string]command{
 
 func run(args []string) error {
 	dir := index.DefaultDir()
+	// Before anything reads or writes: every path deja writes hangs off the
+	// home directory, and it answers "" when there is none, so
+	// `filepath.Join("", ".cache", "deja")` is `.cache/deja` — deja built its
+	// index in whatever directory it happened to be run from, on the commands
+	// an agent runs unattended as much as on the ones a person types. #1690
+	// fixed install; this is the rest (#1692).
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	if stop, err := homelessRefusal(name); stop {
+		return err
+	}
 	if len(args) == 0 {
 		// briefWanted, not logoWanted: a reader who turned colour off still
 		// has an index and a terminal, and the brief is what that reader came
@@ -278,14 +317,6 @@ func run(args []string) error {
 		return cmdGoose(dir, args[1:], sourceInstance)
 	}
 	if cmd, ok := commands[args[0]]; ok {
-		// Every path deja writes hangs off the home directory, and it answers
-		// "" when there is none, so `filepath.Join("", ".cache", "deja")` is
-		// `.cache/deja` — deja built its index in whatever directory it
-		// happened to be run from. #1690 fixed install; this is the rest
-		// (#1692).
-		if err, refused := homelessRefusal(args[0], dir); refused {
-			return err
-		}
 		return cmd(dir, args[1:])
 	}
 	// A `hook-…` this build does not have is a line in a config an older deja

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -119,6 +119,24 @@ func loadFileSources() []model.Session {
 	return ss
 }
 
+// homelessRefusal answers what to do when deja cannot find a home directory
+// and nothing else says where its index goes.
+//
+// A command somebody typed says why it cannot run. A hook does not: it runs
+// unattended on every prompt, a refusal would cost the turn, and the whole
+// design of the hooks is to fail open and stay quiet (#1692). Either way
+// nothing is written, which is the part that matters — the index is a database,
+// and it was landing in whatever repository the agent was working in.
+func homelessRefusal(name, dir string) (error, bool) {
+	if filepath.IsAbs(dir) {
+		return nil, false
+	}
+	if strings.HasPrefix(name, "hook-") || name == "statusline" || name == "warmup-status" {
+		return nil, true
+	}
+	return fmt.Errorf("%s cannot find your home directory — set HOME, or DEJA_INDEX_DIR to an absolute path", name), true
+}
+
 type command func(dir string, rest []string) error
 
 var commands = map[string]command{
@@ -260,6 +278,14 @@ func run(args []string) error {
 		return cmdGoose(dir, args[1:], sourceInstance)
 	}
 	if cmd, ok := commands[args[0]]; ok {
+		// Every path deja writes hangs off the home directory, and it answers
+		// "" when there is none, so `filepath.Join("", ".cache", "deja")` is
+		// `.cache/deja` — deja built its index in whatever directory it
+		// happened to be run from. #1690 fixed install; this is the rest
+		// (#1692).
+		if err, refused := homelessRefusal(args[0], dir); refused {
+			return err
+		}
 		return cmd(dir, args[1:])
 	}
 	// A `hook-…` this build does not have is a line in a config an older deja

--- a/cmd/deja/no_home_test.go
+++ b/cmd/deja/no_home_test.go
@@ -156,6 +156,15 @@ func TestInstallKeepsItsOwnRefusal(t *testing.T) {
 	if !strings.Contains(err.Error(), "HOME") {
 		t.Errorf("the refusal does not name what is missing: %v", err)
 	}
+	// A command deja runs is named; a word the reader typed is not, because
+	// "retry cannot find your home directory" reads as if retry were one.
+	if !strings.HasPrefix(err.Error(), "search ") {
+		t.Errorf("a real command is not named in its own refusal: %v", err)
+	}
+	_, err = homelessRefusal("budget")
+	if err == nil || !strings.HasPrefix(err.Error(), "deja ") {
+		t.Errorf("a query word was named as a command: %v", err)
+	}
 }
 
 // doctor is where the refusal sends the reader, so it runs without a home —

--- a/cmd/deja/no_home_test.go
+++ b/cmd/deja/no_home_test.go
@@ -1,61 +1,145 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestNoHomeHelperProcess is one deja invocation in a process of its own, with
+// no home directory and a working directory of the caller's choosing. In-process
+// is not enough here: the writes this is about come from a detached warmup the
+// parent does not wait for, so a glob taken when the call returns sees nothing
+// whether or not the guard is there.
+func TestNoHomeHelperProcess(t *testing.T) {
+	args := os.Getenv("DEJA_NO_HOME_ARGS")
+	if args == "" {
+		return
+	}
+	// TestMain gives every test in this package a home of its own, so the
+	// child has to take it back off before it asks deja anything.
+	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "DEJA_INDEX_DIR"} {
+		if err := os.Unsetenv(k); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	}
+	code := 0
+	if err := run(strings.Split(args, "\x1f")); err != nil {
+		code = 1
+	}
+	os.Exit(code)
+}
+
+// runWithNoHome runs deja in an empty directory with nothing to say where its
+// index goes, and answers with the exit code and whatever it left behind.
+func runWithNoHome(t *testing.T, args ...string) (int, []string) {
+	t.Helper()
+	wd := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestNoHomeHelperProcess$")
+	cmd.Dir = wd
+	cmd.Stdin = strings.NewReader("{}")
+	cmd.Env = append(os.Environ(),
+		"DEJA_NO_HOME_ARGS="+strings.Join(args, "\x1f"),
+		"HOME=", "USERPROFILE=", "XDG_CONFIG_HOME=", "XDG_CACHE_HOME=", "DEJA_INDEX_DIR=")
+	out, runErr := cmd.CombinedOutput()
+	if testing.Verbose() {
+		t.Logf("%v said: %s", args, out)
+	}
+	code := 0
+	if err := runErr; err != nil {
+		var exit *exec.ExitError
+		if !errors.As(err, &exit) {
+			t.Fatalf("%v: %v", args, err)
+		}
+		code = exit.ExitCode()
+	}
+	// The warmup is detached, so what it writes lands after the process is
+	// gone: wait for it rather than racing it.
+	var left []string
+	for i := 0; i < 20; i++ {
+		found, err := filepath.Glob(filepath.Join(wd, "*"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(found) > 0 {
+			left = found
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	for i, p := range left {
+		left[i] = strings.TrimPrefix(p, wd+string(filepath.Separator))
+	}
+	return code, left
+}
 
 // Every path deja writes hangs off the home directory, and it answers "" when
 // there is none — so `filepath.Join("", ".cache", "deja")` is `.cache/deja`,
-// and with HOME unset deja built its index in whatever directory it was run
-// from. #1690 fixed install; the hooks and `index` still wrote relative, and
-// the hook is the path that runs unattended on every prompt (#1692).
+// and deja built its index in whatever directory it was run from. #1690 fixed
+// install; the rest of the commands, including the ones an agent runs
+// unattended, still wrote relative (#1692).
 func TestWithNoHomeNothingIsWrittenWhereDejaHappensToRun(t *testing.T) {
 	for _, c := range []struct {
-		args  []string
-		stdin string
+		args []string
 		// A hook must never cost a turn, so it declines quietly; a command
-		// somebody typed says why.
-		refuses bool
+		// somebody typed says why; a command that writes nothing anyway just
+		// runs.
+		wantCode int
 	}{
-		{args: []string{"hook-context"}, stdin: "{}"},
-		{args: []string{"hook-prompt"}, stdin: `{"prompt":"anything"}`},
-		{args: []string{"hook-tool"}, stdin: `{"tool_name":"Bash","tool_input":{"command":"ls"}}`},
-		{args: []string{"hook-precompact"}, stdin: "{}"},
-		{args: []string{"index"}, refuses: true},
-		{args: []string{"sources"}, refuses: true},
+		{args: []string{"search", "foo"}, wantCode: 1},
+		{args: []string{"retry", "budget"}, wantCode: 1},
+		{args: []string{"show", "1"}, wantCode: 1},
+		{args: []string{"last"}, wantCode: 1},
+		{args: []string{"index"}, wantCode: 1},
+		{args: []string{"aider"}, wantCode: 1},
+		{args: []string{"goose"}, wantCode: 1},
+		{args: []string{"mcp"}, wantCode: 1},
+		{args: []string{"hook-context"}},
+		{args: []string{"hook-prompt"}},
+		{args: []string{"hook-tool"}},
+		{args: []string{"hook-precompact"}},
+		{args: []string{"statusline"}},
+		// These write nothing without a home, and refusing them takes away the
+		// commands a reader needs precisely when deja cannot find one.
+		{args: []string{"version"}},
+		{args: []string{"help"}},
+		{args: []string{"completion", "bash"}},
+		{args: []string{"sources"}},
+		{args: []string{"doctor"}},
 	} {
 		t.Run(strings.Join(c.args, " "), func(t *testing.T) {
-			wd := t.TempDir()
-			t.Chdir(wd)
-			t.Setenv("HOME", "")
-			t.Setenv("USERPROFILE", "")
-			t.Setenv("XDG_CONFIG_HOME", "")
-			t.Setenv("XDG_CACHE_HOME", "")
-			t.Setenv("DEJA_INDEX_DIR", "")
-			if c.stdin != "" {
-				withHookStdin(t, c.stdin)
-			}
-
-			_, err := captureRun(t, c.args...)
-			if c.refuses {
-				if err == nil {
-					t.Error("a command that cannot find a home directory reported success")
-				} else if !strings.Contains(err.Error(), "home directory") {
-					t.Errorf("the refusal does not say what is missing: %v", err)
-				}
-			} else if err != nil {
-				t.Errorf("a hook cost the turn instead of declining quietly: %v", err)
-			}
-
-			left, rerr := filepath.Glob(filepath.Join(wd, "*"))
-			if rerr != nil {
-				t.Fatal(rerr)
+			code, left := runWithNoHome(t, c.args...)
+			if code != c.wantCode {
+				t.Errorf("exit %d, want %d", code, c.wantCode)
 			}
 			if len(left) > 0 {
 				t.Errorf("deja wrote into the working directory: %v", left)
 			}
 		})
+	}
+}
+
+// install keeps its own refusal: it is the one that can say which account to
+// wire, and the general one would send the reader after DEJA_INDEX_DIR, which
+// does not help install at all.
+func TestInstallKeepsItsOwnRefusal(t *testing.T) {
+	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "DEJA_INDEX_DIR"} {
+		t.Setenv(k, "")
+	}
+	if stop, err := homelessRefusal("install"); stop {
+		t.Errorf("install was refused by the general guard: %v", err)
+	}
+	stop, err := homelessRefusal("search")
+	if !stop || err == nil {
+		t.Fatal("a command that writes an index was allowed to run")
+	}
+	if !strings.Contains(err.Error(), "HOME") {
+		t.Errorf("the refusal does not name what is missing: %v", err)
 	}
 }

--- a/cmd/deja/no_home_test.go
+++ b/cmd/deja/no_home_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every path deja writes hangs off the home directory, and it answers "" when
+// there is none — so `filepath.Join("", ".cache", "deja")` is `.cache/deja`,
+// and with HOME unset deja built its index in whatever directory it was run
+// from. #1690 fixed install; the hooks and `index` still wrote relative, and
+// the hook is the path that runs unattended on every prompt (#1692).
+func TestWithNoHomeNothingIsWrittenWhereDejaHappensToRun(t *testing.T) {
+	for _, c := range []struct {
+		args  []string
+		stdin string
+		// A hook must never cost a turn, so it declines quietly; a command
+		// somebody typed says why.
+		refuses bool
+	}{
+		{args: []string{"hook-context"}, stdin: "{}"},
+		{args: []string{"hook-prompt"}, stdin: `{"prompt":"anything"}`},
+		{args: []string{"hook-tool"}, stdin: `{"tool_name":"Bash","tool_input":{"command":"ls"}}`},
+		{args: []string{"hook-precompact"}, stdin: "{}"},
+		{args: []string{"index"}, refuses: true},
+		{args: []string{"sources"}, refuses: true},
+	} {
+		t.Run(strings.Join(c.args, " "), func(t *testing.T) {
+			wd := t.TempDir()
+			t.Chdir(wd)
+			t.Setenv("HOME", "")
+			t.Setenv("USERPROFILE", "")
+			t.Setenv("XDG_CONFIG_HOME", "")
+			t.Setenv("XDG_CACHE_HOME", "")
+			t.Setenv("DEJA_INDEX_DIR", "")
+			if c.stdin != "" {
+				withHookStdin(t, c.stdin)
+			}
+
+			_, err := captureRun(t, c.args...)
+			if c.refuses {
+				if err == nil {
+					t.Error("a command that cannot find a home directory reported success")
+				} else if !strings.Contains(err.Error(), "home directory") {
+					t.Errorf("the refusal does not say what is missing: %v", err)
+				}
+			} else if err != nil {
+				t.Errorf("a hook cost the turn instead of declining quietly: %v", err)
+			}
+
+			left, rerr := filepath.Glob(filepath.Join(wd, "*"))
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			if len(left) > 0 {
+				t.Errorf("deja wrote into the working directory: %v", left)
+			}
+		})
+	}
+}

--- a/cmd/deja/no_home_test.go
+++ b/cmd/deja/no_home_test.go
@@ -17,8 +17,8 @@ import (
 // parent does not wait for, so a glob taken when the call returns sees nothing
 // whether or not the guard is there.
 func TestNoHomeHelperProcess(t *testing.T) {
-	args := os.Getenv("DEJA_NO_HOME_ARGS")
-	if args == "" {
+	args, running := os.LookupEnv("DEJA_NO_HOME_ARGS")
+	if !running {
 		return
 	}
 	// TestMain gives every test in this package a home of its own, so the
@@ -29,8 +29,12 @@ func TestNoHomeHelperProcess(t *testing.T) {
 			os.Exit(2)
 		}
 	}
+	var argv []string
+	if args != "" {
+		argv = strings.Split(args, "\x1f")
+	}
 	code := 0
-	if err := run(strings.Split(args, "\x1f")); err != nil {
+	if err := run(argv); err != nil {
 		code = 1
 	}
 	os.Exit(code)
@@ -60,9 +64,10 @@ func runWithNoHome(t *testing.T, args ...string) (int, []string) {
 		code = exit.ExitCode()
 	}
 	// The warmup is detached, so what it writes lands after the process is
-	// gone: wait for it rather than racing it.
+	// gone: wait for it rather than racing it. Short, because every clean arm
+	// pays the whole wait.
 	var left []string
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 8; i++ {
 		found, err := filepath.Glob(filepath.Join(wd, "*"))
 		if err != nil {
 			t.Fatal(err)
@@ -108,6 +113,15 @@ func TestWithNoHomeNothingIsWrittenWhereDejaHappensToRun(t *testing.T) {
 		// These write nothing without a home, and refusing them takes away the
 		// commands a reader needs precisely when deja cannot find one.
 		{args: []string{"version"}},
+		// Both spellings of the same command answer the same way, and neither
+		// falls through to the bare-query path, which builds an index.
+		{args: []string{"--version"}},
+		{args: []string{"-version"}},
+		// Not a command at all: allowlisting it let it past the guard, miss
+		// the dispatch map and land in the query path.
+		{args: []string{"-v"}, wantCode: 1},
+		// No arguments at all, which is the brief on a terminal.
+		{args: nil, wantCode: 1},
 		{args: []string{"help"}},
 		{args: []string{"completion", "bash"}},
 		{args: []string{"sources"}},
@@ -141,5 +155,18 @@ func TestInstallKeepsItsOwnRefusal(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HOME") {
 		t.Errorf("the refusal does not name what is missing: %v", err)
+	}
+}
+
+// doctor is where the refusal sends the reader, so it runs without a home —
+// but --deep takes the index lock first, which left a lock file in whatever
+// directory they were standing in.
+func TestDoctorDeepDoesNotTakeALockItCannotHold(t *testing.T) {
+	code, left := runWithNoHome(t, "doctor", "--deep")
+	if code == 0 {
+		t.Error("deep verify of an index that cannot exist reported success")
+	}
+	if len(left) > 0 {
+		t.Errorf("doctor --deep wrote into the working directory: %v", left)
 	}
 }


### PR DESCRIPTION
Closes #1692. Follow-on from #1690, which fixed the same relative-path defect in `install`.

With HOME unset, `homeDir()` answers `""`, so `filepath.Join("", ".cache", "deja")` is `.cache/deja` — and deja built its **index** in whatever directory it was run from. Measured before: `hook-context` left `.cache/deja/index.db` in the working directory and exited 0; `index` left eight files there.

The issue asked for the design call, and it is the one it suggested: a command somebody typed says why it cannot run, and a hook declines quietly. A hook must never cost a turn — that is why they fail open — so refusing loudly there would trade a stray database for a broken session. Both write nothing, which is the part that matters.

Measured after: every entry point leaves the working directory empty; hooks exit 0, `index`, `sources` and `doctor` exit 1 naming HOME and DEJA_INDEX_DIR.