### PR TITLE
chore: drop the grok entry in wholeStoresThisPass, which nothing needed

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2334,14 +2334,6 @@ func wholeStoresThisPass(changed, old map[string]FileState) {
 			harness = "cursor"
 		case "goose-db":
 			harness = "goose"
-		case "grok":
-			// Both grok kinds are registered under one name, and only the
-			// database carries a watermark: its session files are read whole
-			// and judged by their path, the way this function's comment says.
-			if p != sources.GrokDB() {
-				continue
-			}
-			harness = "grok"
 		default:
 			continue
 		}


### PR DESCRIPTION
Following up my own flag on #2812: that PR shipped a path guard in `wholeStoresThisPass` I could not turn into a failing test, and I said so rather than let it read as measured.

Doing hermes (#2813) settled it. That function sets a **harness-wide** flag, and `readWholeThisPass` routes only cursor and goose by store path — so for a harness that can have more than one store, marking it harness-wide is the bug the comment there describes for cursor, not a safeguard. hermes was left out on that reasoning and its four tests pass.

grok is the same shape, and the whole entry turns out to be unnecessary rather than just its guard: the suite is green with the `case "grok"` removed entirely. The watermark work it belonged to — the stamp and `fromDatabase` — stays and is mutation-checked in #2812.

So: two stamped stores, neither in `wholeStoresThisPass`, and no unexercised line left behind.