### PR TITLE
fix: lift a note over its source when either arrived by sync

### DIFF
--- a/internal/search/note_lift_imported_test.go
+++ b/internal/search/note_lift_imported_test.go
@@ -1,0 +1,61 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A note that arrived by sync has its local id rewritten to imported-… and
+// keeps the real one in OrigID. The lift recognised a note by its id alone, so
+// an imported note was never recognised and the transcript it distils outranked
+// it everywhere the rule reaches (#2833).
+func TestAnImportedNoteIsLiftedAboveItsSource(t *testing.T) {
+	hits := []Hit{
+		{Session: model.Session{ID: "other", Harness: "claude"}},
+		{Session: model.Session{ID: "sess1", Harness: "claude"}},
+		{Session: model.Session{ID: "imported-abc", OrigID: "deja-note-claude-sess1", Harness: "deja"}},
+	}
+	liftNotesAboveTheirSource(hits)
+	if got := liftIDs(hits); got[1] != "imported-abc" {
+		t.Errorf("an imported note was not lifted in front of its source: %v", got)
+	}
+}
+
+// And the other side of the pair: an imported *source* is keyed by its
+// original id too, so a note about it has to be matched on that.
+func TestANoteIsLiftedAboveAnImportedSource(t *testing.T) {
+	hits := []Hit{
+		{Session: model.Session{ID: "other", Harness: "claude"}},
+		{Session: model.Session{ID: "imported-def", OrigID: "sess1", Harness: "claude"}},
+		{Session: model.Session{ID: "deja-note-claude-sess1", Harness: "deja"}},
+	}
+	liftNotesAboveTheirSource(hits)
+	if got := liftIDs(hits); got[1] != "deja-note-claude-sess1" {
+		t.Errorf("a note about an imported source was not lifted: %v", got)
+	}
+}
+
+// Both at once, which is what a synced pair actually looks like.
+func TestAnImportedNoteIsLiftedAboveAnImportedSource(t *testing.T) {
+	hits := []Hit{
+		{Session: model.Session{ID: "imported-def", OrigID: "sess1", Harness: "claude"}},
+		{Session: model.Session{ID: "imported-abc", OrigID: "deja-note-claude-sess1", Harness: "deja"}},
+	}
+	liftNotesAboveTheirSource(hits)
+	if got := liftIDs(hits); got[0] != "imported-abc" {
+		t.Errorf("a synced pair was left in source-first order: %v", got)
+	}
+}
+
+// The same rule for a caller that ranks sessions rather than hits.
+func TestAnImportedNoteSessionIsLiftedAboveItsSource(t *testing.T) {
+	ss := []model.Session{
+		{ID: "sess1", Harness: "claude"},
+		{ID: "imported-abc", OrigID: "deja-note-claude-sess1", Harness: "deja"},
+	}
+	LiftNoteSessionsAboveTheirSource(ss)
+	if got := sessionIDs(ss); got[0] != "imported-abc" {
+		t.Errorf("an imported note was not lifted on the session path: %v", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -657,7 +657,8 @@ func LiftNotesAboveTheirSource(hits []Hit) {
 func liftNotesAboveTheirSource(hits []Hit) {
 	order := liftedNoteOrder(len(hits),
 		func(i int) string { return hits[i].Session.Harness },
-		func(i int) string { return hits[i].Session.ID })
+		func(i int) string { return hits[i].Session.ID },
+		func(i int) string { return hits[i].Session.OrigID })
 	if order == nil {
 		return
 	}
@@ -675,7 +676,8 @@ func liftNotesAboveTheirSource(hits []Hit) {
 func LiftNoteSessionsAboveTheirSource(ss []model.Session) {
 	order := liftedNoteOrder(len(ss),
 		func(i int) string { return ss[i].Harness },
-		func(i int) string { return ss[i].ID })
+		func(i int) string { return ss[i].ID },
+		func(i int) string { return ss[i].OrigID })
 	if order == nil {
 		return
 	}
@@ -689,11 +691,26 @@ func LiftNoteSessionsAboveTheirSource(ss []model.Session) {
 // liftedNoteOrder answers where each element goes so that a promoted note sits
 // in front of the transcript it was distilled from, and nothing else moves. It
 // returns nil when there is nothing to lift, so a caller can skip the copy.
-func liftedNoteOrder(n int, harnessAt, idAt func(int) string) []int {
+func liftedNoteOrder(n int, harnessAt, idAt, origAt func(int) string) []int {
+	// A session that arrived by sync has its local id rewritten to imported-…
+	// and keeps the real one in OrigID. Both sides of the pair need reading
+	// that way — the note's own id, and the source's key a note is built from
+	// — or an imported note is never recognised and the transcript it distils
+	// outranks it everywhere this rule reaches (#2833). lifecycle.go and
+	// hook_tool.go already consult OrigID for the same reason (#975).
+	noteID := func(i int) string {
+		if id := idAt(i); strings.HasPrefix(id, "deja-note-") {
+			return id
+		}
+		if orig := origAt(i); strings.HasPrefix(orig, "deja-note-") {
+			return orig
+		}
+		return ""
+	}
 	notes := make(map[string]int, n)
 	for i := 0; i < n; i++ {
-		if harnessAt(i) == notesHarness && strings.HasPrefix(idAt(i), "deja-note-") {
-			notes[idAt(i)] = i
+		if harnessAt(i) == notesHarness && noteID(i) != "" {
+			notes[noteID(i)] = i
 		}
 	}
 	if len(notes) == 0 {
@@ -709,11 +726,21 @@ func liftedNoteOrder(n int, harnessAt, idAt func(int) string) []int {
 		if harnessAt(i) != notesHarness {
 			// Mirrors sources.PromotedNoteID: building the id rather than
 			// parsing one keeps a harness name with a dash in it from
-			// splitting wrong.
-			if j, ok := notes["deja-note-"+harnessAt(i)+"-"+idAt(i)]; ok && j > i {
+			// splitting wrong. Built from the source's own id and from the one
+			// it had before it was imported, since either may be what the note
+			// was made against.
+			for _, key := range []string{idAt(i), origAt(i)} {
+				if key == "" {
+					continue
+				}
+				j, ok := notes["deja-note-"+harnessAt(i)+"-"+key]
+				if !ok || j <= i || taken[j] {
+					continue
+				}
 				order = append(order, j)
 				taken[j] = true
 				moved = true
+				break
 			}
 		}
 		order = append(order, i)


### PR DESCRIPTION
Closes #2833. A synced session keeps its real id in `OrigID` and gets `imported-…` locally, and the lift read only the local one — so an imported note was never recognised as a note, and the transcript it distils outranked it on every surface the rule reaches.

Both sides of the pair, not one: the note is found by its own original id, and the key a note is built from is tried against the source's original id as well, since either may be the imported one. `lifecycle.go` and `hook_tool.go` already read `OrigID` for the same reason (#975).

Four cases, and the third is the one that actually happens after a sync — both halves imported:

    imported note over a local source
    local note over an imported source
    imported note over an imported source
    the same on the session path the prompt hook uses

Three mutations: not reading the note's `OrigID`, not reading the source's, and dropping the already-ahead guard.

The rule lives in one place since #2823, so this reaches the hit path and the session path together; `blame` gets it through the same function.