### PR TITLE
fix(install): take a commented config for copilot and openclaw

### DIFF
--- a/cmd/deja/copilot_openclaw_comments_test.go
+++ b/cmd/deja/copilot_openclaw_comments_test.go
@@ -145,6 +145,7 @@ func TestARoundTripOnACommentedConfigChangesNothing(t *testing.T) {
 		"{\n  // no mcp at all\n  \"theme\": \"dark\"\n}\n",
 		"{\n  // an mcp block with no servers in it\n  \"mcp\": {}\n}\n",
 		"{\n  // servers, but empty\n  \"mcp\": {\n    \"servers\": {}\n  }\n}\n",
+		"{\n  \"mcp\": {\n    // servers go here one day\n  }\n}\n",
 	} {
 		t.Run("", func(t *testing.T) {
 			hermeticEnv(t)

--- a/cmd/deja/copilot_openclaw_comments_test.go
+++ b/cmd/deja/copilot_openclaw_comments_test.go
@@ -135,3 +135,39 @@ func TestANestedBlockIsCreatedInACommentedConfig(t *testing.T) {
 		})
 	}
 }
+
+// Install then uninstall leaves the file as it found it, chain and all: deja
+// writes `mcp` as well as `servers` into a config that had neither, and the
+// parsed path deletes both on the way out, so the text path has to as well
+// (#2783).
+func TestARoundTripOnACommentedConfigChangesNothing(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // no mcp at all\n  \"theme\": \"dark\"\n}\n",
+		"{\n  // an mcp block with no servers in it\n  \"mcp\": {}\n}\n",
+		"{\n  // servers, but empty\n  \"mcp\": {\n    \"servers\": {}\n  }\n}\n",
+	} {
+		t.Run("", func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installOpenClawMCP("/bin/deja", false); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installOpenClawMCP("/bin/deja", true); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(b) != before {
+				t.Errorf("the round trip changed the file:\nwant %q\ngot  %q", before, b)
+			}
+		})
+	}
+}

--- a/cmd/deja/copilot_openclaw_comments_test.go
+++ b/cmd/deja/copilot_openclaw_comments_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The two targets #1664 did not reach: both write their entry through the
+// parsed path only, so a `//` line in the config refused the target outright
+// and the reader who annotated it could not install deja at all (#2783).
+func TestACommentedConfigStillTakesTheEntry(t *testing.T) {
+	for _, c := range []struct {
+		target string
+		write  func(exe string, uninstall bool) (installResult, error)
+		path   func() string
+		before string
+		// block is where the entry ends up, read back from the parsed file.
+		block []string
+	}{{
+		target: "copilot",
+		write:  installCopilotMCP,
+		path:   func() string { return filepath.Join(sources.Home(), ".copilot", "mcp-config.json") },
+		before: "{\n  // the ordering here is deliberate\n  \"mcpServers\": {}\n}\n",
+		block:  []string{"mcpServers"},
+	}, {
+		target: "openclaw",
+		write:  installOpenClawMCP,
+		path:   func() string { return filepath.Join(sources.OpenClawStateDir(), "openclaw.json") },
+		before: "{\n  // the ordering here is deliberate\n  \"mcp\": {\n    \"servers\": {}\n  }\n}\n",
+		block:  []string{"mcp", "servers"},
+	}} {
+		t.Run(c.target, func(t *testing.T) {
+			hermeticEnv(t)
+			path := c.path()
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(c.before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := c.write("/bin/deja", false); err != nil {
+				t.Fatalf("a commented config was refused: %v", err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(b), "// the ordering here is deliberate") {
+				t.Errorf("the comment was dropped:\n%s", b)
+			}
+			if !strings.Contains(string(b), `"deja"`) {
+				t.Fatalf("the entry was not written:\n%s", b)
+			}
+			var root map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+				t.Fatalf("the file no longer parses: %v\n%s", err, b)
+			}
+			m := root
+			for _, key := range c.block {
+				next, ok := m[key].(map[string]any)
+				if !ok {
+					t.Fatalf("%q is not where the entry went:\n%s", key, b)
+				}
+				m = next
+			}
+			if _, ok := m["deja"].(map[string]any); !ok {
+				t.Errorf("the entry is not under %v:\n%s", c.block, b)
+			}
+
+			if _, err := c.write("/bin/deja", true); err != nil {
+				t.Fatalf("uninstall refused the commented config: %v", err)
+			}
+			b, err = os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), `"deja"`) {
+				t.Errorf("the entry stayed behind:\n%s", b)
+			}
+			if !strings.Contains(string(b), "// the ordering here is deliberate") {
+				t.Errorf("the comment was dropped on the way out:\n%s", b)
+			}
+		})
+	}
+}
+
+// And when the block is not there at all: openclaw keeps its servers two keys
+// deep, so a config with neither key needs both written, nested, without
+// disturbing what the reader wrote around them.
+func TestANestedBlockIsCreatedInACommentedConfig(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // no mcp at all\n  \"theme\": \"dark\"\n}\n",
+		"{\n  // an mcp block with no servers in it\n  \"mcp\": {}\n}\n",
+	} {
+		t.Run("", func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installOpenClawMCP("/bin/deja", false); err != nil {
+				t.Fatalf("a commented config was refused: %v", err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var root map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+				t.Fatalf("the file no longer parses: %v\n%s", err, b)
+			}
+			mcp, ok := root["mcp"].(map[string]any)
+			if !ok {
+				t.Fatalf("no mcp block:\n%s", b)
+			}
+			servers, ok := mcp["servers"].(map[string]any)
+			if !ok {
+				t.Fatalf("no servers block:\n%s", b)
+			}
+			if _, ok := servers["deja"].(map[string]any); !ok {
+				t.Errorf("the entry is not under mcp.servers:\n%s", b)
+			}
+			if !strings.Contains(string(b), "//") {
+				t.Errorf("the comment was dropped:\n%s", b)
+			}
+		})
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -2389,6 +2389,13 @@ func installCopilotMCP(exe string, uninstall bool) (installResult, error) {
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// A comment is not a broken file, and refusing the target over one is
+		// how somebody who annotated their config could not install deja at
+		// all (#2783, the two targets #1664 did not reach).
+		command, args := mcpCommandArgs(exe)
+		return writeJSONCEntry(path, old, "mcpServers",
+			map[string]any{"type": "local", "command": command, "args": args, "tools": []string{"*"}}, uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
@@ -2450,6 +2457,12 @@ func installOpenClawMCP(exe string, uninstall bool) (installResult, error) {
 	var note string
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// Two keys deep, which the text writer takes as a dotted block key
+		// (#2783).
+		command, args := mcpCommandArgs(exe)
+		return writeJSONCEntry(path, old, "mcp.servers",
+			map[string]any{"command": command, "args": args}, uninstall)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -67,13 +67,23 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 	if open < 0 {
 		return "", fmt.Errorf("does not look like a settings object; add %q by hand", blockKey)
 	}
-	block := zedFindKey(text, open+1, blockKey)
+	keys := strings.Split(blockKey, ".")
+	block, have := walkJSONCKeys(text, open, keys)
 	if block == nil {
 		if uninstall {
 			return text, nil
 		}
-		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  }%s", blockKey, id, entry, rootComma(text, open))
-		return text[:open+1] + insert + text[open+1:], nil
+		// The keys that are missing, nested inside the deepest one that is
+		// there: openclaw keeps its servers under `mcp.servers`, so a config
+		// with an `mcp` block and no `servers` in it gets one key, and a config
+		// with neither gets both (#2783).
+		at, comma, indent := open, rootComma(text, open), "  "
+		if have > 0 {
+			parent, _ := walkJSONCKeys(text, open, keys[:have])
+			at, comma, indent = parent.valueOpen, blockComma(text, parent), "    "
+		}
+		insert := nestedBlocks(keys[have:], id, entry, indent)
+		return text[:at+1] + insert + comma + text[at+1:], nil
 	}
 	found := zedFindKey(text, block.valueOpen+1, id)
 	if found == nil {
@@ -109,6 +119,42 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 		return text[:cut[0]] + text[cut[1]:], nil
 	}
 	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
+}
+
+// walkJSONCKeys follows a dotted block key from the top-level object, and
+// reports how many of its keys were found: a caller that has to create the rest
+// needs to know where to put them.
+func walkJSONCKeys(text string, open int, keys []string) (*zedSpan, int) {
+	at := open + 1
+	var block *zedSpan
+	for i, key := range keys {
+		found := zedFindKey(text, at, key)
+		if found == nil {
+			return nil, i
+		}
+		block, at = found, found.valueOpen+1
+	}
+	return block, len(keys)
+}
+
+// nestedBlocks is the text of the keys that are missing, one inside the next,
+// with the entry at the bottom.
+func nestedBlocks(keys []string, id, entry, indent string) string {
+	body := fmt.Sprintf("%q: %s", id, entry)
+	for i := len(keys) - 1; i >= 0; i-- {
+		inner := indent + strings.Repeat("  ", i+1)
+		body = fmt.Sprintf("%q: {\n%s%s\n%s}", keys[i], inner, body, indent+strings.Repeat("  ", i))
+	}
+	return "\n" + indent + body
+}
+
+// blockComma is rootComma for a block rather than the whole file: no comma
+// after a key inserted into an object that holds nothing else.
+func blockComma(text string, block *zedSpan) string {
+	if strings.TrimSpace(stripJSONComments(text[block.valueOpen+1:block.valueEnd-1])) == "" {
+		return ""
+	}
+	return ","
 }
 
 // rootComma is the comma after a block inserted at the top of an object, or
@@ -158,15 +204,37 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 	// mcpBlock reads null as "no block", which is right where the writer can
 	// replace the value; here the write is a text insert, so it would leave a
 	// second key of the same name with the reader's value winning (#2740).
-	if v, present := root[blockKey]; present {
-		if _, isObject := v.(map[string]any); !isObject {
+	keys := strings.Split(blockKey, ".")
+	holder := root
+	for _, key := range keys[:len(keys)-1] {
+		v, present := holder[key]
+		if !present {
+			holder = nil
+			break
+		}
+		next, isObject := v.(map[string]any)
+		if !isObject {
 			if uninstall {
 				return installResult{Path: path, Action: "unchanged"}, nil
 			}
-			return installResult{}, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, blockKey)
+			return installResult{}, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, key)
+		}
+		holder = next
+	}
+	if holder != nil {
+		if v, present := holder[keys[len(keys)-1]]; present {
+			if _, isObject := v.(map[string]any); !isObject {
+				if uninstall {
+					return installResult{Path: path, Action: "unchanged"}, nil
+				}
+				return installResult{}, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, blockKey)
+			}
 		}
 	}
-	m, _, err := mcpBlock(root, blockKey, path)
+	if holder == nil {
+		holder = map[string]any{}
+	}
+	m, _, err := mcpBlock(holder, keys[len(keys)-1], path)
 	if err != nil {
 		// A block that is not an object is a config deja does not understand,
 		// and writing a second key of the same name would leave the reader's

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -88,7 +88,7 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool, dropFrom in
 		// A newline before what the parent closes with, or the chain ends up
 		// against the parent's own brace: `}}` on one line, which parses and
 		// reads as a mistake.
-		if have > 0 && comma == "" {
+		if have > 0 && comma == "" && !strings.HasPrefix(text[at+1:], "\n") {
 			insert += "\n" + strings.Repeat("  ", have)
 		}
 		return text[:at+1] + insert + comma + text[at+1:], nil
@@ -101,8 +101,9 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool, dropFrom in
 		// A newline after the entry when the block was written on one line, so
 		// the reader's first entry keeps a line of its own rather than being
 		// pushed against deja's closing brace.
+		rest := text[block.valueOpen+1:]
 		tail := ""
-		if rest := text[block.valueOpen+1:]; rest != "" && rest[0] != '\n' && rest[0] != '}' {
+		if rest != "" && rest[0] != '\n' && rest[0] != '}' {
 			tail = "\n   "
 		}
 		// And no comma into an empty block: `{"deja": {…},}` is not JSON, and
@@ -111,8 +112,16 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool, dropFrom in
 		comma := ","
 		if strings.TrimSpace(stripJSONComments(text[block.valueOpen+1:block.valueEnd-1])) == "" {
 			comma, tail = "", "\n  "
+			// Unless what follows opens a line of its own — a block whose body
+			// is a comment. The closing brace is already where it belongs, and
+			// a tail here left a blank line behind on the way out, one more on
+			// every round trip.
+			if rest != "" && rest[0] == '\n' {
+				tail = ""
+			}
 		}
-		insert := fmt.Sprintf("\n    %q: %s%s%s", id, entry, comma, tail)
+		depth := strings.Repeat("  ", len(keys)+1)
+		insert := fmt.Sprintf("\n%s%q: %s%s%s", depth, id, entryAtDepth(entry, len(keys)), comma, tail)
 		return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
 	}
 	if uninstall {
@@ -134,7 +143,7 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool, dropFrom in
 		cut := zedEntrySpan(text, found)
 		return closeEmptied(text[:cut[0]]+text[cut[1]:], keys), nil
 	}
-	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
+	return text[:found.valueOpen] + entryAtDepth(entry, len(keys)) + text[found.valueEnd:], nil
 }
 
 // walkJSONCKeys follows a dotted block key from the top-level object, and
@@ -151,6 +160,17 @@ func walkJSONCKeys(text string, open int, keys []string) (*zedSpan, int) {
 		block, at = found, found.valueOpen+1
 	}
 	return block, len(keys)
+}
+
+// entryAtDepth re-indents an entry to the block it is going into.
+// jsoncEntryText renders at the depth a single-key writer uses, so an entry two
+// keys deep — openclaw's mcp.servers — came out aligned with the block above
+// it, along with the brace that closes it.
+func entryAtDepth(entry string, depth int) string {
+	if depth <= 1 {
+		return entry
+	}
+	return strings.ReplaceAll(entry, "\n    ", "\n"+strings.Repeat("  ", depth+1))
 }
 
 // closeEmptied puts a block deja emptied back the way it found it: writing an
@@ -181,9 +201,6 @@ func closeEmptied(text string, keys []string) string {
 // nestedBlocks is the text of the keys that are missing, one inside the next,
 // with the entry at the bottom.
 func nestedBlocks(keys []string, id, entry, indent string) string {
-	// jsoncEntryText renders at the depth the single-key writers use; a chain
-	// puts the entry deeper than that, and a body left at the old depth reads
-	// as if it belonged to the block above.
 	entry = strings.ReplaceAll(entry, "\n    ", "\n"+indent+strings.Repeat("  ", len(keys)))
 	body := fmt.Sprintf("%q: %s", id, entry)
 	for i := len(keys) - 1; i >= 0; i-- {

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -62,7 +62,9 @@ func stripJSONComments(text string) string {
 
 // jsoncSetEntry writes deja's entry into a JSONC object under blockKey, or
 // takes it out, leaving every other byte of the file alone.
-func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) (string, error) {
+// dropFrom says how much of the chain an uninstall takes with the entry: the
+// index of the outermost key to remove, or len(keys) for the entry alone.
+func jsoncSetEntry(text, blockKey, id, entry string, uninstall bool, dropFrom int) (string, error) {
 	open := zedTopLevelOpen(text)
 	if open < 0 {
 		return "", fmt.Errorf("does not look like a settings object; add %q by hand", blockKey)
@@ -80,9 +82,15 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 		at, comma, indent := open, rootComma(text, open), "  "
 		if have > 0 {
 			parent, _ := walkJSONCKeys(text, open, keys[:have])
-			at, comma, indent = parent.valueOpen, blockComma(text, parent), "    "
+			at, comma, indent = parent.valueOpen, blockComma(text, parent), strings.Repeat("  ", have+1)
 		}
 		insert := nestedBlocks(keys[have:], id, entry, indent)
+		// A newline before what the parent closes with, or the chain ends up
+		// against the parent's own brace: `}}` on one line, which parses and
+		// reads as a mistake.
+		if have > 0 && comma == "" {
+			insert += "\n" + strings.Repeat("  ", have)
+		}
 		return text[:at+1] + insert + comma + text[at+1:], nil
 	}
 	found := zedFindKey(text, block.valueOpen+1, id)
@@ -108,15 +116,23 @@ func jsoncSetEntry(text, blockKey, id, entry string, uninstall, dropBlock bool) 
 		return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
 	}
 	if uninstall {
-		if dropBlock {
-			return zedDropEntry(text, block, found), nil
+		if dropFrom < len(keys) {
+			// The chain deja created, from the outermost key it wrote: the
+			// parsed path deletes an emptied `mcp` along with its `servers`,
+			// and a round trip has to leave the file as it found it (#2783).
+			if dropFrom < len(keys)-1 {
+				chain, _ := walkJSONCKeys(text, open, keys[:dropFrom+1])
+				cut := zedEntrySpan(text, chain)
+				return closeEmptied(text[:cut[0]]+text[cut[1]:], keys), nil
+			}
+			return closeEmptied(zedDropEntry(text, block, found), keys), nil
 		}
 		// The entry alone. zedDropEntry takes the block with the last entry in
 		// it, which is right for a block deja created and wrong for one the
 		// reader wrote — the rule #2604 and #2583 settled for the other
 		// writers (#2740).
 		cut := zedEntrySpan(text, found)
-		return text[:cut[0]] + text[cut[1]:], nil
+		return closeEmptied(text[:cut[0]]+text[cut[1]:], keys), nil
 	}
 	return text[:found.valueOpen] + entry + text[found.valueEnd:], nil
 }
@@ -137,9 +153,38 @@ func walkJSONCKeys(text string, open int, keys []string) (*zedSpan, int) {
 	return block, len(keys)
 }
 
+// closeEmptied puts a block deja emptied back the way it found it: writing an
+// entry into `"servers": {}` opens the braces onto their own lines, and taking
+// the entry out again left them there, so an install followed by an uninstall
+// did not give the reader their file back.
+//
+// Whitespace only, checked on the raw text: a block holding a comment and
+// nothing else is one the reader wrote something in, and it keeps its shape.
+func closeEmptied(text string, keys []string) string {
+	for i := len(keys); i > 0; i-- {
+		open := zedTopLevelOpen(text)
+		if open < 0 {
+			return text
+		}
+		block, have := walkJSONCKeys(text, open, keys[:i])
+		if block == nil || have < i {
+			continue
+		}
+		body := text[block.valueOpen+1 : block.valueEnd-1]
+		if body != "" && strings.TrimSpace(body) == "" {
+			text = text[:block.valueOpen+1] + text[block.valueEnd-1:]
+		}
+	}
+	return text
+}
+
 // nestedBlocks is the text of the keys that are missing, one inside the next,
 // with the entry at the bottom.
 func nestedBlocks(keys []string, id, entry, indent string) string {
+	// jsoncEntryText renders at the depth the single-key writers use; a chain
+	// puts the entry deeper than that, and a body left at the old depth reads
+	// as if it belonged to the block above.
+	entry = strings.ReplaceAll(entry, "\n    ", "\n"+indent+strings.Repeat("  ", len(keys)))
 	body := fmt.Sprintf("%q: %s", id, entry)
 	for i := len(keys) - 1; i >= 0; i-- {
 		inner := indent + strings.Repeat("  ", i+1)
@@ -206,6 +251,7 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 	// second key of the same name with the reader's value winning (#2740).
 	keys := strings.Split(blockKey, ".")
 	holder := root
+	have := 0
 	for _, key := range keys[:len(keys)-1] {
 		v, present := holder[key]
 		if !present {
@@ -220,6 +266,7 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 			return installResult{}, fmt.Errorf("%s: %q is not an object deja can edit — left as it was", path, key)
 		}
 		holder = next
+		have++
 	}
 	if holder != nil {
 		if v, present := holder[keys[len(keys)-1]]; present {
@@ -249,7 +296,12 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 			return installResult{Path: path, Action: "unchanged"}, nil
 		}
 		m = map[string]any{}
-		noteBlockAdded(path, blockKey)
+		// Every level deja writes, not only the last: an uninstall that knows
+		// it created `mcp` as well as `servers` can leave the file as it found
+		// it (#2783).
+		for i := have; i < len(keys); i++ {
+			noteBlockAdded(path, strings.Join(keys[:i+1], "."))
+		}
 	}
 	key := dejaEntryKey(m)
 	var note string
@@ -258,10 +310,23 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 		delete(m, key)
 		removeAdoptedDejaEntries(path, blockKey, m)
 		note = leftDejaEntriesNote(m)
+		dropFrom := len(keys)
 		if len(m) == 0 && blockWasAdded(path, blockKey) {
+			dropFrom = len(keys) - 1
 			forgetBlockAdded(path, blockKey)
+			// And up, while each level holds nothing but the one below it and
+			// deja is what put it there.
+			holders := chainHolders(root, keys)
+			for i := len(keys) - 2; i >= 0; i-- {
+				prefix := strings.Join(keys[:i+1], ".")
+				if len(holders[i+1]) != 1 || !blockWasAdded(path, prefix) {
+					break
+				}
+				dropFrom = i
+				forgetBlockAdded(path, prefix)
+			}
 		}
-		next, err = jsoncSetEntry(text, blockKey, key, "", true, blockWasAdded(path, blockKey))
+		next, err = jsoncSetEntry(text, blockKey, key, "", true, dropFrom)
 	} else {
 		var merged map[string]any
 		merged, note = mergeDejaEntry(m[key], want)
@@ -271,13 +336,30 @@ func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]a
 		if err != nil {
 			return installResult{}, err
 		}
-		next, err = jsoncSetEntry(text, blockKey, key, entry, false, false)
+		next, err = jsoncSetEntry(text, blockKey, key, entry, false, len(keys))
 	}
 	if err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	a, werr := writeIfChanged(path, old, []byte(next))
 	return installResult{Path: path, Action: a, Note: note}, werr
+}
+
+// chainHolders is the object each key of a dotted block key lives in, so an
+// uninstall can ask what a level would hold once the one below it is gone. A
+// level that is not there yet is an empty map, which holds nothing.
+func chainHolders(root map[string]any, keys []string) []map[string]any {
+	out := make([]map[string]any, len(keys))
+	at := root
+	for i, key := range keys {
+		out[i] = at
+		next, _ := at[key].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+		}
+		at = next
+	}
+	return out
 }
 
 // jsoncSetFlag turns a boolean setting on inside a block, in a config that


### PR DESCRIPTION
Closes #2783, the two targets #1664 did not reach. Both write their MCP entry through the parsed path only, so a `//` line in the config refused the target and whoever annotated it could not install deja at all.

openclaw's block is two keys deep, so `jsoncSetEntry` takes a dotted block key: it walks as far as the config goes, writes the keys that are missing nested inside the deepest one present, and on the way out drops the chain it created — an install followed by an uninstall gives the file back byte for byte. `writeJSONCEntry` checks the whole chain for a key holding something other than an object, not just the first.

Two behaviour changes reach the targets #1664 already converted, both on uninstall: a block deja emptied goes back to `{}` rather than keeping the braces it had opened, and a block whose body is a comment no longer gains a blank line per round trip.

Out of scope and worth its own issue: #2811 — `openclaw-auto` edits the same file (hooks.internal.entries plus a flag) and still refuses a comment.