### PR TITLE
feat(doctor): name the sessions stamped ahead of the clock

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1547,6 +1547,40 @@ func doctorIndex(w io.Writer, idx doctorIndexReport, dir string) {
 		fmt.Fprintf(w, "  ingest   %s: %d unusable line%s skipped, %d path%s unreadable%s — see `deja doctor --json`\n",
 			h, e.MalformedLines, pluralS(e.MalformedLines), e.FailedFiles, pluralS(e.FailedFiles), clipped)
 	}
+	reportFutureDated(w, dir)
+}
+
+// reportFutureDated names the sessions stamped ahead of the clock.
+//
+// One note dated next year sits at the top of `deja last` and stays there. deja
+// cannot tell a skewed clock from a deliberate date, so the ordering is left
+// alone — but saying nothing leaves the reader with a store that looks wrong
+// for no visible reason, and the usual causes are a typo'd year in a
+// hand-edited note file or a millisecond stamp read as seconds (#2063).
+func reportFutureDated(w io.Writer, dir string) {
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		return
+	}
+	// A minute of slack: clocks between machines disagree by seconds, and a
+	// session synced from a peer a moment ago is not a finding.
+	cutoff := time.Now().Add(time.Minute)
+	newest, count := time.Time{}, 0
+	var newestID string
+	for _, meta := range metas {
+		if !meta.Updated.After(cutoff) {
+			continue
+		}
+		count++
+		if meta.Updated.After(newest) {
+			newest, newestID = meta.Updated, meta.Harness+":"+meta.ID
+		}
+	}
+	if count == 0 {
+		return
+	}
+	fmt.Fprintf(w, "  clock    %d session%s stamped in the future, newest %s (%s) — it sorts above real work in `deja last` until the date is corrected\n",
+		count, pluralS(count), newest.Local().Format("2006-01-02"), safeForStatusline(newestID, 80))
 }
 
 // strandedUpdateStagings counts the staging files an interrupted update left

--- a/cmd/deja/doctor_future_dated_test.go
+++ b/cmd/deja/doctor_future_dated_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A note stamped next year sits at the top of `deja last` and stays there: deja
+// cannot tell a skewed clock from a deliberate date, so the ordering is left
+// alone — but the reader is not told either, and a typo'd year or a millisecond
+// stamp read as seconds looks like nothing at all (#2063).
+func TestDoctorNamesASessionStampedInTheFuture(t *testing.T) {
+	tmp := hermeticEnv(t)
+	notes := filepath.Join(tmp, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	next := time.Now().AddDate(1, 0, 0).UTC().Format(time.RFC3339)
+	now := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	body := `{"ts":"` + next + `","project":"tmp/app","text":"a stray note stamped next year"}` + "\n" +
+		`{"ts":"` + now + `","project":"tmp/app","text":"the pgbouncer pool times out under load"}` + "\n"
+	if err := os.WriteFile(notes, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := runDoctor(&out, []string{"--offline"}, stubLookup("1.0.0", false), dir); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "stamped in the future") {
+		t.Errorf("doctor says nothing about a session dated ahead of the clock:\n%s", out.String())
+	}
+
+	// And it stays quiet when nothing is: the line is a finding, not furniture.
+	if err := os.WriteFile(notes, []byte(`{"ts":"`+now+`","project":"tmp/app","text":"the pgbouncer pool times out under load"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runDoctor(&out, []string{"--offline"}, stubLookup("1.0.0", false), dir); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "stamped in the future") {
+		t.Errorf("doctor reports a future stamp with none in the store:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
One of the two leftovers from the survey in #2063 — the half that is not a policy call.

A note stamped next year sits at the top of `deja last` and stays there. deja cannot tell a skewed clock from a deliberate date, so this **does not touch the ordering**: the issue's other two options (clamping a future `ts` at parse time, or leaving it) both decide what a date means, and that is yours. What it fixes is the silence — a typo'd year in a hand-edited note file, or a millisecond stamp read as seconds, currently looks like nothing at all.

    clock    1 session stamped in the future, newest 2027-08-31 (deja:deja-2027-08-31-tmp/app) — it sorts above real work in [claude · goprojects/deja-vu · 2026-08-31 · 2915986c-9f79-4f59-aed1-6cb929ca62b8] делай задачи в next.md
[opencode · shulcz · 2026-08-31 · ses_071066a67ffeo0q2erZxtUxOp0] почему у меня впн hiddify не подключается сейчас больше?
[claude · 23/wt · 2026-08-31 · 59eff8d3-1850-414d-b812-b4f0ce411bbd] прочитай /Users/shulcz/coding/goprojects/deja-vu-loop/EXTENS…
[claude · goprojects/d3fvxl · 2026-08-31 · adf51b62-9ab1-45ae-8c05-18f3beaddd8f] Summary: 1. **Primary Request and Intent:** The overarching…
[claude · Users/shulcz · 2026-08-30 · b218b8fa-3040-42fc-b6e1-ebbb14f65215] я подумываю перейти на ghosty с моего iterm2, потому что как…
[deja · shulcz · 2026-08-30 · deja-2026-08-30-shulcz] VPN front-proxy decision: VPS 92.246.138.179 runs HAProxy TC…
[claude · Users/shulcz · 2026-08-29 · 9a1e6ec6-f8c4-413c-a44a-d33ce777bae7] You are picking up work handed off from a opencode session (…
[claude · Users/shulcz · 2026-08-29 · d2c192f7-4aff-4fa7-a5ae-d1e82f83c589] хочу развивать своего hermes на ssh mini сервере дальше, пок…
[opencode · pin-manifests · 2026-08-28 · ses_fb76fffd1ffev4aC1Ibv3a65m8] "The orders worker is exhausting its database connections un…
[opencode · pin-manifests · 2026-08-28 · ses_fb7701a80ffenYpGow9FPt432H] "The orders worker is exhausting its database connections un… until the date is corrected

A minute of slack, because clocks between machines disagree by seconds and a session synced from a peer a moment ago is not a finding. The line is a finding rather than furniture: nothing is printed when nothing is ahead, and there is a mutation for that.

One correction on the way: my first test captured stderr, and doctor writes this to the writer it is given, so the assertion was reading an empty string and the fixture was fine all along. It drives `runDoctor` directly now, like its neighbours.