### PR TITLE
fix: stop disowning a recalled session that names what was asked

### DIFF
--- a/cmd/deja/context_names_asked_test.go
+++ b/cmd/deja/context_names_asked_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "No session is about this" was printed whenever the relevance tier answered,
+// which on any store with competition is most questions — including the ones
+// whose answer is served at rank 1. Measured on a real store, 20 of 20
+// questions lifted verbatim out of indexed sessions were disowned that way, and
+// an agent told the right answer is about nothing learns to ignore the line —
+// which costs what #2074 bought with it (#2827).
+func TestARelevanceAnswerThatNamesTheAskedIsNotDisowned(t *testing.T) {
+	dir := manySessionStore(t, 40)
+
+	// Reaches the relevance tier — no session holds every word — and the
+	// session it serves is the one that says "quibblesnatch".
+	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"what did the quibblesnatch parser do with the stalled pipeline frames"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "so this one was ranked") {
+		t.Fatalf("the fixture no longer reaches the relevance tier, so this guards nothing:\n%s", firstLines(text, 4))
+	}
+	if strings.Contains(text, "No session is about this") {
+		t.Errorf("a session that names what was asked was disowned:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "rare") {
+		t.Errorf("the session holding the asked-about word was not the one served:\n%s", firstLines(text, 6))
+	}
+}
+
+// And the case the line exists for keeps it: a subject this store has never
+// held, served its nearest neighbour, under the caveat.
+//
+// The fixture is built for that and not borrowed: the question's ordinary words
+// have to be in the store — otherwise the tier refuses and serves nothing,
+// which is the other right answer and not this case — and no session may hold
+// all of them, or an earlier tier answers and this code is never reached. So
+// they go one per session.
+func TestARelevanceAnswerAboutSomethingAbsentKeepsTheCaveat(t *testing.T) {
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	spread := []string{
+		"we did pick the smaller batch size for the ingest job today",
+		"the array of workers was resized after the incident",
+		"tuning the retry budget took the rest of the afternoon",
+	}
+	for i, text := range spread {
+		line := fmt.Sprintf(`{"type":"user","message":{"role":"user","content":%q},"timestamp":"2026-08-0%dT10:00:00Z","sessionId":"n%d","cwd":"/work"}`, text, i+1, i) + "\n"
+		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("n%d.jsonl", i)), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"which crystal did we pick for the antenna array tuning"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "# deja context:") {
+		t.Fatalf("nothing was served, so the caveat this test is about was never reached:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "No session is about this") {
+		t.Errorf("a subject the store never held was reported as named:\n%s", firstLines(text, 4))
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1420,7 +1420,7 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	search.PrintContext(&b, whole, q)
 	text := b.String()
 	if hits[0].Tier != search.TierExact {
-		text = contextTierLead(hits[0].Tier) + text
+		text = contextTierLead(hits[0].Tier, sessionNamesTheAsked(whole, q, result.TermIDF)) + text
 	}
 	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole),
 		// The search path reaches a promoted note as often as the id path
@@ -1441,11 +1441,74 @@ const nothingIsAboutThis = "No session is about this. Nothing matched the query,
 // matched nothing — recall says "No session is about this" in a sentence, and
 // this tool, which returns far more text, said it in one word that reads like
 // a label on an answer (#2787, the shape #2074 fixed for the counted page).
-func contextTierLead(tier string) string {
+func contextTierLead(tier string, namesTheAsked bool) string {
 	if tier == search.TierRelevance {
+		if namesTheAsked {
+			// The tier says the exact match failed; it does not say the answer
+			// is unrelated. On a store with any competition an ordinary
+			// question rarely survives the exact AND, so the sentence below
+			// fired on 20 of 20 questions lifted verbatim out of indexed
+			// sessions — disowning the right answer teaches an agent to
+			// ignore the line, which costs what #2074 bought with it (#2827).
+			return "No session matched every word, so this one was ranked — it does name what you asked about. Check that it describes what is happening now before acting on it.\n"
+		}
 		return nothingIsAboutThis + " so the session below is the nearest by wording — treat it as a lead to check, not as a record, and say plainly if it does not answer.\n"
 	}
 	return "[" + tier + "]\n"
+}
+
+// sessionNamesTheAsked reports whether the served session holds the query's
+// most identifying word — the one the ranking itself weighted highest.
+//
+// That is the difference between "nothing matched exactly" and "nothing here is
+// about this". A subject the store has never held has none of the query's rare
+// words anywhere; a question whose answer is served at rank 1 has them in the
+// session below the line (#2827).
+//
+// Two things about TermIDF decide the shape here, both established by reading
+// relevantMetasCounts rather than assumed: it is keyed by the query's terms as
+// typed, not by their stem forms, and a term the corpus does not hold never
+// reaches it at all. So the terms are RelevanceTerms, not RelevanceMatchTerms —
+// the latter adds stem forms that are absent from the map by construction, and
+// reading them made every question look like it named something unknown. And a
+// term missing from the map is the subject of an absent question, which is why
+// it answers no rather than being skipped.
+func sessionNamesTheAsked(s model.Session, q string, idf map[string]float64) bool {
+	terms := index.RelevanceTerms(q)
+	if len(terms) == 0 {
+		return false
+	}
+	rarest, best := "", -1.0
+	for _, t := range terms {
+		w, ok := idf[t]
+		if !ok {
+			return false
+		}
+		if w > best {
+			rarest, best = t, w
+		}
+	}
+	// The stem forms belong here, where the text is read: the session may say
+	// "pooling" where the question said "pool".
+	forms := index.RelevanceMatchTerms(rarest)
+	holds := func(text string) bool {
+		low := strings.ToLower(text)
+		for _, f := range forms {
+			if f != "" && strings.Contains(low, strings.ToLower(f)) {
+				return true
+			}
+		}
+		return false
+	}
+	if holds(s.Title) {
+		return true
+	}
+	for _, m := range s.Messages {
+		if holds(m.Text) {
+			return true
+		}
+	}
+	return false
 }
 
 func mcpProgress() io.Writer {

--- a/cmd/deja/recall_context_tier_test.go
+++ b/cmd/deja/recall_context_tier_test.go
@@ -12,7 +12,7 @@ import (
 // matched nothing reads as a label on an answer, where recall says it in a
 // sentence (#2787, the shape #2074 fixed for the counted page).
 func TestTheContextLeadSaysWhatTheSessionIs(t *testing.T) {
-	lead := contextTierLead(search.TierRelevance)
+	lead := contextTierLead(search.TierRelevance, false)
 	if strings.HasPrefix(lead, "[") {
 		t.Errorf("a whole session is still introduced by a marker: %q", lead)
 	}
@@ -26,33 +26,48 @@ func TestTheContextLeadSaysWhatTheSessionIs(t *testing.T) {
 // The other tiers keep their marker: they did match, and the marker says how.
 func TestTheOtherTiersKeepTheirMarker(t *testing.T) {
 	for _, tier := range []string{search.TierError, search.TierSemantic, search.TierStemmed, search.TierClose} {
-		lead := contextTierLead(tier)
+		lead := contextTierLead(tier, false)
 		if !strings.HasPrefix(lead, "["+tier+"]") {
 			t.Errorf("%s lost its marker: %q", tier, lead)
 		}
 	}
 }
 
-// End to end, because the wiring is where the risk was: the lead has to reach
-// the agent, inside the frame, with the tier marker gone.
-func TestAnAgentAskingAboutSomethingAbsentIsToldSo(t *testing.T) {
+// The end-to-end case this file used to carry as
+// TestAnAgentAskingAboutSomethingAbsentIsToldSo is gone, and its two halves are
+// covered with premises that hold: the bare marker by
+// TestTheContextLeadSaysWhatTheSessionIs above, and "the agent is told when the
+// session is not about its question" by
+// TestARelevanceAnswerAboutSomethingAbsentKeepsTheCaveat, which builds a store
+// where that case actually happens.
+//
+// Its query, "stalled retry frames parser pipeline empty", is not an absent
+// subject: every one of those words is in the fixture, spread across sessions
+// that each hold some, which is why the relevance tier answers. On this
+// fixture a genuinely absent subject is served nothing at all — the right
+// answer, and not the one that test was written to check (#2827).
+
+// And the query that test used to carry: words the store does hold, no session
+// holding all of them. The tier is the same and the answer is not — the served
+// session says the rarest thing asked about, so it is not disowned (#2827).
+func TestAMashOfWordsTheStoreHoldsIsNotCalledAbsent(t *testing.T) {
 	dir := manySessionStore(t, 40)
 	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"stalled retry frames parser pipeline empty"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(text, "["+search.TierRelevance+"]") {
-		t.Errorf("a whole session still arrives under a bare marker:\n%s", firstLines(text, 4))
+	if !strings.Contains(text, "so this one was ranked") {
+		t.Fatalf("the fixture no longer reaches the relevance tier, so this guards nothing:\n%s", firstLines(text, 4))
 	}
-	if !strings.Contains(text, nothingIsAboutThis) {
-		t.Errorf("the agent is not told the session is not about its question:\n%s", firstLines(text, 4))
+	if strings.Contains(text, nothingIsAboutThis) {
+		t.Errorf("a session holding the words asked about was disowned:\n%s", firstLines(text, 4))
 	}
 }
 
 // One sentence, two surfaces: the page of sessions and the single session say
 // the same thing about the same situation.
 func TestBothRelevanceLeadsShareTheirSentence(t *testing.T) {
-	if !strings.Contains(contextTierLead(search.TierRelevance), nothingIsAboutThis) {
+	if !strings.Contains(contextTierLead(search.TierRelevance, false), nothingIsAboutThis) {
 		t.Error("the single-session lead drifted from the shared sentence")
 	}
 	dir := manySessionStore(t, 40)


### PR DESCRIPTION
Closes #2827. This is the fourth attempt at it; the three that failed are recorded on the issue, and what unblocked this one was building the control I did not have rather than arguing that it would pass.

**The rule.** `sessionNamesTheAsked` reads the query's terms as typed, and answers no if any of them is missing from `TermIDF` — a word the corpus does not hold never reaches that map, and it is exactly the subject of an absent question. Otherwise it takes the highest-IDF term and asks whether the served session says it, matching stem forms. Only then does the lead change; the relevance caveat is untouched everywhere else.

Two facts about `TermIDF` decide that shape, and both come from reading `relevantMetasCounts`, not from assuming: it is keyed by the terms as typed rather than by stem forms, and a term the corpus does not hold never lands in it. Attempts 1 and 2 each guessed one of them wrong.

**Paired measurement on a purpose-built store** — one session holding the question, filler competing on the same vocabulary:

    before   both cases      "No session is about this"
    after    answer here     "No session matched every word, so this one was ranked — it does name what you asked about"
             absent subject  "No session is about this"   (unchanged)

The absent-subject control needed a store where the relevance tier actually answers such a question: its ordinary words must be in the store, or the tier refuses and serves nothing, and no session may hold all of them, or an earlier tier answers and this code is never reached. That is why the test builds its own fixture instead of borrowing `manySessionStore`.

**One test deleted, and I want that visible.** `TestAnAgentAskingAboutSomethingAbsentIsToldSo` asked about "stalled retry frames parser pipeline empty" — not an absent subject at all: every one of those words is in its fixture, spread across sessions that each hold some, which is why relevance answered. Its two halves are now covered by tests whose premises hold: the bare marker by `TestTheContextLeadSaysWhatTheSessionIs`, and "the agent is told when the session is not about its question" by the new control above. Its old query is kept as its own test, asserting what it actually produces now.

Five mutations: never consulting the rule, claiming every relevance answer as named, letting an unknown term through, reading stem forms instead of the terms as typed, and skipping the session text.

The wording of the new sentence is mine and easy to change — the behaviour is what the tests pin.
