### PR TITLE
fix: the salvage scan finds a key where it is a key

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -166,15 +166,28 @@ func toolResponseText(raw json.RawMessage) string {
 	return clampOutput(b.String())
 }
 
-// after returns what follows key, or "" when the key is not there. Scoping the
-// salvage this way keeps it from mining the command in tool_input, which can
-// hold any of the keys below.
+// after returns what follows key where the key is used as a key — the next
+// non-space character is a colon — or "" when it is not there at all. Scoping
+// the salvage this way keeps it from mining the command in tool_input, which
+// can hold any of the keys below.
+//
+// The colon is the whole point. This took the first occurrence anywhere, and
+// on this path the payload is one the decoder could not read — a command
+// spliced in without escaping is how a payload gets that way — so a command
+// running `grep -n "tool_response" hook.go` moved the scope inside itself, and
+// the salvage returned what that same command echoed (#2051).
 func after(s, key string) string {
-	i := strings.Index(s, key)
-	if i < 0 {
-		return ""
+	for i := 0; ; {
+		j := strings.Index(s[i:], key)
+		if j < 0 {
+			return ""
+		}
+		at := i + j + len(key)
+		if rest := strings.TrimLeft(s[at:], " \t\r\n"); strings.HasPrefix(rest, ":") {
+			return s[at:]
+		}
+		i = i + j + 1
 	}
-	return s[i+len(key):]
 }
 
 // salvageToolOutput pulls the tool's output out of a payload the decoder could
@@ -183,16 +196,16 @@ func after(s, key string) string {
 // rather than error — correctly, for real tool output. So find where the value
 // starts, unescape what follows, and hand back that.
 func salvageToolOutput(raw string) string {
+	// `after` finds each key where it is a key, which is what keeps a mention
+	// of "stderr" inside another value from standing in for the field: read at
+	// the mention, the scan gave up on stderr and answered with stdout, the
+	// half of the payload without the error in it (#2051).
 	for _, key := range []string{`"stderr"`, `"error"`, `"output"`, `"stdout"`, `"content"`, `"result"`} {
-		i := strings.Index(raw, key)
-		if i < 0 {
+		at := after(raw, key)
+		if at == "" {
 			continue
 		}
-		v, ok := jsonStringAfter(raw[i+len(key):])
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(v) != "" {
+		if v, ok := jsonStringAfter(at); ok && strings.TrimSpace(v) != "" {
 			return v
 		}
 	}

--- a/cmd/deja/salvage_key_position_test.go
+++ b/cmd/deja/salvage_key_position_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The salvage path reads a payload the decoder could not — a cut megabyte of
+// build log. It looked for each key by its first occurrence anywhere in the
+// bytes, so a mention of the key inside a value stood in for the key itself
+// (#2051).
+func TestSalvageFindsTheKeyNotAMentionOfIt(t *testing.T) {
+	// "stderr" is named inside stdout before the real field arrives. Reading
+	// the mention, the scan gave up on stderr entirely and answered with
+	// stdout — the wrong half of the payload, and the half without the error.
+	// Unescaped on purpose, as above: escaping is what keeps this from
+	// happening in a payload the decoder accepted.
+	raw := `{"stdout":"nothing here, see "stderr" for the failure","stderr":"ld: symbol(s) not found"}`
+	if got := salvageToolOutput(raw); !strings.Contains(got, "symbol(s) not found") {
+		t.Errorf("a mention of the key stood in for the key: %q", got)
+	}
+}
+
+// The salvage is scoped to what follows "tool_response" precisely so it cannot
+// mine the command in tool_input. Scoping on the first occurrence, a command
+// that names the key moved the scope inside itself.
+func TestScopingIsNotMovedByTheCommandNamingTheKey(t *testing.T) {
+	// Unescaped on purpose: this path exists for payloads the decoder could not
+	// read, and a command spliced in without escaping is how one gets that way.
+	raw := `{"tool_name":"Bash","tool_input":{"command":"grep -n "tool_response" hook.go && echo {"stderr": "mined"}"},` +
+		`"tool_response":{"stderr":"ld: symbol(s) not found"}}`
+	got := salvageToolOutput(after(raw, `"tool_response"`))
+	if strings.Contains(got, "mined") {
+		t.Errorf("the salvage mined the command it is scoped away from: %q", got)
+	}
+	if !strings.Contains(got, "symbol(s) not found") {
+		t.Errorf("the real output was not salvaged: %q", got)
+	}
+}


### PR DESCRIPTION
The second half of #2051. Both flaws it names come from the same thing — a key looked up by its first occurrence anywhere in the bytes — and one fix covers them: `after` now returns what follows the key only where the next non-space character is a colon.

Reproducing it took a correction worth recording. My first two attempts passed, because I wrote the payloads with JSON escaping and `\"stderr\"` does not contain `"stderr"`. In a payload the decoder accepted, this cannot happen at all. But this path exists *for payloads the decoder could not read*, and a command spliced in without escaping is how one gets that way — written unescaped, both flaws reproduce:

- `grep -n "tool_response" hook.go && echo {"stderr": "mined"}` moved the scope inside the command, and salvage returned `mined` — mining the command the scoping exists to keep it away from;
- a mention of `"stderr"` inside `"stdout"` stood in for the field, so the scan gave up on stderr and answered with stdout, the half of the payload without the error in it.

I also wrote a per-key loop over all occurrences, and threw it away: with `after` fixed the mutation for it would not go red, and a duplicate key inside one object is not a payload shape worth carrying code for.

**The first half of #2051 does not reproduce.** `commandFailed` reads `strings.LastIndex` over the whole record, not the stored first line, so a heredoc that exited non-zero is skipped at pairing time — I ran it both ways to check. Leaving that issue open only if you disagree with the reading; the pairing side looks closed to me.