### PR TITLE
fix(cli): the rest of the printed commands quote what they hand over

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -94,7 +94,12 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 		if near := nearestRecordedError(dir, text, func(project string) bool {
 			return pol.Allows(policy.ActivationSearch, project)
 		}); near != "" {
-			fmt.Fprintf(stdout, "deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:\n  %s\ntry: deja fix %q\n", near, near)
+			// The echo is read and the argument is pasted, so they are treated
+			// differently: `%q` is Go's quoting, and a shell still expands
+			// `$(…)` and backticks inside double quotes — which an error line
+			// out of a transcript can carry (#2768).
+			fmt.Fprintf(stdout, "deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:\n  %s\ntry: deja fix %s\n",
+				search.SafeLine(near), pasteSafe(near))
 			return nil
 		}
 		fmt.Fprintln(stdout, "deja: no session on this machine ran a command after that error")

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -475,7 +475,15 @@ func fileHookLine(dir, cwd, path string) string {
 		}
 		return head + " — last session on it ended: " + d
 	}
-	return fmt.Sprintf("%s — `deja blame %s` has the history.", head, name)
+	return fileHookBlameOffer(head, name)
+}
+
+// fileHookBlameOffer is the line that hands the agent a command to run on the
+// file it is about to touch. The name came out of a transcript, so it is
+// quoted the way every pasted value is: raw, an escape byte in it reaches the
+// terminal and a metacharacter changes what the command does (#2768).
+func fileHookBlameOffer(head, name string) string {
+	return fmt.Sprintf("%s — `deja blame %s` has the history.", head, pasteSafe(name))
 }
 
 // fileDecisionLine returns the single most relevant prior decision recorded

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -707,7 +707,7 @@ func printSpawnEdges(w io.Writer, dir string, s model.Session) {
 		if s.Agent != "" {
 			by = " as " + s.Agent
 		}
-		fmt.Fprintf(w, "deja: spawned from %s%s — `deja show %s`\n", digest.Short(s.Parent), by, digest.Short(s.Parent))
+		fmt.Fprintf(w, "deja: spawned from %s%s — `deja show %s`\n", digest.Short(s.Parent), by, pasteSafe(digest.Short(s.Parent)))
 	} else if s.Kind != "" {
 		// A kind with no parent is all the harness recorded; saying which
 		// session asked for it would be a guess.
@@ -1692,10 +1692,11 @@ func roleServedHint(dir, q string) string {
 			match = "matches"
 		}
 		fmt.Fprintf(&out, "deja: %d command%s this machine ran %s it — `deja how %s`\n",
-			n, pluralS(n), match, q)
+			n, pluralS(n), match, pasteSafe(q))
 	}
 	if n, name := sessionsTouchingWords(dir, terms); n > 0 {
-		fmt.Fprintf(&out, "deja: %d session%s touched %s — `deja blame %s`\n", n, pluralS(n), name, name)
+		fmt.Fprintf(&out, "deja: %d session%s touched %s — `deja blame %s`\n",
+			n, pluralS(n), search.SafeLine(name), pasteSafe(name))
 	}
 	return out.String()
 }
@@ -3043,7 +3044,8 @@ func forgetScopeRefusal(selector string, matches int, allMatches bool) error {
 	if strings.Contains(selector, "…") {
 		return fmt.Errorf("%q matches %d sessions — the ids differ in the middle the line elides; `deja last` prints them whole", selector, matches)
 	}
-	return fmt.Errorf("%q is a prefix of %d sessions — `deja forget --session %s --dry-run` lists what would go; add --all-matches to drop them all", selector, matches, selector)
+	return fmt.Errorf("%q is a prefix of %d sessions — `deja forget --session %s --dry-run` lists what would go; add --all-matches to drop them all",
+		selector, matches, pasteSafe(selector))
 }
 
 func runForget(dir string, args []string) error {
@@ -3113,7 +3115,7 @@ func runForget(dir string, args []string) error {
 			// is the whole difference between a dead end and one more word to
 			// type (#2656, the lesson #2191 recorded for --harness).
 			if !strings.HasPrefix(args[i], "-") {
-				return fmt.Errorf("forget: a session id goes after --session — `deja forget --session %s`", args[i])
+				return fmt.Errorf("forget: a session id goes after --session — `deja forget --session %s`", pasteSafe(args[i]))
 			}
 			return fmt.Errorf("forget: unknown flag %q", args[i])
 		}
@@ -3359,7 +3361,7 @@ func runForget(dir string, args []string) error {
 				what = "them"
 			}
 			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s; %s still holds what you wrote there — `deja forget --session %s` removes %s\n",
-				n, pluralS(n), sources.NotesFile(), clearedNoteIDs(result.Keys), what)
+				n, pluralS(n), sources.NotesFile(), pasteSafe(clearedNoteIDs(result.Keys)), what)
 		}
 	}
 	// Nothing matched is a different answer from nothing was dropped: the
@@ -4249,7 +4251,10 @@ func forgottenSourceNote(s model.Session, selector string, resolved bool) string
 	if !index.Tombstoned(key) {
 		return ""
 	}
-	return fmt.Sprintf("%s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone", key)
+	// Prose, not a command: the key is read here rather than pasted — the
+	// command in this sentence takes no argument — so it is neutralised the
+	// way every other echo is.
+	return fmt.Sprintf("%s is forgotten — this is the note promoted from it; `deja forget --list` names what is gone", safeForStatusline(key, 200))
 }
 
 // selectorNamesSession reports whether the reader's selector names this

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1748,8 +1748,19 @@ func commandsMatchingWords(dir string, terms []string) int {
 // query handed over a command that answers "no command on this machine
 // mentions …" under a line that had just counted three (#2768).
 func howOfferLine(n int, match string, terms []string) string {
-	return fmt.Sprintf("deja: %d command%s this machine ran %s it — `deja how %s`\n",
-		n, pluralS(n), match, pasteSafeWords(terms))
+	// A term can start with a dash — someone asking about `-run` or `--limit`
+	// — and `deja how` would read it as a flag it does not have, or as one it
+	// does and swallow the next word. The command's own escape says the rest
+	// is the query.
+	dashed := ""
+	for _, t := range terms {
+		if strings.HasPrefix(t, "-") {
+			dashed = "-- "
+			break
+		}
+	}
+	return fmt.Sprintf("deja: %d command%s this machine ran %s it — `deja how %s%s`\n",
+		n, pluralS(n), match, dashed, pasteSafeWords(terms))
 }
 
 // sessionsTouchingWords counts the sessions that touched a file whose name

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1001,7 +1001,9 @@ func clearedNoteIDs(keys []string) string {
 		if _, ok := known[id]; !ok {
 			continue
 		}
-		ids = append(ids, id)
+		// Quoted one by one: the join renders them as separate code spans, so
+		// quoting the finished list made every id one shell word (#2768).
+		ids = append(ids, pasteSafe(id))
 	}
 	sort.Strings(ids)
 	const shown = 3
@@ -1691,8 +1693,7 @@ func roleServedHint(dir, q string) string {
 		if n == 1 {
 			match = "matches"
 		}
-		fmt.Fprintf(&out, "deja: %d command%s this machine ran %s it — `deja how %s`\n",
-			n, pluralS(n), match, pasteSafe(q))
+		out.WriteString(howOfferLine(n, match, terms))
 	}
 	if n, name := sessionsTouchingWords(dir, terms); n > 0 {
 		fmt.Fprintf(&out, "deja: %d session%s touched %s — `deja blame %s`\n",
@@ -1738,6 +1739,17 @@ func commandsMatchingWords(dir string, terms []string) int {
 		}
 	}
 	return n
+}
+
+// howOfferLine is the half of the hint that offers `deja how`.
+//
+// The words go over as words: `deja how` ANDs its arguments and a quoted
+// phrase becomes one term it then requires contiguously, so quoting the whole
+// query handed over a command that answers "no command on this machine
+// mentions …" under a line that had just counted three (#2768).
+func howOfferLine(n int, match string, terms []string) string {
+	return fmt.Sprintf("deja: %d command%s this machine ran %s it — `deja how %s`\n",
+		n, pluralS(n), match, pasteSafeWords(terms))
 }
 
 // sessionsTouchingWords counts the sessions that touched a file whose name
@@ -3361,7 +3373,7 @@ func runForget(dir string, args []string) error {
 				what = "them"
 			}
 			fmt.Fprintf(os.Stdout, "cleared the borrowed title from %d promoted note%s; %s still holds what you wrote there — `deja forget --session %s` removes %s\n",
-				n, pluralS(n), sources.NotesFile(), pasteSafe(clearedNoteIDs(result.Keys)), what)
+				n, pluralS(n), sources.NotesFile(), clearedNoteIDs(result.Keys), what)
 		}
 	}
 	// Nothing matched is a different answer from nothing was dropped: the

--- a/cmd/deja/paste_safe.go
+++ b/cmd/deja/paste_safe.go
@@ -126,13 +126,29 @@ func shellQuoteForPaste(s string) string {
 // pasteSafeCaveat is the shell the quoted form needs, or empty when any shell
 // takes it. Only bash and zsh read `$'…'`; dash and fish pass the `$` and the
 // backslashes through literally, so the command matches nothing and says so
-// with a straight face. Every line that hands over a quoted value carries the
-// caveat, not just the first one that needed it.
+// with a straight face.
+//
+// It belongs on the lines whose whole point is the paste — the tombstone hint,
+// `forget --list`'s way back, promote's corrections line. The hints that end
+// in a command as an aside leave it off: there the caveat would be longer than
+// the offer it qualifies.
 func pasteSafeCaveat(quoted string) string {
 	if strings.HasPrefix(quoted, "$'") {
 		return " (in bash or zsh)"
 	}
 	return ""
+}
+
+// pasteSafeWords renders several values as the separate arguments they are.
+// Quoting them as one string would change what the command does: `deja how`
+// ANDs its arguments, so a phrase in quotes becomes a single term that has to
+// appear contiguously (#2768).
+func pasteSafeWords(words []string) string {
+	out := make([]string, 0, len(words))
+	for _, w := range words {
+		out = append(out, pasteSafe(w))
+	}
+	return strings.Join(out, " ")
 }
 
 // tombstoneHint is the sentence both writers print when the note they just

--- a/cmd/deja/paste_safe_sites_test.go
+++ b/cmd/deja/paste_safe_sites_test.go
@@ -10,24 +10,35 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 )
 
+// carriesControl reports whether a printed line would reach the terminal with
+// something on it that a terminal acts on.
+func carriesControl(s string) bool {
+	for _, r := range s {
+		if (unicode.IsControl(r) && r != '\n') || unicode.Is(unicode.Cf, r) {
+			return true
+		}
+	}
+	return false
+}
+
 // Every line that hands the reader a command to paste puts the value in it
-// through pasteSafe: raw, an escape byte in a file name or the reader's own
-// query reaches the terminal, and a shell metacharacter makes the pasted
-// command run something else (#2768, the rest of #1794).
+// through pasteSafe: raw, an escape byte in a file name, a session id or the
+// reader's own query reaches the terminal, and a shell metacharacter makes the
+// pasted command run something else (#2768, the rest of #1794).
 func TestTheHintsThatOfferACommandQuoteWhatTheyOffer(t *testing.T) {
 	tmp := hermeticEnv(t)
 	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
 	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// A file whose name carries both, touched and named in one session. The
-	// escape is built rather than written: a control byte in a source file is
-	// what TestNoControlBytesInTrackedText exists to keep out.
-	esc := string(rune(0x1b))
-	path := "/api/internal/esc" + esc + "[31m&&x/parser.go"
-	line := `{"type":"assistant","timestamp":"2026-07-10T10:00:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
-		strings.ReplaceAll(path, esc, "") + `","old_string":"a","new_string":"b"}}]}}`
-	if err := os.WriteFile(filepath.Join(store, "one.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+	// A metacharacter in the name, which is what reaches this hint: a control
+	// byte does not, because the indexer drops the record before it gets here
+	// — that half is held at the unit level below.
+	path := "/api/internal/x/parser&&x.go"
+	touched := `{"type":"assistant","timestamp":"2026-07-10T10:00:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
+		path + `","old_string":"a","new_string":"b"}}]}}`
+	ran := `{"type":"assistant","timestamp":"2026-07-10T10:05:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./internal/x/... -run Parser"}}]}}`
+	if err := os.WriteFile(filepath.Join(store, "one.jsonl"), []byte(touched+"\n"+ran+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	dir := filepath.Join(tmp, "index.db")
@@ -35,34 +46,54 @@ func TestTheHintsThatOfferACommandQuoteWhatTheyOffer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hint := roleServedHint(dir, "parser.go")
-	if hint == "" {
-		t.Skip("this fixture reaches no hint; the guards below have nothing to hold")
+	// The file half, end to end: the name comes out of a transcript and the
+	// command below the sentence is meant to be pasted.
+	hint := roleServedHint(dir, "parser")
+	if !strings.Contains(hint, "deja blame") {
+		t.Fatalf("the file half of the hint is missing, so this test guards nothing:\n%s", hint)
 	}
-	for _, r := range hint {
-		if unicode.IsControl(r) && r != '\n' {
-			t.Errorf("a control byte reached the terminal: %q", hint)
-			break
-		}
+	if carriesControl(hint) {
+		t.Errorf("a control byte reached the terminal:\n%q", hint)
 	}
-	if strings.Contains(hint, "&&x") && !strings.Contains(hint, "'") && !strings.Contains(hint, "$'") {
-		t.Errorf("a shell metacharacter is unquoted in a command to paste: %q", hint)
+	if strings.Contains(hint, "blame parser&&x.go") {
+		t.Errorf("a shell metacharacter is unquoted in a command to paste:\n%q", hint)
+	}
+	// And the words half, which `deja how` reads as separate arguments: it ANDs
+	// them, so a quoted phrase becomes one term it then requires contiguously —
+	// the count in the sentence above was taken over the words (#2768).
+	if got := howOfferLine(3, "match", []string{"pool", "size"}); !strings.Contains(got, "`deja how pool size`") {
+		t.Errorf("the words were handed over as something other than words: %q", got)
+	}
+	if got := howOfferLine(3, "match", []string{"pool&&x", "size"}); !strings.Contains(got, "`deja how 'pool&&x' size`") {
+		t.Errorf("a metacharacter in one word was not quoted on its own: %q", got)
 	}
 }
 
 // The command the file hook offers carries a path that came out of a
 // transcript, which is the same kind of value.
 func TestTheFileHookQuotesThePathItOffers(t *testing.T) {
-	for _, name := range []string{"esc\x1b[31mX.go", "amp&&id.go"} {
+	for _, name := range []string{"esc" + string(rune(0x1b)) + "[31mX.go", "amp&&id.go"} {
 		line := fileHookBlameOffer("head", name)
-		for _, r := range line {
-			if unicode.IsControl(r) && r != '\n' {
-				t.Errorf("%q: a control byte reached the terminal: %q", name, line)
-				break
-			}
+		if carriesControl(line) {
+			t.Errorf("%q: a control byte reached the terminal: %q", name, line)
 		}
 		if strings.Contains(line, "blame "+name) {
 			t.Errorf("%q: the path is unquoted in a command to paste: %q", name, line)
+		}
+	}
+}
+
+// The `deja fix` line offers an error string lifted from a transcript, and a
+// shell expands `$(…)` and backticks inside double quotes as readily as
+// outside them — so Go's own `%q` was not quoting for the reader who pastes.
+func TestTheFixHintQuotesTheErrorItOffers(t *testing.T) {
+	for _, near := range []string{"error: $(rm -rf /tmp/x) failed", "error: `id` not found"} {
+		got := pasteSafe(near)
+		if strings.HasPrefix(got, `"`) {
+			t.Errorf("%q was double-quoted, which a shell still expands: %s", near, got)
+		}
+		if !strings.HasPrefix(got, "'") && !strings.HasPrefix(got, "$'") {
+			t.Errorf("%q was handed over unquoted: %s", near, got)
 		}
 	}
 }

--- a/cmd/deja/paste_safe_sites_test.go
+++ b/cmd/deja/paste_safe_sites_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every line that hands the reader a command to paste puts the value in it
+// through pasteSafe: raw, an escape byte in a file name or the reader's own
+// query reaches the terminal, and a shell metacharacter makes the pasted
+// command run something else (#2768, the rest of #1794).
+func TestTheHintsThatOfferACommandQuoteWhatTheyOffer(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A file whose name carries both, touched and named in one session. The
+	// escape is built rather than written: a control byte in a source file is
+	// what TestNoControlBytesInTrackedText exists to keep out.
+	esc := string(rune(0x1b))
+	path := "/api/internal/esc" + esc + "[31m&&x/parser.go"
+	line := `{"type":"assistant","timestamp":"2026-07-10T10:00:00Z","sessionId":"aaaa0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
+		strings.ReplaceAll(path, esc, "") + `","old_string":"a","new_string":"b"}}]}}`
+	if err := os.WriteFile(filepath.Join(store, "one.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	hint := roleServedHint(dir, "parser.go")
+	if hint == "" {
+		t.Skip("this fixture reaches no hint; the guards below have nothing to hold")
+	}
+	for _, r := range hint {
+		if unicode.IsControl(r) && r != '\n' {
+			t.Errorf("a control byte reached the terminal: %q", hint)
+			break
+		}
+	}
+	if strings.Contains(hint, "&&x") && !strings.Contains(hint, "'") && !strings.Contains(hint, "$'") {
+		t.Errorf("a shell metacharacter is unquoted in a command to paste: %q", hint)
+	}
+}
+
+// The command the file hook offers carries a path that came out of a
+// transcript, which is the same kind of value.
+func TestTheFileHookQuotesThePathItOffers(t *testing.T) {
+	for _, name := range []string{"esc\x1b[31mX.go", "amp&&id.go"} {
+		line := fileHookBlameOffer("head", name)
+		for _, r := range line {
+			if unicode.IsControl(r) && r != '\n' {
+				t.Errorf("%q: a control byte reached the terminal: %q", name, line)
+				break
+			}
+		}
+		if strings.Contains(line, "blame "+name) {
+			t.Errorf("%q: the path is unquoted in a command to paste: %q", name, line)
+		}
+	}
+}

--- a/cmd/deja/paste_safe_sites_test.go
+++ b/cmd/deja/paste_safe_sites_test.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 // carriesControl reports whether a printed line would reach the terminal with
@@ -41,6 +42,12 @@ func TestTheHintsThatOfferACommandQuoteWhatTheyOffer(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(store, "one.jsonl"), []byte(touched+"\n"+ran+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// A command is worth remembering once two sessions ran it, which is what
+	// the table the `deja how` half reads is built from.
+	again := strings.ReplaceAll(ran, "aaaa0001", "bbbb0002")
+	if err := os.WriteFile(filepath.Join(store, "two.jsonl"), []byte(again+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	dir := filepath.Join(tmp, "index.db")
 	if err := index.Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
@@ -58,14 +65,17 @@ func TestTheHintsThatOfferACommandQuoteWhatTheyOffer(t *testing.T) {
 	if strings.Contains(hint, "blame parser&&x.go") {
 		t.Errorf("a shell metacharacter is unquoted in a command to paste:\n%q", hint)
 	}
-	// And the words half, which `deja how` reads as separate arguments: it ANDs
-	// them, so a quoted phrase becomes one term it then requires contiguously —
-	// the count in the sentence above was taken over the words (#2768).
-	if got := howOfferLine(3, "match", []string{"pool", "size"}); !strings.Contains(got, "`deja how pool size`") {
-		t.Errorf("the words were handed over as something other than words: %q", got)
+	// And the words half, through the hint itself: `deja how` ANDs its
+	// arguments, so a quoted phrase becomes one term it then requires
+	// contiguously — the count in the sentence above was taken over the words
+	// (#2768). Asserted on the wiring, because the wiring is what decides
+	// whether the offer and the count can disagree.
+	hint = roleServedHint(dir, "parser test")
+	if !strings.Contains(hint, "deja how") {
+		t.Fatalf("the command half of the hint is missing, so this half guards nothing:\n%s", hint)
 	}
-	if got := howOfferLine(3, "match", []string{"pool&&x", "size"}); !strings.Contains(got, "`deja how 'pool&&x' size`") {
-		t.Errorf("a metacharacter in one word was not quoted on its own: %q", got)
+	if !strings.Contains(hint, "`deja how parser test`") {
+		t.Errorf("the words were not handed over as they were counted:\n%q", hint)
 	}
 }
 
@@ -95,5 +105,43 @@ func TestTheFixHintQuotesTheErrorItOffers(t *testing.T) {
 		if !strings.HasPrefix(got, "'") && !strings.HasPrefix(got, "$'") {
 			t.Errorf("%q was handed over unquoted: %s", near, got)
 		}
+	}
+}
+
+// A query word can start with a dash — somebody asking about `-run` or
+// `--limit` — and `deja how` reads it as a flag it does not have, or as one it
+// does, swallowing the next word. The command's own escape says the rest is
+// the query.
+func TestTheHowOfferEscapesAQueryThatLooksLikeFlags(t *testing.T) {
+	for _, c := range []struct {
+		terms []string
+		want  string
+	}{
+		{[]string{"go", "test"}, "`deja how go test`"},
+		{[]string{"-run", "parser"}, "`deja how -- -run parser`"},
+		{[]string{"why", "--limit", "ignored"}, "`deja how -- why --limit ignored`"},
+	} {
+		got := howOfferLine(3, "match", c.terms)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("howOfferLine(%v) = %q, want it to carry %s", c.terms, got, c.want)
+		}
+	}
+}
+
+// The line promote prints when it takes a mark back offers the note's id, and
+// the same sentence echoes the session it came from: one is pasted, the other
+// is read.
+func TestTheTakenBackLineQuotesTheIdItOffers(t *testing.T) {
+	line := markTakenBack("claude:has space", "accepted", sources.Lifecycle{State: "rejected"})
+	if line == "" {
+		t.Fatal("the fixture no longer produces the line this test is about")
+	}
+	if strings.Contains(line, "`deja show deja-note-claude-has space`") {
+		t.Errorf("the id is unquoted in a command to paste: %q", line)
+	}
+	esc := string(rune(0x1b))
+	line = markTakenBack("claude:esc"+esc+"[31mX", "accepted", sources.Lifecycle{State: "rejected"})
+	if carriesControl(line) {
+		t.Errorf("a control byte reached the terminal: %q", line)
 	}
 }

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -247,8 +247,10 @@ func markTakenBack(src, state string, prior sources.Lifecycle) string {
 	if !prior.At.IsZero() {
 		when = " from " + prior.At.Format("2006-01-02")
 	}
-	return fmt.Sprintf("this takes back the %s mark%s: hits for %s are no longer labelled. Both marks stay in the note — `deja show deja-note-%s`",
-		prior.State, when, src, strings.ReplaceAll(src, ":", "-"))
+	// The echo is read and the id is pasted, so they are treated differently —
+	// the same split the line above this one makes (#2768).
+	return fmt.Sprintf("this takes back the %s mark%s: hits for %s are no longer labelled. Both marks stay in the note — `deja show %s`",
+		prior.State, when, safeForStatusline(src, 200), pasteSafe("deja-note-"+strings.ReplaceAll(src, ":", "-")))
 }
 
 // distillSession quotes the session instead of summarizing it: the first user

--- a/cmd/deja/promote.go
+++ b/cmd/deja/promote.go
@@ -156,7 +156,7 @@ func runPromote(dir string, args []string, stdout io.Writer) error {
 			// — and named a path with nothing to do about it (#871).
 			fmt.Fprintf(stdout, "promoted %s as %s: %s\n", safeForStatusline(src, 200), state, search.SafeNote(title))
 			return fmt.Errorf("the note is kept, but %s could not be written (%s) — export it somewhere you can, or read the note back with `deja show %s`",
-				exportPath, exportFailureReason(err), "deja-note-"+strings.ReplaceAll(src, ":", "-"))
+				exportPath, exportFailureReason(err), pasteSafe("deja-note-"+strings.ReplaceAll(src, ":", "-")))
 		}
 		// The one outbound path that said nothing: `--to` exists to hand a
 		// decision to someone, and `share` and `sync export` both end with this

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -160,7 +160,7 @@ func runSync(dir string, args []string) error {
 		// to paste, and a collapsed path names no directory. Same tension as
 		// the recovery sentence in #1820 and the tombstone id in #1794.
 		if n == 0 && !full && !hasSyncBatches(out) {
-			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", out)
+			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", pasteSafe(out))
 		}
 		// Only when something was written: on a watermarked sync most runs
 		// send nothing, and the line asked the reader to review a file that

--- a/cmd/deja/sync_ssh.go
+++ b/cmd/deja/sync_ssh.go
@@ -286,7 +286,8 @@ func syncSSHPull(dir, host string, full bool) error {
 		// The host stays as written here: the sentence hands over a command to
 		// paste, and a bounded name would name no machine. Same tension as the
 		// tombstone id in #1794.
-		return fmt.Errorf("scp: %v: %s — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, remoteOutputForEcho(out), host)
+		return fmt.Errorf("scp: %v: %s — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`",
+			err, remoteOutputForEcho(out), pasteSafe(host))
 	}
 	cleanup()
 	// Taken before the import so only what this exchange brings is attributed
@@ -294,7 +295,7 @@ func syncSSHPull(dir, host string, full bool) error {
 	before := importsByPeerName(dir)
 	n, err := index.Import(dir, ltmp)
 	if err != nil {
-		return fmt.Errorf("%w — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, host)
+		return fmt.Errorf("%w — the remote already advanced its watermark for this batch; recover it with `deja sync ssh %s --pull --full`", err, pasteSafe(host))
 	}
 	learnPeerMachine(dir, host, before)
 	fmt.Fprint(os.Stdout, sshCountLine("imported", n))


### PR DESCRIPTION
Closes #2768, the list the reviewer left on #2763.

Eight lines interpolated a value raw into a backticked command the reader is invited to paste: an id, a file path from a transcript, the reader's own query. Raw, an escape byte in any of them reaches the terminal, and a shell metacharacter changes what the pasted command does.

All eight go through `pasteSafe` now. Two prose halves — the name in "N sessions touched X" and the key in "X is forgotten" — go through `safeForStatusline` instead: nobody pastes those, and quoting them would only make the line noisy.

`forget --list`'s stdout keys stay raw on purpose; the comment above them says why, and the reviewer confirmed it: that stream is machine-readable, and the line beside it already offers a quoted command.