### PR TITLE
fix: the recall page stops disowning a first session that names what was asked

### DIFF
--- a/cmd/deja/context_names_asked_test.go
+++ b/cmd/deja/context_names_asked_test.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/vshulcz/deja-vu/internal/index"
 )
 
 // "No session is about this" was printed whenever the relevance tier answered,
@@ -45,26 +40,7 @@ func TestARelevanceAnswerThatNamesTheAskedIsNotDisowned(t *testing.T) {
 // all of them, or an earlier tier answers and this code is never reached. So
 // they go one per session.
 func TestARelevanceAnswerAboutSomethingAbsentKeepsTheCaveat(t *testing.T) {
-	hermeticEnv(t)
-	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
-	if err := os.MkdirAll(proj, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	spread := []string{
-		"we did pick the smaller batch size for the ingest job today",
-		"the array of workers was resized after the incident",
-		"tuning the retry budget took the rest of the afternoon",
-	}
-	for i, text := range spread {
-		line := fmt.Sprintf(`{"type":"user","message":{"role":"user","content":%q},"timestamp":"2026-08-0%dT10:00:00Z","sessionId":"n%d","cwd":"/work"}`, text, i+1, i) + "\n"
-		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("n%d.jsonl", i)), []byte(line), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	dir := index.DefaultDir()
-	if err := index.Ensure(dir, "", false, nil); err != nil {
-		t.Fatal(err)
-	}
+	dir := spreadWordsStore(t)
 
 	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"which crystal did we pick for the antenna array tuning"}`))
 	if err != nil {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -888,9 +888,16 @@ func recallText(dir, q, harness string, limit, budget int) (string, error) {
 // the question itself — and an agent read three unrelated sessions as the
 // answer to it. On the relevance tier the line says what they are instead
 // (#2074).
-func recallCountLine(q, tier string, offset, served, total int) string {
+func recallCountLine(q, tier string, offset, served, total int, namesTheAsked bool) string {
 	q = clampEcho(q)
 	switch {
+	case tier == search.TierRelevance && namesTheAsked && offset > 0:
+		// "none about it" is the same claim the lead makes, so it follows the
+		// same reading: the exact match failed, and the first session named
+		// what was asked (#2827).
+		return fmt.Sprintf("ranked by wording for %q (%d-%d of %d)\n", q, offset+1, offset+served, total)
+	case tier == search.TierRelevance && namesTheAsked:
+		return fmt.Sprintf("ranked by wording for %q (%d of %d)\n", q, served, total)
 	case tier == search.TierRelevance && offset > 0:
 		// The tier before the page: page two of an answer to a question
 		// nothing is about is still not a page of matches, and saying so only
@@ -948,7 +955,15 @@ const recallCountLineReserve = 64
 // recallHeaderReserve is that plus the count line this answer will actually
 // print.
 func recallHeaderReserve(q, tier string, offset, limit, total int) int {
-	return recallCountLineReserve + len(recallCountLine(q, tier, offset, limit, total))
+	// The longer of the two relevance lines: this reserves room before the
+	// answer is built, and reserving for the shorter one would let the
+	// other overrun what it was promised.
+	short := len(recallCountLine(q, tier, offset, limit, total, true))
+	long := len(recallCountLine(q, tier, offset, limit, total, false))
+	if short > long {
+		long = short
+	}
+	return recallCountLineReserve + long
 }
 
 // twinSessionsFor pairs each session with the same session as it exists on
@@ -1051,6 +1066,11 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	attachAnswers(dir, hits)
 	var b strings.Builder
 	served := 0
+	// One answer for both lines: the lead and the count used to be able to
+	// disagree, and a page that says "the first one names what you asked"
+	// above "none about it" is worse than either alone (#2827).
+	namesTheAsked := result.Tier == search.TierRelevance && len(hits) > 0 &&
+		sessionNamesTheAsked(hits[0].Session, q, result.TermIDF)
 	if stale {
 		fmt.Fprintln(&b, "(index refresh running in the background — the very newest sessions may not appear yet)")
 	}
@@ -1060,6 +1080,13 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 		fmt.Fprintf(&b, "No exact match; using close spellings: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	} else if result.Tier == search.TierError {
 		fmt.Fprintln(&b, "No exact match; these sessions hit the same error (matched by signature).")
+	} else if namesTheAsked {
+		// The same reading recall_context got in #2831: the tier says the
+		// exact match failed, not that the answer is unrelated. On a store
+		// with competition an ordinary question rarely survives the exact AND,
+		// so the sentence below disowned pages whose first session was the
+		// right one (#2827).
+		fmt.Fprintln(&b, "No session matched every word, so these were ranked — the first one names what you asked about. Check that it describes what is happening now before acting on it.")
 	} else if result.Tier == search.TierRelevance {
 		// Not "ranked by relevance", which reads as "here is what I found
 		// about it". Nothing matched: these are the nearest sessions by
@@ -1196,7 +1223,7 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	// From what was served, not from the limit: the loop also stops on the
 	// token budget, and then this said "2 more" while five were left — the
 	// agent asks for offset=served and the arithmetic has to hold.
-	b.WriteString(recallCountLine(q, result.Tier, offset, served, total))
+	b.WriteString(recallCountLine(q, result.Tier, offset, served, total, namesTheAsked))
 	b.WriteString(hb.String())
 	// From what was served, not from the limit: the loop also stops on the
 	// token budget, and then this said "2 more" while five were left — the

--- a/cmd/deja/mcp_match_count_test.go
+++ b/cmd/deja/mcp_match_count_test.go
@@ -98,13 +98,17 @@ func TestRelevanceHitsAreNotCalledMatches(t *testing.T) {
 	// already, and the test went quiet instead of saying so.
 	// The sentinel is the tier's own words, and they changed when the line
 	// stopped reading as "here is what I found about it" (#2074).
-	if !strings.Contains(text, "No session is about this") {
+	// The tier has two leads: it disowns the page when nothing served names
+	// what was asked, and says the first one does when it does (#2827). Either
+	// proves the fixture still reaches the tier, and neither is what this test
+	// is about — the count below is.
+	if !strings.Contains(text, "No session is about this") && !strings.Contains(text, "so these were ranked") {
 		t.Fatalf("the fixture no longer reaches the relevance tier, so this test guards nothing:\n%s", firstLines(text, 3))
 	}
 	if strings.Contains(text, "matched)") {
 		t.Errorf("relevance-tier sessions were reported as matches:\n%s", firstLines(text, 4))
 	}
-	if !strings.Contains(text, "ranked, none about it)") {
+	if !strings.Contains(text, "ranked, none about it)") && !strings.Contains(text, "ranked by wording") {
 		t.Errorf("the count line does not say what the number is:\n%s", firstLines(text, 4))
 	}
 }

--- a/cmd/deja/recall_context_tier_test.go
+++ b/cmd/deja/recall_context_tier_test.go
@@ -70,8 +70,11 @@ func TestBothRelevanceLeadsShareTheirSentence(t *testing.T) {
 	if !strings.Contains(contextTierLead(search.TierRelevance, false), nothingIsAboutThis) {
 		t.Error("the single-session lead drifted from the shared sentence")
 	}
-	dir := manySessionStore(t, 40)
-	text, err := callMCPTool(dir, "recall", []byte(`{"query":"stalled retry frames parser pipeline empty"}`))
+	// On a question the store has an answer to, both surfaces say so instead
+	// (#2831); the shared sentence is the other branch, so the fixture has to
+	// be one that reaches it.
+	dir := spreadWordsStore(t)
+	text, err := callMCPTool(dir, "recall", []byte(`{"query":"which crystal did we pick for the antenna array tuning"}`))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/deja/recall_names_asked_test.go
+++ b/cmd/deja/recall_names_asked_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The counted page carried the same defect recall_context did (#2831): the
+// caveat was keyed to the tier, so a page whose first session is the right one
+// was disowned along with the rest (#2827).
+func TestARelevancePageWhoseFirstSessionNamesTheAskedIsNotDisowned(t *testing.T) {
+	dir := manySessionStore(t, 40)
+
+	text, err := callMCPTool(dir, "recall", []byte(`{"query":"what did the quibblesnatch parser do with the stalled pipeline frames","limit":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "so these were ranked") {
+		t.Fatalf("the fixture no longer reaches the relevance tier, so this guards nothing:\n%s", firstLines(text, 4))
+	}
+	if strings.Contains(text, "No session is about this") {
+		t.Errorf("a page led by the session that names the asked was disowned:\n%s", firstLines(text, 4))
+	}
+	// The count line makes the same claim, so it has to make the same one: a
+	// page reading "the first one names what you asked" above "none about it"
+	// is worse than either line alone.
+	if strings.Contains(text, "none about it") {
+		t.Errorf("the count line disagrees with the lead above it:\n%s", firstLines(text, 4))
+	}
+}
+
+// And a subject the store never held keeps the caveat over its neighbours. The
+// fixture is the one the recall_context control uses, for the same reason: the
+// question's ordinary words must be in the store or the tier serves nothing,
+// and no session may hold all of them or an earlier tier answers.
+func TestARelevancePageAboutSomethingAbsentKeepsTheCaveat(t *testing.T) {
+	dir := spreadWordsStore(t)
+
+	text, err := callMCPTool(dir, "recall", []byte(`{"query":"which crystal did we pick for the antenna array tuning","limit":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "1. [claude]") {
+		t.Fatalf("nothing was served, so the caveat this test is about was never reached:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "No session is about this") {
+		t.Errorf("a page about a subject the store never held was reported as named:\n%s", firstLines(text, 4))
+	}
+}
+
+// spreadWordsStore builds the one shape that serves a nearest neighbour for a
+// subject the store never held: the question's ordinary words are in the store,
+// so the tier does not refuse, and no session holds all of them, so no earlier
+// tier answers. One per session does both.
+func spreadWordsStore(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-work")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, text := range []string{
+		"we did pick the smaller batch size for the ingest job today",
+		"the array of workers was resized after the incident",
+		"tuning the retry budget took the rest of the afternoon",
+	} {
+		line := fmt.Sprintf(`{"type":"user","message":{"role":"user","content":%q},"timestamp":"2026-08-0%dT10:00:00Z","sessionId":"n%d","cwd":"/work"}`, text, i+1, i) + "\n"
+		if err := os.WriteFile(filepath.Join(proj, fmt.Sprintf("n%d.jsonl", i)), []byte(line), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/cmd/deja/recall_relevance_framing_test.go
+++ b/cmd/deja/recall_relevance_framing_test.go
@@ -51,7 +51,7 @@ func TestTheCountLineSaysWhatFollowsIt(t *testing.T) {
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			got := strings.TrimRight(recallCountLine(q, c.tier, c.offset, c.served, c.total), "\n")
+			got := strings.TrimRight(recallCountLine(q, c.tier, c.offset, c.served, c.total, false), "\n")
 			if got != c.want {
 				t.Errorf("got  %s\nwant %s", got, c.want)
 			}
@@ -63,7 +63,7 @@ func TestTheCountLineSaysWhatFollowsIt(t *testing.T) {
 // session is about this, and the line above the payload does not then head it
 // with the question.
 func TestBothLinesOfARelevanceAnswerSayTheSameThing(t *testing.T) {
-	line := recallCountLine("anything at all", search.TierRelevance, 0, 3, 9)
+	line := recallCountLine("anything at all", search.TierRelevance, 0, 3, 9, false)
 	if strings.Contains(line, "deja recall for") {
 		t.Errorf("the payload is headed by the question it does not answer: %s", line)
 	}
@@ -74,7 +74,7 @@ func TestBothLinesOfARelevanceAnswerSayTheSameThing(t *testing.T) {
 
 // The query is echoed back, so it is bounded the way every sibling echo is.
 func TestTheCountLineDoesNotEchoAWholeTranscriptBack(t *testing.T) {
-	line := recallCountLine(strings.Repeat("x", 64_000), search.TierExact, 0, 3, 9)
+	line := recallCountLine(strings.Repeat("x", 64_000), search.TierExact, 0, 3, 9, false)
 	if len(line) > 1_000 {
 		t.Errorf("the count line echoed %d bytes of query back", len(line))
 	}
@@ -98,7 +98,7 @@ func TestALongQueryStillLeavesRoomForTheLineThatSaysHowToPage(t *testing.T) {
 	}
 	// The count line is written whole, with the query in it: the room kept for
 	// it is measured from the line itself rather than guessed at.
-	want := strings.TrimRight(recallCountLine(q, search.TierRelevance, 0, 3, 41), "\n")
+	want := strings.TrimRight(recallCountLine(q, search.TierRelevance, 0, 3, 41, false), "\n")
 	if !strings.Contains(text, want) {
 		t.Errorf("the count line did not survive whole:\nwant %s\ngot\n%s", want, text)
 	}


### PR DESCRIPTION
The other half of #2827. #2831 fixed `recall_context`; the counted page carried the same defect, measured on the same stand:

    before   answer is in the store   "No session is about this…"   first hit: the right session
    after                             "No session matched every word, so these were ranked — the first one names what you asked about"
             absent subject           "No session is about this…"   unchanged

**The count line follows the same answer**, and that is the part worth reviewing. It said "(3 of 41 ranked, none about it)", which is the same claim as the lead — so a half-done change would have produced a page reading "the first one names what you asked" above "none about it". One value is computed once and both lines take it; there is a mutation that makes them disagree and it turns a test red. `recallHeaderReserve` now reserves for the longer of the two lines, since it runs before the answer is built.

Three existing tests moved rather than being deleted, and each for the same reason: their fixture no longer produces the case they were written for.

- `TestRelevanceHitsAreNotCalledMatches` recognised the tier by its lead. There are two leads now, so it accepts either — its subject is the count, not the sentence.
- `TestBothRelevanceLeadsShareTheirSentence` asked with a query the store has an answer to, which now takes the other branch. It moved to a store where the shared sentence is what happens.
- `recall_relevance_framing_test.go` call sites take the new argument.

The fixture that makes an absent subject reach this tier is shared by the three tests that need it, as `spreadWordsStore`: its ordinary words must be in the store or the tier serves nothing, and no session may hold all of them or an earlier tier answers.