### PR TITLE
fix: the error and relevance tiers keep a note ahead of its own transcript

### DIFF
--- a/internal/search/note_lift_tiers_test.go
+++ b/internal/search/note_lift_tiers_test.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The note-over-source rule lived in the sort, so it reached the tiers that go
+// through it and missed the two that arrive already ranked: a pasted error and
+// the "ranked by relevance" screen served a note behind the transcript it was
+// distilled from — the one ordering `promote` prints a promise about (#2803).
+func TestTheErrorAndRelevanceTiersLiftANoteOverItsSource(t *testing.T) {
+	note := model.Session{ID: "deja-note-claude-sess1", Harness: "deja",
+		Messages: []model.Message{{Role: "user", Text: "pgbouncer pool cap settled at 40"}}}
+	source := model.Session{ID: "sess1", Harness: "claude",
+		Messages: []model.Message{{Role: "user", Text: "pgbouncer pool cap settled at 40 after a long argument"}}}
+	other := model.Session{ID: "other", Harness: "claude",
+		Messages: []model.Message{{Role: "user", Text: "pgbouncer restarts on deploy"}}}
+
+	// Ranked with the source ahead of its own note, which is the order the
+	// callers of these two builders hand in.
+	ranked := []model.Session{other, source, note}
+
+	for _, tc := range []struct {
+		name string
+		hits []Hit
+	}{
+		{"error", ErrorHits(ranked)},
+		{"relevance", RelevanceHitsWeighted(ranked, []string{"pgbouncer", "pool"}, nil)},
+	} {
+		var at = map[string]int{}
+		for i, h := range tc.hits {
+			at[h.Session.ID] = i
+		}
+		if at["deja-note-claude-sess1"] > at["sess1"] {
+			t.Errorf("%s: the note is behind the transcript it was promoted from: %v", tc.name, liftIDs(tc.hits))
+		}
+		// The scores have to agree with the order, or a caller that re-sorts
+		// reads the old one back.
+		for i := 1; i < len(tc.hits); i++ {
+			if tc.hits[i-1].Score < tc.hits[i].Score {
+				t.Errorf("%s: score disagrees with position at %d: %v", tc.name, i, liftIDs(tc.hits))
+			}
+		}
+		// And nothing else moved: the rule reorders one pair.
+		if at["other"] != 0 {
+			t.Errorf("%s: an unrelated session was moved: %v", tc.name, liftIDs(tc.hits))
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -622,6 +622,23 @@ func scoreBM25(documents []bm25Document, df []int, corpusDocuments int, avgLengt
 	return hits
 }
 
+// liftedNotes applies the note-over-source rule to a tier that ranks by
+// position rather than by a score the sort respects, and re-stamps the scores
+// so a caller that re-sorts reads the same order back.
+//
+// The rule lived in the sort, so it reached the tiers that go through it and
+// missed the two that build their hits already ranked: a pasted error and the
+// "ranked by relevance" screen put a note behind the transcript it was
+// distilled from, which is the ordering `promote` prints a promise about
+// (#2803).
+func liftedNotes(hits []Hit) []Hit {
+	liftNotesAboveTheirSource(hits)
+	for i := range hits {
+		hits[i].Score = float64(len(hits) - i)
+	}
+	return hits
+}
+
 // liftNotesAboveTheirSource keeps a promoted note in front of the transcript it
 // was distilled from. The two say the same thing, so nothing is buried by the
 // swap — but the note says it in one line with a state attached, and that is
@@ -2161,7 +2178,7 @@ func ErrorHits(ss []model.Session) []Hit {
 		}
 		hits = append(hits, hit)
 	}
-	return hits
+	return liftedNotes(hits)
 }
 
 // sessionHolds says whether a term appears anywhere in a session, stopping at
@@ -2303,7 +2320,7 @@ func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]fl
 		hit.Score = float64(len(ss) - rank)
 		hits = append(hits, hit)
 	}
-	return hits
+	return liftedNotes(hits)
 }
 
 // SafeText neutralises what a terminal acts on rather than prints. Transcript


### PR DESCRIPTION
Two of the four gaps in #2803 — the ones where the rule simply was not called.

`liftNotesAboveTheirSource` sat in `sortHits`, so it reached the tiers that go through the sort and missed the two that build their hits already ranked: `ErrorHits` and `RelevanceHitsWeighted`. A pasted error and the "ranked by relevance" screen therefore served a note behind the transcript it was distilled from — the one ordering `promote` prints a promise about.

Both builders now return through `liftedNotes`, which applies the rule and re-stamps the position-derived scores so a caller that re-sorts reads the same order back. That second half is not decoration: both tiers score by rank, and lifting without re-stamping leaves a score that says the old order. There is a mutation for it.

Not in this PR, and still open on the issue: the semantic fallback cuts to the top 10 by cosine and drops anything under the floor before the lift can see it — a note worded further from the query than its transcript is *cut*, not misordered, which is a different fix. And the prompt hook ranks `[]model.Session` and never builds a `Hit`, so there is no rule there to reach.

I said on the issue that I was taking these two, so the hunt branch and I do not write it twice.