### PR TITLE
fix(search): lift a note that arrived by sync

### DIFF
--- a/internal/search/lift_imported_test.go
+++ b/internal/search/lift_imported_test.go
@@ -48,3 +48,63 @@ func TestAnImportedNoteIsLiftedAboveALocalSource(t *testing.T) {
 		t.Errorf("an imported note lost to a local transcript: %s first", hits[0].Session.ID)
 	}
 }
+
+// The other direction: a transcript that arrived by sync and was promoted
+// *here*. promote builds the note id from the local id, so the note names
+// `imported-…` — and a rule that only looked through OrigID would miss it,
+// which is the pairing the first fix traded away.
+func TestANoteMadeHereAboutAnImportedSourceIsLifted(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "imported-aaa111", OrigID: "longs", Project: "imported:api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "the goblin pool deadlocks under load", Time: now}},
+	}
+	note := model.Session{
+		Harness: "deja", ID: "deja-note-claude-imported-aaa111", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
+	}
+	other := model.Session{
+		Harness: "claude", ID: "unrelated", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "something else entirely", Time: now}},
+	}
+	hits := []Hit{{Session: source}, {Session: other}, {Session: note}}
+	LiftNotesAboveTheirSource(hits)
+	if hits[0].Session.ID != note.ID {
+		t.Errorf("the note made here about an imported transcript did not lift: %s first", hits[0].Session.ID)
+	}
+	// A rotation, not a swap: the unrelated hit keeps its place behind the
+	// source rather than jumping over it.
+	if hits[1].Session.ID != source.ID || hits[2].Session.ID != other.ID {
+		t.Errorf("the hits between the pair were not rotated: %s, %s", hits[1].Session.ID, hits[2].Session.ID)
+	}
+}
+
+// Two machines promoted the same session, and one of the notes travelled. Both
+// end above the source, and this machine's own note is the one on top: the tie
+// deja breaks everywhere else.
+func TestThisMachinesOwnNoteOutranksAnImportedCopy(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "longs", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "the goblin pool deadlocks under load", Time: now}},
+	}
+	local := model.Session{
+		Harness: "deja", ID: "deja-note-claude-longs", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
+	}
+	peer := model.Session{
+		Harness: "deja", ID: "imported-ccc333", OrigID: "deja-note-claude-longs",
+		Project: "imported:api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the pool was too small", Time: now}},
+	}
+	hits := []Hit{{Session: source}, {Session: local}, {Session: peer}}
+	LiftNotesAboveTheirSource(hits)
+	if hits[0].Session.ID != local.ID {
+		t.Errorf("the peer's copy was put above this machine's own note: %s first", hits[0].Session.ID)
+	}
+	for i, h := range hits {
+		if h.Session.ID == source.ID && i == 0 {
+			t.Error("the source stayed on top")
+		}
+	}
+}

--- a/internal/search/lift_imported_test.go
+++ b/internal/search/lift_imported_test.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A note that arrived by sync keeps its own id in OrigID and carries an
+// `imported-…` one locally, so the rule that recognises a note by its id never
+// saw it — and the transcript it distils outranked it on every surface (#2833).
+// Both sides are rewritten: the source arrives imported too.
+func TestAnImportedNoteIsLiftedAboveItsSource(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "imported-aaa111", OrigID: "longs", Project: "imported:api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "the goblin pool deadlocks under load", Time: now}},
+	}
+	note := model.Session{
+		Harness: "deja", ID: "imported-bbb222", OrigID: "deja-note-claude-longs",
+		Project: "imported:api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
+	}
+	hits := []Hit{{Session: source}, {Session: note}}
+	LiftNotesAboveTheirSource(hits)
+	if hits[0].Session.ID != note.ID {
+		t.Errorf("the imported transcript stayed above the note made from it: %s first", hits[0].Session.ID)
+	}
+}
+
+// And the half-imported case: the note came across, the transcript is this
+// machine's own.
+func TestAnImportedNoteIsLiftedAboveALocalSource(t *testing.T) {
+	now := time.Now()
+	source := model.Session{
+		Harness: "claude", ID: "longs", Project: "api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "the goblin pool deadlocks under load", Time: now}},
+	}
+	note := model.Session{
+		Harness: "deja", ID: "imported-bbb222", OrigID: "deja-note-claude-longs",
+		Project: "imported:api", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: "[accepted] the goblin pool was too small", Time: now}},
+	}
+	hits := []Hit{{Session: source}, {Session: note}}
+	LiftNotesAboveTheirSource(hits)
+	if hits[0].Session.ID != note.ID {
+		t.Errorf("an imported note lost to a local transcript: %s first", hits[0].Session.ID)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -640,6 +640,31 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 // carries the query words in its title and the note does not, and once a note
 // is dated by its evidence rather than by the day it was filed (V4) the two are
 // equally fresh, so the transcript won its own distillation.
+
+// noteID is the id a promoted note has on the machine that made it, and "" for
+// a session that is not one. Mirrors cmd/deja's promotedNoteID: after a sync
+// the local id is `imported-…` and the real one rides in OrigID (#975, #2833).
+func noteID(s model.Session) string {
+	if s.Harness != notesHarness {
+		return ""
+	}
+	if strings.HasPrefix(s.ID, "deja-note-") {
+		return s.ID
+	}
+	if strings.HasPrefix(s.OrigID, "deja-note-") {
+		return s.OrigID
+	}
+	return ""
+}
+
+// sessionOrigID is the id a session had where it was recorded.
+func sessionOrigID(s model.Session) string {
+	if s.OrigID != "" {
+		return s.OrigID
+	}
+	return s.ID
+}
+
 func liftNotesAboveTheirSource(hits []Hit) {
 	liftNotesBy(hits, func(h Hit) model.Session { return h.Session })
 }
@@ -649,8 +674,8 @@ func liftNotesAboveTheirSource(hits []Hit) {
 func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 	notes := make(map[string]int, len(hits))
 	for i, h := range hits {
-		if s := of(h); s.Harness == notesHarness && strings.HasPrefix(s.ID, "deja-note-") {
-			notes[s.ID] = i
+		if id := noteID(of(h)); id != "" {
+			notes[id] = i
 		}
 	}
 	if len(notes) == 0 {
@@ -663,7 +688,12 @@ func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 		}
 		// Mirrors sources.PromotedNoteID: building the id rather than parsing
 		// one keeps a harness name with a dash in it from splitting wrong.
-		id := "deja-note-" + src.Harness + "-" + src.ID
+		//
+		// From the id the source had on the machine that made the note, which
+		// is what the note names. After a sync the local id is `imported-…`
+		// and the original is in OrigID, so a pair that travelled was never
+		// recognised as one (#2833).
+		id := "deja-note-" + src.Harness + "-" + sessionOrigID(src)
 		j, ok := notes[id]
 		if !ok || j < i {
 			continue
@@ -672,8 +702,8 @@ func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 		copy(hits[i+1:j+1], hits[i:j])
 		hits[i] = note
 		for k := i; k <= j; k++ {
-			if s := of(hits[k]); s.Harness == notesHarness && strings.HasPrefix(s.ID, "deja-note-") {
-				notes[s.ID] = k
+			if id := noteID(of(hits[k])); id != "" {
+				notes[id] = k
 			}
 		}
 	}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -640,21 +640,8 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 // carries the query words in its title and the note does not, and once a note
 // is dated by its evidence rather than by the day it was filed (V4) the two are
 // equally fresh, so the transcript won its own distillation.
-
 func liftNotesAboveTheirSource(hits []Hit) {
 	liftNotesBy(hits, func(h Hit) model.Session { return h.Session })
-}
-
-// firstBelow is the highest-ranked hit at or after i among the ones recorded
-// for an id: the pair is made with the best copy of the note, and a copy that
-// already outranks the source is left where it is.
-func firstBelow(at []int, i int) (int, bool) {
-	for _, j := range at {
-		if j >= i {
-			return j, true
-		}
-	}
-	return 0, false
 }
 
 // indexNotes is where each promoted note sits, by the id it names, in rank
@@ -702,38 +689,41 @@ func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 	if len(notes) == 0 {
 		return
 	}
-	for i := 0; i < len(hits); i++ {
+	// One pass, emitting each source's notes just before it. Reordering in
+	// place meant reindexing after every rotation, which is a map rebuild per
+	// pair over the whole matched set — measured at 622ms and a gigabyte on a
+	// store where every transcript outranked its own note (#2833).
+	done := make([]bool, len(hits))
+	out := make([]T, 0, len(hits))
+	for i := range hits {
 		src := of(hits[i])
-		if src.Harness == notesHarness {
-			continue
-		}
-		// Mirrors sources.PromotedNoteID: building the id rather than parsing
-		// one keeps a harness name with a dash in it from splitting wrong.
-		//
-		// Both ids. The note names the session as it was on the machine that
-		// made it — which is the local id when this machine promoted it, and
-		// the original when the note travelled — and after a sync a session
-		// carries `imported-…` locally with the original in OrigID. Either can
-		// be the one the note was built from, so both are tried (#2833).
-		j, ok := -1, false
-		for _, id := range []string{
-			"deja-note-" + src.Harness + "-" + src.ID,
-			"deja-note-" + src.Harness + "-" + sessionOrigID(src),
-		} {
-			if j, ok = firstBelow(notes[id], i); ok {
-				break
+		if src.Harness != notesHarness {
+			// Both ids. The note names the session as it was on the machine
+			// that made it — the local id where this machine promoted it, the
+			// original where the note travelled — and after a sync a session
+			// carries `imported-…` locally with the original in OrigID (#2833).
+			//
+			// Every copy that has not been placed yet, in rank order, so two
+			// machines' notes about one session both land above it and this
+			// machine's own comes first.
+			for _, id := range []string{
+				"deja-note-" + src.Harness + "-" + src.ID,
+				"deja-note-" + src.Harness + "-" + sessionOrigID(src),
+			} {
+				for _, j := range notes[id] {
+					if j > i && !done[j] {
+						done[j] = true
+						out = append(out, hits[j])
+					}
+				}
 			}
 		}
-		if !ok {
-			continue
+		if !done[i] {
+			done[i] = true
+			out = append(out, hits[i])
 		}
-		note := hits[j]
-		copy(hits[i+1:j+1], hits[i:j])
-		hits[i] = note
-		// Rebuilt rather than patched: the rotation moved everything between
-		// the two, and the id may name more than one of them.
-		notes = indexNotes(hits, of)
 	}
+	copy(hits, out)
 }
 
 // sortHits orders a ranked result set.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -641,6 +641,36 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 // is dated by its evidence rather than by the day it was filed (V4) the two are
 // equally fresh, so the transcript won its own distillation.
 
+func liftNotesAboveTheirSource(hits []Hit) {
+	liftNotesBy(hits, func(h Hit) model.Session { return h.Session })
+}
+
+// firstBelow is the highest-ranked hit at or after i among the ones recorded
+// for an id: the pair is made with the best copy of the note, and a copy that
+// already outranks the source is left where it is.
+func firstBelow(at []int, i int) (int, bool) {
+	for _, j := range at {
+		if j >= i {
+			return j, true
+		}
+	}
+	return 0, false
+}
+
+// indexNotes is where each promoted note sits, by the id it names, in rank
+// order. Every hit holding an id rather than one of them: two machines can
+// promote the same session, and keeping only the last put the peer's copy
+// above this machine's own note.
+func indexNotes[T any](hits []T, of func(T) model.Session) map[string][]int {
+	notes := make(map[string][]int, len(hits))
+	for i, h := range hits {
+		if id := noteID(of(h)); id != "" {
+			notes[id] = append(notes[id], i)
+		}
+	}
+	return notes
+}
+
 // noteID is the id a promoted note has on the machine that made it, and "" for
 // a session that is not one. Mirrors cmd/deja's promotedNoteID: after a sync
 // the local id is `imported-…` and the real one rides in OrigID (#975, #2833).
@@ -665,19 +695,10 @@ func sessionOrigID(s model.Session) string {
 	return s.ID
 }
 
-func liftNotesAboveTheirSource(hits []Hit) {
-	liftNotesBy(hits, func(h Hit) model.Session { return h.Session })
-}
-
 // liftNotesBy is the rule itself, over anything that names a session: blame
 // ranks its own hit type and had the same omission (#2829).
 func liftNotesBy[T any](hits []T, of func(T) model.Session) {
-	notes := make(map[string]int, len(hits))
-	for i, h := range hits {
-		if id := noteID(of(h)); id != "" {
-			notes[id] = i
-		}
-	}
+	notes := indexNotes(hits, of)
 	if len(notes) == 0 {
 		return
 	}
@@ -689,23 +710,29 @@ func liftNotesBy[T any](hits []T, of func(T) model.Session) {
 		// Mirrors sources.PromotedNoteID: building the id rather than parsing
 		// one keeps a harness name with a dash in it from splitting wrong.
 		//
-		// From the id the source had on the machine that made the note, which
-		// is what the note names. After a sync the local id is `imported-…`
-		// and the original is in OrigID, so a pair that travelled was never
-		// recognised as one (#2833).
-		id := "deja-note-" + src.Harness + "-" + sessionOrigID(src)
-		j, ok := notes[id]
-		if !ok || j < i {
+		// Both ids. The note names the session as it was on the machine that
+		// made it — which is the local id when this machine promoted it, and
+		// the original when the note travelled — and after a sync a session
+		// carries `imported-…` locally with the original in OrigID. Either can
+		// be the one the note was built from, so both are tried (#2833).
+		j, ok := -1, false
+		for _, id := range []string{
+			"deja-note-" + src.Harness + "-" + src.ID,
+			"deja-note-" + src.Harness + "-" + sessionOrigID(src),
+		} {
+			if j, ok = firstBelow(notes[id], i); ok {
+				break
+			}
+		}
+		if !ok {
 			continue
 		}
 		note := hits[j]
 		copy(hits[i+1:j+1], hits[i:j])
 		hits[i] = note
-		for k := i; k <= j; k++ {
-			if id := noteID(of(hits[k])); id != "" {
-				notes[id] = k
-			}
-		}
+		// Rebuilt rather than patched: the rotation moved everything between
+		// the two, and the id may name more than one of them.
+		notes = indexNotes(hits, of)
 	}
 }
 


### PR DESCRIPTION
Closes #2833. The lift recognised a note by its id, and a note that travelled carries `imported-…` locally with the real id in `OrigID` — so the pair was never matched and the transcript outranked its own note on every surface the rule covers, blame included. Both sides are read through `OrigID` now, the way `promotedNoteID` and the lifecycle readers already do.