### PR TITLE
fix(install): take a commented config for openclaw-auto too

### DIFF
--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -132,6 +132,13 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 	return writeIfChanged(path, old, next)
 }
 
+// flagRecordKey names the switch in the wiring state, beside the blocks deja
+// records there. A key of its own rather than the block's, so "deja created
+// this block" and "deja turned this switch on" cannot be confused.
+func flagRecordKey(keys []string, flagKey string) string {
+	return strings.Join(keys[:len(keys)-1], ".") + "." + flagKey
+}
+
 // setOpenClawEntryJSONC writes one of openclaw's entries — the bootstrap hook,
 // or the plugin — into a config carrying comments, as text, so the reader's own
 // lines stay where they are.
@@ -176,14 +183,18 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		}
 		delete(have, id)
 		dropFrom := len(keys)
-		dropFlag := false
+		// The switch comes out only where deja is what turned it on. A reader
+		// who had set it themselves keeps it: deleting it left their own hook
+		// wired and switched off (#2811).
+		dropFlag := flagKey != "" && blockWasAdded(path, flagRecordKey(keys, flagKey))
 		if len(have) == 0 && blockWasAdded(path, blockKey) {
 			dropFrom = len(keys) - 1
-			dropFlag = flagKey != ""
 			forgetBlockAdded(path, blockKey)
 			// The switch goes with the entries it was for, and so does each
 			// level above that deja created and that holds nothing else.
-			delete(held, flagKey)
+			if dropFlag {
+				delete(held, flagKey)
+			}
 			for i := len(keys) - 2; i >= 0; i-- {
 				prefix := strings.Join(keys[:i+1], ".")
 				if len(holders[i+1]) != 1 || !blockWasAdded(path, prefix) {
@@ -201,6 +212,9 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		// condition the parsed path uses. Taken on the ordinary
 		// entry-comes-out case it deleted a switch the reader had set
 		// themselves, leaving their own hook wired and turned off (#2811).
+		if dropFlag {
+			forgetBlockAdded(path, flagRecordKey(keys, flagKey))
+		}
 		if dropFlag && dropFrom >= len(keys)-1 {
 			// The chain stayed, so the switch is still in it and comes out on
 			// its own.
@@ -228,6 +242,11 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		return "", configParseError(path, err)
 	}
 	if flagKey != "" {
+		// Recorded the way a block deja created is, so an uninstall can tell a
+		// switch deja turned on from one the reader set.
+		if _, present := held[flagKey]; !present {
+			noteBlockAdded(path, flagRecordKey(keys, flagKey))
+		}
 		next, err = jsoncSetFlag(next, strings.Join(keys[:len(keys)-1], "."), flagKey, true)
 		if err != nil {
 			return "", configParseError(path, err)

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -215,6 +215,17 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		if dropFlag {
 			forgetBlockAdded(path, flagRecordKey(keys, flagKey))
 		}
+		// A switch deja turned on over the reader's own "off" goes back to off
+		// rather than staying on: an uninstall that leaves internal hooks
+		// running for someone who had switched them off is a setting deja
+		// changed and did not give back.
+		if !dropFlag && flagKey != "" && blockWasAdded(path, flagRecordKey(keys, flagKey)+"=false") {
+			forgetBlockAdded(path, flagRecordKey(keys, flagKey)+"=false")
+			next, err = jsoncSetFlag(next, strings.Join(keys[:len(keys)-1], "."), flagKey, false)
+			if err != nil {
+				return "", configParseError(path, err)
+			}
+		}
 		if dropFlag && dropFrom >= len(keys)-1 {
 			// The chain stayed, so the switch is still in it and comes out on
 			// its own.
@@ -244,8 +255,13 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 	if flagKey != "" {
 		// Recorded the way a block deja created is, so an uninstall can tell a
 		// switch deja turned on from one the reader set.
-		if _, present := held[flagKey]; !present {
+		switch was, present := held[flagKey]; {
+		case !present:
 			noteBlockAdded(path, flagRecordKey(keys, flagKey))
+		case was == false:
+			// Theirs, and off: deja needs it on while it is installed, so what
+			// it changed is written down to be put back.
+			noteBlockAdded(path, flagRecordKey(keys, flagKey)+"=false")
 		}
 		next, err = jsoncSetFlag(next, strings.Join(keys[:len(keys)-1], "."), flagKey, true)
 		if err != nil {

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -260,7 +260,9 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 			noteBlockAdded(path, flagRecordKey(keys, flagKey))
 		case was == false:
 			// Theirs, and off: deja needs it on while it is installed, so what
-			// it changed is written down to be put back.
+			// it changed is written down to be put back. The boolean only —
+			// deja cannot know what a `null` or a `0` there was meant to say,
+			// and writing a guess back is worse than leaving the switch on.
 			noteBlockAdded(path, flagRecordKey(keys, flagKey)+"=false")
 		}
 		next, err = jsoncSetFlag(next, strings.Join(keys[:len(keys)-1], "."), flagKey, true)

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
@@ -80,6 +81,11 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 			return "unchanged", nil
 		}
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// A comment is not a broken file, and this writer shares openclaw.json
+		// with the MCP one — so refusing here left a target that wrote half its
+		// wiring, or could not take its own hook back out (#2811).
+		return setOpenClawEntryJSONC(path, old, "hooks.internal.entries", openclawHookName, "enabled", on)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return "", configParseError(path, err)
 	}
@@ -124,6 +130,84 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 	}
 	next = append(next, '\n')
 	return writeIfChanged(path, old, next)
+}
+
+// setOpenClawEntryJSONC writes one of openclaw's entries — the bootstrap hook,
+// or the plugin — into a config carrying comments, as text, so the reader's own
+// lines stay where they are.
+//
+// flagKey is the switch beside the entries block, "" where there is none. For
+// the hook it matters as much as the entry does: without it the pack is
+// discovered, listed as ready, and never invoked, so the two are written
+// together and taken back out together (#2811).
+func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string, on bool) (string, error) {
+	text := string(old)
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(text)), &root); err != nil {
+		return "", configParseError(path, err)
+	}
+	keys := strings.Split(blockKey, ".")
+	holders := chainHolders(root, keys)
+	held := holders[len(keys)-1]
+	have, _ := mapAt(held, keys[len(keys)-1])
+	if !on {
+		if have[id] == nil {
+			return "unchanged", nil
+		}
+		delete(have, id)
+		dropFrom := len(keys)
+		if len(have) == 0 && blockWasAdded(path, blockKey) {
+			dropFrom = len(keys) - 1
+			forgetBlockAdded(path, blockKey)
+			// The switch goes with the entries it was for, and so does each
+			// level above that deja created and that holds nothing else.
+			delete(held, flagKey)
+			for i := len(keys) - 2; i >= 0; i-- {
+				prefix := strings.Join(keys[:i+1], ".")
+				if len(holders[i+1]) != 1 || !blockWasAdded(path, prefix) {
+					break
+				}
+				dropFrom = i
+				forgetBlockAdded(path, prefix)
+			}
+		}
+		next, err := jsoncSetEntry(text, blockKey, id, "", true, dropFrom)
+		if err != nil {
+			return "", configParseError(path, err)
+		}
+		if flagKey != "" && dropFrom >= len(keys)-1 {
+			// The chain stayed, so the switch is still in it and comes out on
+			// its own.
+			flagBlock := strings.Join(keys[:len(keys)-1], ".")
+			next, err = jsoncRemoveKey(next, flagBlock, flagKey, len(keys)-1)
+			if err != nil {
+				return "", configParseError(path, err)
+			}
+		}
+		return writeIfChanged(path, old, []byte(next))
+	}
+	if have == nil {
+		for i := range keys {
+			if _, ok := holders[i][keys[i]].(map[string]any); !ok {
+				noteBlockAdded(path, strings.Join(keys[:i+1], "."))
+			}
+		}
+	}
+	entry, err := jsoncEntryText(map[string]any{"enabled": true})
+	if err != nil {
+		return "", err
+	}
+	next, err := jsoncSetEntry(text, blockKey, id, entry, false, len(keys))
+	if err != nil {
+		return "", configParseError(path, err)
+	}
+	if flagKey != "" {
+		next, err = jsoncSetFlag(next, strings.Join(keys[:len(keys)-1], "."), flagKey, true)
+		if err != nil {
+			return "", configParseError(path, err)
+		}
+	}
+	return writeIfChanged(path, old, []byte(next))
 }
 
 func mapAt(parent map[string]any, key string) (map[string]any, bool) {

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -147,6 +147,26 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		return "", configParseError(path, err)
 	}
 	keys := strings.Split(blockKey, ".")
+	// A key holding something other than an object is a config deja does not
+	// understand, and the text writer would insert a second key of the same
+	// name beside it — where the reader's value wins the decode and deja is
+	// silently unwired (#2399, and #2811 for this writer).
+	holder := root
+	for i, key := range keys {
+		v, present := holder[key]
+		if !present {
+			break
+		}
+		next, isObject := v.(map[string]any)
+		if !isObject {
+			if !on {
+				return "unchanged", nil
+			}
+			return "", fmt.Errorf("%s: %q is not an object deja can edit — left as it was",
+				path, strings.Join(keys[:i+1], "."))
+		}
+		holder = next
+	}
 	holders := chainHolders(root, keys)
 	held := holders[len(keys)-1]
 	have, _ := mapAt(held, keys[len(keys)-1])
@@ -156,8 +176,10 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		}
 		delete(have, id)
 		dropFrom := len(keys)
+		dropFlag := false
 		if len(have) == 0 && blockWasAdded(path, blockKey) {
 			dropFrom = len(keys) - 1
+			dropFlag = flagKey != ""
 			forgetBlockAdded(path, blockKey)
 			// The switch goes with the entries it was for, and so does each
 			// level above that deja created and that holds nothing else.
@@ -175,7 +197,11 @@ func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string
 		if err != nil {
 			return "", configParseError(path, err)
 		}
-		if flagKey != "" && dropFrom >= len(keys)-1 {
+		// Only where the entries block deja created has emptied — the same
+		// condition the parsed path uses. Taken on the ordinary
+		// entry-comes-out case it deleted a switch the reader had set
+		// themselves, leaving their own hook wired and turned off (#2811).
+		if dropFlag && dropFrom >= len(keys)-1 {
 			// The chain stayed, so the switch is still in it and comes out on
 			// its own.
 			flagBlock := strings.Join(keys[:len(keys)-1], ".")

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -81,6 +81,10 @@ func setOpenClawPluginEnabled(on bool) (string, error) {
 			return "unchanged", nil
 		}
 		root = map[string]any{}
+	} else if configIsJSONC(old) {
+		// The same file the hook and the MCP entry are written into, and the
+		// same reason not to refuse it over a comment (#2811).
+		return setOpenClawEntryJSONC(path, old, "plugins.entries", openclawPluginID, "", on)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return "", configParseError(path, err)
 	}

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -256,7 +256,11 @@ func zedFindKey(text string, from int, key string) *zedSpan {
 			if end < 0 {
 				return nil
 			}
-			if depth == 0 && text[i:end] == want {
+			// A string *value* equal to the key's name is not the key: without
+			// this a `"note": "internal"` beside the real `"internal"` block
+			// read as the block itself, and the writer put a second one in
+			// beside it — where the reader's value wins the decode (#2811).
+			if depth == 0 && text[i:end] == want && jsoncIsKey(text, end) {
 				open := zedValueOpen(text, end)
 				if open < 0 {
 					return nil

--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -160,7 +160,7 @@ func zedHasKey(text string, from int, key string) bool {
 			if end < 0 {
 				return false
 			}
-			if depth == 0 && text[i:end] == want {
+			if depth == 0 && text[i:end] == want && jsoncIsKey(text, end) {
 				return true
 			}
 			i = end - 1

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -471,9 +471,14 @@ func jsoncRemoveKey(text, blockKey, key string, dropFrom int) (string, error) {
 	// is what would be left dangling — `{…,\n  }` is not JSON, and the file is
 	// then refused on every later run with a message pointing at the reader's
 	// own comment (#2740 again, one key over).
+	//
+	// Looked for on the comment-blanked copy, whose offsets are the original's:
+	// a comment sitting between the two keys ends in a non-whitespace byte, and
+	// a backward walk that stops there never reaches the comma (#2811).
 	if !tookComma {
+		blank := stripJSONComments(text)
 		for i := start - 1; i > block.valueOpen; i-- {
-			if c := text[i]; c == ' ' || c == '\t' || c == '\n' {
+			if c := blank[i]; c == ' ' || c == '\t' || c == '\n' {
 				continue
 			} else if c == ',' {
 				start = i

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -459,11 +459,27 @@ func jsoncRemoveKey(text, blockKey, key string, dropFrom int) (string, error) {
 	for end < len(text) && (text[end] == ' ' || text[end] == '\t') {
 		end++
 	}
+	tookComma := false
 	if end < len(text) && text[end] == ',' {
 		end++
+		tookComma = true
 	}
-	for start > 0 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n') {
+	for start > block.valueOpen+1 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n') {
 		start--
+	}
+	// The last key in a block has no comma after it, and the one in front of it
+	// is what would be left dangling — `{…,\n  }` is not JSON, and the file is
+	// then refused on every later run with a message pointing at the reader's
+	// own comment (#2740 again, one key over).
+	if !tookComma {
+		for i := start - 1; i > block.valueOpen; i-- {
+			if c := text[i]; c == ' ' || c == '\t' || c == '\n' {
+				continue
+			} else if c == ',' {
+				start = i
+			}
+			break
+		}
 	}
 	return closeEmptied(text[:start]+text[end:], keys), nil
 }

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -392,10 +392,21 @@ func jsoncSetFlag(text, blockKey, key string, value bool) (string, error) {
 	if value {
 		rendered = "true"
 	}
-	block := zedFindKey(text, open+1, blockKey)
+	// A dotted block key, for a switch that lives deeper than the top level:
+	// openclaw's is `hooks.internal.enabled` (#2811).
+	keys := strings.Split(blockKey, ".")
+	block, have := walkJSONCKeys(text, open, keys)
 	if block == nil {
-		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  }%s", blockKey, key, rendered, rootComma(text, open))
-		return text[:open+1] + insert + text[open+1:], nil
+		at, comma, indent := open, rootComma(text, open), "  "
+		if have > 0 {
+			parent, _ := walkJSONCKeys(text, open, keys[:have])
+			at, comma, indent = parent.valueOpen, blockComma(text, parent), strings.Repeat("  ", have+1)
+		}
+		insert := nestedBlocks(keys[have:], key, rendered, indent)
+		if have > 0 && comma == "" && !strings.HasPrefix(text[at+1:], "\n") {
+			insert += "\n" + strings.Repeat("  ", have)
+		}
+		return text[:at+1] + insert + comma + text[at+1:], nil
 	}
 	if at := jsoncScalarValue(text, block, key); at != nil {
 		return text[:at[0]] + rendered + text[at[1]:], nil
@@ -408,8 +419,53 @@ func jsoncSetFlag(text, blockKey, key string, value bool) (string, error) {
 	if strings.TrimSpace(stripJSONComments(text[block.valueOpen+1:block.valueEnd-1])) == "" {
 		comma, tail = "", "\n  "
 	}
-	insert := fmt.Sprintf("\n    %q: %s%s%s", key, rendered, comma, tail)
+	insert := fmt.Sprintf("\n%s%q: %s%s%s", strings.Repeat("  ", len(keys)+1), key, rendered, comma, tail)
 	return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
+}
+
+// jsoncRemoveKey takes a scalar setting back out, and the blocks it was the
+// last thing in when deja is what created them. It is the other half of
+// jsoncSetFlag: a switch deja turned on has to go off the same way the entry
+// beside it goes (#2811).
+func jsoncRemoveKey(text, blockKey, key string, dropFrom int) (string, error) {
+	open := zedTopLevelOpen(text)
+	if open < 0 {
+		return text, nil
+	}
+	keys := strings.Split(blockKey, ".")
+	if dropFrom < len(keys) {
+		chain, have := walkJSONCKeys(text, open, keys[:dropFrom+1])
+		if chain == nil || have <= dropFrom {
+			return text, nil
+		}
+		cut := zedEntrySpan(text, chain)
+		return closeEmptied(text[:cut[0]]+text[cut[1]:], keys), nil
+	}
+	block, have := walkJSONCKeys(text, open, keys)
+	if block == nil || have < len(keys) {
+		return text, nil
+	}
+	at := jsoncScalarValue(text, block, key)
+	if at == nil {
+		return text, nil
+	}
+	// From the key's own quote to the end of its value, plus the comma behind
+	// it and the whitespace in front, the way an entry is taken out.
+	start := strings.LastIndex(text[:at[0]], `"`+key+`"`)
+	if start < 0 {
+		return text, nil
+	}
+	end := at[1]
+	for end < len(text) && (text[end] == ' ' || text[end] == '\t') {
+		end++
+	}
+	if end < len(text) && text[end] == ',' {
+		end++
+	}
+	for start > 0 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n') {
+		start--
+	}
+	return closeEmptied(text[:start]+text[end:], keys), nil
 }
 
 // jsoncScalarValue is where a scalar setting's value sits inside a block, or

--- a/cmd/deja/openclaw_auto_comments_test.go
+++ b/cmd/deja/openclaw_auto_comments_test.go
@@ -291,8 +291,11 @@ func TestOpenClawAutoRemovesASwitchTheReaderMoved(t *testing.T) {
 	if entry == "" {
 		t.Fatalf("could not find the entry deja wrote:\n%s", b)
 	}
+	// A key of the reader's own between the entries block and the switch, or
+	// the entries block takes its own comma with it when it goes and the walk
+	// has nothing to find.
 	moved := "{\n  // mine\n  \"hooks\": {\n    \"internal\": {\n      \"entries\": {\n        " +
-		entry + "\n      },\n      // deja turned this on\n      \"enabled\": true\n    }\n  }\n}\n"
+		entry + "\n      },\n      \"timeoutMs\": 500,\n      // deja turned this on\n      \"enabled\": true\n    }\n  }\n}\n"
 	if err := os.WriteFile(path, []byte(moved), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -313,5 +316,8 @@ func TestOpenClawAutoRemovesASwitchTheReaderMoved(t *testing.T) {
 	}
 	if !strings.Contains(string(b), "// mine") {
 		t.Errorf("the reader's own comment was dropped:\n%s", b)
+	}
+	if !strings.Contains(string(b), `"timeoutMs": 500`) {
+		t.Errorf("the reader's own key went with it:\n%s", b)
 	}
 }

--- a/cmd/deja/openclaw_auto_comments_test.go
+++ b/cmd/deja/openclaw_auto_comments_test.go
@@ -98,15 +98,60 @@ func TestOpenClawAutoLeavesTheReadersWiringAlone(t *testing.T) {
 	}
 }
 
-// The switch written last in its block: taking it out has to take the comma in
-// front of it, or what is left is `{…,}` and every later run refuses the file.
+// The switch written last in its block, with a key in front of it: taking it
+// out has to take the comma in front too, or what is left is `{…,}` and every
+// later run refuses the file — including across a comment between the two,
+// which a backward walk stops at.
 func TestOpenClawAutoRemovesASwitchWrittenLast(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // reader's own block\n  \"hooks\": {\n    \"internal\": {}\n  }\n}\n",
+		"{\n  // reader's own block\n  \"hooks\": {\n    \"internal\": {\n      \"timeoutMs\": 500\n    }\n  }\n}\n",
+		"{\n  // reader's own block\n  \"hooks\": {\n    \"internal\": {\n      \"timeoutMs\": 500,\n      // the internal hook system\n      \"other\": true\n    }\n  }\n}\n",
+		"{\n  \"hooks\": {\n    \"internal\": {\n      \"timeoutMs\": 500, /* keep */ \"other\": true\n    }\n  }\n}\n",
+	} {
+		t.Run("", func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+				t.Fatalf("a commented config was refused: %v", err)
+			}
+			if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+				t.Fatalf("uninstall refused the commented config: %v", err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var root map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+				t.Fatalf("the file no longer parses: %v\n%s", err, b)
+			}
+			if strings.Contains(string(b), `"enabled"`) {
+				t.Errorf("the switch deja turned on stayed behind:\n%s", b)
+			}
+			if string(b) != before {
+				t.Errorf("the round trip changed the file:\nwant %q\ngot  %q", before, b)
+			}
+		})
+	}
+}
+
+// A switch the reader set themselves is theirs: deja overwrites it while it is
+// installed and leaves it behind on the way out, rather than deleting a setting
+// it never wrote.
+func TestOpenClawAutoKeepsASwitchTheReaderSet(t *testing.T) {
 	hermeticEnv(t)
 	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	before := "{\n  // reader's own block\n  \"hooks\": {\n    \"internal\": {}\n  }\n}\n"
+	before := "{\n  // mine\n  \"hooks\": {\n    \"internal\": {\n      \"enabled\": false\n    }\n  }\n}\n"
 	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -120,12 +165,49 @@ func TestOpenClawAutoRemovesASwitchWrittenLast(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if !strings.Contains(string(b), `"enabled"`) {
+		t.Errorf("the reader's own switch was deleted:\n%s", b)
+	}
 	var root map[string]any
 	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
 		t.Fatalf("the file no longer parses: %v\n%s", err, b)
 	}
-	if strings.Contains(string(b), "enabled") {
-		t.Errorf("the switch deja turned on stayed behind:\n%s", b)
+}
+
+// A string value equal to a block's name is not that block: the writer read it
+// as one and put a second block in beside the reader's, where the decoder takes
+// the reader's and deja is silently unwired.
+func TestOpenClawAutoIsNotFooledByAValueNamedLikeAKey(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // a value can be spelled like a key\n  \"hooks\": {\n    \"note\": \"internal\",\n    \"internal\": {\n      \"entries\": {\n        \"mine\": { \"enabled\": true }\n      }\n    }\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+		t.Fatalf("install refused the config: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(b), `"internal"`); n != 2 {
+		// The key itself and the reader's string value: one of each, and no
+		// second block.
+		t.Errorf("%d occurrences of the key, so a second block went in beside it:\n%s", n, b)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file no longer parses: %v\n%s", err, b)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	internal, _ := mapAt(hooks, "internal")
+	entries, _ := mapAt(internal, "entries")
+	if entries[openclawHookName] == nil {
+		t.Errorf("the entry did not reach the reader's own block:\n%s", b)
 	}
 }
 

--- a/cmd/deja/openclaw_auto_comments_test.go
+++ b/cmd/deja/openclaw_auto_comments_test.go
@@ -65,3 +65,106 @@ func TestOpenClawAutoTakesACommentedConfig(t *testing.T) {
 		t.Errorf("the round trip changed the file:\nwant %q\ngot  %q", before, b)
 	}
 }
+
+// The reader already has the block, their own switch and a hook of their own.
+// Deja's entry comes out and nothing else moves: the switch is theirs, and
+// deleting it left their hook wired and turned off (#2811).
+func TestOpenClawAutoLeavesTheReadersWiringAlone(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // mine, and I mean it\n  \"hooks\": {\n    \"internal\": {\n      \"entries\": {\n        \"mine\": { \"enabled\": true }\n      },\n      \"enabled\": true\n    }\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+		t.Fatalf("a commented config was refused: %v", err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall refused the commented config: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != before {
+		t.Errorf("the round trip changed the reader's file:\nwant %q\ngot  %q", before, b)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file no longer parses: %v\n%s", err, b)
+	}
+}
+
+// The switch written last in its block: taking it out has to take the comma in
+// front of it, or what is left is `{…,}` and every later run refuses the file.
+func TestOpenClawAutoRemovesASwitchWrittenLast(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // reader's own block\n  \"hooks\": {\n    \"internal\": {}\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+		t.Fatalf("a commented config was refused: %v", err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall refused the commented config: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file no longer parses: %v\n%s", err, b)
+	}
+	if strings.Contains(string(b), "enabled") {
+		t.Errorf("the switch deja turned on stayed behind:\n%s", b)
+	}
+}
+
+// A level holding something that is not an object is refused rather than
+// written beside: a second key of the same name loses the decode to the
+// reader's value, and deja reports an install that did nothing.
+func TestOpenClawAutoRefusesALevelItCannotEdit(t *testing.T) {
+	for _, before := range []string{
+		"{\n  // not an object\n  \"hooks\": { \"internal\": \"off\" }\n}\n",
+		"{\n  // not an object\n  \"hooks\": { \"internal\": { \"entries\": [] } }\n}\n",
+	} {
+		t.Run("", func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := installOpenClawAuto("/bin/deja", false); err == nil {
+				t.Error("a level deja cannot edit was written into anyway")
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The MCP and plugin entries are written before the hook one, so
+			// the file does change — what must not is the block deja refused.
+			if strings.Count(string(b), `"internal"`) != 1 {
+				t.Errorf("a second key was written beside the one deja refused:\n%s", b)
+			}
+			if !strings.Contains(string(b), "// not an object") {
+				t.Errorf("the comment was dropped:\n%s", b)
+			}
+			var root map[string]any
+			if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+				t.Fatalf("the file no longer parses: %v\n%s", err, b)
+			}
+		})
+	}
+}

--- a/cmd/deja/openclaw_auto_comments_test.go
+++ b/cmd/deja/openclaw_auto_comments_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// openclaw-auto writes into the same config the MCP entry does, and it still
+// went through the parsed path only — so a `//` line refused the target, on the
+// way in and on the way out, which is how a reader ends up with the hook entry
+// stuck in the file (#2811).
+func TestOpenClawAutoTakesACommentedConfig(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	before := "{\n  // the ordering here is deliberate\n  \"theme\": \"dark\"\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+		t.Fatalf("a commented config was refused: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "// the ordering here is deliberate") {
+		t.Errorf("the comment was dropped:\n%s", b)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file no longer parses: %v\n%s", err, b)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	internal, _ := mapAt(hooks, "internal")
+	entries, _ := mapAt(internal, "entries")
+	if entries[openclawHookName] == nil {
+		t.Fatalf("the hook entry was not written:\n%s", b)
+	}
+	// Without the switch beside it the pack is discovered and never invoked,
+	// which is the state the parsed path is careful to avoid.
+	if on, _ := internal["enabled"].(bool); !on {
+		t.Errorf("the entry went in without the switch that runs it:\n%s", b)
+	}
+
+	if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall refused the commented config: %v", err)
+	}
+	b, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), openclawHookName) {
+		t.Errorf("the hook entry stayed behind:\n%s", b)
+	}
+	if string(b) != before {
+		t.Errorf("the round trip changed the file:\nwant %q\ngot  %q", before, b)
+	}
+}

--- a/cmd/deja/openclaw_auto_comments_test.go
+++ b/cmd/deja/openclaw_auto_comments_test.go
@@ -168,6 +168,12 @@ func TestOpenClawAutoKeepsASwitchTheReaderSet(t *testing.T) {
 	if !strings.Contains(string(b), `"enabled"`) {
 		t.Errorf("the reader's own switch was deleted:\n%s", b)
 	}
+	// And it is theirs, value and all: an install that switched internal hooks
+	// on for someone who had switched them off is not something an uninstall
+	// should leave behind.
+	if !strings.Contains(string(b), "\"enabled\": false") {
+		t.Errorf("the reader had it off and it came back on:\n%s", b)
+	}
 	var root map[string]any
 	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
 		t.Fatalf("the file no longer parses: %v\n%s", err, b)
@@ -248,5 +254,64 @@ func TestOpenClawAutoRefusesALevelItCannotEdit(t *testing.T) {
 				t.Fatalf("the file no longer parses: %v\n%s", err, b)
 			}
 		})
+	}
+}
+
+// The population this writer is for: someone who hand-edits an annotated
+// config. They move deja's switch to the end of the block and put a note above
+// it, and the uninstall has to take the comma in front of it with it — the one
+// after it is not there to take (#2811).
+func TestOpenClawAutoRemovesASwitchTheReaderMoved(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{\n  // mine\n  \"hooks\": {\n    \"internal\": {}\n  }\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+		t.Fatalf("a commented config was refused: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"enabled"`) {
+		t.Fatalf("the switch was not written, so there is nothing to take out:\n%s", b)
+	}
+	// The reader tidies: the switch goes last, with a line about it. Written
+	// out rather than edited, so the fixture is exactly the shape being tested.
+	var entry string
+	if i := strings.Index(string(b), `"deja-recall"`); i >= 0 {
+		if j := strings.Index(string(b)[i:], "}"); j >= 0 {
+			entry = string(b)[i : i+j+1]
+		}
+	}
+	if entry == "" {
+		t.Fatalf("could not find the entry deja wrote:\n%s", b)
+	}
+	moved := "{\n  // mine\n  \"hooks\": {\n    \"internal\": {\n      \"entries\": {\n        " +
+		entry + "\n      },\n      // deja turned this on\n      \"enabled\": true\n    }\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(moved), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall refused the config: %v", err)
+	}
+	b, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+		t.Fatalf("the file no longer parses: %v\n%s", err, b)
+	}
+	if strings.Contains(string(b), `"enabled"`) {
+		t.Errorf("the switch deja turned on stayed behind:\n%s", b)
+	}
+	if !strings.Contains(string(b), "// mine") {
+		t.Errorf("the reader's own comment was dropped:\n%s", b)
 	}
 }


### PR DESCRIPTION
Closes #2811, the last writer of `openclaw.json` still on the parsed path. A `//` line refused the target on the way in and on the way out, which is how the hook entry ends up stuck in the file.

Three primitives carried it: `jsoncSetFlag` takes a dotted block key like the entry writer already does, `jsoncRemoveKey` takes a scalar back out, and `setOpenClawEntryJSONC` composes them — the hook entry with its `hooks.internal.enabled` switch, the plugin entry without one. Install then uninstall gives the file back byte for byte, chain and switch included.