### PR TITLE
fix: recall_context names the query words the search could not use

### DIFF
--- a/cmd/deja/context_ignored_words_test.go
+++ b/cmd/deja/context_ignored_words_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// When a query's subject is a word no session holds, the stemmed tier answers
+// on what is left. The counted page says which words it threw away — "ignored:
+// no session matches it with the rest" — and recall_context, which returns a
+// whole session, printed only `[stemmed]`. So the tool that hands an agent the
+// most text was the one that did not say the question's subject had been
+// dropped, which is the failure #2074 is about (#2827).
+func TestTheContextDigestNamesTheWordsItIgnored(t *testing.T) {
+	dir := manySessionStore(t, 40)
+
+	// "quibblesnatch" is in the store, "wombatron" is in no session, so the
+	// tier answers on the rest and drops the invented word.
+	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"the wombatron quibblesnatch parser rejects frames"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "# deja context:") {
+		t.Fatalf("nothing was served, so there is nothing to caveat:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "wombatron") {
+		t.Errorf("the word the search dropped is not named:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "ignored") {
+		t.Errorf("the digest does not say the word was ignored:\n%s", firstLines(text, 4))
+	}
+}
+
+// And a query every word of which the store holds says nothing of the sort.
+func TestTheContextDigestIsQuietWhenNothingWasIgnored(t *testing.T) {
+	dir := manySessionStore(t, 40)
+	if _, err := index.AllMeta(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "recall_context", []byte(`{"query":"quibblesnatch parser"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "ignored") {
+		t.Errorf("nothing was dropped and the digest said otherwise:\n%s", firstLines(text, 4))
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1447,12 +1447,37 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	search.PrintContext(&b, whole, q)
 	text := b.String()
 	if hits[0].Tier != search.TierExact {
-		text = contextTierLead(hits[0].Tier, sessionNamesTheAsked(whole, q, result.TermIDF)) + text
+		text = contextTierLead(hits[0].Tier, sessionNamesTheAsked(whole, q, result.TermIDF)) +
+			contextIgnoredWords(result) + text
 	}
 	return text, 1, rawSize([]model.Session{whole}), []string{whole.ID}, projectsOf(whole),
 		// The search path reaches a promoted note as often as the id path
 		// does — the note carries the id in its own text.
 		forgottenSourceNote(whole, q, false), nil
+}
+
+// contextIgnoredWords names the query words the search could not use, the way
+// the counted page already does.
+//
+// When the subject of a question is a word no session holds, the stemmed tier
+// answers on what is left. recall says which words it threw away — "ignored: no
+// session matches it with the rest" — and this tool, which hands an agent a
+// whole session rather than a line, printed only `[stemmed]`. So the surface
+// carrying the most text was the one that did not say the question's subject
+// had been dropped, which is what an agent then answers from (#2827).
+func contextIgnoredWords(result index.SearchResult) string {
+	if !result.Stemmed && !result.Fuzzy {
+		return ""
+	}
+	summary := fuzzySummary(result.Variants)
+	if len(summary) == 0 {
+		return ""
+	}
+	what := "word forms"
+	if result.Fuzzy && !result.Stemmed {
+		what = "close spellings"
+	}
+	return fmt.Sprintf("No exact match; using %s: %s\n", what, strings.Join(summary, ", "))
 }
 
 // nothingIsAboutThis is the half both surfaces share. The wording was tuned in


### PR DESCRIPTION
Found while building the negative control #2827 was missing — a real corpus with an isolated index, asked about subjects minted at run time so the store could not already hold them.

The result was not the one I went looking for. On a real store an invented subject does not reach the relevance tier at all: the **stemmed** tier answers, and the two surfaces then say different things about the same situation.

    recall          No exact match; using word forms: 5d920quell (ignored: no session matches it with the rest), …
    recall_context  [stemmed]

So the tool that hands an agent a whole session was the one that did not say the question's subject had been thrown away. That is #2074's failure with the caveat missing rather than misplaced, on a path it never covered.

The marker stays — `TestTheOtherTiersKeepTheirMarker` is right that these tiers did match, and I am not touching that. What was missing is the line recall already prints, so `recall_context` prints it too, from the same `fuzzySummary`.

Three mutations: never adding the line, printing it when nothing was ignored, and dropping the words from it. The second does not go red: with neither `Stemmed` nor `Fuzzy` set the summary is empty and the function returns nothing anyway. I kept the guard rather than removing it, because removing it *widens* what can print — a close-tier answer carrying variants would gain a line no test asked for — and flagging an unexercised guard is better than a silent behaviour change. Same call I made for grok in #2812, and there hermes later proved it unnecessary and it came out in #2815; if a close-tier case turns up here, this one should go the same way.
