### PR TITLE
fix: the log of a query no longer answers it

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -290,6 +290,29 @@ func looksLikeListingDump(line string) bool {
 // read.
 func IsPlumbing(s string) bool { return noisyMessage(s) }
 
+// toolCallRecordRE matches a harness marker, a tool name and the opening of a
+// JSON object of arguments — the shape a captured tool-call log has.
+var toolCallRecordRE = regexp.MustCompile(`[⚙⏺▶►]\s*[A-Za-z_][\w.:-]*\s*\{\s*"`)
+
+// IsToolCallRecord reports whether a line records a call being made rather than
+// anything anyone said.
+//
+// An agent run from inside a session has its stdout captured into that
+// session's transcript, so the log of the queries it sent lands in an assistant
+// message — where the tool role, which is how deja separates machine output,
+// never applies. A later question then matches the record of that same question
+// being asked, and it outranks the answer: asked which wording was picked for
+// the repository description, recall's top hit was a line reading
+// `⚙ deja_recall {"query":"deja-vu repository descriptio…` and the agent
+// invented the rest (#2067).
+//
+// Barred from matching rather than dropped at ingest. That a call happened is
+// what `deja how` and `deja fix` are built on, and this only says such a line
+// is not a candidate for the slot that answers a question.
+func IsToolCallRecord(line string) bool {
+	return toolCallRecordRE.MatchString(line)
+}
+
 func noisyMessage(s string) bool {
 	t := strings.TrimSpace(s)
 	if t == "" {

--- a/internal/digest/tool_call_record_test.go
+++ b/internal/digest/tool_call_record_test.go
@@ -1,0 +1,33 @@
+package digest
+
+import "testing"
+
+// A line that records a call being made is not a candidate for the slot that
+// answers a question — it matches the question because it *is* the question,
+// asked earlier by an agent whose stdout was captured (#2067).
+func TestToolCallRecordIsNotSomethingSaid(t *testing.T) {
+	records := []string{
+		`claude  goprojects/deja-vu  > builder · gpt-5.6-luna ⚙ deja_recall {"query":"deja-vu repository description wording"}`,
+		`⏺ Bash {"command":"go test ./..."}`,
+		`▶ read_file { "path": "internal/index/index.go" }`,
+	}
+	for _, line := range records {
+		if !IsToolCallRecord(line) {
+			t.Errorf("a captured tool call read as something said: %q", line)
+		}
+	}
+
+	// Prose about the same subjects stays a candidate. The marker alone is not
+	// the shape — a status line uses one too.
+	said := []string{
+		"⚙ настройки переехали в конфиг, ключ читается один раз на старте",
+		"we picked the second wording option for the repository description",
+		"deja_recall returns the ranked sessions, not the raw store",
+		"⏺ Bash закончился ошибкой, разбираю",
+	}
+	for _, line := range said {
+		if IsToolCallRecord(line) {
+			t.Errorf("prose barred as a tool call: %q", line)
+		}
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -536,7 +536,7 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 		// An envelope can carry the query's words and say nothing a reader
 		// wanted: a wrapped inter-agent notification quoting a session id
 		// matched, and the block opened with truncated JSON (#2735).
-		if digest.IsPlumbing(line) {
+		if digest.IsPlumbing(line) || digest.IsToolCallRecord(line) {
 			continue
 		}
 		matchedAt[i] = true
@@ -608,6 +608,14 @@ func matchedLinesAsked(s model.Session, terms []string, asked string) (string, [
 			// removing it changes cost and not output.
 			line, _ := densestLine(m.Text, terms)
 			if line == "" || !digest.CarriesDecision(line) || saysItHasNoMemory(line) {
+				continue
+			}
+			// The same two bars the loop above applies. This path reached the
+			// slot without them, so a captured `⚙ deja_recall {"query":…}`
+			// carrying a decision word — and the log of a question carries the
+			// question's words by construction — was quoted as the answer to
+			// the question it recorded (#2067).
+			if digest.IsPlumbing(line) || digest.IsToolCallRecord(line) {
 				continue
 			}
 			if text := contextText(line, false); strings.TrimSpace(text) != "" {

--- a/internal/search/tool_call_echo_test.go
+++ b/internal/search/tool_call_echo_test.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// An agent run from inside a session has its stdout captured into that
+// session's transcript, so the log of the queries it sent lands in an assistant
+// message. A later question then matches the record of that question being
+// asked — and it outranks the answer, because it repeats every word of the
+// query and the answer repeats one (#2067).
+func TestTheLogOfAQueryDoesNotAnswerIt(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "какой вариант описания репозитория выбрали"},
+		{Role: "assistant", Text: `claude  goprojects/deja-vu  > builder ⚙ deja_recall {"query":"вариант описания репозитория выбрали"}`},
+		{Role: "assistant", Text: "в итоге выбрали второй вариант описания — про восстановление контекста"},
+	}}
+	_, lines := matchedLinesAsked(s, []string{"описания", "репозитория", "вариант"},
+		"какой вариант описания репозитория выбрали")
+	if len(lines) == 0 {
+		t.Fatal("nothing was quoted at all")
+	}
+	if quoted(lines, "deja_recall") {
+		t.Errorf("the record of the question was quoted as its answer: %q", lines)
+	}
+	if !quoted(lines, "второй вариант") {
+		t.Errorf("the line that answered it was not quoted: %q", lines)
+	}
+}


### PR DESCRIPTION
Closes #2067.

An agent run from inside a session has its stdout captured into that session's transcript, so the log of the queries it sent lands in an *assistant* message — where the tool role, which is how deja separates machine output, never applies. A later question then matches the record of that question being asked, and it wins: the record repeats every word of the query and the answer repeats one.

`IsToolCallRecord` bars a line whose shape is a harness marker, a tool name and a JSON object of arguments. Barred from matching, not dropped at ingest — that a call happened is what `deja how` and `deja fix` are built on.

Two seams, and the second is the one that actually bit. The candidate loop already bars plumbing; the "take the agent's next lines after a matched one" path did not, and it admits a line on `CarriesDecision` alone — so `⚙ deja_recall {"query":"…вариант…выбрали"}` got in on "выбрали", a decision word the log carries because the *question* carried it. That path now applies both bars, plumbing included.

On frequency, honestly: this shape occurs once in 429,684 assistant lines in my store, and that one is the line from the issue. I could not reproduce it at scale here, so this is not a measured win — it is a categorical one. A line that records a call being made is not a candidate for the slot that answers a question, however well it matches.

Mutation-checked three ways: either bar removed, or the predicate stubbed to false, turns a test red.