### PR TITLE
fix(hooks): the deja-vu hook says when it could not read the payload

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -136,7 +136,13 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// than unmarshalled, so a host that writes anything after the object (a
 	// second line, a trailing NUL) keeps its recall instead of losing the
 	// whole payload to a syntax error.
-	_ = json.NewDecoder(bytes.NewReader(readHookPayload(stdin, hookStdinWait))).Decode(&input)
+	payload := readHookPayload(stdin, hookStdinWait)
+	// The error is kept, not swallowed: a decode that fails on a later field —
+	// `{"prompt":"…","session_id":123}` — reads the prompt, injects on it, and
+	// leaves a row saying the host named no session, when it named one deja
+	// could not read (#2773). The prompt is what this hook recalls from, so a
+	// payload it cannot read at all injects nothing and this never fires.
+	unreadable := json.NewDecoder(bytes.NewReader(payload)).Decode(&input) != nil
 	// The kill switch. It reached the session-start hook and nothing else, so
 	// this hook — every user message, and the wiring for seven harnesses —
 	// kept injecting on a machine with recall off (#2701).
@@ -411,8 +417,13 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	out := frameRecall(body)
 	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
 	rememberInjectedFor(dir, input.SessionID, projectKey, ss)
-	usage.RecordDigestFrom(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
-		terms, sessionProjects(ss), sessionIDs(ss))
+	if unreadable {
+		usage.RecordDigestFromUnread(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
+			terms, sessionProjects(ss), sessionIDs(ss))
+	} else {
+		usage.RecordDigestFrom(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
+			terms, sessionProjects(ss), sessionIDs(ss))
+	}
 	if plain {
 		fmt.Fprintln(stdout, out)
 		return nil

--- a/cmd/deja/hook_prompt_unread_test.go
+++ b/cmd/deja/hook_prompt_unread_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// seedDejaVuStore lays out a session the déjà vu hook will recall, and returns
+// the index directory.
+func seedDejaVuStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "vuterm", []string{
+		`{"type":"user","sessionId":"vuterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+	return dir
+}
+
+// dejaVuRows reads back what the hook recorded.
+func dejaVuRows(t *testing.T, dir string) []usage.Snapshot {
+	t.Helper()
+	b, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil {
+		return nil
+	}
+	var out []usage.Snapshot
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var snap usage.Snapshot
+		if json.Unmarshal([]byte(line), &snap) != nil {
+			continue
+		}
+		if snap.Kind == usage.KindDejaVu {
+			out = append(out, snap)
+		}
+	}
+	return out
+}
+
+// The session-start hook injects whatever the payload said, so a payload it
+// could not read left a row with no receiver (#2769). This hook cannot: the
+// prompt is what it recalls from, and a payload it cannot read has no prompt
+// in it — so it injects nothing and records nothing. There is no row to
+// mislabel, which is why #2773 is not the same bug.
+func TestAPayloadTheDejaVuHookCannotReadInjectsNothingAtAll(t *testing.T) {
+	for _, c := range []struct{ name, payload string }{
+		{"prose", "not a payload at all"},
+		{"truncated", `{"prompt":"pgbouncer transaction mode prepared statements"`},
+		{"binary", "\x00\x01\x02"},
+		{"a list", "[1, 2]"},
+		{"empty", ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			dir := seedDejaVuStore(t)
+			var out bytes.Buffer
+			if err := runHookPromptMode(dir, strings.NewReader(c.payload), &out, true); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(out.String(), "transaction mode") {
+				t.Errorf("a payload deja could not read still injected:\n%s", out.String())
+			}
+			if rows := dejaVuRows(t, dir); len(rows) != 0 {
+				t.Errorf("a payload deja could not read left %d row(s): %+v", len(rows), rows)
+			}
+		})
+	}
+}
+
+// And a payload it read is recorded with whatever receiver it named.
+func TestTheDejaVuHookRecordsTheReceiverThePayloadNamed(t *testing.T) {
+	for _, c := range []struct{ name, payload, into string }{
+		{"named", `{"prompt":"pgbouncer transaction mode prepared statements","session_id":"ses_vu"}`, "ses_vu"},
+		{"no session named", `{"prompt":"pgbouncer transaction mode prepared statements"}`, ""},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			dir := seedDejaVuStore(t)
+			var out bytes.Buffer
+			if err := runHookPromptMode(dir, strings.NewReader(c.payload), &out, true); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), "transaction mode") {
+				t.Fatalf("the hook injected nothing:\n%s", out.String())
+			}
+			rows := dejaVuRows(t, dir)
+			if len(rows) != 1 {
+				t.Fatalf("want one déjà vu row, got %d", len(rows))
+			}
+			if rows[0].Unreadable {
+				t.Errorf("a payload deja read was reported as broken: %+v", rows[0])
+			}
+			if rows[0].Into != c.into {
+				t.Errorf("into = %q, want %q", rows[0].Into, c.into)
+			}
+		})
+	}
+}

--- a/cmd/deja/hook_prompt_unread_test.go
+++ b/cmd/deja/hook_prompt_unread_test.go
@@ -57,11 +57,10 @@ func dejaVuRows(t *testing.T, dir string) []usage.Snapshot {
 	return out
 }
 
-// The session-start hook injects whatever the payload said, so a payload it
-// could not read left a row with no receiver (#2769). This hook cannot: the
-// prompt is what it recalls from, and a payload it cannot read has no prompt
-// in it — so it injects nothing and records nothing. There is no row to
-// mislabel, which is why #2773 is not the same bug.
+// A payload this hook cannot read at all injects nothing: the prompt is what
+// it recalls from, and there is none. That covers the whole-payload failures —
+// what it does not cover is a decode that fails on a later field, which is
+// where the real hole was (see the test below).
 func TestAPayloadTheDejaVuHookCannotReadInjectsNothingAtAll(t *testing.T) {
 	for _, c := range []struct{ name, payload string }{
 		{"prose", "not a payload at all"},
@@ -110,6 +109,36 @@ func TestTheDejaVuHookRecordsTheReceiverThePayloadNamed(t *testing.T) {
 			}
 			if rows[0].Into != c.into {
 				t.Errorf("into = %q, want %q", rows[0].Into, c.into)
+			}
+		})
+	}
+}
+
+// The hole #2773 named, found by measurement rather than by reading: a decode
+// that fails on a *later* field reads the prompt, injects on it, and leaves a
+// row saying the host named no session — for a payload that named one deja
+// could not read. Identical, in the log, to a host that named none.
+func TestADecodeThatFailsAfterThePromptIsRecordedAsUnreadable(t *testing.T) {
+	for _, payload := range []string{
+		`{"prompt":"pgbouncer transaction mode prepared statements","session_id":123}`,
+		`{"prompt":"pgbouncer transaction mode prepared statements","session_id":{"a":1}}`,
+		`{"prompt":"pgbouncer transaction mode prepared statements","cwd":7}`,
+	} {
+		t.Run(payload, func(t *testing.T) {
+			dir := seedDejaVuStore(t)
+			var out bytes.Buffer
+			if err := runHookPromptMode(dir, strings.NewReader(payload), &out, true); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out.String(), "transaction mode") {
+				t.Fatalf("the premise moved — this payload is meant to inject:\n%s", out.String())
+			}
+			rows := dejaVuRows(t, dir)
+			if len(rows) != 1 {
+				t.Fatalf("want one déjà vu row, got %d", len(rows))
+			}
+			if !rows[0].Unreadable {
+				t.Errorf("the row reads as a host that named no session: %+v", rows[0])
 			}
 		})
 	}

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -201,6 +201,17 @@ func RecordDigestPolicySessionsFrom(indexDir, kind, digest, into string, session
 	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, projects, at)
 }
 
+// RecordDigestFromUnread is RecordDigestFrom for a hook whose payload could
+// not be decoded. A decode that fails on one field keeps the ones it read, so
+// the receiver — when the payload did name one — travels as it does anywhere
+// else; the flag is about the payload (#2773, the shape #2161 fixed for the
+// session-start hook).
+func RecordDigestFromUnread(indexDir, kind, digest, into string, sessions int, raw int64, terms, projects, ids []string) {
+	at := time.Now().UTC()
+	recordFullAtUnread(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at, true)
+	snapshotWriteAt(indexDir, kind, digest, into, sessions, "", terms, projects, at, true)
+}
+
 // RecordDigestPolicySessionsUnread is RecordDigestPolicySessionsFrom for a
 // hook whose payload could not be decoded. The memory goes out regardless — an
 // agent that asked for context gets it — and the row says the payload was

--- a/internal/usage/unreadable_test.go
+++ b/internal/usage/unreadable_test.go
@@ -61,3 +61,31 @@ func TestAReadablePayloadIsNotFlagged(t *testing.T) {
 		t.Errorf("the snapshot carries the flag for a payload deja read:\n%s", b)
 	}
 }
+
+// The déjà vu hook's own recorder: the prompt is what it recalls from, so a
+// decode that fails on a later field still injects — and the row carries the
+// receiver the payload did name beside the flag about the payload (#2773).
+func TestTheDejaVuRecorderKeepsBothTheFlagAndTheReceiver(t *testing.T) {
+	dir := t.TempDir()
+	RecordDigestFromUnread(dir, KindDejaVu, "a digest", "ses_vu", 2, 4000,
+		[]string{"pgbouncer"}, []string{"beta"}, []string{"claude:one"})
+
+	events := read(Path(dir))
+	if len(events) != 1 {
+		t.Fatalf("want one event, got %d", len(events))
+	}
+	if !events[0].Unreadable || events[0].Into != "ses_vu" {
+		t.Errorf("the event lost half of what it was told: %+v", events[0])
+	}
+	b, err := os.ReadFile(SnapshotPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snap Snapshot
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(b))), &snap); err != nil {
+		t.Fatal(err)
+	}
+	if !snap.Unreadable || snap.Into != "ses_vu" || len(snap.Terms) != 1 {
+		t.Errorf("the snapshot lost a field on the way: %+v", snap)
+	}
+}


### PR DESCRIPTION
Closes #2773.

I first read this as not-a-bug and the reviewer measured otherwise, which is the right way round: `{"prompt":"…","session_id":123}` makes `Decode` fail **after** reading the prompt, so the hook injects on it and records a row with an empty receiver — identical, in the log, to a host that named no session. It also empties the per-session cooldown for that turn.

The decode error is kept now, and a row from a payload deja could not read carries `unreadable`, the way #2769 did it for the session-start hook — with whatever receiver the payload did name, since the flag is about the payload.

The whole-payload failures really do inject nothing — prose, binary, a list, an empty payload, and a truncated object whichever order its fields are in — and the tests keep that, because it rests on the prompt being unusable rather than on anything explicit.