### PR TITLE
fix: how counts the withheld sessions the question matched, not the store's

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -180,7 +180,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 // hid, and an agent told nothing exists invents something.
 func howEntries(dir string, terms []string, project, activation string) ([]howEntry, int, int, error) {
 	pol := policy.Load()
-	hidden := 0
+	hidden := map[string]bool{}
 	// The other rule that takes sessions out of an answer. It is applied inside
 	// retrieval, and this screen reads the record log instead of ranking, so it
 	// was not applied here at all: a tree the reader asked deja to stay out of
@@ -189,14 +189,15 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 	ignored := map[string]bool{}
 	byCmd := map[string]*howEntry{}
 	err := index.EachRecordOfRole(dir, "command", func(meta index.SessionMeta, r index.Record) {
-		if !pol.Allows(activation, meta.Project) {
-			hidden++
-			return
-		}
-		if pol.Ignored(meta.Path, meta.Project) {
-			ignored[meta.Harness+":"+meta.ID] = true
-			return
-		}
+		// Whether the record is withheld is decided here; whether it was ever
+		// an answer to *this* question is decided below, and the counts are
+		// taken there. Counted here, they were store-wide: `how terraform` on
+		// a machine whose hidden sessions only ever ran `go test` said three
+		// matching sessions were being kept back, and "matching" is the word
+		// the sentence uses (#2766). `files` already scopes its number this
+		// way, by counting over hits that were searched.
+		denied := !pol.Allows(activation, meta.Project)
+		ign := !denied && pol.Ignored(meta.Path, meta.Project)
 		if project != "" && !strings.Contains(strings.ToLower(meta.Project), strings.ToLower(project)) {
 			return
 		}
@@ -213,6 +214,17 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 			if !commandMentions(low, strings.ToLower(t)) {
 				return
 			}
+		}
+		// In scope for the question, so now it is worth saying it is withheld.
+		// Sessions rather than records, which is the noun the line uses: two
+		// commands of one hidden session read as two hidden sessions.
+		if denied {
+			hidden[meta.Harness+":"+meta.ID] = true
+			return
+		}
+		if ign {
+			ignored[meta.Harness+":"+meta.ID] = true
+			return
 		}
 		e := byCmd[low]
 		if e == nil {
@@ -236,7 +248,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 	})
 	if err != nil {
-		return nil, hidden, len(ignored), fmt.Errorf("read: %w", err)
+		return nil, len(hidden), len(ignored), fmt.Errorf("read: %w", err)
 	}
 	out := make([]howEntry, 0, len(byCmd))
 	for _, e := range byCmd {
@@ -254,7 +266,7 @@ func howEntries(dir string, terms []string, project, activation string) ([]howEn
 		}
 		return out[i].Command < out[j].Command
 	})
-	return out, hidden, len(ignored), nil
+	return out, len(hidden), len(ignored), nil
 }
 
 func pluralRuns(n int) string {

--- a/cmd/deja/how_hidden_scope_test.go
+++ b/cmd/deja/how_hidden_scope_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// "the trust policy hides N matching sessions" counted every withheld command
+// record in the store — before the terms were checked and before --project.
+// So asking about terraform on a machine whose hidden sessions only ever ran
+// `go test` was told three matching sessions were being kept from it, and an
+// agent reading that has been handed a reason to distrust an honest answer
+// (#2766).
+func TestHowCountsOnlyWhatTheQuestionAsked(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// One hidden session, and what it ran has nothing to do with the question
+	// asked below.
+	body := `{"type":"user","sessionId":"sess-one","cwd":"/app","timestamp":"2026-10-01T09:00:00Z","message":{"role":"user","content":"run the suite"}}
+{"type":"assistant","sessionId":"sess-one","cwd":"/app","timestamp":"2026-10-01T09:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}
+{"type":"assistant","sessionId":"sess-one","cwd":"/app","timestamp":"2026-10-01T09:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go vet ./..."}}]}}
+`
+	if err := os.WriteFile(filepath.Join(proj, "sess-one.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+
+	cfg := filepath.Join(tmp, "config", "deja")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "policy.json"),
+		[]byte(`{"activations":{"search":{"local":false}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	if policy.Load().Allows(policy.ActivationSearch, "app") {
+		t.Fatal("the policy did not take effect, so this test would pass for the wrong reason")
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Asked about something the hidden session never ran.
+	_, hidden, _, err := howEntries(dir, []string{"terraform"}, "", policy.ActivationSearch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hidden != 0 {
+		t.Errorf("said %d sessions matching \"terraform\" are hidden; the hidden session ran go test", hidden)
+	}
+
+	// Asked about what it did run, the count has to survive — a scoped number
+	// that is always zero would pass the check above and hide a real leak.
+	_, hidden, _, err = howEntries(dir, []string{"vet"}, "", policy.ActivationSearch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hidden == 0 {
+		t.Error("a command the question does match was withheld with nothing said")
+	}
+}


### PR DESCRIPTION
Closes #2766.

Both counters ran before the term match and before `--project`, so the number was store-wide while the sentence said "the trust policy hides N **matching** sessions on this path". On a machine whose hidden sessions only ever ran `go test`, `deja how terraform` claimed matching sessions were being kept back — and an agent reading that has been handed a reason to distrust an honest answer.

Both are now taken after the record has been shown to answer the question, the way `files` already scopes its number.

The repro also turned up the noun: `hidden` counted *records*, so one hidden session with two commands read as two hidden sessions. It is a session set now, like `ignored` — the half #1641 fixed on the other side of the same sentence.

Test asserts both directions, since a scoped number that is always zero would pass the first check and hide a real leak. Mutation-checked both ways.