### PR TITLE
fix(policy): a trust policy is read from a home directory or from nowhere

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -920,7 +920,7 @@ func doctorPolicy(w io.Writer, dir string) {
 		// was local-only, on the one screen someone opens to find out what is
 		// allowed (#939).
 		if pol := policy.Load(); pol.Describe(policy.ActivationAuto) != "local+imported" {
-			fmt.Fprintf(w, "  %-12s no file at %s\n", "default", reportPath(policy.Path()))
+			fmt.Fprintf(w, "  %-12s %s\n", "default", noPolicyFileLine())
 			withheld, total := policyWithheldCounts(dir)
 			for _, activation := range []string{policy.ActivationSearch, policy.ActivationMCP, policy.ActivationAuto} {
 				line := pol.Describe(activation)
@@ -932,7 +932,7 @@ func doctorPolicy(w io.Writer, dir string) {
 			fmt.Fprintf(w, "  %-12s DEJA_AUTORECALL_LOCAL_ONLY is set in this environment\n", "from env")
 			return
 		}
-		fmt.Fprintf(w, "  %-12s no file at %s — every origin activates everywhere\n", "default", reportPath(policy.Path()))
+		fmt.Fprintf(w, "  %-12s %s — every origin activates everywhere\n", "default", noPolicyFileLine())
 		// Except one thing, which is in force with or without a file and is
 		// the reason a directory can be missing from recall (#2050).
 		printIgnored(w, policy.Load())
@@ -1670,4 +1670,14 @@ func printIgnored(w io.Writer, pol policy.Policy) {
 		what = "from the file"
 	}
 	fmt.Fprintf(w, "  %-12s %s (%s)\n", "not recalled", strings.Join(pats, ", "), what)
+}
+
+// noPolicyFileLine says where the policy would be, or that there is nowhere
+// for it: with no home directory doctor printed "no file at " and stopped
+// (#2785), on the screen somebody opens to find out where the file goes.
+func noPolicyFileLine() string {
+	if p := policy.Path(); p != "" {
+		return "no file at " + reportPath(p)
+	}
+	return "no policy file — deja cannot find a home directory to look in"
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1624,11 +1624,11 @@ func printNoMatches(w io.Writer, dir, q string, regex bool) {
 		// put a store hidden by a path pattern under a sentence about the
 		// trust policy, quoting a trust rule that allows everything.
 		if trusted == 0 {
-			fmt.Fprintf(w, "deja: the trust policy withholds every indexed session from this path (%s: %s) — see %s\n",
-				policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch), policy.Path())
+			fmt.Fprintf(w, "deja: the trust policy withholds every indexed session from this path (%s: %s)%s\n",
+				policy.ActivationSearch, policy.Load().Describe(policy.ActivationSearch), seePolicyFile())
 		} else {
-			fmt.Fprintf(w, "deja: the ignore rule withholds every indexed session from this path (%s) — see %s\n",
-				strings.Join(policy.Load().IgnorePatterns(), ", "), policy.Path())
+			fmt.Fprintf(w, "deja: the ignore rule withholds every indexed session from this path (%s)%s\n",
+				strings.Join(policy.Load().IgnorePatterns(), ", "), seePolicyFile())
 		}
 		return
 	} else if ok {

--- a/cmd/deja/policy_path_lines_test.go
+++ b/cmd/deja/policy_path_lines_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// With no home directory there is no policy file to point at, and the lines
+// that pointed at one ended in "see " and nothing — including doctor, which is
+// the screen somebody opens to find out where the file goes (#2785).
+func TestTheLinesAboutThePolicyDoNotPointAtNothing(t *testing.T) {
+	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "DEJA_POLICY_FILE"} {
+		t.Setenv(k, "")
+	}
+	if got := seePolicyFile(); got != "" {
+		t.Errorf("a sentence still points at a file: %q", got)
+	}
+	line := noPolicyFileLine()
+	if strings.HasSuffix(strings.TrimSpace(line), "at") || strings.Contains(line, "at  ") {
+		t.Errorf("doctor names nowhere as somewhere: %q", line)
+	}
+	if !strings.Contains(line, "home directory") {
+		t.Errorf("doctor does not say why there is no file: %q", line)
+	}
+}
+
+// With one, both still name it.
+func TestTheLinesAboutThePolicyNameItWhenThereIsOne(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DEJA_POLICY_FILE", dir+"/policy.json")
+	if got := seePolicyFile(); !strings.Contains(got, "policy.json") {
+		t.Errorf("the sentence lost the path: %q", got)
+	}
+	if got := noPolicyFileLine(); !strings.Contains(got, "policy.json") {
+		t.Errorf("doctor lost the path: %q", got)
+	}
+}

--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -56,8 +56,8 @@ func ignoredHiddenNoteFor(where string, hidden int) string {
 		return ""
 	}
 	pats := policy.Load().IgnorePatterns()
-	return fmt.Sprintf("deja: the ignore rule keeps %d session%s out of this %s (%s) — see %s\n",
-		hidden, pluralS(hidden), where, strings.Join(pats, ", "), policy.Path())
+	return fmt.Sprintf("deja: the ignore rule keeps %d session%s out of this %s (%s)%s\n",
+		hidden, pluralS(hidden), where, strings.Join(pats, ", "), seePolicyFile())
 }
 
 // policyFilterBlame is policyFilterHits for blame results, which carry whole
@@ -105,4 +105,15 @@ func denyPolicyHidden(id string, s model.Session, w io.Writer) error {
 		return fmt.Errorf("no session matches %q", id)
 	}
 	return nil
+}
+
+// seePolicyFile points at the file the rule is written in, when there is one.
+// The ignore rule has defaults and holds with no file at all, and with no home
+// directory there is no path to name — the sentence used to end in "see " and
+// nothing (#2785).
+func seePolicyFile() string {
+	if p := policy.Path(); p != "" {
+		return " — see " + p
+	}
+	return ""
 }

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -48,6 +48,15 @@ func Path() string {
 	if base == "" {
 		base = filepath.Join(sources.Home(), ".config")
 	}
+	// Nowhere, rather than somewhere relative. Home() answers "" when there is
+	// no home directory, so this was `.config/deja/policy.json` — and deja read
+	// whatever a checkout happened to have there as the reader's own trust
+	// policy, which is the wrong direction for the file that decides what
+	// recall may hand over (#2785). The spec says the same of XDG_CONFIG_HOME:
+	// a relative value is to be ignored.
+	if !filepath.IsAbs(base) {
+		return ""
+	}
 	return filepath.Join(base, "deja", "policy.json")
 }
 
@@ -203,6 +212,9 @@ func Filter[T any](p Policy, activation string, items []T, projectOf func(T) str
 // one mechanism separating local memory from imported (#661).
 func Diagnose() (exists bool, unknown []string, err error) {
 	path := Path()
+	if path == "" {
+		return false, nil, nil
+	}
 	b, rerr := os.ReadFile(path)
 	if rerr != nil {
 		if os.IsNotExist(rerr) {

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -44,16 +44,17 @@ func Path() string {
 	if p := os.Getenv("DEJA_POLICY_FILE"); p != "" {
 		return p
 	}
+	// A relative XDG_CONFIG_HOME is ignored rather than followed — the spec
+	// says so, and it is what this repository's own xdgConfigHome does.
 	base := os.Getenv("XDG_CONFIG_HOME")
-	if base == "" {
+	if !filepath.IsAbs(base) {
 		base = filepath.Join(sources.Home(), ".config")
 	}
-	// Nowhere, rather than somewhere relative. Home() answers "" when there is
-	// no home directory, so this was `.config/deja/policy.json` — and deja read
-	// whatever a checkout happened to have there as the reader's own trust
-	// policy, which is the wrong direction for the file that decides what
-	// recall may hand over (#2785). The spec says the same of XDG_CONFIG_HOME:
-	// a relative value is to be ignored.
+	// And nowhere, rather than somewhere relative: Home() answers "" when
+	// there is no home directory, so this was `.config/deja/policy.json` —
+	// deja read whatever a checkout happened to have there as the reader's own
+	// trust policy, which is the wrong direction for the file that decides
+	// what recall may hand over (#2785).
 	if !filepath.IsAbs(base) {
 		return ""
 	}

--- a/internal/policy/relative_path_test.go
+++ b/internal/policy/relative_path_test.go
@@ -65,3 +65,26 @@ func TestAPolicyNamedByAnAbsolutePathIsStillRead(t *testing.T) {
 		t.Error("a policy under an absolute XDG_CONFIG_HOME was ignored")
 	}
 }
+
+// A relative XDG_CONFIG_HOME is not the reader saying "read nothing": it is a
+// value the spec says to ignore, and the home directory is still there.
+func TestARelativeConfigHomeFallsBackToTheHomeDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_POLICY_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", "relconf")
+	if err := os.MkdirAll(filepath.Join(home, ".config", "deja"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"activations":{"search":{"*":false}}}`
+	if err := os.WriteFile(filepath.Join(home, ".config", "deja", "policy.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := Path(), filepath.Join(home, ".config", "deja", "policy.json"); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+	if Load().Allows(ActivationSearch, "anything") {
+		t.Error("the reader's own policy was skipped over a relative XDG_CONFIG_HOME")
+	}
+}

--- a/internal/policy/relative_path_test.go
+++ b/internal/policy/relative_path_test.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The trust policy decides what recall may hand over, and its path is built
+// from the home directory — which answers "" when there is none, so
+// `filepath.Join("", ".config")` is `.config`. deja then read
+// `./.config/deja/policy.json`: a file in whatever repository it happened to
+// be run from was read as the reader's own trust policy (#2785).
+func TestAPolicyIsNotReadFromWhereverDejaHappensToRun(t *testing.T) {
+	wd := t.TempDir()
+	t.Chdir(wd)
+	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "DEJA_POLICY_FILE"} {
+		t.Setenv(k, "")
+	}
+	dir := filepath.Join(wd, ".config", "deja")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A rule that would withhold everything, sitting in a checkout.
+	body := `{"activations":{"search":{"*":false},"auto":{"*":false},"mcp":{"*":false}}}`
+	if err := os.WriteFile(filepath.Join(dir, "policy.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if p := Path(); p != "" && !filepath.IsAbs(p) {
+		t.Errorf("the policy path is relative to the working directory: %q", p)
+	}
+	if !Load().Allows(ActivationSearch, "anything") {
+		t.Error("a policy file from the working directory decided what recall may hand over")
+	}
+	exists, _, err := Diagnose()
+	if err != nil {
+		t.Fatalf("diagnose: %v", err)
+	}
+	if exists {
+		t.Error("deja reported a trust policy it found in the working directory")
+	}
+}
+
+// And an absolute path is still read, whichever variable named it.
+func TestAPolicyNamedByAnAbsolutePathIsStillRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	if err := os.WriteFile(path, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", path)
+	if Load().Allows(ActivationSearch, "anything") {
+		t.Error("a policy deja was pointed at was ignored")
+	}
+	t.Setenv("DEJA_POLICY_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := os.MkdirAll(filepath.Join(dir, "deja"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "deja", "policy.json"), []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if Load().Allows(ActivationSearch, "anything") {
+		t.Error("a policy under an absolute XDG_CONFIG_HOME was ignored")
+	}
+}


### PR DESCRIPTION
Closes #2785, found by the reviewer on #2782.

`Path()` builds the policy path from the home directory, which answers `""` when there is none — so `filepath.Join("", ".config")` is `.config`, and deja read `./.config/deja/policy.json`. A file in whatever repository it happened to be run from was read as the reader's own trust policy, and that file decides what recall may hand over.

It answers "" now for a base that is not absolute, and `Diagnose` reads that as no policy — which is also what the XDG spec says about a relative `XDG_CONFIG_HOME`. An absolute path from either variable is still read.

#2782 could not cover this: `warnBrokenPolicy` runs before the guard it added.