### PR TITLE
fix(mcp): frame the command fix hands an agent

### DIFF
--- a/cmd/deja/fix_frame_test.go
+++ b/cmd/deja/fix_frame_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The other half of the sweep that framed `how` (#2844): `fix` hands an agent a
+// command to run at the moment it has just hit an error, which is the moment it
+// is most likely to run it without reading. It arrived with no frame and no
+// note — the same gap, on the sharper surface.
+func TestTheFixToolFramesTheCommandItServes(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const errLine = "ld: symbol(s) not found for architecture arm64"
+	// Twice, in two sessions: one sighting is held back as unconfirmed.
+	for i, sid := range []string{"s1", "s2"} {
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + string(rune('1'+i)) + `T09:00:00Z","message":{"role":"user","content":"build is broken again"}}
+{"type":"user","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + string(rune('1'+i)) + `T09:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"` + errLine + `"}]}}
+{"type":"assistant","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + string(rune('1'+i)) + `T09:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go build -ldflags=-w ./..."}}]}}
+`
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "fix", json.RawMessage(`{"error":"`+errLine+`"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "go build -ldflags=-w") {
+		t.Fatalf("no command was served, so there is nothing to frame:\n%s", text)
+	}
+	if !strings.Contains(text, "untrusted reference data") {
+		t.Errorf("a command to run arrives with nothing saying where it came from:\n%s", text)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -442,7 +442,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
 				commandListingLine(p.Command))
 		}
-		return strings.TrimRight(fb.String(), "\n"), nil
+		// Framed like `how` (#2844) and for a sharper reason: this hands an
+		// agent a command at the moment it has just hit an error, which is
+		// the moment it is most likely to run it without reading. The
+		// command came out of a transcript, which recall_frame.go names as
+		// data an attacker may have influenced.
+		return frameRecall(strings.TrimRight(fb.String(), "\n")), nil
 	case "how":
 		var a struct {
 			What    string    `json:"what"`


### PR DESCRIPTION
Settles the question I left open in #2844. There I said `fix`'s framing was unverified because the corpus I measured only ever produced refusals, and that someone should check it with a confirmed pair. Built that store — an error line in tool output followed by the command that ran next, twice so the pair is confirmed rather than a lone sighting — and it returns:

    ld: symbol(s) not found for architecture arm64 (2026-08-02)
      ran next: $ go build -ldflags=-w ./...

with no frame and no note, the same gap `how` had.

Sharper here than there. `fix` serves a command at the moment an agent has just hit an error, which is the moment it is most likely to run it without reading, and the command came out of a transcript — data `recall_frame.go` says may have been influenced by whoever wrote it.

One mutation: dropping the frame turns the test red. The fixture is the stand from the measurement, seeded in the test rather than described.