### PR TITLE
fix(mcp): recall_context says what a relevance session is, in a sentence

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1067,7 +1067,7 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 		// questions about subjects this machine has never held — eight of
 		// eight came back with sessions rather than nothing, and the tool
 		// description promises an empty result means no record (#2074).
-		fmt.Fprintln(&b, "No session is about this. Nothing matched the query, so the sessions below are the nearest by wording — treat them as leads to check, not as a record, and say plainly if none of them answers.")
+		fmt.Fprintln(&b, nothingIsAboutThis+" so the sessions below are the nearest by wording — treat them as leads to check, not as a record, and say plainly if none of them answers.")
 	}
 	if note := demotedNote(hits, demoted); note != "" {
 		fmt.Fprintln(&b, note+" — read the order as the user's judgement, not as recency.")
@@ -1428,6 +1428,12 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 		forgottenSourceNote(whole, q, false), nil
 }
 
+// nothingIsAboutThis is the half both surfaces share. The wording was tuned in
+// #2074 and then written twice — once in the plural over a page of sessions,
+// once in the singular over one — so an edit to either would have drifted from
+// the other without anything noticing.
+const nothingIsAboutThis = "No session is about this. Nothing matched the query,"
+
 // contextTierLead says what the session below it is, for a tier that is not an
 // exact match.
 //
@@ -1437,7 +1443,7 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 // a label on an answer (#2787, the shape #2074 fixed for the counted page).
 func contextTierLead(tier string) string {
 	if tier == search.TierRelevance {
-		return "No session is about this. Nothing matched the query, so the session below is the nearest by wording — treat it as a lead to check, not as a record, and say plainly if it does not answer.\n"
+		return nothingIsAboutThis + " so the session below is the nearest by wording — treat it as a lead to check, not as a record, and say plainly if it does not answer.\n"
 	}
 	return "[" + tier + "]\n"
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1420,12 +1420,26 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	search.PrintContext(&b, whole, q)
 	text := b.String()
 	if hits[0].Tier != search.TierExact {
-		text = "[" + hits[0].Tier + "]\n" + text
+		text = contextTierLead(hits[0].Tier) + text
 	}
 	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole),
 		// The search path reaches a promoted note as often as the id path
 		// does — the note carries the id in its own text.
 		forgottenSourceNote(whole, q, false), nil
+}
+
+// contextTierLead says what the session below it is, for a tier that is not an
+// exact match.
+//
+// A bare `[relevance]` marker was all an agent got above a whole session that
+// matched nothing — recall says "No session is about this" in a sentence, and
+// this tool, which returns far more text, said it in one word that reads like
+// a label on an answer (#2787, the shape #2074 fixed for the counted page).
+func contextTierLead(tier string) string {
+	if tier == search.TierRelevance {
+		return "No session is about this. Nothing matched the query, so the session below is the nearest by wording — treat it as a lead to check, not as a record, and say plainly if it does not answer.\n"
+	}
+	return "[" + tier + "]\n"
 }
 
 func mcpProgress() io.Writer {

--- a/cmd/deja/recall_context_tier_test.go
+++ b/cmd/deja/recall_context_tier_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// recall_context returns the most text of any tool — a whole session — and
+// said what it was in one bracketed word. `[relevance]` above a session that
+// matched nothing reads as a label on an answer, where recall says it in a
+// sentence (#2787, the shape #2074 fixed for the counted page).
+func TestTheContextLeadSaysWhatTheSessionIs(t *testing.T) {
+	lead := contextTierLead(search.TierRelevance)
+	if strings.HasPrefix(lead, "[") {
+		t.Errorf("a whole session is still introduced by a marker: %q", lead)
+	}
+	for _, want := range []string{"No session is about this", "nearest by wording", "not as a record"} {
+		if !strings.Contains(lead, want) {
+			t.Errorf("the lead does not say %q: %q", want, lead)
+		}
+	}
+}
+
+// The other tiers keep their marker: they did match, and the marker says how.
+func TestTheOtherTiersKeepTheirMarker(t *testing.T) {
+	for _, tier := range []string{search.TierError, search.TierSemantic, "close"} {
+		lead := contextTierLead(tier)
+		if !strings.HasPrefix(lead, "["+tier+"]") {
+			t.Errorf("%s lost its marker: %q", tier, lead)
+		}
+	}
+}

--- a/cmd/deja/recall_context_tier_test.go
+++ b/cmd/deja/recall_context_tier_test.go
@@ -25,10 +25,42 @@ func TestTheContextLeadSaysWhatTheSessionIs(t *testing.T) {
 
 // The other tiers keep their marker: they did match, and the marker says how.
 func TestTheOtherTiersKeepTheirMarker(t *testing.T) {
-	for _, tier := range []string{search.TierError, search.TierSemantic, "close"} {
+	for _, tier := range []string{search.TierError, search.TierSemantic, search.TierStemmed, search.TierClose} {
 		lead := contextTierLead(tier)
 		if !strings.HasPrefix(lead, "["+tier+"]") {
 			t.Errorf("%s lost its marker: %q", tier, lead)
 		}
+	}
+}
+
+// End to end, because the wiring is where the risk was: the lead has to reach
+// the agent, inside the frame, with the tier marker gone.
+func TestAnAgentAskingAboutSomethingAbsentIsToldSo(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"stalled retry frames parser pipeline empty"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "["+search.TierRelevance+"]") {
+		t.Errorf("a whole session still arrives under a bare marker:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, nothingIsAboutThis) {
+		t.Errorf("the agent is not told the session is not about its question:\n%s", firstLines(text, 4))
+	}
+}
+
+// One sentence, two surfaces: the page of sessions and the single session say
+// the same thing about the same situation.
+func TestBothRelevanceLeadsShareTheirSentence(t *testing.T) {
+	if !strings.Contains(contextTierLead(search.TierRelevance), nothingIsAboutThis) {
+		t.Error("the single-session lead drifted from the shared sentence")
+	}
+	dir := manySessionStore(t, 40)
+	text, err := callMCPTool(dir, "recall", []byte(`{"query":"stalled retry frames parser pipeline empty"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, nothingIsAboutThis) {
+		t.Errorf("the page of sessions drifted from the shared sentence:\n%s", firstLines(text, 4))
 	}
 }


### PR DESCRIPTION
Closes #2787, found by the reviewer on #2786.

`recall_context` returns the most text of any tool — a whole session — and said what it was in one bracketed word. `[relevance]` above a session that matched nothing reads as a label on an answer, which is the failure #2074 measured live: plausible material about the wrong thing, framed as a record.

It now leads with the same sentence `recall` uses, in the singular. The other tiers keep their marker: they did match, and the marker says how.