### PR TITLE
fix(stats): count the withheld sessions its filters would have shown

### DIFF
--- a/cmd/deja/policyfilter.go
+++ b/cmd/deja/policyfilter.go
@@ -78,6 +78,21 @@ func policyFilterSessionsCounted(activation string, ss []model.Session) ([]model
 	return kept, before - len(kept)
 }
 
+// policyFilterSessionsSplit is policyFilterSessionsCounted with the withheld
+// sessions kept rather than counted, for a caller whose note is about the ones
+// its own filters would have shown (#2816).
+func policyFilterSessionsSplit(activation string, ss []model.Session) (keep, withheld []model.Session) {
+	p := policy.Load()
+	for _, s := range ss {
+		if p.Allows(activation, s.Project) {
+			keep = append(keep, s)
+			continue
+		}
+		withheld = append(withheld, s)
+	}
+	return keep, withheld
+}
+
 // policyHiddenProjects names the projects a rule is withholding right now. The
 // view page needs them by name rather than by session: a stored digest carries
 // no project field, so the only way to keep withheld content off a shareable

--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -150,7 +150,13 @@ func runStats(dir string, args []string) error {
 	// other machine's project, in an artifact meant to be shown to someone
 	// (#966). Browsing your own store is the search activation, as in `last`
 	// (#937).
-	ss, policyHidden := policyFilterSessionsCounted(policy.ActivationSearch, ss)
+	// Counted over what the screen would have shown: the note says a rule hides
+	// *matching* sessions, and taken over the whole store `deja stats --project
+	// alpha` reported the ones hidden in beta (#2816, the class #2795 and #2814
+	// closed for how and friction).
+	kept, withheld := policyFilterSessionsSplit(policy.ActivationSearch, ss)
+	policyHidden := len(stats.Filter(withheld, options))
+	ss = kept
 	if note := policyHiddenNote(policy.ActivationSearch, policyHidden); note != "" {
 		fmt.Fprintln(os.Stderr, note)
 	}

--- a/cmd/deja/stats_withheld_matching_test.go
+++ b/cmd/deja/stats_withheld_matching_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The note says a rule hides matching sessions, and stats counted every hidden
+// session in the store — so `deja stats --project alpha` reported the sessions
+// hidden in beta as matching ones (#2816, the class #2766 and #2794 fixed for
+// how and friction).
+func TestStatsCountsTheWithheldSessionsItsFiltersWouldShow(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, p := range []struct{ project, id string }{{"alpha", "aaaa0001"}, {"beta", "bbbb0001"}} {
+		dir := filepath.Join(root, "-"+p.project)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := `{"type":"user","timestamp":"2026-07-10T10:00:00Z","sessionId":"` + p.id +
+			`-1111-4000-8000-d6e7f8a9b0c1","cwd":"/` + p.project +
+			`","message":{"role":"user","content":"the pool is too small"}}`
+		if err := os.WriteFile(filepath.Join(dir, p.id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(filepath.Join(tmp, "index.db"), "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	pol := filepath.Join(tmp, "policy.json")
+	if err := os.WriteFile(pol, []byte(`{"activations":{"search":{"local":false}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_POLICY_FILE", pol)
+
+	note, err := captureRunStderr(t, "stats", "--project", "alpha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "hides 1 matching session") {
+		t.Errorf("one hidden session is in alpha; the note counts the store:\n%s", note)
+	}
+
+	// And without a filter the number is the store's again.
+	note, err = captureRunStderr(t, "stats")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(note, "hides 2 matching sessions") {
+		t.Errorf("with no filter both hidden sessions match:\n%s", note)
+	}
+}


### PR DESCRIPTION
Closes #2816, the last surface of the class #2795 and #2814 closed for `how` and `friction`. The count was taken over the whole store and the filters ran after it, so `deja stats --project alpha` said the sessions hidden in beta were matching ones.