### PR TITLE
fix(hook): keep salvage off the command, and heredocs out of fix pairs

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -99,7 +99,7 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 		// `pytest -v` whose log runs past a megabyte (#1716). What arrived is
 		// still worth reading: pull the output back out of the cut JSON rather
 		// than throwing away a megabyte that begins with the error.
-		out = clampOutput(salvageToolOutput(after(string(raw), `"tool_response"`)))
+		out = salvageFromPayload(string(raw))
 	}
 	if out == "" {
 		return nil
@@ -166,15 +166,52 @@ func toolResponseText(raw json.RawMessage) string {
 	return clampOutput(b.String())
 }
 
-// after returns what follows key, or "" when the key is not there. Scoping the
-// salvage this way keeps it from mining the command in tool_input, which can
-// hold any of the keys below.
+// after returns what follows key where it is used as one, or "" when the key is
+// not there. Scoping the salvage this way keeps it from mining the command in
+// tool_input, which can hold any of the keys below.
+//
+// Where it is used as one, because the first occurrence is inside the command
+// whenever the command mentions it — and this path exists for payloads the
+// decoder could not read, which is where an unescaped `"tool_response"` in a
+// command shows up. A key is followed by a colon; a mention is not (#2051).
 func after(s, key string) string {
-	i := strings.Index(s, key)
-	if i < 0 {
-		return ""
+	for i := 0; ; {
+		j := strings.Index(s[i:], key)
+		if j < 0 {
+			return ""
+		}
+		at := i + j + len(key)
+		if rest := strings.TrimLeft(s[at:], " \t\r\n"); strings.HasPrefix(rest, ":") {
+			return s[at:]
+		}
+		i = at
 	}
-	return s[i+len(key):]
+}
+
+// salvageFromPayload is the whole salvage: scope to the tool's response, pull a
+// value out of it, and bound what comes back.
+func salvageFromPayload(raw string) string {
+	return clampOutput(salvageToolOutput(afterLast(raw, `"tool_response"`)))
+}
+
+// afterLast is after, from the last place the key is used as one. A tool's
+// response is written after the input that produced it, so where a command
+// quotes a whole payload of its own — a shape this path sees, since a command
+// with unescaped quotes in it is why the decoder failed — the real key is the
+// later one (#2051).
+func afterLast(s, key string) string {
+	out := ""
+	for i := 0; ; {
+		j := strings.Index(s[i:], key)
+		if j < 0 {
+			return out
+		}
+		at := i + j + len(key)
+		if rest := strings.TrimLeft(s[at:], " \t\r\n"); strings.HasPrefix(rest, ":") {
+			out = s[at:]
+		}
+		i = at
+	}
 }
 
 // salvageToolOutput pulls the tool's output out of a payload the decoder could
@@ -184,16 +221,19 @@ func after(s, key string) string {
 // starts, unescape what follows, and hand back that.
 func salvageToolOutput(raw string) string {
 	for _, key := range []string{`"stderr"`, `"error"`, `"output"`, `"stdout"`, `"content"`, `"result"`} {
-		i := strings.Index(raw, key)
-		if i < 0 {
-			continue
-		}
-		v, ok := jsonStringAfter(raw[i+len(key):])
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(v) != "" {
-			return v
+		// Every occurrence, not the first: a mention of the key that is not a
+		// key — `grep "stderr" build.log` — made this give up on the key
+		// entirely and skip the real one further along (#2051).
+		for i := 0; ; {
+			j := strings.Index(raw[i:], key)
+			if j < 0 {
+				break
+			}
+			at := i + j + len(key)
+			if v, ok := jsonStringAfter(raw[at:]); ok && strings.TrimSpace(v) != "" {
+				return v
+			}
+			i = at
 		}
 	}
 	return ""

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -174,19 +174,7 @@ func toolResponseText(raw json.RawMessage) string {
 // whenever the command mentions it — and this path exists for payloads the
 // decoder could not read, which is where an unescaped `"tool_response"` in a
 // command shows up. A key is followed by a colon; a mention is not (#2051).
-func after(s, key string) string {
-	for i := 0; ; {
-		j := strings.Index(s[i:], key)
-		if j < 0 {
-			return ""
-		}
-		at := i + j + len(key)
-		if rest := strings.TrimLeft(s[at:], " \t\r\n"); strings.HasPrefix(rest, ":") {
-			return s[at:]
-		}
-		i = at
-	}
-}
+func after(s, key string) string { return afterKey(s, key, false) }
 
 // salvageFromPayload is the whole salvage: scope to the tool's response, pull a
 // value out of it, and bound what comes back.
@@ -199,7 +187,11 @@ func salvageFromPayload(raw string) string {
 // quotes a whole payload of its own — a shape this path sees, since a command
 // with unescaped quotes in it is why the decoder failed — the real key is the
 // later one (#2051).
-func afterLast(s, key string) string {
+func afterLast(s, key string) string { return afterKey(s, key, true) }
+
+// afterKey is both: what follows the first or the last place key is used as
+// one. A key is followed by a colon; a mention of it in a command is not.
+func afterKey(s, key string, last bool) string {
 	out := ""
 	for i := 0; ; {
 		j := strings.Index(s[i:], key)
@@ -209,6 +201,9 @@ func afterLast(s, key string) string {
 		at := i + j + len(key)
 		if rest := strings.TrimLeft(s[at:], " \t\r\n"); strings.HasPrefix(rest, ":") {
 			out = s[at:]
+			if !last {
+				return out
+			}
 		}
 		i = at
 	}

--- a/cmd/deja/salvage_scope_test.go
+++ b/cmd/deja/salvage_scope_test.go
@@ -9,8 +9,6 @@ import (
 // its keys by text — so a command that mentions one takes the search with it.
 // This is the composition the hook runs: scope to the tool's response, then
 // pull a value out of it.
-func salvaged(raw string) string { return salvageFromPayload(raw) }
-
 // The scoping exists to keep salvage off the command, and it was done from the
 // first occurrence of the key — which is the one inside the command whenever
 // the command mentions it (#2051).
@@ -19,7 +17,7 @@ func TestSalvageDoesNotMineTheCommand(t *testing.T) {
 	// salvage is running at all.
 	raw := `{"tool_name":"Bash","tool_input":{"command":"echo '{"tool_response": {"stderr": "mined from the command"}}'"},` +
 		`"tool_response":{"stderr":"connection refused on port 5432"}}`
-	got := salvaged(raw)
+	got := salvageFromPayload(raw)
 	if strings.Contains(got, "mined from the command") {
 		t.Errorf("salvage answered with the command's own text: %q", got)
 	}
@@ -33,7 +31,7 @@ func TestSalvageDoesNotMineTheCommand(t *testing.T) {
 // further along was never reached.
 func TestSalvageKeepsLookingPastAMentionOfTheKey(t *testing.T) {
 	raw := `{"tool_response":{"command":"grep "stderr" build.log","stderr":"undefined: snorblefunc"}}`
-	if got := salvaged(raw); !strings.Contains(got, "undefined: snorblefunc") {
+	if got := salvageFromPayload(raw); !strings.Contains(got, "undefined: snorblefunc") {
 		t.Errorf("a mention of the key hid the real one: %q", got)
 	}
 }

--- a/cmd/deja/salvage_scope_test.go
+++ b/cmd/deja/salvage_scope_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// salvage is the path for a payload the decoder could not read, and it finds
+// its keys by text — so a command that mentions one takes the search with it.
+// This is the composition the hook runs: scope to the tool's response, then
+// pull a value out of it.
+func salvaged(raw string) string { return salvageFromPayload(raw) }
+
+// The scoping exists to keep salvage off the command, and it was done from the
+// first occurrence of the key — which is the one inside the command whenever
+// the command mentions it (#2051).
+func TestSalvageDoesNotMineTheCommand(t *testing.T) {
+	// Unescaped quotes inside the command, which is why the decoder failed and
+	// salvage is running at all.
+	raw := `{"tool_name":"Bash","tool_input":{"command":"echo '{"tool_response": {"stderr": "mined from the command"}}'"},` +
+		`"tool_response":{"stderr":"connection refused on port 5432"}}`
+	got := salvaged(raw)
+	if strings.Contains(got, "mined from the command") {
+		t.Errorf("salvage answered with the command's own text: %q", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("salvage missed the tool's stderr: %q", got)
+	}
+}
+
+// And a mention that is not a key at all must not stop the search: the loop
+// moved on to the next key rather than the next occurrence, so a real "stderr"
+// further along was never reached.
+func TestSalvageKeepsLookingPastAMentionOfTheKey(t *testing.T) {
+	raw := `{"tool_response":{"command":"grep "stderr" build.log","stderr":"undefined: snorblefunc"}}`
+	if got := salvaged(raw); !strings.Contains(got, "undefined: snorblefunc") {
+		t.Errorf("a mention of the key hid the real one: %q", got)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -373,7 +373,19 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 // one. A pair stores that line and a reader runs it, so a heredoc opener is not
 // a remedy but a hang.
 func opensMoreInput(cmd string) bool {
-	return strings.Contains(cmd, "<<") || strings.HasSuffix(cmd, "\\")
+	// A herestring is a whole command — `psql <<< "$sql"` reads from the line
+	// it is on — so it is not one of these.
+	for i := strings.Index(cmd, "<<"); i >= 0; i = strings.Index(cmd[i:], "<<") {
+		rest := cmd[i+2:]
+		if !strings.HasPrefix(rest, "<") {
+			return true
+		}
+		i += 3
+		if i >= len(cmd) {
+			break
+		}
+	}
+	return strings.HasSuffix(cmd, "\\")
 }
 
 // firstFrictionLine returns the first line of a record that names something

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -330,10 +330,15 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 				continue
 			}
 			cmd := strings.TrimSpace(firstLineOf(ms[j].Text))
-			if cmd == "" || len(cmd) > fixCommandMax {
+			if cmd == "" || len(cmd) > fixCommandMax || opensMoreInput(cmd) {
 				// A heredoc or pasted script right after the error is not the
 				// remedy; keep scanning the window for the real one-liner two
 				// records on, instead of abandoning the error entirely.
+				//
+				// The length bound is what caught most of those, and it caught
+				// them by luck: a short first line — `python - <<'EOF'` — was
+				// stored whole and handed to an agent as the command to run,
+				// where it waits on input that is not coming (#2051).
 				continue
 			}
 			if lastSeen[sig] > j {
@@ -362,6 +367,13 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 		}
 	}
 	return out
+}
+
+// opensMoreInput reports whether a command's first line is only the start of
+// one. A pair stores that line and a reader runs it, so a heredoc opener is not
+// a remedy but a hang.
+func opensMoreInput(cmd string) bool {
+	return strings.Contains(cmd, "<<") || strings.HasSuffix(cmd, "\\")
 }
 
 // firstFrictionLine returns the first line of a record that names something

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -375,15 +375,16 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 func opensMoreInput(cmd string) bool {
 	// A herestring is a whole command — `psql <<< "$sql"` reads from the line
 	// it is on — so it is not one of these.
-	for i := strings.Index(cmd, "<<"); i >= 0; i = strings.Index(cmd[i:], "<<") {
-		rest := cmd[i+2:]
-		if !strings.HasPrefix(rest, "<") {
-			return true
-		}
-		i += 3
-		if i >= len(cmd) {
+	for i := 0; ; {
+		j := strings.Index(cmd[i:], "<<")
+		if j < 0 {
 			break
 		}
+		at := i + j
+		if !strings.HasPrefix(cmd[at+2:], "<") {
+			return true
+		}
+		i = at + 3
 	}
 	return strings.HasSuffix(cmd, "\\")
 }

--- a/internal/index/fixpair_multiline_test.go
+++ b/internal/index/fixpair_multiline_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-// The exit status a source records is appended to the whole command record,
-// and a pair stores its first line — so for a heredoc or a pasted script the
-// marker is left behind and what the reader is handed is a command that failed,
-// offered as the one that settled the error (#2051).
+// A guard rather than a fix: #2051 expected the marker to be lost with the
+// rest of the record, because a pair stores only the first line. It is not —
+// commandFailed reads the whole record — and this is what says so, so the
+// next change to either end has to keep it true.
 func TestAFailedMultiLineCommandIsNotAFix(t *testing.T) {
 	now := time.Now()
 	script := "python - <<'EOF'\nimport socket\nsocket.create_connection(('db', 5432))\nEOF  → exit 1"
@@ -25,22 +25,23 @@ func TestAFailedMultiLineCommandIsNotAFix(t *testing.T) {
 	}
 }
 
-// And what is stored carries the marker when the source recorded one, so a
-// reader downstream can still tell: the pair is the whole command's story, not
-// its opening line.
-func TestAStoredCommandKeepsTheExitItWasJudgedOn(t *testing.T) {
+// Skipping a heredoc is not abandoning the error: the window keeps being
+// scanned, and the one-liner two records on is the pair worth having.
+func TestTheCommandAfterASkippedHeredocIsStillThePair(t *testing.T) {
 	now := time.Now()
 	ms := []model.Message{
 		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
-		{Role: "command", Text: "pg_isready -h db -p 5432\n  → exit 0", Time: now.Add(time.Minute)},
-		{Role: "tool-output", Text: "db:5432 - accepting connections", Time: now.Add(2 * time.Minute)},
+		{Role: "command", Text: "python - <<'EOF'\nimport socket\nEOF", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "ok", Time: now.Add(2 * time.Minute)},
+		{Role: "command", Text: "docker compose up -d db", Time: now.Add(3 * time.Minute)},
+		{Role: "tool-output", Text: "db started", Time: now.Add(4 * time.Minute)},
 	}
 	pairs := fixPairsIn(ms, "claude:s1", "p")
 	if len(pairs) != 1 {
-		t.Fatalf("want one pair, got %d", len(pairs))
+		t.Fatalf("want one pair, got %d: %+v", len(pairs), pairs)
 	}
-	if strings.Contains(pairs[0].Command, "exit") {
-		t.Errorf("a successful run carried its exit status into the stored command: %q", pairs[0].Command)
+	if pairs[0].Command != "docker compose up -d db" {
+		t.Errorf("wrong command stored: %q", pairs[0].Command)
 	}
 }
 
@@ -58,5 +59,19 @@ func TestAHeredocFirstLineIsNotOfferedAsTheFix(t *testing.T) {
 		if strings.Contains(p.Command, "<<") {
 			t.Errorf("a heredoc opener was stored as the fix: %q", p.Command)
 		}
+	}
+}
+
+// A herestring is a whole command, not the opening of one.
+func TestAHerestringIsStillAFix(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: `psql <<< "select 1"`, Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "1", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 || pairs[0].Command != `psql <<< "select 1"` {
+		t.Errorf("a herestring was read as an opener: %+v", pairs)
 	}
 }

--- a/internal/index/fixpair_multiline_test.go
+++ b/internal/index/fixpair_multiline_test.go
@@ -1,0 +1,62 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The exit status a source records is appended to the whole command record,
+// and a pair stores its first line — so for a heredoc or a pasted script the
+// marker is left behind and what the reader is handed is a command that failed,
+// offered as the one that settled the error (#2051).
+func TestAFailedMultiLineCommandIsNotAFix(t *testing.T) {
+	now := time.Now()
+	script := "python - <<'EOF'\nimport socket\nsocket.create_connection(('db', 5432))\nEOF  → exit 1"
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: script, Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "done", Time: now.Add(2 * time.Minute)},
+	}
+	if pairs := fixPairsIn(ms, "claude:s1", "p"); len(pairs) != 0 {
+		t.Errorf("a command that exited 1 was stored as the fix: %+v", pairs)
+	}
+}
+
+// And what is stored carries the marker when the source recorded one, so a
+// reader downstream can still tell: the pair is the whole command's story, not
+// its opening line.
+func TestAStoredCommandKeepsTheExitItWasJudgedOn(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: "pg_isready -h db -p 5432\n  → exit 0", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "db:5432 - accepting connections", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 {
+		t.Fatalf("want one pair, got %d", len(pairs))
+	}
+	if strings.Contains(pairs[0].Command, "exit") {
+		t.Errorf("a successful run carried its exit status into the stored command: %q", pairs[0].Command)
+	}
+}
+
+// The stored command is what a reader is told to run. A heredoc's first line
+// is not a command — it opens one — so storing it hands the agent something
+// that hangs waiting for input.
+func TestAHeredocFirstLineIsNotOfferedAsTheFix(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: "python - <<'EOF'\nimport socket\nsocket.create_connection(('db', 5432))\nEOF", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "ok", Time: now.Add(2 * time.Minute)},
+	}
+	for _, p := range fixPairsIn(ms, "claude:s1", "p") {
+		if strings.Contains(p.Command, "<<") {
+			t.Errorf("a heredoc opener was stored as the fix: %q", p.Command)
+		}
+	}
+}

--- a/internal/index/fixpair_multiline_test.go
+++ b/internal/index/fixpair_multiline_test.go
@@ -75,3 +75,22 @@ func TestAHerestringIsStillAFix(t *testing.T) {
 		t.Errorf("a herestring was read as an opener: %+v", pairs)
 	}
 }
+
+// A herestring followed by a heredoc: the shape the carve-out has to read
+// correctly, and the one a scan that advances by a relative offset never
+// finishes reading at all.
+func TestAHerestringBeforeAHeredocStillOpensMoreInput(t *testing.T) {
+	for cmd, want := range map[string]bool{
+		"tr a b <<<x; cat <<EOF":      true,
+		`cmp <<<"$a" <<<"$b"`:         false,
+		"a<<<a<<":                     true,
+		"psql -h db <<'SQL'":          true,
+		`psql <<< "select 1"`:         false,
+		"docker run --rm \\\\":        true,
+		`cat <<<"$h" && psql <<'SQL'`: true,
+	} {
+		if got := opensMoreInput(cmd); got != want {
+			t.Errorf("opensMoreInput(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2051.

The salvage half is real, both parts of it. The path runs on payloads the decoder could not read — which is where an unescaped quote in a command comes from — and it found its keys by text from the first occurrence. So a command that echoed a payload of its own took the scope with it and salvage answered with the command; and a command that merely mentioned `"stderr"` made the search give up on that key and skip the real one further along. Scope is taken from the last place the key is used as a key, and each key is now searched at every occurrence.

The multi-line half does not reproduce: `commandFailed` reads the whole record, so a heredoc that exited non-zero is already dropped. Two tests pin that. But the probe turned up the neighbouring defect — a heredoc that *succeeded* was stored as the fix by its first line, so an agent was handed `python - <<'EOF'`, which waits on input that is not coming. Short first lines slipped under `fixCommandMax`, which the issue called luck rather than a guard, and it was right.