### PR TITLE
fix(how): count the hidden sessions that match the question, not the store

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -213,14 +213,6 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 	ignored := map[string]bool{}
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
-		if !pol.Allows(activation, meta.Project) {
-			hidden[meta.Harness+":"+meta.ID] = true
-			return
-		}
-		if pol.Ignored(meta.Path, meta.Project) {
-			ignored[meta.Harness+":"+meta.ID] = true
-			return
-		}
 		if project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(project)) {
 			return
 		}
@@ -237,6 +229,21 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 			if !commandMentions(low, strings.ToLower(t)) {
 				return
 			}
+		}
+		// The rules after the question, not before it: the sentence says the
+		// policy "hides N matching sessions", and counting every withheld
+		// session that ran any command at all made that number about the
+		// store rather than about what was asked — `deja how terraform` said
+		// three were hidden on a machine whose hidden sessions only ever ran
+		// `go test` (#2766). `files` is the shape this follows: it counts
+		// from what was already searched.
+		if !pol.Allows(activation, meta.Project) {
+			hidden[meta.Harness+":"+meta.ID] = true
+			return
+		}
+		if pol.Ignored(meta.Path, meta.Project) {
+			ignored[meta.Harness+":"+meta.ID] = true
+			return
 		}
 		e := byCmd[low]
 		if e == nil {

--- a/cmd/deja/how_hidden_matching_test.go
+++ b/cmd/deja/how_hidden_matching_test.go
@@ -62,3 +62,51 @@ func TestHowCountsTheHiddenSessionsThatMatchTheQuestion(t *testing.T) {
 		t.Errorf("a question no hidden session answers was told the policy withheld something:\n%s", out)
 	}
 }
+
+// The ignore rule moved with the trust policy and says the same kind of thing
+// — "keeps N sessions out of this answer" — so it is counted the same way:
+// against what was asked, not against the store.
+func TestHowCountsTheIgnoredSessionsThatMatchTheQuestion(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := func(name, id, day, command string) {
+		t.Helper()
+		line := `{"type":"assistant","timestamp":"2026-07-` + day + `T10:00:00Z","sessionId":"` + id +
+			`","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + command + `"}}]}}`
+		if err := os.WriteFile(filepath.Join(store, name), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("one.jsonl", "aaaa0001-1111-4000-8000-d6e7f8a9b0c1", "10", "go test ./...")
+	seed("two.jsonl", "cccc0003-1111-4000-8000-d6e7f8a9b0c1", "12", "terraform apply -auto-approve")
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	body := `{"ignore":["` + strings.ReplaceAll(store, `\`, `\\`) + `/*"]}`
+	if err := os.WriteFile(pol, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	// The ignore note goes to stderr, beside the answer rather than in it.
+	out, err := captureRunStderr(t, "how", "terraform")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "keeps 1 session") {
+		t.Errorf("one ignored session ran terraform; the note says otherwise:\n%s", out)
+	}
+	out, err = captureRunStderr(t, "how", "kubectl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "ignore rule keeps") {
+		t.Errorf("a question no ignored session answers was told the rule withheld something:\n%s", out)
+	}
+}

--- a/cmd/deja/how_hidden_matching_test.go
+++ b/cmd/deja/how_hidden_matching_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The sentence says the trust policy "hides N matching sessions", and the
+// count was taken before the terms were matched — so a question about
+// terraform on a machine whose hidden sessions only ever ran `go test` was
+// told three of them were hidden from the answer (#2766).
+func TestHowCountsTheHiddenSessionsThatMatchTheQuestion(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := func(name, id, day, command string) {
+		t.Helper()
+		line := `{"type":"assistant","timestamp":"2026-07-` + day + `T10:00:00Z","sessionId":"` + id +
+			`","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + command + `"}}]}}`
+		if err := os.WriteFile(filepath.Join(store, name), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed("one.jsonl", "aaaa0001-1111-4000-8000-d6e7f8a9b0c1", "10", "go test ./...")
+	seed("two.jsonl", "bbbb0002-1111-4000-8000-d6e7f8a9b0c1", "11", "go test ./internal/...")
+	seed("three.jsonl", "cccc0003-1111-4000-8000-d6e7f8a9b0c1", "12", "terraform apply -auto-approve")
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	out, err := captureRun(t, "how", "terraform")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "hides 1 matching session") {
+		t.Errorf("one hidden session ran terraform; the note says otherwise:\n%s", out)
+	}
+	if strings.Contains(out, "hides 3") {
+		t.Errorf("sessions that ran something else were counted as matching:\n%s", out)
+	}
+
+	// And a question nothing hidden answers is not told anything was hidden
+	// from it.
+	out, err = captureRun(t, "how", "kubectl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "hides") {
+		t.Errorf("a question no hidden session answers was told the policy withheld something:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #2766, found by the reviewer on #1641.

`howEntries` applied the trust policy and the ignore rule before the terms, so the note said "the trust policy hides 3 matching sessions" for `deja how terraform` on a machine whose hidden sessions only ever ran `go test`. The word in the sentence is "matching"; the number was about the store.

The rules now run after the question — the same shape `files` already has, where the count comes from what was already searched. A question nothing hidden answers is no longer told anything was hidden from it.

The ignore rule's count moved with it, for the same reason: its own note says "keeps N sessions out of this answer".