### PR TITLE
fix(index): read the exit marker as the suffix it is written as

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -392,11 +392,6 @@ func fixLine(p index.FixPair, sessions int) string {
 	return "deja: this error came up" + how + " " + where + " before" + when + " — what followed it: " + cmd
 }
 
-// exitMarker is the shape a source appends when it knows what a command
-// returned: two spaces, the marker, the digits, end of string
-// (internal/sources/codex.go:259, internal/sources/opencode.go:202).
-const exitMarker = "  → exit "
-
 // withoutFailedExit drops the recorded exit status from a command, and reports
 // false when that status says the command failed.
 //

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -405,18 +405,9 @@ const exitMarker = "  → exit "
 // it read was `0"` — a command that mentions deja's own marker is still just a
 // command (#2048).
 func withoutFailedExit(cmd string) (string, bool) {
-	i := strings.LastIndex(cmd, exitMarker)
-	if i < 0 {
+	rest, code, recorded := index.CommandExitOutcome(cmd)
+	if !recorded {
 		return cmd, true
 	}
-	code := cmd[i+len(exitMarker):]
-	if code == "" {
-		return cmd, true
-	}
-	for _, r := range code {
-		if r < '0' || r > '9' {
-			return cmd, true
-		}
-	}
-	return strings.TrimSpace(cmd[:i]), code == "0"
+	return rest, code == 0
 }

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -431,6 +431,35 @@ func CommandExitStatus(s string) (int, bool) {
 	return n, true
 }
 
+// CommandExitOutcome splits a command from the exit status a source appended to
+// it, for every reader of that suffix.
+//
+// recorded is whether the marker is there as the shape it is written in — two
+// spaces, the marker, digits, end of record. Read anywhere in the record it
+// took `echo "  → exit 1" >> notes.txt` for a command that failed (#2820); read
+// without the digits it cut prose that merely ends like the marker (#2048).
+func CommandExitOutcome(s string) (cmd string, code int, recorded bool) {
+	trimmed := strings.TrimRight(s, " \t\r\n")
+	i := strings.LastIndex(trimmed, commandExitMarker)
+	if i < 0 {
+		return s, 0, false
+	}
+	token := trimmed[i+len(commandExitMarker):]
+	if token == "" || strings.ContainsAny(token, " \t\r\n") {
+		return s, 0, false
+	}
+	n := 0
+	for _, r := range token {
+		if r < '0' || r > '9' {
+			// Not the marker but prose that ends like it — "→ exit later" —
+			// and cutting the line there loses what the command was (#2048).
+			return s, 0, false
+		}
+		n = n*10 + int(r-'0')
+	}
+	return strings.TrimSpace(trimmed[:i]), n, true
+}
+
 // firstTextLine is the first line of a record, which for a command record is
 // the invocation itself.
 func firstTextLine(s string) string {

--- a/internal/index/commands.go
+++ b/internal/index/commands.go
@@ -380,23 +380,8 @@ func normalizeCommand(s string) string {
 // runs and 7 (#2590). The status stays in the records, where the fix-pair miner
 // reads it (commandFailed).
 func withoutExitStatus(s string) string {
-	i := strings.LastIndex(s, commandExitMarker)
-	if i < 0 {
-		return s
-	}
-	code := s[i+len(commandExitMarker):]
-	if code == "" {
-		return s
-	}
-	// Digits to the end, or it is not the marker: looking for it anywhere cut
-	// `echo "→ exit 0"` down to `echo "`, the trap #2048 already recorded for
-	// the after-hook's reading of the same suffix.
-	for _, r := range code {
-		if r < '0' || r > '9' {
-			return s
-		}
-	}
-	return strings.TrimSpace(s[:i])
+	cmd, _, _ := CommandExitOutcome(s)
+	return cmd
 }
 
 // commandExitMarker is the shape a source appends when it knows what a command
@@ -413,22 +398,8 @@ func CommandWithoutExitStatus(s string) string { return withoutExitStatus(s) }
 // surfaces that group commands themselves and then have to say what those runs
 // did. The same strict shape: two spaces, the marker, digits to the end.
 func CommandExitStatus(s string) (int, bool) {
-	i := strings.LastIndex(s, commandExitMarker)
-	if i < 0 {
-		return 0, false
-	}
-	code := s[i+len(commandExitMarker):]
-	if code == "" {
-		return 0, false
-	}
-	n := 0
-	for _, r := range code {
-		if r < '0' || r > '9' {
-			return 0, false
-		}
-		n = n*10 + int(r-'0')
-	}
-	return n, true
+	_, code, recorded := CommandExitOutcome(s)
+	return code, recorded
 }
 
 // CommandExitOutcome splits a command from the exit status a source appended to
@@ -445,7 +416,7 @@ func CommandExitOutcome(s string) (cmd string, code int, recorded bool) {
 		return s, 0, false
 	}
 	token := trimmed[i+len(commandExitMarker):]
-	if token == "" || strings.ContainsAny(token, " \t\r\n") {
+	if token == "" {
 		return s, 0, false
 	}
 	n := 0

--- a/internal/index/exit_marker_test.go
+++ b/internal/index/exit_marker_test.go
@@ -1,0 +1,44 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The exit status is written as a suffix — two spaces, the marker, the digits,
+// end of record — and it was read anywhere in the record, so a command whose
+// own text carries a line ending that way was taken for a command that failed
+// and dropped from the pairs (#2820, the trap #2048 recorded for the hook's
+// reading of the same suffix).
+func TestTheMarkerCountsOnlyWhereItIsWritten(t *testing.T) {
+	now := time.Now()
+	script := "docker compose run --rm db sh -c 'psql\n  → exit 1\nselect 1'"
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: script, Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "db is up", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 {
+		t.Fatalf("a command carrying the marker in its own text was read as a failed one: %+v", pairs)
+	}
+}
+
+// A token that is not a number is prose that ends like the marker, not a
+// status: the sources write decimal and nothing else, and cutting the line
+// there loses what the command was (#2048). So the command is kept whole, and
+// both readers of the suffix agree on that.
+func TestATokenThatIsNotANumberIsNotAStatus(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
+		{Role: "command", Text: "pg_isready -h db  → exit 0x1", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "ok", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 || pairs[0].Command != "pg_isready -h db  → exit 0x1" {
+		t.Errorf("prose ending like the marker was read as a status: %+v", pairs)
+	}
+}

--- a/internal/index/exit_marker_test.go
+++ b/internal/index/exit_marker_test.go
@@ -26,19 +26,42 @@ func TestTheMarkerCountsOnlyWhereItIsWritten(t *testing.T) {
 	}
 }
 
-// A token that is not a number is prose that ends like the marker, not a
-// status: the sources write decimal and nothing else, and cutting the line
-// there loses what the command was (#2048). So the command is kept whole, and
-// both readers of the suffix agree on that.
-func TestATokenThatIsNotANumberIsNotAStatus(t *testing.T) {
-	now := time.Now()
-	ms := []model.Message{
-		{Role: "tool-output", Text: "connection refused on port 5432", Time: now},
-		{Role: "command", Text: "pg_isready -h db  → exit 0x1", Time: now.Add(time.Minute)},
-		{Role: "tool-output", Text: "ok", Time: now.Add(2 * time.Minute)},
-	}
-	pairs := fixPairsIn(ms, "claude:s1", "p")
-	if len(pairs) != 1 || pairs[0].Command != "pg_isready -h db  → exit 0x1" {
-		t.Errorf("prose ending like the marker was read as a status: %+v", pairs)
+// The parser is what the three readers share, so the decisions live here: a
+// token that is not a number is prose that ends like the marker rather than a
+// status (#2048), a status is read through trailing whitespace, and it counts
+// only where a source writes it — at the end of the record, after the last
+// line of a multi-line script (internal/sources/codex.go).
+func TestTheExitOutcomeIsReadWhereItIsWritten(t *testing.T) {
+	for _, c := range []struct {
+		text     string
+		cmd      string
+		code     int
+		recorded bool
+	}{
+		{"$ make test  → exit 2", "$ make test", 2, true},
+		{"$ make test  → exit 0", "$ make test", 0, true},
+		{"$ make test  → exit 2\n", "$ make test", 2, true},
+		// Prose that ends like the marker: kept whole.
+		{"pg_isready -h db  → exit 0x1", "pg_isready -h db  → exit 0x1", 0, false},
+		{`echo "  → exit later"`, `echo "  → exit later"`, 0, false},
+		// Not where it is written: a line of the command's own text.
+		{"run.sh\n  → exit 1\nmore", "run.sh\n  → exit 1\nmore", 0, false},
+		// Where it is written, for a script: after the last line.
+		{"python - <<'EOF'\nprint(1)\nEOF  → exit 1", "python - <<'EOF'\nprint(1)\nEOF", 1, true},
+		{"go build ./...", "go build ./...", 0, false},
+	} {
+		cmd, code, recorded := CommandExitOutcome(c.text)
+		if cmd != c.cmd || code != c.code || recorded != c.recorded {
+			t.Errorf("CommandExitOutcome(%q) = %q, %d, %v; want %q, %d, %v",
+				c.text, cmd, code, recorded, c.cmd, c.code, c.recorded)
+		}
+		// And the two older readers say the same thing, because they are this
+		// one.
+		if got := withoutExitStatus(c.text); got != cmd {
+			t.Errorf("withoutExitStatus(%q) = %q, want %q", c.text, got, cmd)
+		}
+		if got, ok := CommandExitStatus(c.text); got != code || ok != recorded {
+			t.Errorf("CommandExitStatus(%q) = %d, %v; want %d, %v", c.text, got, ok, code, recorded)
+		}
 	}
 }

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -284,16 +284,8 @@ func outputReadsAsFailure(text string) bool {
 // commandFailed reads the exit status the record carries, for the harnesses
 // that store one (codex and opencode append it; Claude does not).
 func commandFailed(text string) bool {
-	i := strings.LastIndex(text, "→ exit ")
-	if i < 0 {
-		return false
-	}
-	code := strings.TrimSpace(text[i+len("→ exit "):])
-	if j := strings.IndexAny(code, " \n"); j >= 0 {
-		code = code[:j]
-	}
-	n, err := strconv.Atoi(code)
-	return err == nil && n != 0
+	_, code, recorded := CommandExitOutcome(text)
+	return recorded && code != 0
 }
 
 // outputFailed reports whether what came back from the command is itself an


### PR DESCRIPTION
Closes #2820. `commandFailed` took `→ exit ` anywhere in the record, so a command whose own text carries a line ending that way was read as a command that failed and dropped from the pairs. It shares one parser with the hook's `withoutFailedExit` now — two spaces, the marker, digits, end of record — which is the shape the sources write and the one #2048 already required on the other side.

The issue's second half turned out to be a decision rather than a defect: a token that is not a number is prose that ends like the marker, and cutting the line there loses what the command was. `TestTheExitMarkerIsReadAsASuffix` has pinned that since #2048; the new test says the same thing from the miner's side, so both readers now agree in one place instead of two.