### PR TITLE
fix(install): give back the openclaw switch on the parsed path too

### DIFF
--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -85,7 +85,7 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		// A comment is not a broken file, and this writer shares openclaw.json
 		// with the MCP one — so refusing here left a target that wrote half its
 		// wiring, or could not take its own hook back out (#2811).
-		return setOpenClawEntryJSONC(path, old, "hooks.internal.entries", openclawHookName, "enabled", on)
+		return setOpenClawEntryJSONC(path, old, openclawHookEntries, openclawHookName, openclawHookSwitch, on)
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return "", configParseError(path, err)
 	}
@@ -97,10 +97,20 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 			return "unchanged", nil
 		}
 		delete(entries, openclawHookName)
-		// Leave the user's other hooks — and the master switch — alone.
+		// Leave the user's other hooks alone — and the switch, unless deja is
+		// what turned it on. It records that at install time, the way it
+		// records a block it created, so an uninstall gives back a setting the
+		// reader had rather than deleting one deja only overwrote (#2830, the
+		// rule the text writer got in #2811).
 		if len(entries) == 0 {
 			delete(internal, "entries")
-			delete(internal, "enabled")
+			switch was := hookSwitchWas(path); {
+			case was == nil:
+				delete(internal, "enabled")
+			default:
+				internal["enabled"] = was
+			}
+			forgetHookSwitch(path)
 		}
 		if len(internal) == 0 {
 			delete(hooks, "internal")
@@ -121,6 +131,7 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 			entries = map[string]any{}
 			internal["entries"] = entries
 		}
+		noteHookSwitch(path, internal["enabled"])
 		internal["enabled"] = true
 		entries[openclawHookName] = map[string]any{"enabled": true}
 	}
@@ -131,6 +142,56 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 	next = append(next, '\n')
 	return writeIfChanged(path, old, next)
 }
+
+// hookSwitchKeys name what deja found under the switch, in the wiring state
+// beside the blocks it records there. Three states rather than two: the reader
+// had it on, the reader had it off, or there was nothing there and it is
+// deja's to remove.
+func hookSwitchKeys(path string) (on, off string) {
+	keys := strings.Split(openclawHookEntries, ".")
+	base := flagRecordKey(keys, openclawHookSwitch)
+	return base + "=true", base + "=false"
+}
+
+// noteHookSwitch records what was under the switch before deja wrote to it.
+func noteHookSwitch(path string, was any) {
+	on, off := hookSwitchKeys(path)
+	switch v, ok := was.(bool); {
+	case !ok:
+		// Absent, or something that is not a boolean: deja overwrites it and
+		// takes it away again, since it cannot know what a `null` or a `0`
+		// there was meant to say.
+	case v:
+		noteBlockAdded(path, on)
+	default:
+		noteBlockAdded(path, off)
+	}
+}
+
+// hookSwitchWas is what to put back, or nil where the switch is deja's own.
+func hookSwitchWas(path string) any {
+	on, off := hookSwitchKeys(path)
+	switch {
+	case blockWasAdded(path, on):
+		return true
+	case blockWasAdded(path, off):
+		return false
+	}
+	return nil
+}
+
+func forgetHookSwitch(path string) {
+	on, off := hookSwitchKeys(path)
+	forgetBlockAdded(path, on)
+	forgetBlockAdded(path, off)
+}
+
+const (
+	// openclawHookEntries and openclawHookSwitch are where the bootstrap hook
+	// lives and the switch that runs it, named once so the two writers agree.
+	openclawHookEntries = "hooks.internal.entries"
+	openclawHookSwitch  = "enabled"
+)
 
 // flagRecordKey names the switch in the wiring state, beside the blocks deja
 // records there. A key of its own rather than the block's, so "deja created

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -147,20 +147,32 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 // beside the blocks it records there. Three states rather than two: the reader
 // had it on, the reader had it off, or there was nothing there and it is
 // deja's to remove.
-func hookSwitchKeys(path string) (on, off string) {
+func hookSwitchKeys() (deja, on, off string) {
 	keys := strings.Split(openclawHookEntries, ".")
 	base := flagRecordKey(keys, openclawHookSwitch)
-	return base + "=true", base + "=false"
+	// The bare key is the one the text writer uses for "deja put this here",
+	// so a config that gains or loses a comment between install and uninstall
+	// still reads the same record (#2830).
+	return base, base + "=true", base + "=false"
 }
 
 // noteHookSwitch records what was under the switch before deja wrote to it.
 func noteHookSwitch(path string, was any) {
-	on, off := hookSwitchKeys(path)
+	deja, on, off := hookSwitchKeys()
+	// Once. A second install reads the switch deja itself set on the first, so
+	// recording again would say the reader had it on and hand it back that way
+	// — which is #2830 again, by way of an upgrade.
+	for _, k := range []string{deja, on, off} {
+		if blockWasAdded(path, k) {
+			return
+		}
+	}
 	switch v, ok := was.(bool); {
 	case !ok:
 		// Absent, or something that is not a boolean: deja overwrites it and
 		// takes it away again, since it cannot know what a `null` or a `0`
 		// there was meant to say.
+		noteBlockAdded(path, deja)
 	case v:
 		noteBlockAdded(path, on)
 	default:
@@ -170,7 +182,7 @@ func noteHookSwitch(path string, was any) {
 
 // hookSwitchWas is what to put back, or nil where the switch is deja's own.
 func hookSwitchWas(path string) any {
-	on, off := hookSwitchKeys(path)
+	_, on, off := hookSwitchKeys()
 	switch {
 	case blockWasAdded(path, on):
 		return true
@@ -181,7 +193,8 @@ func hookSwitchWas(path string) any {
 }
 
 func forgetHookSwitch(path string) {
-	on, off := hookSwitchKeys(path)
+	deja, on, off := hookSwitchKeys()
+	forgetBlockAdded(path, deja)
 	forgetBlockAdded(path, on)
 	forgetBlockAdded(path, off)
 }

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -104,10 +104,9 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		// rule the text writer got in #2811).
 		if len(entries) == 0 {
 			delete(internal, "entries")
-			switch was := hookSwitchWas(path); {
-			case was == nil:
+			if was := hookSwitchWas(path); was == nil {
 				delete(internal, "enabled")
-			default:
+			} else {
 				internal["enabled"] = was
 			}
 			forgetHookSwitch(path)

--- a/cmd/deja/openclaw_parsed_switch_test.go
+++ b/cmd/deja/openclaw_parsed_switch_test.go
@@ -55,6 +55,12 @@ func TestTheParsedPathGivesBackASwitchTheReaderSet(t *testing.T) {
 			if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
 				t.Fatal(err)
 			}
+			// Twice: reinstalling after an upgrade is ordinary, and the second
+			// install reads the switch deja itself set — recording that would
+			// hand the reader back deja's own value as if it were theirs.
+			if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+				t.Fatal(err)
+			}
 			// While installed the switch is on whatever the reader had.
 			if on := readOpenClawSwitch(t, path); on != true {
 				t.Errorf("the hook was wired with the switch %v, so it never runs", on)

--- a/cmd/deja/openclaw_parsed_switch_test.go
+++ b/cmd/deja/openclaw_parsed_switch_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The parsed writer deleted `hooks.internal.enabled` whenever the entries block
+// emptied, including when the reader had set it themselves and deja only
+// overwrote it — so an install switched internal hooks on for someone who had
+// switched them off, and the uninstall took the setting away rather than
+// giving it back (#2830, the parity the JSONC path gained in #2825).
+func TestTheParsedPathGivesBackASwitchTheReaderSet(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		start map[string]any
+		// want is what hooks.internal.enabled should hold afterwards; nil for
+		// "the key should be gone".
+		want any
+	}{
+		{
+			name:  "the reader had it off",
+			start: map[string]any{"hooks": map[string]any{"internal": map[string]any{"enabled": false}}},
+			want:  false,
+		},
+		{
+			name:  "the reader had it on",
+			start: map[string]any{"hooks": map[string]any{"internal": map[string]any{"enabled": true}}},
+			want:  true,
+		},
+		{
+			name:  "deja turned it on itself",
+			start: map[string]any{},
+			want:  nil,
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			before, err := json.MarshalIndent(c.start, "", "  ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, append(before, '\n'), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := installOpenClawAuto("/bin/deja", false); err != nil {
+				t.Fatal(err)
+			}
+			// While installed the switch is on whatever the reader had.
+			if on := readOpenClawSwitch(t, path); on != true {
+				t.Errorf("the hook was wired with the switch %v, so it never runs", on)
+			}
+			if _, err := installOpenClawAuto("/bin/deja", true); err != nil {
+				t.Fatal(err)
+			}
+			if got := readOpenClawSwitch(t, path); got != c.want {
+				t.Errorf("after uninstall the switch is %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func readOpenClawSwitch(t *testing.T, path string) any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatalf("the config no longer parses: %v\n%s", err, b)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	internal, _ := mapAt(hooks, "internal")
+	if internal == nil {
+		return nil
+	}
+	v, ok := internal["enabled"]
+	if !ok {
+		return nil
+	}
+	return v
+}


### PR DESCRIPTION
Closes #2830. The parsed writer deleted `hooks.internal.enabled` whenever the entries block emptied, including when the reader had set it themselves and deja only overwrote it — so an install switched internal hooks on for someone who had switched them off, and the uninstall took the setting away instead of giving it back. The text writer learned this in #2825; both paths now record what they found and restore it, and the two key names are shared rather than spelled twice.