### PR TITLE
perf: ask the grok store only for what is new

### DIFF
--- a/internal/index/grok_watermark_test.go
+++ b/internal/index/grok_watermark_test.go
@@ -1,0 +1,234 @@
+package index
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// seedGrokDB writes one session and its messages into a grok store, replacing
+// what is there.
+func seedGrokDB(t *testing.T, db string, msgs [][2]string) {
+	t.Helper()
+	stmts := `create table if not exists sessions (id text primary key, workspace_id text, title text, cwd_last text, created_at text);
+create table if not exists messages (session_id text, seq integer, role text, message_json text, created_at text);
+insert or replace into sessions values ('s1','w1','pool timeouts','/work/api','2026-01-01T10:00:00.000Z');
+`
+	for i, m := range msgs {
+		stmts += fmt.Sprintf("insert into messages values ('s1',%d,'user',json('{\"role\":\"user\",\"content\":\"%s\"}'),'%s');\n",
+			i, m[0], m[1])
+	}
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+// grok's database has a since-the-watermark parser wired into the registry and
+// nothing ever stamped it, so its LastUpdated stayed 0 for the life of the
+// index and every pass read the store whole — the pass with one new line to
+// index cost what reading everything costs (#2075).
+//
+// The store is only safe to stamp because its parser selects messages rather
+// than sessions and normalises both sides of the comparison with a millisecond
+// backoff (#2150): the same shape as opencode and cursor. hermes and zed do
+// neither, which is why they are not stamped here.
+func TestTheGrokStoreIsAskedOnlyForWhatIsNew(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "grok.db")
+	t.Setenv("DEJA_GROK_DB", db)
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+
+	seedGrokDB(t, db, [][2]string{{"marker-grok-one", "2026-01-01T10:00:00.000Z"}})
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	hits := func(marker string) int {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: marker, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(got)
+	}
+	if hits("marker-grok-one") != 1 {
+		t.Fatalf("the store was not indexed at all, so this measures nothing")
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files[db].LastUpdated == 0 {
+		t.Errorf("the store carries no watermark, so the next pass reads it whole")
+	}
+
+	// A line lands after the watermark, and one lands in the same millisecond
+	// as it — the case the backoff exists for.
+	seedGrokDB(t, db, [][2]string{
+		{"marker-grok-same", "2026-01-01T10:00:00.000Z"},
+		{"marker-grok-two", "2026-01-01T11:00:00.000Z"},
+	})
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits("marker-grok-two"); n != 1 {
+		t.Errorf("the line added after the watermark is not indexed: %d hits", n)
+	}
+	if n := hits("marker-grok-same"); n != 1 {
+		t.Errorf("a line stamped at the watermark itself was skipped: %d hits", n)
+	}
+	// And the session is counted once: a cursor that hands back turns already
+	// held would grow the count on every pass (#2025).
+	if n := hits("marker-grok-one"); n != 1 {
+		t.Errorf("the first line is held %d times", n)
+	}
+}
+
+// The other half of stamping a shared store: the database changes whenever any
+// session in it does, so a pass that reads only the new messages must not drop
+// the records of the sessions it did not ask about — which is what the
+// changed-file rule would do without fromDatabase knowing this store (#2033).
+func TestAQuietGrokSessionSurvivesAPassThatDidNotAskForIt(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "grok.db")
+	t.Setenv("DEJA_GROK_DB", db)
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
+
+	stmts := `create table sessions (id text primary key, workspace_id text, title text, cwd_last text, created_at text);
+create table messages (session_id text, seq integer, role text, message_json text, created_at text);
+insert into sessions values ('quiet','w1','quiet','/work/api','2026-01-01T09:00:00.000Z');
+insert into sessions values ('busy','w1','busy','/work/api','2026-01-01T10:00:00.000Z');
+insert into messages values ('quiet',0,'user',json('{"role":"user","content":"marker-grok-quiet"}'),'2026-01-01T09:00:00.000Z');
+insert into messages values ('busy',0,'user',json('{"role":"user","content":"marker-grok-busy"}'),'2026-01-01T10:00:00.000Z');
+`
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	hits := func(marker string) int {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: marker, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(got)
+	}
+	if hits("marker-grok-quiet") != 1 || hits("marker-grok-busy") != 1 {
+		t.Fatalf("both sessions were not indexed, so this measures nothing")
+	}
+
+	// Only the busy session gains a turn. The quiet one is not in what the
+	// store hands back, and it has to still be there afterwards.
+	add := `insert into messages values ('busy',1,'user',json('{"role":"user","content":"marker-grok-added"}'),'2026-01-01T11:00:00.000Z');`
+	if out, err := exec.Command("sqlite3", db, add).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 add: %v %s", err, out)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits("marker-grok-added"); n != 1 {
+		t.Errorf("the added turn is not indexed: %d hits", n)
+	}
+	if n := hits("marker-grok-quiet"); n != 1 {
+		t.Errorf("the session the pass did not ask about was dropped: %d hits", n)
+	}
+}
+
+// grok registers its database and its session files under one kind name, so
+// "this pass read the store whole" cannot be decided by the kind. Deciding it
+// that way marks the whole harness whole whenever a session file changes, and
+// then the database's continued session — read from its watermark, so only the
+// new turn came back — has its earlier turns dropped by key (#2075, the shape
+// readWholeThisPass exists to prevent).
+func TestATouchedGrokFileDoesNotCostTheDatabaseItsEarlierTurns(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "grok.db")
+	t.Setenv("DEJA_GROK_DB", db)
+	root := filepath.Join(tmp, "grok")
+	t.Setenv("DEJA_GROK_ROOT", root)
+
+	// A session file beside the store, so both grok kinds are in this pass.
+	fileDir := filepath.Join(root, "sessions", url.PathEscape("/work/app"), "019f-file-session")
+	if err := os.MkdirAll(fileDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	updates := filepath.Join(fileDir, "updates.jsonl")
+	line := func(ts int, text string) string {
+		return fmt.Sprintf(`{"timestamp":%d,"method":"session/update","params":{"update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"%s"},"_meta":{"promptIndex":0}}}}`+"\n", ts, text)
+	}
+	if err := os.WriteFile(updates, []byte(line(1782900001, "marker-grok-file")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedGrokDB(t, db, [][2]string{{"marker-grok-first", "2026-01-01T10:00:00.000Z"}})
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	hits := func(marker string) int {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: marker, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return len(got)
+	}
+	if hits("marker-grok-first") != 1 || hits("marker-grok-file") != 1 {
+		t.Fatalf("the store and the session file were not both indexed, so this measures nothing")
+	}
+
+	// Both move in the same pass: the file gains a line, and the store's one
+	// session gains a turn past its watermark.
+	if err := os.WriteFile(updates,
+		[]byte(line(1782900001, "marker-grok-file")+line(1782900009, "marker-grok-file-two")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	add := `insert into messages values ('s1',9,'user',json('{"role":"user","content":"marker-grok-later"}'),'2026-01-01T12:00:00.000Z');`
+	if out, err := exec.Command("sqlite3", db, add).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 add: %v %s", err, out)
+	}
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits("marker-grok-later"); n != 1 {
+		t.Errorf("the turn added to the store is not indexed: %d hits", n)
+	}
+	if n := hits("marker-grok-first"); n != 1 {
+		t.Errorf("the store's earlier turn went with the touched session file: %d hits", n)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2271,6 +2271,14 @@ func fromDatabase(r Record) bool {
 	if h, _, ok := strings.Cut(r.Key, ":"); ok && h == "opencode" {
 		return true
 	}
+	// grok's database, by path rather than by kind: both grok kinds are
+	// registered under one name, so the kind cannot tell the store from the
+	// session files beside it. Without this the changed-file rule dropped every
+	// session the incremental pass did not ask about, which is what stamping
+	// the store turned on (#2075).
+	if r.SourcePath == sources.GrokDB() {
+		return true
+	}
 	switch h := harnessForPath(r.SourcePath); h {
 	case "cursor-db", "goose-db":
 		return true
@@ -2311,10 +2319,10 @@ var passWholeStores map[string]bool
 // wholeStoresThisPass records them, under both the store path and the harness:
 // a record names the first where it can and the second otherwise.
 //
-// Only these three stores are stamped with a watermark (setStoreLastUpdated).
-// Everything else is read whole on every pass and judged by its path, which is
-// why it needs none of this — a watermark added to another database later would
-// have to join fromDatabase and this function in the same change.
+// Only the stamped stores belong here (setStoreLastUpdated). Everything else is
+// read whole on every pass and judged by its path, which is why it needs none of
+// this — a watermark added to another database later has to join fromDatabase
+// and this function in the same change, and grok did (#2075).
 func wholeStoresThisPass(changed, old map[string]FileState) {
 	passWholeStores = map[string]bool{}
 	for p := range changed {
@@ -2326,6 +2334,14 @@ func wholeStoresThisPass(changed, old map[string]FileState) {
 			harness = "cursor"
 		case "goose-db":
 			harness = "goose"
+		case "grok":
+			// Both grok kinds are registered under one name, and only the
+			// database carries a watermark: its session files are read whole
+			// and judged by their path, the way this function's comment says.
+			if p != sources.GrokDB() {
+				continue
+			}
+			harness = "grok"
 		default:
 			continue
 		}
@@ -3098,6 +3114,16 @@ func harnessForPath(p string) string {
 func setOpencodeLastUpdated(files map[string]FileState, sessions map[string]SessionMeta) {
 	setStoreLastUpdated(files, sessions, "opencode", sources.OpencodeDB())
 	setStoreLastUpdated(files, sessions, "goose", sources.GooseDB())
+	// grok's database had a since-the-watermark parser in the registry and
+	// nothing ever stamped it, so every pass read the store whole — the pass
+	// with one new line cost what reading everything costs (#2075).
+	//
+	// Safe to stamp because ParseGrokDBSince selects messages rather than
+	// sessions and normalises both sides with a millisecond backoff (#2150),
+	// which is the opencode and cursor shape. hermes compares whole seconds
+	// with a strict >, and zed returns whole threads; each needs its own fix
+	// before it can be stamped, so neither is here.
+	setStoreLastUpdated(files, sessions, "grok", sources.GrokDB())
 	for _, db := range sources.CursorDBs() {
 		setStoreLastUpdated(files, sessions, "cursor", db)
 	}


### PR DESCRIPTION
One of the three stores in #2075. Reading the parsers first showed they are not one task, so this is grok alone — the analysis for the other two is on the issue.

grok is the safe one: `ParseGrokDBSince` selects *messages* rather than sessions and normalises both sides with a millisecond backoff (#2150), which is the opencode and cursor shape. hermes compares whole seconds with a strict `>`, so stamping it would drop every message sharing a second with the watermark; zed returns whole threads, which is the goose shape and needs `rereadsWholeSessions`. Neither is here.

The issue's quoted comment asks that a new watermark join `fromDatabase` and `wholeStoresThisPass` in the same change. It turned out to be three functions, and the third was not optional: with only the stamp, the second test in this PR fails — a session the incremental pass did not ask about is dropped from the index, because the changed-file rule takes every record naming a store that `fromDatabase` does not recognise. That is silent content loss, and it is why this is three tests rather than one.

Both grok kinds are registered under one name, so the store cannot be told from the session files beside it by kind; `wholeStoresThisPass` compares the path.

Two of the three pieces are mutation-checked. The third — the path guard in `wholeStoresThisPass` — I could not build a case that reaches: with the stamp in place the store marks itself, and removing the guard did not turn any test red. It stays on the reasoning `readWholeThisPass`'s own comment gives (a harness-wide flag is wrong once a harness has more than one store, and grok now does), and I am flagging it as reasoning rather than measurement.