### PR TITLE
fix(mcp): the line above a relevance answer says what follows it

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -881,6 +881,33 @@ func recallText(dir, q, harness string, limit, budget int) (string, error) {
 	return text, err
 }
 
+// recallCountLine introduces the sessions below it.
+//
+// It said "deja recall for <the query>" whatever the tier, so an answer whose
+// first line says no session is about this went on to head the payload with
+// the question itself — and an agent read three unrelated sessions as the
+// answer to it. On the relevance tier the line says what they are instead
+// (#2074).
+func recallCountLine(q, tier string, offset, served, total int) string {
+	switch {
+	case offset > 0:
+		return fmt.Sprintf("deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+served, total)
+	case tier == search.TierRelevance && served < total:
+		return fmt.Sprintf("nearest by wording to %q (%d of %d ranked, none about it)\n", q, served, total)
+	case tier == search.TierRelevance:
+		return fmt.Sprintf("nearest by wording to %q (%d ranked, none about it)\n", q, served)
+	case served < total:
+		// How many came back is not how many matched, and the agent is the
+		// reader that cannot ask a human. "(5 match(es))" reads as five exist,
+		// which is a different answer from sixteen thousand matched and here
+		// are five — one is worth acting on, the other is a sample that will
+		// fill a context window with whatever ranked highest (#1308).
+		return fmt.Sprintf("deja recall for %q (%d of %d matched)\n", q, served, total)
+	default:
+		return fmt.Sprintf("deja recall for %q (%d match(es))\n", q, served)
+	}
+}
+
 // wholeSessionForMCP reads one session for a caller that must not wait.
 //
 // `findByPrefix` is the CLI helper and opens with a blocking `index.Ensure` —
@@ -1148,23 +1175,7 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	// From what was served, not from the limit: the loop also stops on the
 	// token budget, and then this said "2 more" while five were left — the
 	// agent asks for offset=served and the arithmetic has to hold.
-	switch {
-	case offset > 0:
-		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+served, total)
-	case served < total && result.Tier == search.TierRelevance:
-		// The tier line above already says nothing matched; these are the
-		// nearest sessions, so calling them matches here would contradict it.
-		fmt.Fprintf(&b, "deja recall for %q (%d of %d ranked)\n", q, served, total)
-	case served < total:
-		// How many came back is not how many matched, and the agent is the
-		// reader that cannot ask a human. "(5 match(es))" reads as five exist,
-		// which is a different answer from sixteen thousand matched and here
-		// are five — one is worth acting on, the other is a sample that will
-		// fill a context window with whatever ranked highest (#1308).
-		fmt.Fprintf(&b, "deja recall for %q (%d of %d matched)\n", q, served, total)
-	default:
-		fmt.Fprintf(&b, "deja recall for %q (%d match(es))\n", q, served)
-	}
+	b.WriteString(recallCountLine(q, result.Tier, offset, served, total))
 	b.WriteString(hb.String())
 	// From what was served, not from the limit: the loop also stops on the
 	// token budget, and then this said "2 more" while five were left — the

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -889,7 +889,13 @@ func recallText(dir, q, harness string, limit, budget int) (string, error) {
 // answer to it. On the relevance tier the line says what they are instead
 // (#2074).
 func recallCountLine(q, tier string, offset, served, total int) string {
+	q = clampEcho(q)
 	switch {
+	case tier == search.TierRelevance && offset > 0:
+		// The tier before the page: page two of an answer to a question
+		// nothing is about is still not a page of matches, and saying so only
+		// on page one was the same contradiction one line further down.
+		return fmt.Sprintf("nearest by wording to %q (%d-%d of %d ranked, none about it)\n", q, offset+1, offset+served, total)
 	case offset > 0:
 		return fmt.Sprintf("deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+served, total)
 	case tier == search.TierRelevance && served < total:
@@ -927,12 +933,23 @@ func wholeSessionForMCP(dir string, s model.Session) (model.Session, bool, error
 	return index.FindByIdentity(dir, s.Harness, s.ID)
 }
 
-// recallCountLineReserve is what the two lines around the hits cost — the
-// count above them and the "N more, call again with offset=N" below — kept out
-// of the budget the hits spend. Both are written after the loop, and the final
-// trim cut the navigation line off the end, which is the one line an agent
-// needs precisely when the answer was too big to fit.
-const recallCountLineReserve = 160
+// recallCountLineReserve is what the "N more, call again with offset=N" line
+// below the hits costs, kept out of the budget the hits spend. It is written
+// after the loop, and the final trim cut the navigation line off the end,
+// which is the one line an agent needs precisely when the answer was too big
+// to fit.
+//
+// The count line above the hits is measured rather than guessed: it carries
+// the query, and a constant that fitted a short one stopped covering an error
+// string pasted in whole — which is exactly what the tool description asks
+// agents to send.
+const recallCountLineReserve = 64
+
+// recallHeaderReserve is that plus the count line this answer will actually
+// print.
+func recallHeaderReserve(q, tier string, offset, limit, total int) int {
+	return recallCountLineReserve + len(recallCountLine(q, tier, offset, limit, total))
+}
 
 // twinSessionsFor pairs each session with the same session as it exists on
 // another machine, so a page holding both copies can say so. One manifest read
@@ -1020,7 +1037,11 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	demoted := demoteRejected(hits)
 	if offset > 0 {
 		if offset >= total {
-			return fmt.Sprintf("No more matches for %q: %d total, offset %d.", clampEcho(q), total, offset), 0, 0, nil, nil, nil
+			what := "matches"
+			if result.Tier == search.TierRelevance {
+				what = "sessions ranked by wording"
+			}
+			return fmt.Sprintf("No more %s for %q: %d total, offset %d.", what, clampEcho(q), total, offset), 0, 0, nil, nil, nil
 		}
 		hits = hits[offset:]
 	}
@@ -1056,7 +1077,7 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	// the token budget: the header promised fifteen while nine arrived, and the
 	// follow-up line was trimmed off the end (#1308).
 	var hb strings.Builder
-	headerRoom := b.Len() + recallCountLineReserve
+	headerRoom := b.Len() + recallHeaderReserve(q, result.Tier, offset, limit, total)
 	for i, h := range hits {
 		fmt.Fprintf(&hb, "\n%d. [%s] %s · %s · %d matches", i+1,
 			recallListingLine(h.Session.Harness), recallListingLine(h.Session.Project), recallListingLine(h.Session.ID), h.Count)
@@ -1182,7 +1203,13 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	// agent asks for offset=served and the arithmetic has to hold.
 	more := ""
 	if left := total - offset - served; left > 0 {
-		more = fmt.Sprintf("\n%d more match(es) — call recall again with offset=%d.\n", left, offset+served)
+		what := "match(es)"
+		if result.Tier == search.TierRelevance {
+			// Nothing matched, so there are no more matches to offer — only
+			// more of the nearest wording.
+			what = "ranked by wording"
+		}
+		more = fmt.Sprintf("\n%d more %s — call recall again with offset=%d.\n", left, what, offset+served)
 	}
 	// The paging line is the instruction, not the evidence: appending it before
 	// the trim made a full page drop the one thing that says how to reach the

--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -98,7 +98,7 @@ func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
 	// already, and the test went quiet instead of saying so.
 	// The sentinel is the tier's own words, and they changed when the line
 	// stopped reading as "here is what I found about it" (#2074).
-	if !strings.Contains(text, "nearest by wording") {
+	if !strings.Contains(text, "No session is about this") {
 		t.Fatalf("the fixture no longer reaches the relevance tier, so this test guards nothing:\n%s", firstLines(text, 3))
 	}
 	if strings.Contains(text, "matched)") {

--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -104,7 +104,7 @@ func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
 	if strings.Contains(text, "matched)") {
 		t.Errorf("relevance-tier sessions were reported as matches:\n%s", firstLines(text, 4))
 	}
-	if !strings.Contains(text, "ranked)") {
+	if !strings.Contains(text, "ranked, none about it)") {
 		t.Errorf("the count line does not say what the number is:\n%s", firstLines(text, 4))
 	}
 }

--- a/cmd/deja/recall_relevance_framing_test.go
+++ b/cmd/deja/recall_relevance_framing_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The line that introduces the sessions said "deja recall for <the query>"
+// whatever the tier — so an answer whose first line says no session is about
+// this went on to head the payload with the question itself. Measured live,
+// that is what one invented answer was built on: plausible sessions about the
+// wrong thing, under a heading that read as an answer (#2074).
+func TestTheCountLineSaysWhatFollowsIt(t *testing.T) {
+	const q = "why did the quokka telemetry sharding keep failing"
+	for _, c := range []struct {
+		name           string
+		tier           string
+		offset, served int
+		total          int
+		want           string
+	}{
+		{
+			name: "nothing is about it", tier: search.TierRelevance, served: 3, total: 37,
+			want: `nearest by wording to "` + q + `" (3 of 37 ranked, none about it)`,
+		},
+		{
+			name: "nothing is about it, all of them shown", tier: search.TierRelevance, served: 2, total: 2,
+			want: `nearest by wording to "` + q + `" (2 ranked, none about it)`,
+		},
+		{
+			name: "a real match", tier: search.TierExact, served: 3, total: 37,
+			want: `deja recall for "` + q + `" (3 of 37 matched)`,
+		},
+		{
+			name: "a real match, all of them shown", tier: search.TierExact, served: 2, total: 2,
+			want: `deja recall for "` + q + `" (2 match(es))`,
+		},
+		{
+			// A page of a longer answer says where it is, and the tier line
+			// above it has already said what these are.
+			name: "the second page", tier: search.TierRelevance, offset: 3, served: 3, total: 37,
+			want: `deja recall for "` + q + `" (matches 4-6 of 37)`,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			got := strings.TrimRight(recallCountLine(q, c.tier, c.offset, c.served, c.total), "\n")
+			if got != c.want {
+				t.Errorf("got  %s\nwant %s", got, c.want)
+			}
+		})
+	}
+}
+
+// And the two halves of a relevance answer agree: the tier line says no
+// session is about this, and the line above the payload does not then head it
+// with the question.
+func TestBothLinesOfARelevanceAnswerSayTheSameThing(t *testing.T) {
+	line := recallCountLine("anything at all", search.TierRelevance, 0, 3, 9)
+	if strings.Contains(line, "deja recall for") {
+		t.Errorf("the payload is headed by the question it does not answer: %s", line)
+	}
+	if !strings.Contains(line, "none about it") {
+		t.Errorf("the line does not say what the sessions are: %s", line)
+	}
+}

--- a/cmd/deja/recall_relevance_framing_test.go
+++ b/cmd/deja/recall_relevance_framing_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -38,9 +39,14 @@ func TestTheCountLineSaysWhatFollowsIt(t *testing.T) {
 			want: `deja recall for "` + q + `" (2 match(es))`,
 		},
 		{
-			// A page of a longer answer says where it is, and the tier line
-			// above it has already said what these are.
-			name: "the second page", tier: search.TierRelevance, offset: 3, served: 3, total: 37,
+			// Page two of an answer to a question nothing is about is still
+			// not a page of matches: saying so only on page one left the same
+			// contradiction one page further in.
+			name: "the second page of a relevance answer", tier: search.TierRelevance, offset: 3, served: 3, total: 37,
+			want: `nearest by wording to "` + q + `" (4-6 of 37 ranked, none about it)`,
+		},
+		{
+			name: "the second page of a real answer", tier: search.TierExact, offset: 3, served: 3, total: 37,
 			want: `deja recall for "` + q + `" (matches 4-6 of 37)`,
 		},
 	} {
@@ -63,5 +69,40 @@ func TestBothLinesOfARelevanceAnswerSayTheSameThing(t *testing.T) {
 	}
 	if !strings.Contains(line, "none about it") {
 		t.Errorf("the line does not say what the sessions are: %s", line)
+	}
+}
+
+// The query is echoed back, so it is bounded the way every sibling echo is.
+func TestTheCountLineDoesNotEchoAWholeTranscriptBack(t *testing.T) {
+	line := recallCountLine(strings.Repeat("x", 64_000), search.TierExact, 0, 3, 9)
+	if len(line) > 1_000 {
+		t.Errorf("the count line echoed %d bytes of query back", len(line))
+	}
+}
+
+// The room kept for the lines around the hits has to cover the count line as
+// it will actually be written — it carries the query, and the tool
+// description asks agents to paste whole error strings. A constant that fitted
+// a short query stopped covering a long one, and the line an agent navigates
+// by is the one that goes first.
+func TestALongQueryStillLeavesRoomForTheLineThatSaysHowToPage(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	q := "parser rejects frames the pipeline stalled " + strings.Repeat("and the retry budget was exhausted ", 4)
+	arg, _ := json.Marshal(map[string]any{"query": q, "limit": 3})
+	text, err := callMCPTool(dir, "recall", arg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "call recall again with offset=") {
+		t.Errorf("the line an agent pages by was trimmed off:\n%s", text)
+	}
+	// The count line is written whole, with the query in it: the room kept for
+	// it is measured from the line itself rather than guessed at.
+	want := strings.TrimRight(recallCountLine(q, search.TierRelevance, 0, 3, 41), "\n")
+	if !strings.Contains(text, want) {
+		t.Errorf("the count line did not survive whole:\nwant %s\ngot\n%s", want, text)
+	}
+	if len(text) > recallMCPBudget {
+		t.Errorf("the answer is %d bytes, budget is %d", len(text), recallMCPBudget)
 	}
 }


### PR DESCRIPTION
Closes #2074.

The tier line already says "No session is about this" — and then the next line said `deja recall for "<the question>" (3 of 37 ranked)` directly above three real sessions, which reads as an answer to it. Measured live on opencode, that is what one invented answer was built on: plausible sessions about the wrong thing under a heading that read as a record.

It now says `nearest by wording to "<the question>" (3 of 37 ranked, none about it)`. A query that actually matched still reads as a recall, because it is one.

The count line moved into `recallCountLine` so it can be held to that directly — the relevance tier needs a store big enough to reach it, which a fixture cannot honestly provide.