### PR TITLE
fix(fix): take an error line that starts with a dash

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -36,11 +36,22 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 				return fmt.Errorf("fix: --limit wants a positive number, got %q", args[i])
 			}
 			limit = n
+		case "--":
+			// An error line can start with a dash, and Go's own test output is
+			// the commonest one a reader pastes: `deja fix -- '--- FAIL: …'`
+			// (#2799).
+			parts = append(parts, args[i+1:]...)
+			i = len(args)
 		default:
 			// A flag deja does not know must not be swallowed into the error
 			// text — `deja fix "..." --json` used to search for a string that
 			// contained "--json" and answer "no session ran a command".
-			if strings.HasPrefix(args[i], "-") && args[i] != "-" {
+			//
+			// A pasted failure line is the exception: it starts with the three
+			// dashes go test writes, no flag has that shape, and refusing it
+			// left the reader with a command deja itself had printed and
+			// nothing that would run it (#2799).
+			if strings.HasPrefix(args[i], "-") && args[i] != "-" && !looksLikeAPastedLine(args[i]) {
 				return fmt.Errorf("fix: unknown flag %q", args[i])
 			}
 			parts = append(parts, args[i])
@@ -98,8 +109,8 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			// differently: `%q` is Go's quoting, and a shell still expands
 			// `$(…)` and backticks inside double quotes — which an error line
 			// out of a transcript can carry (#2768).
-			fmt.Fprintf(stdout, "deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:\n  %s\ntry: deja fix %s\n",
-				search.SafeLine(near), pasteSafe(near))
+			fmt.Fprintf(stdout, "deja: nothing recorded for that line — deja matches a whole error line, and the closest it holds is:\n  %s\ntry: %s\n",
+				search.SafeLine(near), fixHintCommand(near))
 			return nil
 		}
 		fmt.Fprintln(stdout, "deja: no session on this machine ran a command after that error")
@@ -148,4 +159,21 @@ func nearestRecordedError(dir, text string, allow func(string) bool) string {
 		}
 	}
 	return search.SafeLine(best)
+}
+
+// looksLikeAPastedLine tells a mistyped flag from an error line that happens to
+// start with one. A flag is one word; what a reader pastes is a sentence, and
+// the shape that brought this up is go test's "--- FAIL: TestX (0.01s)".
+func looksLikeAPastedLine(arg string) bool {
+	return strings.HasPrefix(arg, "--- ") || strings.ContainsAny(arg, " \t")
+}
+
+// fixHintCommand is the command deja prints for the reader to paste, escaped so
+// that it runs: a line starting with a dash needs the `--` in front of it, or
+// the command deja just offered answers with "unknown flag" (#2799).
+func fixHintCommand(line string) string {
+	if strings.HasPrefix(line, "-") {
+		return "deja fix -- " + pasteSafe(line)
+	}
+	return "deja fix " + pasteSafe(line)
 }

--- a/cmd/deja/fix_dash_argument_test.go
+++ b/cmd/deja/fix_dash_argument_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Go's own test output is the commonest thing a reader pastes at `deja fix`,
+// and every failing line of it starts with a dash. Without the escape the
+// command deja prints for the reader cannot be run (#2799).
+func TestFixTakesALineThatStartsWithADash(t *testing.T) {
+	dir := t.TempDir()
+	line := "--- FAIL: TestX (0.01s)"
+
+	var out bytes.Buffer
+	if err := runFix(dir, []string{line}, &out); err != nil {
+		t.Errorf("a pasted failure line was read as a flag: %v", err)
+	}
+	out.Reset()
+	if err := runFix(dir, []string{"--", line}, &out); err != nil {
+		t.Errorf("the escape did not take the line either: %v", err)
+	}
+	// The flags still have to be flags after it: an unknown one is a mistake
+	// worth reporting, not a search term.
+	if err := runFix(dir, []string{"--json"}, &out); err == nil {
+		t.Error("--json was swallowed as text")
+	}
+}
+
+// The hint is a command the reader pastes, so it has to carry the escape when
+// the line needs it.
+func TestTheFixHintEscapesADashLeadingLine(t *testing.T) {
+	line := "--- FAIL: TestX (0.01s)"
+	got := fixHintCommand(line)
+	if !strings.HasPrefix(got, "deja fix -- ") {
+		t.Errorf("the hint is not runnable as printed: %q", got)
+	}
+	if plain := fixHintCommand("pq: canceling statement due to user request"); strings.Contains(plain, " -- ") {
+		t.Errorf("a line that needs no escape got one: %q", plain)
+	}
+}


### PR DESCRIPTION
Closes #2799. `runFix` had no `--` case, so `deja fix '--- FAIL: TestX (0.01s)'` — the commonest thing there is to paste — was refused as an unknown flag, including when deja itself had just printed that command. It takes `--` now, a pasted line is told from a mistyped flag by its shape, and the hint carries the escape when the line needs it.