### PR TITLE
fix(friction): count the withheld sessions it would have reported

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -28,9 +28,14 @@ import (
 // hasFrictionLine reports whether a record holds anything friction would put in
 // its answer. The note about what a rule withheld is a sentence about that
 // answer, so a hidden session is only worth counting when it holds one.
+// The threshold friction applies to what it prints — a failure has to recur
+// across sessions — is deliberately not applied here: it cannot be, without
+// building the signature map a second time over records the reader may not see.
+// So the note counts sessions holding a failure, not sessions holding a
+// recurring one, which is the bar `how` uses for the same sentence.
 func hasFrictionLine(text string) bool {
 	for _, line := range strings.Split(text, "\n") {
-		if _, _, ok := index.FrictionSignature(line); ok {
+		if _, ok := index.FrictionLine(line); ok {
 			return true
 		}
 	}
@@ -86,6 +91,11 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	// the rule is applied and read the ignored tree's errors as this machine's
 	// own (#2630).
 	ignoredSessions := map[string]bool{}
+	// And the sessions a rule took away that recorded tool output at all, green
+	// or not: that is what the lines on stdout are about, and it is a different
+	// number from the one the note above them uses.
+	withheldOutput := map[string]bool{}
+	ignoredOutput := map[string]bool{}
 	// One pass over the record log rather than a load per session: loading by
 	// identity walks the whole log each time, which put this command at 2m46s
 	// on a 1150-session store.
@@ -100,13 +110,23 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		denied := !pol.Allows(policy.ActivationSearch, meta.Project)
 		ignored := !denied && pol.Ignored(meta.Path, meta.Project)
 		if denied || ignored {
-			if !hasFrictionLine(r.Text) {
-				return
-			}
+			// Two counts, because two sentences: the note on stderr says a rule
+			// hides *matching* sessions, and the line on stdout says the
+			// sessions that *recorded tool output* are the ones a rule took
+			// away. A session whose output is all green belongs to the second
+			// and not the first.
+			hit := hasFrictionLine(r.Text)
+			key := meta.Harness + ":" + meta.ID
 			if denied {
-				withheldSessions[meta.Harness+":"+meta.ID] = true
+				withheldOutput[key] = true
+				if hit {
+					withheldSessions[key] = true
+				}
 			} else {
-				ignoredSessions[meta.Harness+":"+meta.ID] = true
+				ignoredOutput[key] = true
+				if hit {
+					ignoredSessions[key] = true
+				}
 			}
 			return
 		}
@@ -190,20 +210,20 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			// someone lands when recall feels thin, so it is the worst place
 			// to say the history is not there (#1044).
 			fmt.Fprintln(stdout, strings.TrimPrefix(emptyIndexHint("nothing recurring"), "deja: "))
-		case len(sessions) == 0 && len(withheldSessions) > 0:
+		case len(sessions) == 0 && len(withheldOutput) > 0:
 			// The sessions that recorded tool output are exactly the ones a
 			// rule took away, and saying the machine never had them is a claim
 			// about the store rather than about the rule — the misread #637
 			// and #1044 closed elsewhere. The stderr note above says the same
 			// thing, and stdout is what a redirect keeps (#2319).
 			fmt.Fprintf(stdout, "nothing recurring — the trust policy withheld the %d session%s that recorded tool output, which is what friction reads errors from\n",
-				len(withheldSessions), pluralS(len(withheldSessions)))
-		case len(sessions) == 0 && len(ignoredSessions) > 0:
+				len(withheldOutput), pluralS(len(withheldOutput)))
+		case len(sessions) == 0 && len(ignoredOutput) > 0:
 			// The same claim about the store rather than about the rule, for
 			// the other rule: the sessions with the tool output are there and
 			// the ignore rule is what keeps them out (#2630).
 			fmt.Fprintf(stdout, "nothing recurring — the ignore rule keeps the %d session%s that recorded tool output out of recall, which is what friction reads errors from\n",
-				len(ignoredSessions), pluralS(len(ignoredSessions)))
+				len(ignoredOutput), pluralS(len(ignoredOutput)))
 		case len(sessions) == 0 && total == 0:
 			// Every session on this machine is behind a rule, and none of them
 			// recorded tool output — so neither arm above fired and the count

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -25,6 +25,18 @@ import (
 // So this reports friction, not knowledge, and it is deliberately a small
 // claim: the same specific error, in N separate sessions.
 
+// hasFrictionLine reports whether a record holds anything friction would put in
+// its answer. The note about what a rule withheld is a sentence about that
+// answer, so a hidden session is only worth counting when it holds one.
+func hasFrictionLine(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if _, _, ok := index.FrictionSignature(line); ok {
+			return true
+		}
+	}
+	return false
+}
+
 func runFriction(dir string, args []string, stdout io.Writer) error {
 	limit := 10
 	for i := 0; i < len(args); i++ {
@@ -78,12 +90,24 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	// identity walks the whole log each time, which put this command at 2m46s
 	// on a 1150-session store.
 	if err := index.EachToolOutput(dir, func(meta index.SessionMeta, r index.Record) {
-		if !pol.Allows(policy.ActivationSearch, meta.Project) {
-			withheldSessions[meta.Harness+":"+meta.ID] = true
-			return
-		}
-		if pol.Ignored(meta.Path, meta.Project) {
-			ignoredSessions[meta.Harness+":"+meta.ID] = true
+		// Whether the record is withheld is decided here; whether friction
+		// would have said anything about it is decided below, and that is where
+		// the counts are taken. Counted here, they were about tool output
+		// rather than about failures: a machine whose hidden sessions only ever
+		// printed `ok 12 tests passed` was told a rule was keeping matching
+		// sessions back, and "matching" is the word the sentence uses (#2794,
+		// the sibling of #2766).
+		denied := !pol.Allows(policy.ActivationSearch, meta.Project)
+		ignored := !denied && pol.Ignored(meta.Path, meta.Project)
+		if denied || ignored {
+			if !hasFrictionLine(r.Text) {
+				return
+			}
+			if denied {
+				withheldSessions[meta.Harness+":"+meta.ID] = true
+			} else {
+				ignoredSessions[meta.Harness+":"+meta.ID] = true
+			}
 			return
 		}
 		key := meta.Harness + ":" + meta.ID

--- a/cmd/deja/friction_withheld_matching_test.go
+++ b/cmd/deja/friction_withheld_matching_test.go
@@ -41,6 +41,16 @@ func TestFrictionCountsTheWithheldSessionsItWouldHaveReported(t *testing.T) {
 	if strings.Contains(note, "hides") {
 		t.Errorf("the hidden session holds nothing friction reports, and the note claims otherwise:\n%s", note)
 	}
+	// The line on stdout counts something else — the sessions a rule took away
+	// that recorded tool output at all — and it still has to be true, and still
+	// has to name the rule that actually applies.
+	out, err := captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "the trust policy withheld the 1 session that recorded tool output") {
+		t.Errorf("the line about what the rule took away is wrong:\n%s", out)
+	}
 
 	// And a hidden session that does hold a failure is still counted: the
 	// sentence has to keep working where it is true.
@@ -57,5 +67,12 @@ func TestFrictionCountsTheWithheldSessionsItWouldHaveReported(t *testing.T) {
 	}
 	if !strings.Contains(note, "hides 1 matching session") {
 		t.Errorf("the session with a failure in it was not counted:\n%s", note)
+	}
+	out, err = captureRun(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "withheld the 2 sessions that recorded tool output") {
+		t.Errorf("both sessions recorded tool output; the line says otherwise:\n%s", out)
 	}
 }

--- a/cmd/deja/friction_withheld_matching_test.go
+++ b/cmd/deja/friction_withheld_matching_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The note says the policy hides matching sessions, so a hidden session has to
+// hold something friction would have reported before it counts. It counted
+// every session that recorded any tool output at all, so a machine whose hidden
+// history is `ok 12 tests passed` was told a rule was keeping its recurring
+// failures back (#2794, the sibling of #2766).
+func TestFrictionCountsTheWithheldSessionsItWouldHaveReported(t *testing.T) {
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	quiet := `{"type":"user","timestamp":"2026-07-10T10:00:00Z","sessionId":"bbbb0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a1","content":"ok 12 tests passed\nHEAD is now at 1a2b3c4"}]}}`
+	if err := os.WriteFile(filepath.Join(store, "quiet.jsonl"), []byte(quiet+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"*":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	note, err := captureRunStderr(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(note, "hides") {
+		t.Errorf("the hidden session holds nothing friction reports, and the note claims otherwise:\n%s", note)
+	}
+
+	// And a hidden session that does hold a failure is still counted: the
+	// sentence has to keep working where it is true.
+	loud := `{"type":"user","timestamp":"2026-07-10T11:00:00Z","sessionId":"cccc0001-1111-4000-8000-d6e7f8a9b0c1","cwd":"/api","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a2","content":"connection refused on port 5432"}]}}`
+	if err := os.WriteFile(filepath.Join(store, "loud.jsonl"), []byte(loud+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	note, err = captureRunStderr(t, "friction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "hides 1 matching session") {
+		t.Errorf("the session with a failure in it was not counted:\n%s", note)
+	}
+}


### PR DESCRIPTION
Closes #2794, the sibling of #2766. The counts were taken before `index.FrictionSignature`, so a hidden session whose only tool output was `ok 12 tests passed` and `HEAD is now at 1a2b3c4` still produced "the trust policy hides 1 matching session". Same shape as #2795: decide withheld where the policy is read, count where the answer is built.