### PR TITLE
fix(forget): take the id an imported session came with

### DIFF
--- a/cmd/deja/forget_scope_test.go
+++ b/cmd/deja/forget_scope_test.go
@@ -17,7 +17,7 @@ func TestForgetScopeRefusal(t *testing.T) {
 		t.Fatal("a prefix of twelve sessions was not refused")
 	}
 	got := err.Error()
-	for _, want := range []string{"prefix of 12 sessions", "--dry-run", "--all-matches"} {
+	for _, want := range []string{"matches 12 sessions", "--dry-run", "--all-matches"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("refusal does not mention %q: %q", want, got)
 		}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3067,7 +3067,7 @@ func forgetScopeRefusal(selector string, matches int, allMatches bool) error {
 	if strings.Contains(selector, "…") {
 		return fmt.Errorf("%q matches %d sessions — the ids differ in the middle the line elides; `deja last` prints them whole", selector, matches)
 	}
-	return fmt.Errorf("%q is a prefix of %d sessions — `deja forget --session %s --dry-run` lists what would go; add --all-matches to drop them all",
+	return fmt.Errorf("%q matches %d sessions — `deja forget --session %s --dry-run` lists what would go; add --all-matches to drop them all",
 		selector, matches, pasteSafe(selector))
 }
 

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -584,8 +584,15 @@ func tombstoneMatches(key, prefix string) bool {
 		id = key[i+1:]
 	}
 	// Same widening as the forget selector: the id a reader copies off a
-	// result line carries the elision (#855).
-	return key == prefix || strings.HasPrefix(id, prefix) || idMatchesElided(id, prefix)
+	// result line carries the elision (#855), and a session that arrived by
+	// sync answers to the id it came with — which forget now takes, so undo
+	// has to take it too or the reader can drop a session and not put it back
+	// without reading `forget --list` for an id they never chose (#2843).
+	if key == prefix || strings.HasPrefix(id, prefix) || idMatchesElided(id, prefix) {
+		return true
+	}
+	harness, _, ok := strings.Cut(key, ":")
+	return ok && id == ImportedSessionID(harness, prefix)
 }
 
 // Unforget lifts tombstones and reports how many it lifted. The count is not

--- a/internal/index/privacy.go
+++ b/internal/index/privacy.go
@@ -317,14 +317,30 @@ func SelectorMatches(meta SessionMeta, sel string) bool { return selectorMatches
 // beside it, and in promote's receipts — which `show` refused and
 // `forget --session` accepted while matching nothing (#921).
 func selectorMatches(meta SessionMeta, sel string) bool {
-	if strings.HasPrefix(meta.ID, sel) || idMatchesElided(meta.ID, sel) {
+	if selectorMatchesID(meta.ID, sel) || selectorMatchesOrigID(meta, sel) {
 		return true
 	}
 	harness, id := splitSelector(sel)
 	if harness == "" || !strings.EqualFold(meta.Harness, harness) {
 		return false
 	}
-	return strings.HasPrefix(meta.ID, id) || idMatchesElided(meta.ID, id)
+	return selectorMatchesID(meta.ID, id) || selectorMatchesOrigID(meta, id)
+}
+
+func selectorMatchesID(have, sel string) bool {
+	return strings.HasPrefix(have, sel) || idMatchesElided(have, sel)
+}
+
+// selectorMatchesOrigID takes the id a session had where it was recorded. A
+// sync rewrites the id, so the one the reader knows — the one the other machine
+// prints, the one a note promoted from it carries — named nothing here, and the
+// session could only be forgotten by an id nobody chose (#2843).
+//
+// The whole id, not a prefix of it: the local id is what a reader resolves
+// against, and a prefix of the original is a guess about a session this machine
+// never named that way.
+func selectorMatchesOrigID(meta SessionMeta, sel string) bool {
+	return meta.OrigID != "" && meta.OrigID == sel
 }
 
 // splitSelector takes the `harness:` off a pasted selector. The whole string is

--- a/internal/index/selector_orig_id_test.go
+++ b/internal/index/selector_orig_id_test.go
@@ -21,4 +21,22 @@ func TestASelectorFindsAnImportedSessionByTheIdItCameWith(t *testing.T) {
 	if selectorMatches(meta, "codex:longs") {
 		t.Error("the harness is not being checked")
 	}
+	if selectorMatches(SessionMeta{Harness: "claude", ID: "other", OrigID: "longshoreman"}, "claude:longs") {
+		t.Error("a prefix of another session's original id matched through the harness form")
+	}
+}
+
+// And the round trip: what forget takes, unforget gives back by the same
+// string. Taking a session by an id whose undo needs a different one is worse
+// than not taking it (#2843).
+func TestATombstoneAnswersToTheIdItWasForgottenBy(t *testing.T) {
+	key := "claude:" + ImportedSessionID("claude", "longs")
+	for _, sel := range []string{"longs", key, ImportedSessionID("claude", "longs")} {
+		if !tombstoneMatches(key, sel) {
+			t.Errorf("%q does not lift the tombstone forget wrote for it", sel)
+		}
+	}
+	if tombstoneMatches(key, "someone-elses-session") {
+		t.Error("an unrelated id lifted the tombstone")
+	}
 }

--- a/internal/index/selector_orig_id_test.go
+++ b/internal/index/selector_orig_id_test.go
@@ -1,0 +1,24 @@
+package index
+
+import "testing"
+
+// A session that arrived by sync is keyed here by the id the import gave it,
+// so the id the reader knows — the one the machine that recorded it prints,
+// the one a note promoted from it carries — matched nothing, and the only way
+// to forget it was an id nobody chose (#2843).
+func TestASelectorFindsAnImportedSessionByTheIdItCameWith(t *testing.T) {
+	meta := SessionMeta{Harness: "claude", ID: ImportedSessionID("claude", "longs"), OrigID: "longs"}
+	for _, sel := range []string{"longs", "claude:longs", meta.ID, "claude:" + meta.ID} {
+		if !selectorMatches(meta, sel) {
+			t.Errorf("%q does not name the session", sel)
+		}
+	}
+	// And it stays a name rather than a substring: a session that merely
+	// starts the same way is not the one the reader asked for.
+	if selectorMatches(SessionMeta{Harness: "claude", ID: "other", OrigID: "longshoreman"}, "longs") {
+		t.Error("a prefix of another session's original id matched")
+	}
+	if selectorMatches(meta, "codex:longs") {
+		t.Error("the harness is not being checked")
+	}
+}


### PR DESCRIPTION
Closes #2843. A session that arrived by sync is keyed here by the id the import gave it, and `selectorMatches` looked at that alone — so `deja forget --session longs`, with the id the other machine prints and the note promoted from it carries, matched nothing, and the only way to forget it was an `imported-…` id the reader never chose.

The original id counts as a name now, on both the bare and the `harness:id` forms, and `unforget` takes the same string back — the local id is a pure function of the original, so the tombstone can be found without it. Whole id rather than a prefix: a prefix resolves against the local id, and guessing at one this machine never used is a different promise. That does leave forget's selector stricter than the lookups, which take an OrigID prefix, so `deja show longs…` can resolve a session `forget --session` with the same string reports as no match.

Known gap, measured by the reviewer and not this PR's to close: where the local original and its imported twin both exist, forget's exact-id guard still takes only the local copy and says "1 session".