### PR TITLE
perf: ask the hermes store only for what is new

### DIFF
--- a/internal/index/hermes_watermark_test.go
+++ b/internal/index/hermes_watermark_test.go
@@ -1,0 +1,167 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// hermesEnv points every other store somewhere empty and returns the hermes
+// home, so a pass sees this store and nothing else.
+func hermesEnv(t *testing.T) (tmp, home string) {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	tmp = t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_GOOSE_DB", filepath.Join(tmp, "none-goose.db"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none-opencode.db"))
+	t.Setenv("DEJA_GROK_DB", filepath.Join(tmp, "none-grok.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	home = filepath.Join(tmp, "hermes")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_HERMES_HOME", home)
+	return tmp, home
+}
+
+func seedHermes(t *testing.T, db string, rows string) {
+	t.Helper()
+	stmts := `create table if not exists messages (id integer primary key, session_id text, role text, content text, timestamp real);` + rows
+	if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3 seed: %v %s", err, out)
+	}
+}
+
+func hermesHits(t *testing.T, dir, marker string) int {
+	t.Helper()
+	got, err := Search(dir, search.Options{Query: marker, All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(got)
+}
+
+// hermes had a since-the-watermark parser wired into the registry and nothing
+// stamped its store, so every pass read the whole history to index one line
+// (#2075). Stamping it needs the second-resolution backoff first: without it
+// the turns sharing the watermark's second are skipped for good.
+func TestTheHermesStoreIsAskedOnlyForWhatIsNew(t *testing.T) {
+	tmp, home := hermesEnv(t)
+	db := filepath.Join(home, "state.db")
+	seedHermes(t, db, `insert into messages values (1,'s1','user','marker-hermes-one',1767268800);`)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if hermesHits(t, dir, "marker-hermes-one") != 1 {
+		t.Fatalf("the store was not indexed at all, so this measures nothing")
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files[db].LastUpdated == 0 {
+		t.Errorf("the store carries no watermark, so the next pass reads it whole")
+	}
+
+	// One turn after the watermark, and one in the same whole second as it.
+	seedHermes(t, db, `insert into messages values (2,'s1','user','marker-hermes-same',1767268800);`+
+		`insert into messages values (3,'s1','user','marker-hermes-two',1767272400);`)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-two"); n != 1 {
+		t.Errorf("the turn added after the watermark is not indexed: %d hits", n)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-same"); n != 1 {
+		t.Errorf("a turn stamped in the watermark's own second was skipped: %d hits", n)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-one"); n != 1 {
+		t.Errorf("the first turn is held %d times", n)
+	}
+}
+
+// The other half: the store changes whenever any session in it does, so a pass
+// that reads only the new messages must not drop the sessions it did not ask
+// about. Without fromDatabase knowing the store, the changed-file rule takes
+// them — which is what stamping turns on.
+func TestAQuietHermesSessionSurvivesAPassThatDidNotAskForIt(t *testing.T) {
+	tmp, home := hermesEnv(t)
+	db := filepath.Join(home, "state.db")
+	seedHermes(t, db, `insert into messages values (1,'quiet','user','marker-hermes-quiet',1767268800);`+
+		`insert into messages values (2,'busy','user','marker-hermes-busy',1767272400);`)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if hermesHits(t, dir, "marker-hermes-quiet") != 1 || hermesHits(t, dir, "marker-hermes-busy") != 1 {
+		t.Fatalf("both sessions were not indexed, so this measures nothing")
+	}
+
+	seedHermes(t, db, `insert into messages values (3,'busy','user','marker-hermes-added',1767276000);`)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-added"); n != 1 {
+		t.Errorf("the added turn is not indexed: %d hits", n)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-quiet"); n != 1 {
+		t.Errorf("the session the pass did not ask about was dropped: %d hits", n)
+	}
+}
+
+// Older builds shard the store per profile, so a machine can hold several. Each
+// carries its own watermark: stamping them alike would give a quiet profile the
+// busy one's time and skip everything it gained below that line (#2071).
+func TestEachHermesProfileKeepsItsOwnWatermark(t *testing.T) {
+	tmp, home := hermesEnv(t)
+	profiles := filepath.Join(home, "profiles")
+	var dbs []string
+	for i, name := range []string{"busy", "quiet"} {
+		dir := filepath.Join(profiles, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		db := filepath.Join(dir, "state.db")
+		seedHermes(t, db, fmt.Sprintf(`insert into messages values (1,'s%d','user','marker-hermes-%s',%d);`,
+			i, name, 1767268800+int64(i)*-3600))
+		dbs = append(dbs, db)
+	}
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if hermesHits(t, dir, "marker-hermes-busy") != 1 || hermesHits(t, dir, "marker-hermes-quiet") != 1 {
+		t.Fatalf("the two profiles were not both indexed, so this measures nothing")
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Files[dbs[1]].LastUpdated == m.Files[dbs[0]].LastUpdated {
+		t.Errorf("both profiles carry one watermark (%d), so the quiet one is stamped with the busy one's newest",
+			m.Files[dbs[1]].LastUpdated)
+	}
+
+	// The quiet profile gains a turn newer than anything it holds and older
+	// than the busy profile's newest.
+	seedHermes(t, dbs[1], `insert into messages values (2,'s1','user','marker-hermes-quiet-two',1767267000);`)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hermesHits(t, dir, "marker-hermes-quiet-two"); n != 1 {
+		t.Errorf("the turn added to the quiet profile is not indexed: %d hits", n)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2280,7 +2280,7 @@ func fromDatabase(r Record) bool {
 		return true
 	}
 	switch h := harnessForPath(r.SourcePath); h {
-	case "cursor-db", "goose-db":
+	case "cursor-db", "goose-db", "hermes":
 		return true
 	default:
 		// A path that names a per-file kind settles it: two transcripts in
@@ -3124,6 +3124,14 @@ func setOpencodeLastUpdated(files map[string]FileState, sessions map[string]Sess
 	// with a strict >, and zed returns whole threads; each needs its own fix
 	// before it can be stamped, so neither is here.
 	setStoreLastUpdated(files, sessions, "grok", sources.GrokDB())
+	// hermes, once its reader stopped dropping the watermark's own second
+	// (#2075). Several stores on one machine: current builds keep one at the
+	// root and older ones shard per profile, and each is stamped with its own
+	// newest — stamping them alike would give a quiet profile the busy one's
+	// time (#2071).
+	for _, db := range sources.HermesDBs() {
+		setStoreLastUpdated(files, sessions, "hermes", db)
+	}
 	for _, db := range sources.CursorDBs() {
 		setStoreLastUpdated(files, sessions, "cursor", db)
 	}

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -92,11 +92,18 @@ func ParseHermesDB(db string) ([]model.Session, error) {
 // ParseHermesDBSince reads only what changed, so a re-index of an unchanged
 // profile costs one query instead of the whole history. timestamp is REAL
 // seconds since the epoch in Hermes' schema.
+//
+// A second back from the watermark, which is the guard grok's reader spells in
+// milliseconds (#2150). The column is REAL but a store may write whole seconds
+// into it, and then every message sharing the watermark's second compares equal
+// to it and a strict `>` leaves it out for good — measured on such a store, 0
+// of 2 came back. The cost is re-reading one second of history, and those turns
+// are already held (#2075).
 func ParseHermesDBSince(db string, t time.Time) ([]model.Session, error) {
 	if t.IsZero() {
 		return parseHermesDBWhere(db, "")
 	}
-	return parseHermesDBWhere(db, fmt.Sprintf(" and timestamp > %d", t.Unix()))
+	return parseHermesDBWhere(db, fmt.Sprintf(" and timestamp > %d", t.Add(-time.Second).Unix()))
 }
 
 func parseHermesDBWhere(db, where string) ([]model.Session, error) {

--- a/internal/sources/hermes_since_boundary_test.go
+++ b/internal/sources/hermes_since_boundary_test.go
@@ -1,0 +1,52 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The watermark is the newest message deja has, and the filter has to hand back
+// everything after it — including the messages written in the same instant.
+//
+// The column is REAL seconds, and the filter compared against whole seconds
+// with a strict `>`. On a store that writes fractional stamps that over-reads
+// harmlessly; on one that writes whole seconds, every other message of the
+// watermark's own second is skipped, permanently. Measured before the fix:
+// whole seconds handed back 0 of 2, fractional handed back 2 of 2 (#2075).
+func TestHermesHandsBackTheWatermarksOwnSecond(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	const at = int64(1767268800)
+	for _, tc := range []struct{ name, a, b string }{
+		{"whole seconds", "1767268800", "1767268800"},
+		{"fractional", "1767268800.2", "1767268800.7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db := filepath.Join(t.TempDir(), "state.db")
+			stmts := `create table messages (id integer primary key, session_id text, role text, content text, timestamp real);` +
+				`insert into messages values (1,'s1','user','first turn',` + tc.a + `);` +
+				`insert into messages values (2,'s1','user','second turn',` + tc.b + `);`
+			if out, err := exec.Command("sqlite3", db, stmts).CombinedOutput(); err != nil {
+				t.Fatalf("seed: %v %s", err, out)
+			}
+			ss, err := ParseHermesDBSince(db, time.Unix(at, 0))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var text []string
+			for _, s := range ss {
+				for _, m := range s.Messages {
+					text = append(text, m.Text)
+				}
+			}
+			joined := strings.Join(text, " | ")
+			if !strings.Contains(joined, "second turn") {
+				t.Errorf("a message stamped in the watermark's own second was skipped: %q", joined)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The second of the three stores in #2075, after grok in #2812. zed is still open — it returns whole threads, which is the goose shape.

**The hazard was real, and narrower than I claimed on the issue.** `ParseHermesDBSince` filtered ` and timestamp > t.Unix()` — whole seconds, strictly greater — against a REAL column. Probed both shapes before touching anything:

    whole-second stamps   watermark 1767268800 -> 0 of 2 messages back
    fractional stamps     watermark 1767268800 -> 2 of 2 messages back

So a store that writes fractions over-reads harmlessly and one that writes whole seconds loses every turn sharing the watermark's second, permanently. Harmless today only because the since form never ran. Fixed with a one-second backoff — the guard grok's reader spells in milliseconds (#2150) — and the cost is re-reading one second of history that is already held.

Then the stamp, with the same two companions grok needed: `setStoreLastUpdated` per store (hermes keeps one at the root on current builds and shards per profile on older ones, so each is stamped with its own newest — #2071), and `fromDatabase` taught the store so the changed-file rule stops taking the sessions an incremental pass did not ask about.

**Not** added to `wholeStoresThisPass`. No test needs it, and unlike grok there is no argument for it: that function sets a harness-wide flag, `readWholeThisPass` routes only cursor and goose by store path, and hermes can have several stores — so a new profile appearing with no watermark would let one pass replace sessions in a store it had read only the tail of, which is the exact bug the comment there describes for cursor. Leaving it out is the conservative half.

Four tests, three of them mutation-checked (the fourth is the one I removed rather than ship untested).