### PR TITLE
fix(peers): keep the peer list nowhere rather than in the working directory

### DIFF
--- a/internal/peers/lock.go
+++ b/internal/peers/lock.go
@@ -32,6 +32,12 @@ const (
 // (a read-only config mount) runs the write unlocked, which is what deja did
 // before this existed.
 func withLock(fn func() error) error {
+	if Path() == "" {
+		// Nowhere to keep the list means nowhere to keep its lock, and
+		// creating the directory anyway is what put a `.config` in whatever
+		// checkout the command ran in (#2790).
+		return errors.New("no home directory, so there is nowhere to keep the peer list")
+	}
 	path := Path() + ".lock"
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fn()

--- a/internal/peers/lock.go
+++ b/internal/peers/lock.go
@@ -32,13 +32,14 @@ const (
 // (a read-only config mount) runs the write unlocked, which is what deja did
 // before this existed.
 func withLock(fn func() error) error {
-	if Path() == "" {
+	list := Path()
+	if list == "" {
 		// Nowhere to keep the list means nowhere to keep its lock, and
 		// creating the directory anyway is what put a `.config` in whatever
 		// checkout the command ran in (#2790).
-		return errors.New("no home directory, so there is nowhere to keep the peer list")
+		return errNoHome
 	}
-	path := Path() + ".lock"
+	path := list + ".lock"
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return fn()
 	}

--- a/internal/peers/no_home_test.go
+++ b/internal/peers/no_home_test.go
@@ -1,0 +1,58 @@
+package peers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// With no home directory the config base is relative, and this file is one deja
+// writes: `deja peer add` on such a machine left `./.config/deja/peers.json` in
+// whatever checkout it happened to run in. Nowhere is the right answer, the way
+// policy.Path answers it (#2790).
+func TestPeersHaveNoPathWithoutAHome(t *testing.T) {
+	t.Setenv("DEJA_PEERS_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	if p := Path(); p != "" {
+		t.Errorf("Path() = %q with no home, want nowhere", p)
+	}
+	// A relative XDG_CONFIG_HOME is the same case by another route: the spec
+	// says to ignore it, and following it writes into the working directory.
+	t.Setenv("XDG_CONFIG_HOME", ".config")
+	if p := Path(); p != "" {
+		t.Errorf("Path() = %q for a relative XDG_CONFIG_HOME, want nowhere", p)
+	}
+}
+
+// And a write says so rather than creating the directory it would have written
+// into: silently putting a list somewhere it will never be read again is worse
+// than refusing.
+func TestPeerWritesRefuseWithoutAHome(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	t.Setenv("DEJA_PEERS_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	if err := Record("box", true, time.Now(), nil); err == nil {
+		t.Error("peer add wrote the list somewhere with no home to write it to")
+	} else if !strings.Contains(err.Error(), "home") {
+		t.Errorf("the refusal does not say what is missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".config")); err == nil {
+		t.Error("the list went into the working directory")
+	}
+	if list := Load(); len(list) != 0 {
+		t.Errorf("read back %d peer(s) from nowhere", len(list))
+	}
+}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -61,9 +61,19 @@ func Path() string {
 	if p := os.Getenv("DEJA_PEERS_FILE"); p != "" {
 		return p
 	}
+	// A relative XDG_CONFIG_HOME is ignored rather than followed — the spec
+	// says so, and it is what this repository's own xdgConfigHome does.
 	base := os.Getenv("XDG_CONFIG_HOME")
-	if base == "" {
+	if !filepath.IsAbs(base) {
 		base = filepath.Join(sources.Home(), ".config")
+	}
+	// And nowhere, rather than somewhere relative: Home() answers "" when there
+	// is no home directory, so this was `.config/deja/peers.json` — and this
+	// file is one deja writes, so `deja peer add` left a list in whatever
+	// checkout it ran in, where nothing would read it again (#2790, the shape
+	// #2785 fixed for the policy file).
+	if !filepath.IsAbs(base) {
+		return ""
 	}
 	return filepath.Join(base, "deja", "peers.json")
 }
@@ -313,6 +323,9 @@ func save(list []Peer) error {
 		return err
 	}
 	path := Path()
+	if path == "" {
+		return errors.New("no home directory, so there is nowhere to keep the peer list")
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -316,6 +316,10 @@ func forgetLocked(host string) (bool, error) {
 	return true, save(out)
 }
 
+// errNoHome is what every writer answers when there is nowhere to keep the
+// list. It names the way out, as deja's own homeless refusal does.
+var errNoHome = errors.New("no home directory, so there is nowhere to keep the peer list — set HOME or XDG_CONFIG_HOME to an absolute path")
+
 func save(list []Peer) error {
 	sort.Slice(list, func(i, j int) bool { return list[i].Host < list[j].Host })
 	b, err := json.MarshalIndent(file{Peers: list}, "", "  ")
@@ -324,7 +328,7 @@ func save(list []Peer) error {
 	}
 	path := Path()
 	if path == "" {
-		return errors.New("no home directory, so there is nowhere to keep the peer list")
+		return errNoHome
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -46,8 +46,11 @@ func NotesFile() string {
 		return p
 	}
 	// An explicit XDG_DATA_HOME wins on every platform so relocation and
-	// hermetic tests behave the same everywhere.
-	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+	// hermetic tests behave the same everywhere — an absolute one. A relative
+	// value is ignored, as the spec says and as this repository already does
+	// for XDG_CONFIG_HOME: followed, it puts the notes in whatever directory
+	// the command ran in (#2790).
+	if dir := os.Getenv("XDG_DATA_HOME"); filepath.IsAbs(dir) {
 		return filepath.Join(dir, "deja", "notes.jsonl")
 	}
 	if runtime.GOOS == "windows" {

--- a/internal/sources/notes_relative_xdg_test.go
+++ b/internal/sources/notes_relative_xdg_test.go
@@ -1,0 +1,26 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// A relative XDG_DATA_HOME is ignored, the way a relative XDG_CONFIG_HOME
+// already is: followed, it puts the notes file in whatever directory the
+// command happened to run in (#2790).
+func TestNotesIgnoreARelativeDataHome(t *testing.T) {
+	t.Setenv("DEJA_NOTES_FILE", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	t.Setenv("XDG_DATA_HOME", "share")
+	if p := NotesFile(); !filepath.IsAbs(p) {
+		t.Errorf("NotesFile() = %q for a relative XDG_DATA_HOME, want a path under the home", p)
+	}
+	abs := filepath.Join(home, "elsewhere")
+	t.Setenv("XDG_DATA_HOME", abs)
+	if p := NotesFile(); p != filepath.Join(abs, "deja", "notes.jsonl") {
+		t.Errorf("NotesFile() = %q, want it under the absolute XDG_DATA_HOME", p)
+	}
+}


### PR DESCRIPTION
Closes #2790. `peers.Path()` built its path the way `policy.Path()` did before #2788 — config home falling back to `Home()/.config`, which is relative when there is no home — and this file is written, so a write created `./.config/deja/peers.json` in whatever checkout the command ran in. It answers nowhere now, and both writers (the save and the lock that precedes it) refuse instead of creating the directory.