### PR TITLE
fix(search): put a note above its source in every tier

### DIFF
--- a/internal/search/lift_every_tier_test.go
+++ b/internal/search/lift_every_tier_test.go
@@ -21,9 +21,15 @@ func TestEveryTierPutsANoteAboveItsSource(t *testing.T) {
 		Harness: "deja", ID: "deja-note-claude-longs", Project: "api", Updated: now,
 		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
 	}
+	// A session between them, so the lift has to rotate rather than swap: a
+	// two-element fixture cannot tell the two apart.
+	between := model.Session{
+		Harness: "claude", ID: "other", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "goblin pool notes from an unrelated session", Time: now}},
+	}
 	// Source first, which is the order a score-only ranking produces when the
 	// transcript is the longer text.
-	ss := []model.Session{source, note}
+	ss := []model.Session{source, between, note}
 
 	for name, hits := range map[string][]Hit{
 		"error":     ErrorHits(ss),
@@ -43,6 +49,13 @@ func TestEveryTierPutsANoteAboveItsSource(t *testing.T) {
 		}
 		if noteAt > sourceAt {
 			t.Errorf("%s tier put the transcript above its own note", name)
+		}
+		// And the hit in between kept its place relative to the source rather
+		// than being swapped past it.
+		for i, h := range hits {
+			if h.Session.ID == "other" && i < sourceAt {
+				t.Errorf("%s tier moved an unrelated hit above the source", name)
+			}
 		}
 	}
 }

--- a/internal/search/lift_every_tier_test.go
+++ b/internal/search/lift_every_tier_test.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// `deja promote` tells the reader the note now outranks the transcript it was
+// made from. Two tiers build their hits themselves and never called the lift,
+// so on a pasted error and on the "ranked by relevance" screen the transcript
+// came back above its own note (#2803).
+func TestEveryTierPutsANoteAboveItsSource(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "longs", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "the goblin pool deadlocks under load", Time: now}},
+	}
+	note := model.Session{
+		Harness: "deja", ID: "deja-note-claude-longs", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
+	}
+	// Source first, which is the order a score-only ranking produces when the
+	// transcript is the longer text.
+	ss := []model.Session{source, note}
+
+	for name, hits := range map[string][]Hit{
+		"error":     ErrorHits(ss),
+		"relevance": RelevanceHits(ss, []string{"goblin", "pool"}),
+	} {
+		var noteAt, sourceAt = -1, -1
+		for i, h := range hits {
+			switch h.Session.ID {
+			case "deja-note-claude-longs":
+				noteAt = i
+			case "longs":
+				sourceAt = i
+			}
+		}
+		if noteAt < 0 || sourceAt < 0 {
+			t.Fatalf("%s tier: both should be in the answer, got %d hits", name, len(hits))
+		}
+		if noteAt > sourceAt {
+			t.Errorf("%s tier put the transcript above its own note", name)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2172,6 +2172,10 @@ func ErrorHits(ss []model.Session) []Hit {
 		}
 		hits = append(hits, hit)
 	}
+	// The rule promote promises holds here too: a tier that builds its own hits
+	// has to arrange them the way Run does, or a pasted error answers with the
+	// transcript above the note made from it (#2803).
+	liftNotesAboveTheirSource(hits)
 	return hits
 }
 
@@ -2314,6 +2318,9 @@ func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]fl
 		hit.Score = float64(len(ss) - rank)
 		hits = append(hits, hit)
 	}
+	// As in Run and in ErrorHits: what promote promises is a property of the
+	// answer, not of one tier (#2803).
+	liftNotesAboveTheirSource(hits)
 	return hits
 }
 


### PR DESCRIPTION
Part of #2803. `ErrorHits` and `RelevanceHitsWeighted` build their hits themselves and never called the lift, so on a pasted error and on the "ranked by relevance" screen a promoted note lost to the transcript it was made from — the thing `deja promote` prints a promise about.

The other two halves of #2803 stay open: the semantic fallback cuts by cosine before the lift can see the note, and the prompt hook ranks sessions rather than hits and has no such rule at all. Both are policy rather than a missing call.