### PR TITLE
fix: the semantic tier serves a promoted note with the source it distils

### DIFF
--- a/internal/embed/held_notes_test.go
+++ b/internal/embed/held_notes_test.go
@@ -1,0 +1,68 @@
+package embed
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func heldIDs(hits []search.Hit) []string {
+	out := make([]string, 0, len(hits))
+	for _, h := range hits {
+		out = append(out, h.Session.ID)
+	}
+	return out
+}
+
+func noteMatch(id string, score float64) match {
+	return match{
+		session: model.Session{ID: id, Harness: "deja"},
+		record:  index.Record{Text: "pool cap settled at 40"},
+		score:   score,
+	}
+}
+
+// A promoted note is one distilled line where its transcript is a whole
+// session, so it is often worded further from the query than the source it was
+// made from. The floor then cut the note while serving the source — and the
+// answer `promote` says it just put in front was not in the result at all,
+// which is the "not in fifty results" case of #2803.
+func TestANoteBelowTheFloorIsServedWithItsSource(t *testing.T) {
+	out := []search.Hit{
+		{Session: model.Session{ID: "other", Harness: "claude"}, Score: 0.81},
+		{Session: model.Session{ID: "sess1", Harness: "claude"}, Score: 0.62},
+	}
+	held := map[string]match{
+		"deja:deja-note-claude-sess1": noteMatch("deja-note-claude-sess1", 0.30),
+		// A note whose source nobody asked about stays out.
+		"deja:deja-note-claude-elsewhere": noteMatch("deja-note-claude-elsewhere", 0.40),
+	}
+	got := withHeldNotes(out, held)
+	search.LiftNotesAboveTheirSource(got)
+
+	ids := heldIDs(got)
+	want := []string{"other", "deja-note-claude-sess1", "sess1"}
+	if len(ids) != len(want) {
+		t.Fatalf("got %v, want %v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("got %v, want %v", ids, want)
+		}
+	}
+}
+
+// Nothing held, nothing changed — and a held note whose source is absent is not
+// a result on its own.
+func TestHeldNotesTravelOnlyWithTheirSource(t *testing.T) {
+	out := []search.Hit{{Session: model.Session{ID: "sess1", Harness: "claude"}, Score: 0.7}}
+	if got := withHeldNotes(out, nil); len(got) != 1 {
+		t.Errorf("nothing was held and the answer changed: %v", heldIDs(got))
+	}
+	held := map[string]match{"deja:deja-note-claude-gone": noteMatch("deja-note-claude-gone", 0.4)}
+	if got := withHeldNotes(out, held); len(got) != 1 {
+		t.Errorf("a note whose source is not in the answer was served anyway: %v", heldIDs(got))
+	}
+}

--- a/internal/embed/semantic.go
+++ b/internal/embed/semantic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -12,6 +13,14 @@ import (
 
 // semanticFloor avoids turning unrelated vectors into search results.
 const semanticFloor = 0.55
+
+// match is one vector's session, the record it came from and how close it
+// scored — the unit both the served set and the held notes are kept in.
+type match struct {
+	session model.Session
+	record  index.Record
+	score   float64
+}
 
 // SemanticSearch searches every covered record and returns the best vector
 // match per session. The caller is responsible for checking generation and
@@ -43,12 +52,8 @@ func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar S
 	for _, record := range records {
 		byOffset[record.Offset] = record.Record
 	}
-	type match struct {
-		session model.Session
-		record  index.Record
-		score   float64
-	}
 	best := make(map[string]match)
+	heldNotes := make(map[string]match)
 	for _, vector := range sidecar.Vectors {
 		session, ok := byKey[vector.Key]
 		if !ok {
@@ -60,6 +65,17 @@ func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar S
 		}
 		score := Cosine(query[0], vector.Values)
 		if score < semanticFloor {
+			// A promoted note is held rather than dropped. It is one distilled
+			// line where its transcript is a whole session, so it is often
+			// worded further from the query than the source it was made from —
+			// and then the floor cut the note while serving the source, which
+			// is the answer `promote` says it just put in front (#2803). It is
+			// only ever served beside that source, below.
+			if session.Harness == notesHarness && strings.HasPrefix(session.ID, notePrefix) {
+				if old, ok := heldNotes[vector.Key]; !ok || score > old.score {
+					heldNotes[vector.Key] = match{session: session, record: record, score: score}
+				}
+			}
 			continue
 		}
 		if old, ok := best[vector.Key]; !ok || score > old.score {
@@ -86,8 +102,47 @@ func SemanticSearch(ctx context.Context, dir string, o search.Options, sidecar S
 		}
 		return out[i].Session.ID < out[j].Session.ID
 	})
+	out = withHeldNotes(out, heldNotes)
+	search.LiftNotesAboveTheirSource(out)
 	if len(out) > 10 {
 		out = out[:10]
 	}
 	return out, nil
+}
+
+// notePrefix is how a promoted note's id begins; sources.PromotedNoteID builds
+// the rest of it from the source session's key.
+const notePrefix = "deja-note-"
+
+// notesHarness is the pseudo-harness deja files its own notes under.
+const notesHarness = "deja"
+
+// withHeldNotes puts back the notes the floor cut, but only those whose own
+// source is being served — a note nobody asked about stays out, and one that
+// distils an answer already in the answer travels with it.
+//
+// Before the lift below, so the pair is ordered by the same rule every other
+// tier uses, and before the cut to ten, so a note cannot be the element the
+// truncation takes.
+func withHeldNotes(out []search.Hit, held map[string]match) []search.Hit {
+	if len(held) == 0 {
+		return out
+	}
+	for _, hit := range out {
+		if hit.Session.Harness == notesHarness {
+			continue
+		}
+		found, ok := held[notesHarness+":"+notePrefix+hit.Session.Harness+"-"+hit.Session.ID]
+		if !ok {
+			continue
+		}
+		out = append(out, search.Hit{
+			Session:    found.session,
+			Snippets:   []string{search.Snippet(found.record.Text, "")},
+			Score:      found.score,
+			Tier:       search.TierSemantic,
+			TierDetail: fmt.Sprintf("%.2f", found.score),
+		})
+	}
+	return out
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -639,6 +639,14 @@ func liftedNotes(hits []Hit) []Hit {
 	return hits
 }
 
+// LiftNotesAboveTheirSource applies the note-over-source rule to a hit list a
+// caller outside this package built. The semantic path is such a caller: it
+// ranks by cosine alone and never goes through the sort the rule lived in
+// (#2803).
+func LiftNotesAboveTheirSource(hits []Hit) {
+	liftNotesAboveTheirSource(hits)
+}
+
 // liftNotesAboveTheirSource keeps a promoted note in front of the transcript it
 // was distilled from. The two say the same thing, so nothing is buried by the
 // swap — but the note says it in one line with a state attached, and that is


### PR DESCRIPTION
The third of the four gaps in #2803, after the error and relevance tiers in #2804. Only the prompt hook is left, and it is a different problem — it ranks `[]model.Session` and never builds a `Hit`, so there is no rule there to reach.

This one is not a misordering. A promoted note is one distilled line where its transcript is a whole session, so it is routinely worded *further* from the query than the source it was made from — and the 0.55 floor then cut the note while serving the source. That is the issue's "in one query it was not in fifty results at all", observed at 0.30.

A note that falls below the floor is now held rather than dropped, and put back **only when its own source is in the answer**: a note nobody asked about stays out, and one that distils an answer already being served travels with it. Then the lift orders the pair by the same rule every other tier uses, and both happen before the cut to ten so a note cannot be the element truncation takes.

`liftNotesAboveTheirSource` is exported for this — the semantic path ranks by cosine alone and never goes through the sort the rule lived in.

Two mutations: never putting held notes back, and putting any held note back regardless of its source.