### PR TITLE
fix: the per-prompt hook puts a note ahead of the transcript it distils

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -225,6 +225,12 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		skip[input.SessionID] = true
 	}
 	ranked, matched, strong, idfOf, err := index.ProjectRelevantSkipping(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates, skip)
+	// The rule every other surface applies: a promoted note goes in front of
+	// the transcript it was distilled from. This hook ranks sessions and never
+	// builds a search.Hit, so it had no note-over-source rule at all and the
+	// two slots below could go to the transcript while its own note waited
+	// behind it (#2803).
+	search.LiftNoteSessionsAboveTheirSource(ranked)
 	rankedAlreadyShown = 0
 	for _, s := range ranked {
 		if skip[s.ID] {

--- a/cmd/deja/hook_prompt_note_lift_test.go
+++ b/cmd/deja/hook_prompt_note_lift_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Every other surface puts a promoted note in front of the transcript it was
+// distilled from. The per-prompt hook ranks sessions and never builds a
+// search.Hit, so the rule could not reach it and the block led with the
+// transcript while its own note waited behind (#2803).
+func TestTheHookLiftsANoteAboveItsSource(t *testing.T) {
+	skipWindowsEmptySessionID(t)
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	// The transcript says the question's words several times over; the note is
+	// the one line distilled from it. That is the shape the rule exists for —
+	// on score alone the source wins its own distillation.
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "s14", []string{
+		`{"type":"user","sessionId":"s14","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer pool cap settled at 40 for the ticker service"}}`,
+		`{"type":"user","sessionId":"s14","timestamp":"` + old +
+			`","message":{"role":"user","content":"what should the pgbouncer pool cap be for the ticker service"}}`,
+		`{"type":"user","sessionId":"s14","timestamp":"` + old +
+			`","message":{"role":"user","content":"the pgbouncer pool cap keeps coming up, cap the pool"}}`,
+	})
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "promote", "s14"); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"what did we settle for the pgbouncer pool cap","session_id":"ses_ask"}`)
+	if err := runHookPromptMode(dir, in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	block := out.String()
+	// The ids as the block prints them, in backticks. The note's own line
+	// carries "-s14`" and not "`s14`", so the two needles do not collide — an
+	// earlier version of this test searched for "· s14", which is not how the
+	// line is written, and the order below was never actually checked.
+	note := strings.Index(block, "`deja-note-claude-s14`")
+	source := strings.Index(block, "`s14`")
+	// Not a skip: a block holding neither is a fixture that stopped reaching
+	// the path, and a test that goes quiet there guards nothing (#1412).
+	if note < 0 {
+		t.Fatalf("the note promoted from the session is not in the block:\n%s", block)
+	}
+	if source < 0 {
+		t.Fatalf("the transcript is not in the block, so there is no order to check:\n%s", block)
+	}
+	if note > source {
+		t.Errorf("the transcript came before the note distilled from it:\n%s", block)
+	}
+}

--- a/internal/search/note_lift_sessions_test.go
+++ b/internal/search/note_lift_sessions_test.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func sessionIDs(ss []model.Session) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s.ID)
+	}
+	return out
+}
+
+// The per-prompt hook ranks sessions and never builds a Hit, so the rule the
+// sort carries could not reach it: the transcript a note was distilled from
+// took a slot in the block while the note itself waited behind it (#2803).
+func TestNoteSessionsAreLiftedAboveTheirSource(t *testing.T) {
+	ss := []model.Session{
+		{ID: "other", Harness: "claude"},
+		{ID: "sess1", Harness: "claude"},
+		{ID: "unrelated", Harness: "claude"},
+		{ID: "deja-note-claude-sess1", Harness: "deja"},
+	}
+	LiftNoteSessionsAboveTheirSource(ss)
+	want := []string{"other", "deja-note-claude-sess1", "sess1", "unrelated"}
+	got := sessionIDs(ss)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("note not lifted in front of its source: got %v want %v", got, want)
+		}
+	}
+}
+
+// A note already ahead of its source stays put, a note whose source is absent
+// is left alone, and a harness whose name carries a dash does not split wrong.
+func TestNoteSessionLiftLeavesEverythingElseAlone(t *testing.T) {
+	ss := []model.Session{
+		{ID: "deja-note-claude-sess1", Harness: "deja"},
+		{ID: "sess1", Harness: "claude"},
+		{ID: "deja-note-claude-gone", Harness: "deja"},
+		{ID: "deja-2026-01-02-proj", Harness: "deja"},
+	}
+	before := sessionIDs(ss)
+	LiftNoteSessionsAboveTheirSource(ss)
+	after := sessionIDs(ss)
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("order changed with nothing to lift: %v -> %v", before, after)
+		}
+	}
+
+	dashed := []model.Session{
+		{ID: "one", Harness: "codex-history"},
+		{ID: "deja-note-codex-history-one", Harness: "deja"},
+	}
+	LiftNoteSessionsAboveTheirSource(dashed)
+	if got := sessionIDs(dashed); got[0] != "deja-note-codex-history-one" {
+		t.Errorf("a harness name with a dash was not matched: %v", got)
+	}
+
+	LiftNoteSessionsAboveTheirSource(nil)
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -655,36 +655,73 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 // is dated by its evidence rather than by the day it was filed (V4) the two are
 // equally fresh, so the transcript won its own distillation.
 func liftNotesAboveTheirSource(hits []Hit) {
-	notes := make(map[string]int, len(hits))
-	for i, h := range hits {
-		if h.Session.Harness == notesHarness && strings.HasPrefix(h.Session.ID, "deja-note-") {
-			notes[h.Session.ID] = i
+	order := liftedNoteOrder(len(hits),
+		func(i int) string { return hits[i].Session.Harness },
+		func(i int) string { return hits[i].Session.ID })
+	if order == nil {
+		return
+	}
+	out := make([]Hit, len(hits))
+	for at, from := range order {
+		out[at] = hits[from]
+	}
+	copy(hits, out)
+}
+
+// LiftNoteSessionsAboveTheirSource is the same rule for a caller that ranks
+// sessions and never builds a Hit. The per-prompt hook is one: it had no
+// note-over-source rule at all, so the transcript a note was distilled from
+// went into the block ahead of the note (#2803).
+func LiftNoteSessionsAboveTheirSource(ss []model.Session) {
+	order := liftedNoteOrder(len(ss),
+		func(i int) string { return ss[i].Harness },
+		func(i int) string { return ss[i].ID })
+	if order == nil {
+		return
+	}
+	out := make([]model.Session, len(ss))
+	for at, from := range order {
+		out[at] = ss[from]
+	}
+	copy(ss, out)
+}
+
+// liftedNoteOrder answers where each element goes so that a promoted note sits
+// in front of the transcript it was distilled from, and nothing else moves. It
+// returns nil when there is nothing to lift, so a caller can skip the copy.
+func liftedNoteOrder(n int, harnessAt, idAt func(int) string) []int {
+	notes := make(map[string]int, n)
+	for i := 0; i < n; i++ {
+		if harnessAt(i) == notesHarness && strings.HasPrefix(idAt(i), "deja-note-") {
+			notes[idAt(i)] = i
 		}
 	}
 	if len(notes) == 0 {
-		return
+		return nil
 	}
-	for i := 0; i < len(hits); i++ {
-		h := hits[i]
-		if h.Session.Harness == notesHarness {
+	order := make([]int, 0, n)
+	taken := make(map[int]bool, len(notes))
+	moved := false
+	for i := 0; i < n; i++ {
+		if taken[i] {
 			continue
 		}
-		// Mirrors sources.PromotedNoteID: building the id rather than parsing
-		// one keeps a harness name with a dash in it from splitting wrong.
-		id := "deja-note-" + h.Session.Harness + "-" + h.Session.ID
-		j, ok := notes[id]
-		if !ok || j < i {
-			continue
-		}
-		note := hits[j]
-		copy(hits[i+1:j+1], hits[i:j])
-		hits[i] = note
-		for k := i; k <= j; k++ {
-			if hits[k].Session.Harness == notesHarness && strings.HasPrefix(hits[k].Session.ID, "deja-note-") {
-				notes[hits[k].Session.ID] = k
+		if harnessAt(i) != notesHarness {
+			// Mirrors sources.PromotedNoteID: building the id rather than
+			// parsing one keeps a harness name with a dash in it from
+			// splitting wrong.
+			if j, ok := notes["deja-note-"+harnessAt(i)+"-"+idAt(i)]; ok && j > i {
+				order = append(order, j)
+				taken[j] = true
+				moved = true
 			}
 		}
+		order = append(order, i)
 	}
+	if !moved {
+		return nil
+	}
+	return order
 }
 
 // sortHits orders a ranked result set.


### PR DESCRIPTION
The last gap in #2803, after #2804 and #2821. I said on the issue this was a fork — session-level rule, or the hook starts building hits — and on looking it is the ordinary of the two: the rule is about provenance, not about what a `Hit` carries, so it gets a session-level form and nothing else changes.

The ordering algorithm is now written once over accessors and both wrappers call it, so the hit path and the session path cannot drift.

Measured before wiring anything, because the fixture is the whole test here: `ProjectRelevantSkipping` ranks the source first and its own note second, which is exactly the case the rule exists for.

**Two corrections to my own test, both worth naming:**

- it first *skipped* itself — the fixture never reached the hook, so the assertion was never run. A test that goes quiet where it should fail guards nothing (#1412); it now fails there instead.
- then it passed while the wiring was mutated away, because the needle `"· s14"` is not how the block writes an id. With `"\`s14\`"` the order is actually compared, and removing the call turns it red.

Three mutations: the session lift doing nothing, lifting a note that is already ahead, and the hook not calling it.