### PR TITLE
fix(index): wait out a rename another pass is holding open

### DIFF
--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -536,7 +536,7 @@ func consumeField(b []byte) (string, []byte, bool) {
 func swapIndexDir(dir, tmp string) error {
 	old := dir + ".old"
 	_ = os.RemoveAll(old)
-	if err := os.Rename(dir, old); err != nil && !os.IsNotExist(err) {
+	if err := renameWaiting(dir, old); err != nil && !os.IsNotExist(err) {
 		// The parking spot survived the removal above — a leftover from an
 		// interrupted swap whose permissions stop deja from clearing it. The
 		// bare `rename …: file exists` names two paths nobody chose and gives
@@ -546,7 +546,7 @@ func swapIndexDir(dir, tmp string) error {
 		}
 		return err
 	}
-	if err := os.Rename(tmp, dir); err != nil {
+	if err := renameWaiting(tmp, dir); err != nil {
 		// Put the previous index back rather than leaving nothing.
 		_ = os.Rename(old, dir)
 		return err
@@ -554,6 +554,39 @@ func swapIndexDir(dir, tmp string) error {
 	_ = os.RemoveAll(old)
 	return nil
 }
+
+// renameWaiting is os.Rename with a short wait for a rename another pass is
+// holding the directory open against.
+//
+// Windows refuses to rename a directory while any handle inside it is open, so
+// two ordinary passes at once — a hook's warmup and a `deja index` from a shell
+// — left the loser unable to swap, and the store a session short until
+// something rebuilt it. On Unix the loser renames over the winner and both end
+// up consistent, which is why this went unmeasured (#2228). The reader holding
+// those handles is finishing a read, not doing work, so the wait is short and
+// bounded; a rename still refused at the end is reported rather than retried
+// forever, and the caller puts the previous index back.
+func renameWaiting(from, to string) error {
+	err := renameFile(from, to)
+	for wait := swapRenameWait; err != nil && !os.IsNotExist(err) && wait > 0; wait -= swapRenameStep {
+		time.Sleep(swapRenameStep)
+		err = renameFile(from, to)
+	}
+	return err
+}
+
+const (
+	// swapRenameWait is how long a swap waits out a reader. Measured against
+	// the read it is waiting on: a search opens the store, reads what it needs
+	// and closes, which is milliseconds — so this is generous by two orders of
+	// magnitude and still shorter than the pass that would have to run again.
+	swapRenameWait = 2 * time.Second
+	swapRenameStep = 20 * time.Millisecond
+)
+
+// renameFile is os.Rename, indirected so a test can refuse a rename the way
+// Windows does without needing Windows.
+var renameFile = os.Rename
 
 // recoverIndexDir finishes an interrupted swapIndexDir: if the index dir is
 // missing but its .old sibling survives, restore it.

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -9,14 +9,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/policy"
@@ -536,19 +539,22 @@ func consumeField(b []byte) (string, []byte, bool) {
 func swapIndexDir(dir, tmp string) error {
 	old := dir + ".old"
 	_ = os.RemoveAll(old)
-	if err := renameWaiting(dir, old); err != nil && !os.IsNotExist(err) {
-		// The parking spot survived the removal above — a leftover from an
-		// interrupted swap whose permissions stop deja from clearing it. The
-		// bare `rename …: file exists` names two paths nobody chose and gives
-		// nothing to do about either (#1009).
-		if _, statErr := os.Stat(old); statErr == nil {
-			return fmt.Errorf("an earlier index swap left %s behind and deja cannot replace it — remove that directory and run `deja index` again", old)
-		}
+	// The parking spot survived the removal above — a leftover from an
+	// interrupted swap whose permissions stop deja from clearing it. The bare
+	// `rename …: file exists` names two paths nobody chose and gives nothing to
+	// do about either (#1009). Decided before the wait: no amount of waiting
+	// clears it, and the reader has to act on the message either way.
+	if _, statErr := os.Stat(old); statErr == nil {
+		return fmt.Errorf("an earlier index swap left %s behind and deja cannot replace it — remove that directory and run `deja index` again", old)
+	}
+	if err := renameWaiting(dir, old); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 	if err := renameWaiting(tmp, dir); err != nil {
-		// Put the previous index back rather than leaving nothing.
-		_ = os.Rename(old, dir)
+		// Put the previous index back rather than leaving nothing — and with
+		// the same wait, since this runs exactly when renames on this
+		// directory are being refused.
+		_ = renameWaiting(old, dir)
 		return err
 	}
 	_ = os.RemoveAll(old)
@@ -568,20 +574,53 @@ func swapIndexDir(dir, tmp string) error {
 // forever, and the caller puts the previous index back.
 func renameWaiting(from, to string) error {
 	err := renameFile(from, to)
-	for wait := swapRenameWait; err != nil && !os.IsNotExist(err) && wait > 0; wait -= swapRenameStep {
+	for wait := swapRenameWait; err != nil && renameHeldOpen(err) && wait > 0; wait -= swapRenameStep {
 		time.Sleep(swapRenameStep)
 		err = renameFile(from, to)
 	}
 	return err
 }
 
+// renameHeldOpen reports whether a refusal is the kind that clears on its own.
+// A handle in the directory is; a read-only filesystem, a path that is a file,
+// a parking spot deja cannot replace (#1009) are not, and waiting two seconds
+// to say so delays a message the reader has to act on either way.
+//
+// By errno rather than by fs.ErrPermission, which does not discriminate here:
+// Windows reports both a sharing refusal and a real ACL denial as
+// ERROR_ACCESS_DENIED.
+func renameHeldOpen(err error) bool {
+	if errors.Is(err, fs.ErrNotExist) {
+		return false
+	}
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch uintptr(errno) {
+	case 5, 32, 33: // ACCESS_DENIED, SHARING_VIOLATION, LOCK_VIOLATION
+		// Those numbers mean something else on Unix, where the rename does not
+		// fail this way at all, so the wait is Windows' alone. A variable
+		// rather than runtime.GOOS so a test can stand where Windows is.
+		return renameOS == "windows"
+	}
+	return false
+}
+
+// renameOS is runtime.GOOS, indirected for the tests that inject a refusal.
+var renameOS = runtime.GOOS
+
 const (
-	// swapRenameWait is how long a swap waits out a reader. Measured against
-	// the read it is waiting on: a search opens the store, reads what it needs
-	// and closes, which is milliseconds — so this is generous by two orders of
-	// magnitude and still shorter than the pass that would have to run again.
-	swapRenameWait = 2 * time.Second
-	swapRenameStep = 20 * time.Millisecond
+	// swapRenameWait is how long a swap waits out a reader, and it is bounded
+	// by what a reader will wait for it: swapWindowTries × swapWindowWait is
+	// 200ms, after which a reader stops looking and gets the bare ENOENT that
+	// swapInFlight exists to absorb. Waiting longer than that turns one pass
+	// losing its swap into every reader losing (#2228).
+	//
+	// The same refusal atomicfile.publish waits out, measured on windows CI at
+	// 20 × 5ms; this is the same order, in the steps the reader side uses.
+	swapRenameWait = swapWindowTries * swapWindowWait
+	swapRenameStep = swapWindowWait
 )
 
 // renameFile is os.Rename, indirected so a test can refuse a rename the way
@@ -599,7 +638,9 @@ func recoverIndexDir(dir string) {
 		return
 	}
 	if _, err := os.Stat(dir + ".old"); err == nil {
-		_ = os.Rename(dir+".old", dir)
+		// The same wait: this is the crash-recovery path, and a refusal here
+		// leaves the index missing for the whole run.
+		_ = renameWaiting(dir+".old", dir)
 	}
 }
 

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -547,14 +547,29 @@ func swapIndexDir(dir, tmp string) error {
 	if _, statErr := os.Stat(old); statErr == nil {
 		return fmt.Errorf("an earlier index swap left %s behind and deja cannot replace it — remove that directory and run `deja index` again", old)
 	}
-	if err := renameWaiting(dir, old); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	// The parking step can afford to wait: the index is still where readers
+	// look until it succeeds, so nobody is waiting on it, and this is the
+	// rename a pass that spent seconds building tmp would otherwise give up on
+	// for the sake of a search that held a handle for a quarter of a second.
+	if err := renameWaiting(dir, old, parkRenameWait); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	if err := renameWaiting(tmp, dir); err != nil {
-		// Put the previous index back rather than leaving nothing — and with
-		// the same wait, since this runs exactly when renames on this
-		// directory are being refused.
-		_ = renameWaiting(old, dir)
+	// From here the index is not where readers look, so this rename and the
+	// restore that may follow it share one deadline: the window a reader waits
+	// out, spent once between them rather than twice.
+	deadline := time.Now().Add(swapRenameWait)
+	if err := renameWaitingUntil(tmp, dir, deadline); err != nil {
+		// Put the previous index back rather than leaving nothing, with
+		// whatever is left of that window — this runs exactly when renames on
+		// this directory are being refused.
+		floor := time.Now().Add(restoreRenameFloor)
+		if floor.After(deadline) {
+			// A little past the window rather than none of it: the restore is
+			// the one rename that must not fail, and a second rename that
+			// spent the whole budget would otherwise leave it none.
+			deadline = floor
+		}
+		_ = renameWaitingUntil(old, dir, deadline)
 		return err
 	}
 	_ = os.RemoveAll(old)
@@ -572,9 +587,17 @@ func swapIndexDir(dir, tmp string) error {
 // those handles is finishing a read, not doing work, so the wait is short and
 // bounded; a rename still refused at the end is reported rather than retried
 // forever, and the caller puts the previous index back.
-func renameWaiting(from, to string) error {
+func renameWaiting(from, to string, wait time.Duration) error {
+	return renameWaitingUntil(from, to, time.Now().Add(wait))
+}
+
+// renameWaitingUntil is renameWaiting against a deadline the caller keeps, so a
+// swap and the restore that follows it share one window rather than each
+// getting a fresh one — two full budgets in a row is the index away for twice
+// as long as a reader will wait (#2228).
+func renameWaitingUntil(from, to string, deadline time.Time) error {
 	err := renameFile(from, to)
-	for wait := swapRenameWait; err != nil && renameHeldOpen(err) && wait > 0; wait -= swapRenameStep {
+	for err != nil && renameHeldOpen(err) && time.Now().Before(deadline) {
 		time.Sleep(swapRenameStep)
 		err = renameFile(from, to)
 	}
@@ -621,6 +644,17 @@ const (
 	// 20 × 5ms; this is the same order, in the steps the reader side uses.
 	swapRenameWait = swapWindowTries * swapWindowWait
 	swapRenameStep = swapWindowWait
+	// parkRenameWait is the other side of that: the parking step and the
+	// crash-recovery restore happen while the index is still (or already)
+	// where readers look, so nothing is waiting on them and the only cost of
+	// waiting is the pass's own. Long enough to outlast a search holding a
+	// handle, short enough that a directory nobody will ever release still
+	// reports inside a scheduled run.
+	parkRenameWait = 2 * time.Second
+	// restoreRenameFloor is what the restore gets when the rename before it
+	// spent the shared window. Three attempts, which is what the refusal this
+	// waits out clears in.
+	restoreRenameFloor = 3 * swapRenameStep
 )
 
 // renameFile is os.Rename, indirected so a test can refuse a rename the way
@@ -640,7 +674,7 @@ func recoverIndexDir(dir string) {
 	if _, err := os.Stat(dir + ".old"); err == nil {
 		// The same wait: this is the crash-recovery path, and a refusal here
 		// leaves the index missing for the whole run.
-		_ = renameWaiting(dir+".old", dir)
+		_ = renameWaiting(dir+".old", dir, parkRenameWait)
 	}
 }
 

--- a/internal/index/swap_refused_rename_test.go
+++ b/internal/index/swap_refused_rename_test.go
@@ -5,9 +5,24 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
+
+// heldOpen is the refusal Windows gives while a handle inside the directory is
+// still open, so a test can stand where Windows is without needing it.
+func heldOpen(from, to string) error {
+	return &os.LinkError{Op: "rename", Old: from, New: to, Err: syscall.Errno(32)}
+}
+
+// onWindows makes the wait apply on the machine running the test.
+func onWindows(t *testing.T) {
+	t.Helper()
+	was := renameOS
+	renameOS = "windows"
+	t.Cleanup(func() { renameOS = was })
+}
 
 // Windows refuses to rename a directory while a handle inside it is open, so
 // two ordinary passes at once left the loser unable to swap and the store a
@@ -25,12 +40,13 @@ func TestASwapWaitsOutARefusedRename(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	onWindows(t)
 	var refusals atomic.Int32
 	refusals.Store(3)
 	real := renameFile
 	renameFile = func(from, to string) error {
 		if refusals.Add(-1) >= 0 {
-			return &os.LinkError{Op: "rename", Old: from, New: to, Err: errors.New("Access is denied.")}
+			return heldOpen(from, to)
 		}
 		return real(from, to)
 	}
@@ -61,12 +77,21 @@ func TestASwapThatCannotRenameKeepsTheOldIndex(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte("old"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	onWindows(t)
+	var held atomic.Int32
+	held.Store(2)
 	real := renameFile
 	renameFile = func(from, to string) error {
-		// Only the second rename is refused, so the parking step succeeds and
-		// the restore has something to put back.
-		if filepath.Base(from) == "index.db.tmp" {
-			return &os.LinkError{Op: "rename", Old: from, New: to, Err: errors.New("Access is denied.")}
+		// The second rename is refused for good; the restore is refused twice
+		// and then allowed, which is the shape a swap meets when the same
+		// handles are holding both.
+		switch filepath.Base(from) {
+		case "index.db.tmp":
+			return heldOpen(from, to)
+		case "index.db.old":
+			if held.Add(-1) >= 0 {
+				return heldOpen(from, to)
+			}
 		}
 		return real(from, to)
 	}
@@ -76,10 +101,110 @@ func TestASwapThatCannotRenameKeepsTheOldIndex(t *testing.T) {
 	if err := swapIndexDir(dir, tmp); err == nil {
 		t.Fatal("a rename refused for the whole wait was reported as a swap")
 	}
-	if took := time.Since(start); took > 10*time.Second {
-		t.Errorf("the swap waited %v, which is no longer a bounded wait", took)
+	// Bounded by what a reader will wait for it, not by "eventually": a
+	// raised ceiling has to be visible here.
+	if took := time.Since(start); took > 2*swapRenameWait {
+		t.Errorf("the swap waited %v, past the %v ceiling", took, swapRenameWait)
 	}
 	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
 		t.Errorf("the previous index is not where it was: %q %v", b, err)
+	}
+}
+
+// The second rename is the one that matters to a reader: between it and the
+// parking step the index is not where readers look, so a swap that waits there
+// has to be done inside the window a reader waits for it (swapWindowTries ×
+// swapWindowWait). This is that path — refused, then allowed.
+func TestASwapWaitsOutTheSecondRenameWithinTheReadersWindow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "records.bin"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	onWindows(t)
+	var refusals atomic.Int32
+	refusals.Store(3)
+	real := renameFile
+	renameFile = func(from, to string) error {
+		if filepath.Base(from) == "index.db.tmp" && refusals.Add(-1) >= 0 {
+			return heldOpen(from, to)
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	start := time.Now()
+	if err := swapIndexDir(dir, tmp); err != nil {
+		t.Fatalf("the swap gave up on the rename readers were holding: %v", err)
+	}
+	if took := time.Since(start); took > swapRenameWait {
+		t.Errorf("the index was away for %v, past the %v a reader waits", took, swapRenameWait)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "new" {
+		t.Errorf("the new index is not in place: %q %v", b, err)
+	}
+}
+
+// A refusal that will not clear — a read-only filesystem, a path that is a
+// file — is reported at once rather than waited out: the reader has to act on
+// it either way.
+func TestASwapDoesNotWaitOutARefusalThatWillNotClear(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	onWindows(t)
+	real := renameFile
+	renameFile = func(from, to string) error {
+		if filepath.Base(from) == "index.db.tmp" {
+			return &os.LinkError{Op: "rename", Old: from, New: to, Err: syscall.EROFS}
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	start := time.Now()
+	if err := swapIndexDir(dir, tmp); err == nil {
+		t.Fatal("a read-only filesystem was reported as a swap")
+	}
+	if took := time.Since(start); took > swapRenameStep*2 {
+		t.Errorf("waited %v on a refusal that cannot clear", took)
+	}
+}
+
+// And a refusal that is not an errno at all — whatever a filesystem driver or
+// a test double hands back — is reported rather than waited out.
+func TestASwapDoesNotWaitOutAnUnrecognisedRefusal(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	onWindows(t)
+	real := renameFile
+	renameFile = func(from, to string) error {
+		if filepath.Base(from) == "index.db.tmp" {
+			return errors.New("the volume was dismounted")
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	start := time.Now()
+	if err := swapIndexDir(dir, tmp); err == nil {
+		t.Fatal("an unrecognised refusal was reported as a swap")
+	}
+	if took := time.Since(start); took > swapRenameStep*2 {
+		t.Errorf("waited %v on a refusal deja cannot read", took)
 	}
 }

--- a/internal/index/swap_refused_rename_test.go
+++ b/internal/index/swap_refused_rename_test.go
@@ -105,7 +105,8 @@ func TestASwapThatCannotRenameKeepsTheOldIndex(t *testing.T) {
 	// failed rename and the restore share that window, with a floor under the
 	// restore so it is never left none of it.
 	if took := time.Since(start); took > swapRenameWait+restoreRenameFloor+swapRenameStep {
-		t.Errorf("the index was away for %v, past the %v a reader waits", took, swapRenameWait)
+		t.Errorf("the index was away for %v, past the %v it may take", took,
+			swapRenameWait+restoreRenameFloor+swapRenameStep)
 	}
 	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
 		t.Errorf("the previous index is not where it was: %q %v", b, err)
@@ -223,5 +224,46 @@ func TestASwapDoesNotWaitOutAnUnrecognisedRefusal(t *testing.T) {
 	// happen, not one that took the index with it.
 	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
 		t.Errorf("the previous index is not where it was: %q %v", b, err)
+	}
+}
+
+// The parking step is the rename nobody is waiting on — the index is still
+// where readers look until it lands — so it waits far past the window that
+// bounds the pair after it. That is the case #2228 is about: a pass that spent
+// seconds building the new index must not give up because a search held a
+// handle for a quarter of a second.
+func TestTheParkingStepWaitsPastTheReadersWindow(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "records.bin"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	onWindows(t)
+	// Past the reader's window by a margin, and well inside the parking step's.
+	refusals := int32(swapRenameWait/swapRenameStep) + 5
+	var left atomic.Int32
+	left.Store(refusals)
+	real := renameFile
+	renameFile = func(from, to string) error {
+		if filepath.Base(from) == "index.db" && left.Add(-1) >= 0 {
+			return heldOpen(from, to)
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	if err := swapIndexDir(dir, tmp); err != nil {
+		t.Fatalf("the swap gave up on the parking step: %v", err)
+	}
+	if left.Load() >= 0 {
+		t.Fatalf("the parking step was never held for the whole window: %d refusals left", left.Load())
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "new" {
+		t.Errorf("the new index is not in place: %q %v", b, err)
 	}
 }

--- a/internal/index/swap_refused_rename_test.go
+++ b/internal/index/swap_refused_rename_test.go
@@ -1,0 +1,85 @@
+package index
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Windows refuses to rename a directory while a handle inside it is open, so
+// two ordinary passes at once left the loser unable to swap and the store a
+// session short (#2228). The reader it is waiting on is finishing a read, so
+// the swap waits it out rather than giving up on the pass.
+func TestASwapWaitsOutARefusedRename(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "records.bin"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var refusals atomic.Int32
+	refusals.Store(3)
+	real := renameFile
+	renameFile = func(from, to string) error {
+		if refusals.Add(-1) >= 0 {
+			return &os.LinkError{Op: "rename", Old: from, New: to, Err: errors.New("Access is denied.")}
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	if err := swapIndexDir(dir, tmp); err != nil {
+		t.Fatalf("the swap gave up on a rename that was only being held: %v", err)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "new" {
+		t.Errorf("the new index is not in place: %q %v", b, err)
+	}
+	if _, err := os.Stat(dir + ".old"); err == nil {
+		t.Error("the parking spot was left behind")
+	}
+}
+
+// A rename refused for the whole wait is a failure the pass reports, with the
+// previous index still where it was: leaving nothing there is worse than
+// leaving what the reader already had.
+func TestASwapThatCannotRenameKeepsTheOldIndex(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	tmp := dir + ".tmp"
+	for _, d := range []string{dir, tmp} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	real := renameFile
+	renameFile = func(from, to string) error {
+		// Only the second rename is refused, so the parking step succeeds and
+		// the restore has something to put back.
+		if filepath.Base(from) == "index.db.tmp" {
+			return &os.LinkError{Op: "rename", Old: from, New: to, Err: errors.New("Access is denied.")}
+		}
+		return real(from, to)
+	}
+	t.Cleanup(func() { renameFile = real })
+
+	start := time.Now()
+	if err := swapIndexDir(dir, tmp); err == nil {
+		t.Fatal("a rename refused for the whole wait was reported as a swap")
+	}
+	if took := time.Since(start); took > 10*time.Second {
+		t.Errorf("the swap waited %v, which is no longer a bounded wait", took)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
+		t.Errorf("the previous index is not where it was: %q %v", b, err)
+	}
+}

--- a/internal/index/swap_refused_rename_test.go
+++ b/internal/index/swap_refused_rename_test.go
@@ -101,10 +101,11 @@ func TestASwapThatCannotRenameKeepsTheOldIndex(t *testing.T) {
 	if err := swapIndexDir(dir, tmp); err == nil {
 		t.Fatal("a rename refused for the whole wait was reported as a swap")
 	}
-	// Bounded by what a reader will wait for it, not by "eventually": a
-	// raised ceiling has to be visible here.
-	if took := time.Since(start); took > 2*swapRenameWait {
-		t.Errorf("the swap waited %v, past the %v ceiling", took, swapRenameWait)
+	// Bounded by what a reader will wait for it, not by "eventually": the
+	// failed rename and the restore share that window, with a floor under the
+	// restore so it is never left none of it.
+	if took := time.Since(start); took > swapRenameWait+restoreRenameFloor+swapRenameStep {
+		t.Errorf("the index was away for %v, past the %v a reader waits", took, swapRenameWait)
 	}
 	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
 		t.Errorf("the previous index is not where it was: %q %v", b, err)
@@ -161,6 +162,9 @@ func TestASwapDoesNotWaitOutARefusalThatWillNotClear(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	onWindows(t)
 	real := renameFile
 	renameFile = func(from, to string) error {
@@ -178,6 +182,11 @@ func TestASwapDoesNotWaitOutARefusalThatWillNotClear(t *testing.T) {
 	if took := time.Since(start); took > swapRenameStep*2 {
 		t.Errorf("waited %v on a refusal that cannot clear", took)
 	}
+	// And the previous index is back: a fail-fast is still a swap that did not
+	// happen, not one that took the index with it.
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
+		t.Errorf("the previous index is not where it was: %q %v", b, err)
+	}
 }
 
 // And a refusal that is not an errno at all — whatever a filesystem driver or
@@ -189,6 +198,9 @@ func TestASwapDoesNotWaitOutAnUnrecognisedRefusal(t *testing.T) {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "records.bin"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 	onWindows(t)
 	real := renameFile
@@ -206,5 +218,10 @@ func TestASwapDoesNotWaitOutAnUnrecognisedRefusal(t *testing.T) {
 	}
 	if took := time.Since(start); took > swapRenameStep*2 {
 		t.Errorf("waited %v on a refusal deja cannot read", took)
+	}
+	// And the previous index is back: a fail-fast is still a swap that did not
+	// happen, not one that took the index with it.
+	if b, err := os.ReadFile(filepath.Join(dir, "records.bin")); err != nil || string(b) != "old" {
+		t.Errorf("the previous index is not where it was: %q %v", b, err)
 	}
 }


### PR DESCRIPTION
Closes #2228. Windows refuses to rename a directory while any handle inside it is open, so two ordinary passes at once — a hook's warmup and a `deja index` from a shell — left the loser unable to swap, and the store a session short until something rebuilt it. On Unix the loser renames over the winner and both end up consistent, which is why this had gone unmeasured.

The swap waits the reader out: 2s in 20ms steps, which is generous against a read that takes milliseconds and still shorter than the pass that would otherwise have to run again. A rename still refused at the end is reported, with the previous index put back rather than nothing left in its place.

Needs the `windows` label to check the leg this is about. `TestTwoPassesAtOnceKeepTheCountsAndTheAnswers` is the test #2228 was filed from; the leg is red for 35 unrelated reasons (#2808), so read that test's result specifically.