### PR TITLE
fix: the recall header stops claiming the query it did not match

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1140,12 +1140,20 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	// token budget, and then this said "2 more" while five were left — the
 	// agent asks for offset=served and the arithmetic has to hold.
 	switch {
+	case result.Tier == search.TierRelevance:
+		// Nothing matched, and the header is the line an agent reads as the
+		// answer's title. "deja recall for <query>" one line under "no session
+		// is about this" contradicts it, and with an offset the old header
+		// called them matches outright — the two shapes #2074 measured an
+		// agent inventing facts from.
+		if offset > 0 {
+			fmt.Fprintf(&b, "deja recall: no session about %q; nearest by wording, %d-%d of %d ranked\n",
+				q, offset+1, offset+served, total)
+			break
+		}
+		fmt.Fprintf(&b, "deja recall: no session about %q; nearest by wording (%d of %d ranked)\n", q, served, total)
 	case offset > 0:
 		fmt.Fprintf(&b, "deja recall for %q (matches %d-%d of %d)\n", q, offset+1, offset+served, total)
-	case served < total && result.Tier == search.TierRelevance:
-		// The tier line above already says nothing matched; these are the
-		// nearest sessions, so calling them matches here would contradict it.
-		fmt.Fprintf(&b, "deja recall for %q (%d of %d ranked)\n", q, served, total)
 	case served < total:
 		// How many came back is not how many matched, and the agent is the
 		// reader that cannot ask a human. "(5 match(es))" reads as five exist,

--- a/cmd/deja/mcp_relevance_header_test.go
+++ b/cmd/deja/mcp_relevance_header_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// One line says no session is about this; the next used to open "deja recall
+// for <query>" over three sessions, and with an offset it called them matches
+// outright. The caveat and the header cannot both be true, and the header is
+// the one an agent reads as the answer's title (#2074).
+func TestTheRelevanceHeaderDoesNotClaimTheQuery(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	const q = "parser rejects frames the pipeline stalled"
+
+	for _, offset := range []int{0, 1} {
+		text, _, _, _, err := recallTextResult(dir, q, "", 3, offset, 4096)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(text, "nearest by wording") {
+			t.Fatalf("the fixture no longer reaches the relevance tier, so this guards nothing:\n%s", firstLines(text, 3))
+		}
+		header := ""
+		for _, l := range strings.Split(text, "\n") {
+			if strings.HasPrefix(l, "deja recall") {
+				header = l
+				break
+			}
+		}
+		if header == "" {
+			t.Fatalf("offset %d: no header line at all:\n%s", offset, firstLines(text, 4))
+		}
+		if strings.Contains(header, "recall for") {
+			t.Errorf("offset %d: the header calls the sessions the query's own: %q", offset, header)
+		}
+		if strings.Contains(header, "match") {
+			t.Errorf("offset %d: the header calls them matches: %q", offset, header)
+		}
+		if !strings.Contains(header, "ranked") {
+			t.Errorf("offset %d: the header does not say what the number is: %q", offset, header)
+		}
+		// Paging is arithmetic the agent navigates by: it asks for
+		// offset=served next, so where it already is has to be on the line.
+		if offset > 0 && !strings.Contains(header, "2-") {
+			t.Errorf("offset %d: the header lost where the page starts: %q", offset, header)
+		}
+	}
+}


### PR DESCRIPTION
The rest of #2074's second direction. Reproduced first: the eight absent-subject questions still come back with three sessions each on a real store, and the caveat line added earlier does fire —

    No session is about this. Nothing matched the query, so the sessions below are the nearest by wording…
    deja recall for "how did we configure the flux capacitor for the delorean" (3 of 40 ranked)

— and the line under it takes it straight back. The header is what an agent reads as the answer's title. With an offset it was worse: `(matches 2-4 of 40)`, the word outright, because the paging branch was checked before the tier.

Now on the relevance tier, both with and without an offset:

    deja recall: no session about "…"; nearest by wording (3 of 40 ranked)
    deja recall: no session about "…"; nearest by wording, 2-4 of 40 ranked

The page range stays on the line — the agent asks for offset=served next, so that arithmetic is what it navigates by, and a test pins it.

Not in this PR, and still yours to call: the issue's first direction, returning nothing when the best tier is relevance and no session carries a query term outside filler. That trades a real convenience for silence and needs `bench recall` before and after.

One thing checked and found already honest: `fix`'s "an empty result means this machine has no record" is true — `FixesFor` matches by error signature only and has no relevance fallback.

Mutation-checked both ways: dropping the tier case, and dropping the offset branch inside it.