### PR TITLE
fix(mcp): frame the commands how hands an agent

### DIFF
--- a/cmd/deja/how_frame_test.go
+++ b/cmd/deja/how_frame_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// recall_frame.go states the rule: recalled transcript text is data an
+// attacker may have influenced, so agent-facing output is framed as untrusted.
+// `how` is agent-facing and returns the most directly actionable thing deja
+// serves — command lines lifted out of transcripts — and it was the one MCP
+// answer with no frame and no note at all.
+func TestTheHowToolFramesWhatItServes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","sessionId":"s1","cwd":"/app","timestamp":"2026-08-01T09:00:00Z","message":{"role":"user","content":"how do we deploy"}}
+{"type":"assistant","sessionId":"s1","cwd":"/app","timestamp":"2026-08-01T09:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"helm upgrade zonkomatic --set replicas=9"}}]}}
+`
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "how", json.RawMessage(`{"what":"zonkomatic"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "helm upgrade zonkomatic") {
+		t.Fatalf("the command was not served, so there is nothing to frame:\n%s", text)
+	}
+	if !strings.Contains(text, "untrusted reference data") {
+		t.Errorf("a command drawn from a transcript arrives with nothing saying where it came from:\n%s", text)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -496,7 +496,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			// travel with the answer rather than to a terminal it never sees.
 			out += "\n\n" + note
 		}
-		return out, nil
+		// Framed like every other agent-facing recall: these are command lines
+		// lifted out of transcripts, which recall_frame.go names as data an
+		// attacker may have influenced — and they are the most directly
+		// actionable thing deja serves, since an agent may run them. This was
+		// the one MCP answer with neither frame nor note (#2827's sweep).
+		return frameRecall(out), nil
 	case "remember":
 		var a struct {
 			Text    string   `json:"text"`


### PR DESCRIPTION
Found by sweeping every MCP tool for the framing `recall_frame.go` says agent-facing output must carry — "recalled transcript text is historical data an attacker may have influenced… agent-facing recall output is therefore framed as untrusted".

    recall          frame yes   untrusted note yes
    recall_context  frame yes   untrusted note yes
    blame           frame no    untrusted note yes   (its JSON carries the note as a field)
    how             frame NO    untrusted note NO

`how` was the one answer with neither — and it is the tool that serves the most directly actionable thing deja has, command lines lifted out of transcripts, which an agent may run. It now returns through `frameRecall` like its siblings.

`fix` is not in the table on purpose: on the corpus I measured it only ever returned refusals and "no session ran a command after that error", so its non-empty framing is unverified and I am not claiming anything about it. Worth a look by someone who can produce a confirmed pair.

Measured on a copy of a real store with an isolated index; the test seeds one session whose Bash command is the answer and asserts the note travels with it. One mutation: dropping the frame turns it red.