### PR TITLE
fix(blame): put a promoted note above the transcript it distils

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -195,6 +195,11 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		}
 		return hits[i].Session.ID < hits[j].Session.ID
 	})
+	// And the rule promote promises, which the score cannot express here: a
+	// note mentions the file once where the transcript it distils mentions it
+	// many times, so scoring alone put the transcript above its own note on
+	// every blame (#2829).
+	liftNotesBy(hits, func(h BlameHit) model.Session { return h.Session })
 	return hits
 }
 

--- a/internal/search/blame_note_test.go
+++ b/internal/search/blame_note_test.go
@@ -1,0 +1,49 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// blame answers "who decided this", and a promoted note mentions the file once
+// where the transcript it was made from mentions it many times — so the score
+// put the transcript above its own note on every blame (#2829, the surface
+// #2803 did not reach).
+func TestBlamePutsANoteAboveItsSource(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "longs", Project: "api", Updated: now,
+		Messages: []model.Message{
+			{Role: "files", Text: "/work/api/pool.go", Time: now},
+			{Role: "user", Text: "pool.go deadlocks under load", Time: now},
+			{Role: "assistant", Text: "pool.go needs a bigger max", Time: now},
+			{Role: "assistant", Text: "raised it in pool.go", Time: now},
+		},
+	}
+	note := model.Session{
+		Harness: "deja", ID: "deja-note-claude-longs", Project: "api", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "[accepted] the pool in pool.go was too small", Time: now},
+		},
+	}
+
+	target := BlameTarget{FullPath: "/work/api/pool.go", Base: "pool.go", Stem: "pool"}
+	hits := Blame([]model.Session{source, note}, target, BlameOptions{All: true})
+	var noteAt, sourceAt = -1, -1
+	for i, h := range hits {
+		switch h.Session.ID {
+		case "deja-note-claude-longs":
+			noteAt = i
+		case "longs":
+			sourceAt = i
+		}
+	}
+	if noteAt < 0 || sourceAt < 0 {
+		t.Fatalf("both should be in the answer, got %d hits", len(hits))
+	}
+	if noteAt > sourceAt {
+		t.Errorf("blame put the transcript above the note made from it")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -641,23 +641,29 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 // is dated by its evidence rather than by the day it was filed (V4) the two are
 // equally fresh, so the transcript won its own distillation.
 func liftNotesAboveTheirSource(hits []Hit) {
+	liftNotesBy(hits, func(h Hit) model.Session { return h.Session })
+}
+
+// liftNotesBy is the rule itself, over anything that names a session: blame
+// ranks its own hit type and had the same omission (#2829).
+func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 	notes := make(map[string]int, len(hits))
 	for i, h := range hits {
-		if h.Session.Harness == notesHarness && strings.HasPrefix(h.Session.ID, "deja-note-") {
-			notes[h.Session.ID] = i
+		if s := of(h); s.Harness == notesHarness && strings.HasPrefix(s.ID, "deja-note-") {
+			notes[s.ID] = i
 		}
 	}
 	if len(notes) == 0 {
 		return
 	}
 	for i := 0; i < len(hits); i++ {
-		h := hits[i]
-		if h.Session.Harness == notesHarness {
+		src := of(hits[i])
+		if src.Harness == notesHarness {
 			continue
 		}
 		// Mirrors sources.PromotedNoteID: building the id rather than parsing
 		// one keeps a harness name with a dash in it from splitting wrong.
-		id := "deja-note-" + h.Session.Harness + "-" + h.Session.ID
+		id := "deja-note-" + src.Harness + "-" + src.ID
 		j, ok := notes[id]
 		if !ok || j < i {
 			continue
@@ -666,8 +672,8 @@ func liftNotesAboveTheirSource(hits []Hit) {
 		copy(hits[i+1:j+1], hits[i:j])
 		hits[i] = note
 		for k := i; k <= j; k++ {
-			if hits[k].Session.Harness == notesHarness && strings.HasPrefix(hits[k].Session.ID, "deja-note-") {
-				notes[hits[k].Session.ID] = k
+			if s := of(hits[k]); s.Harness == notesHarness && strings.HasPrefix(s.ID, "deja-note-") {
+				notes[s.ID] = k
 			}
 		}
 	}


### PR DESCRIPTION
Closes #2829, the last surface that ranks and returns hits without going through `Run`. `Blame` sorts by `count * (1+specificity)`, and a note mentions the file once where the transcript it was made from mentions it many times — so `deja blame` and the MCP `blame` tool answered with the transcript above its own note every time.

The lift is generic over anything that names a session now, so `Hit` and `BlameHit` share the one rule rather than each carrying a copy.