### PR TITLE
fix(blame): order by how specifically a session names the file

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -664,12 +664,15 @@ const blameMCPBudget = 8192
 // blameHitJSON is what the MCP blame tool returns: the same shape as the CLI's
 // --json minus the session's message list.
 type blameHitJSON struct {
-	Session  blameSessionJSON `json:"session"`
-	Title    string           `json:"title,omitempty"`
-	Count    int              `json:"count"`
-	Score    float64          `json:"score"`
-	Tier     string           `json:"tier,omitempty"`
-	Snippets []string         `json:"snippets,omitempty"`
+	Session blameSessionJSON `json:"session"`
+	Title   string           `json:"title,omitempty"`
+	Count   int              `json:"count"`
+	Score   float64          `json:"score"`
+	// Specificity is what orders the list, ahead of the score, so an agent
+	// reading these rows can see why one came first (#2840).
+	Specificity float64  `json:"specificity"`
+	Tier        string   `json:"tier,omitempty"`
+	Snippets    []string `json:"snippets,omitempty"`
 }
 
 type blameSessionJSON struct {
@@ -728,7 +731,8 @@ func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []by
 				Started: h.Session.Started, Updated: h.Session.Updated, Touched: h.Session.Touched,
 			},
 			Title: search.SafeNoteTitle(h.Session.Title), Count: h.Count, Score: h.Score,
-			Tier: h.Tier, Snippets: h.Snippets,
+			Specificity: h.Specificity,
+			Tier:        h.Tier, Snippets: h.Snippets,
 		})
 	}
 	if omitted > 0 {

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -592,10 +592,11 @@ Returns a JSON array of blame hits (same stability rules as exact search):
 ]
 ```
 
-`specificity` is how fully the session named the file — a path counts for more
-than a bare filename, and the deeper the path the more it counts. It is what
-orders the list, ahead of `score`, so the sessions that named the file the way
-the caller did come first.
+`specificity` says whether the session wrote the file as a path or as a bare
+name. It orders the list ahead of `score`, so a session that spelled the path
+out comes before one that only mentioned the filename. It is deliberately
+coarse: ordering on how deep the path was put a same-named file from another
+project above the sessions that had worked on this one.
 
 A hit for a session whose decision was promoted also carries `lifecycle`,
 `lifecycle_note` and `lifecycle_at`. Every state appears there, `accepted`

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -586,10 +586,16 @@ Returns a JSON array of blame hits (same stability rules as exact search):
     "count": 3,
     "snippets": ["… parser.go …"],
     "score": 1.5,
+    "specificity": 1.75,
     "tier": "exact"
   }
 ]
 ```
+
+`specificity` is how fully the session named the file — a path counts for more
+than a bare filename, and the deeper the path the more it counts. It is what
+orders the list, ahead of `score`, so the sessions that named the file the way
+the caller did come first.
 
 A hit for a session whose decision was promoted also carries `lifecycle`,
 `lifecycle_note` and `lifecycle_at`. Every state appears there, `accepted`

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -257,6 +257,13 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 	count := 0
 	level := 1.0
 	for _, form := range forms {
+		// The bare basename is one of the forms, and it matches inside a path
+		// as well as on its own — so every mention was already "specific" and
+		// the rule below could never fire. A name is what the caller asked
+		// with; a path is what says which file the session meant (#2840).
+		if !strings.Contains(strings.Trim(form, "/"), "/") {
+			continue
+		}
 		if pathFormCount(low, form) > 0 {
 			candidate := 1.0 + float64(len(strings.Split(form, "/")))/4
 			if candidate > level {

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -271,19 +271,13 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 			}
 		}
 	}
-	// What the session wrote around the name, for a caller who gave only the
-	// name: `internal/index/ingest.go` says more about which file it means
-	// than `ingest.go` does, and blame's own description promises the more
-	// specific mention first (#2840).
-	//
-	// One step, not a depth. Counting the directories a session wrote made a
-	// deeply nested file of the same name in another project the most specific
-	// mention there is — measured on a real store, `blame cmd/deja/main.go`
-	// answered with an unrelated `…/apps/image2video/cmd/dfprocessing/main.go`
-	// above every session that had actually worked on the file.
-	if level == 1.0 && writtenPathDepth(low, base) > 0 {
-		level = 1.25
-	}
+	// Only the target's own directories count, which is what the forms above
+	// are. Crediting any directory a session wrote instead — measured on a
+	// real store — handed `blame Makefile` to three other projects' Makefiles
+	// and dropped this repo's own from rank 2 to rank 24, because "wrote a
+	// deep path" is a proxy for working in a deep tree rather than for meaning
+	// this file. A target with no directory of its own leaves every mention at
+	// 1.0, and the rule sits out (#2840).
 	for pos := 0; ; {
 		i := strings.Index(low[pos:], base)
 		if i < 0 {
@@ -296,51 +290,6 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 		pos = i + len(base)
 	}
 	return count, level
-}
-
-// writtenPathDepth is how many directories a session wrote in front of the
-// name, at the deepest place it named it. Zero when the name stands alone.
-func writtenPathDepth(low, base string) int {
-	deepest := 0
-	for pos := 0; ; {
-		i := strings.Index(low[pos:], base)
-		if i < 0 {
-			return deepest
-		}
-		i += pos
-		pos = i + len(base)
-		if !pathComponentOrWord(low, i, pos) {
-			continue
-		}
-		depth := 0
-		for j := i; j > 0 && low[j-1] == '/'; {
-			k := j - 1
-			for k > 0 && isPathByte(low[k-1]) {
-				k--
-			}
-			if k == j-1 {
-				break
-			}
-			depth++
-			j = k
-		}
-		if depth > deepest {
-			deepest = depth
-		}
-	}
-}
-
-// isPathByte reports whether a byte can sit inside a path component as an
-// agent writes one. Deliberately narrow: a quote or a space ends the path, and
-// reading past one would count an English sentence as directories.
-func isPathByte(b byte) bool {
-	switch {
-	case b >= 'a' && b <= 'z', b >= '0' && b <= '9':
-		return true
-	case b == '.' || b == '-' || b == '_':
-		return true
-	}
-	return false
 }
 
 func pathFormCount(s, form string) int {

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -191,12 +191,17 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 		hits = append(hits, hit)
 	}
 	sort.Slice(hits, func(i, j int) bool {
-		// How specifically the session names the file, before anything else:
-		// the description this answers to says so, and recency alone put a
-		// same-named file from another tree above the sessions that named the
-		// path asked about (#2840).
-		if hits[i].Specificity != hits[j].Specificity {
-			return hits[i].Specificity > hits[j].Specificity
+		// Whether the session named a path at all, before anything else: the
+		// description this answers to promises the most specific mention
+		// first, and recency alone put a bare mention above the sessions that
+		// spelled the path out (#2840).
+		//
+		// Whether, not how deeply — ordering on the depth itself put one
+		// mention of an unrelated file above a session that had worked on this
+		// one for a thousand lines, which is the opposite of what blame
+		// answers.
+		if namedAPath(hits[i]) != namedAPath(hits[j]) {
+			return namedAPath(hits[i])
 		}
 		if hits[i].Score != hits[j].Score {
 			return hits[i].Score > hits[j].Score
@@ -213,6 +218,11 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 	liftNotesBy(hits, func(h BlameHit) model.Session { return h.Session })
 	return hits
 }
+
+// namedAPath reports whether the session wrote the file as a path rather than
+// as a bare name. It is the coarse half of specificity — the half that orders
+// the answer; the rest is left to the score, where the number of mentions is.
+func namedAPath(h BlameHit) bool { return h.Specificity > 1.0 }
 
 // BlameCap is how many hits the default listing shows. The rest are behind
 // --all, so a caller that cuts the list here owes the reader the count it cut
@@ -258,10 +268,14 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 	// name: `internal/index/ingest.go` says more about which file it means
 	// than `ingest.go` does, and blame's own description promises the more
 	// specific mention first (#2840).
-	if written := writtenPathDepth(low, base); written > 0 {
-		if candidate := 1.0 + float64(written)/4; candidate > level {
-			level = candidate
-		}
+	//
+	// One step, not a depth. Counting the directories a session wrote made a
+	// deeply nested file of the same name in another project the most specific
+	// mention there is — measured on a real store, `blame cmd/deja/main.go`
+	// answered with an unrelated `…/apps/image2video/cmd/dfprocessing/main.go`
+	// above every session that had actually worked on the file.
+	if level == 1.0 && writtenPathDepth(low, base) > 0 {
+		level = 1.25
 	}
 	for pos := 0; ; {
 		i := strings.Index(low[pos:], base)

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -35,7 +35,10 @@ type BlameHit struct {
 	Count    int           `json:"count"`
 	Snippets []string      `json:"snippets"`
 	Score    float64       `json:"score"`
-	Tier     string        `json:"tier"`
+	// Specificity is how fully the session named the file — a path against a
+	// bare name — and is what orders the answer before the score does (#2840).
+	Specificity float64 `json:"specificity"`
+	Tier        string  `json:"tier"`
 	// Lifecycle carries a decision that did not hold. blame answers "who
 	// decided this", and it was answering with the accepted line of a decision
 	// that had been taken back (#1017).
@@ -184,9 +187,17 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 			score *= 1.35
 		}
 		hit.Score = score * freshnessDecay(session.Updated, now)
+		hit.Specificity = specificity
 		hits = append(hits, hit)
 	}
 	sort.Slice(hits, func(i, j int) bool {
+		// How specifically the session names the file, before anything else:
+		// the description this answers to says so, and recency alone put a
+		// same-named file from another tree above the sessions that named the
+		// path asked about (#2840).
+		if hits[i].Specificity != hits[j].Specificity {
+			return hits[i].Specificity > hits[j].Specificity
+		}
 		if hits[i].Score != hits[j].Score {
 			return hits[i].Score > hits[j].Score
 		}
@@ -243,6 +254,15 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 			}
 		}
 	}
+	// What the session wrote around the name, for a caller who gave only the
+	// name: `internal/index/ingest.go` says more about which file it means
+	// than `ingest.go` does, and blame's own description promises the more
+	// specific mention first (#2840).
+	if written := writtenPathDepth(low, base); written > 0 {
+		if candidate := 1.0 + float64(written)/4; candidate > level {
+			level = candidate
+		}
+	}
 	for pos := 0; ; {
 		i := strings.Index(low[pos:], base)
 		if i < 0 {
@@ -255,6 +275,51 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 		pos = i + len(base)
 	}
 	return count, level
+}
+
+// writtenPathDepth is how many directories a session wrote in front of the
+// name, at the deepest place it named it. Zero when the name stands alone.
+func writtenPathDepth(low, base string) int {
+	deepest := 0
+	for pos := 0; ; {
+		i := strings.Index(low[pos:], base)
+		if i < 0 {
+			return deepest
+		}
+		i += pos
+		pos = i + len(base)
+		if !pathComponentOrWord(low, i, pos) {
+			continue
+		}
+		depth := 0
+		for j := i; j > 0 && low[j-1] == '/'; {
+			k := j - 1
+			for k > 0 && isPathByte(low[k-1]) {
+				k--
+			}
+			if k == j-1 {
+				break
+			}
+			depth++
+			j = k
+		}
+		if depth > deepest {
+			deepest = depth
+		}
+	}
+}
+
+// isPathByte reports whether a byte can sit inside a path component as an
+// agent writes one. Deliberately narrow: a quote or a space ends the path, and
+// reading past one would count an English sentence as directories.
+func isPathByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z', b >= '0' && b <= '9':
+		return true
+	case b == '.' || b == '-' || b == '_':
+		return true
+	}
+	return false
 }
 
 func pathFormCount(s, form string) int {

--- a/internal/search/blame_json_contract_test.go
+++ b/internal/search/blame_json_contract_test.go
@@ -13,7 +13,7 @@ import (
 func TestBlameHitShapeIsStable(t *testing.T) {
 	want := map[string]bool{
 		"session": true, "title": true, "count": true, "snippets": true,
-		"score": true, "tier": true,
+		"score": true, "specificity": true, "tier": true,
 		"lifecycle": true, "lifecycle_note": true, "lifecycle_at": true,
 	}
 	got := map[string]bool{}

--- a/internal/search/blame_specificity_test.go
+++ b/internal/search/blame_specificity_test.go
@@ -1,0 +1,70 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// blame tells every agent "most specific mentions come first". Asked by a bare
+// filename the order was recency, and a session naming a different file with
+// the same basename came ahead of the ones naming the path asked about (#2840).
+func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
+	day := func(d int) time.Time { return time.Date(2026, 8, d, 0, 0, 0, 0, time.UTC) }
+	session := func(id, text string, at time.Time) model.Session {
+		return model.Session{
+			Harness: "claude", ID: id, Project: "api", Updated: at,
+			Messages: []model.Message{{Role: "user", Text: text, Time: at}},
+		}
+	}
+	// Oldest first, so recency alone would reverse them.
+	ss := []model.Session{
+		session("abs", "we edited /work/api/internal/index/ingest.go and fixed the watermark", day(10)),
+		session("rel", "the change went into internal/index/ingest.go, one function", day(11)),
+		session("base", "ingest.go needed a second pass, nothing else", day(12)),
+		session("other", "we touched cmd/tools/ingest.go in the other repo entirely", day(13)),
+	}
+
+	order := func(target BlameTarget) []string {
+		hits := Blame(ss, target, BlameOptions{All: true})
+		out := make([]string, 0, len(hits))
+		for _, h := range hits {
+			out = append(out, h.Session.ID)
+		}
+		return out
+	}
+	bare := order(BlameTarget{Base: "ingest.go", Stem: "ingest"})
+	if len(bare) < 4 {
+		t.Fatalf("every session names the file: %v", bare)
+	}
+	// The two that name the path asked about come before the bare mention and
+	// before the file in another tree.
+	place := func(list []string, id string) int {
+		for i, got := range list {
+			if got == id {
+				return i
+			}
+		}
+		return -1
+	}
+	// Every session that wrote a path around the name says more about which
+	// file it means than the one that wrote the name alone, whichever tree it
+	// names — with only a base name to go on, deja cannot prefer a tree, and
+	// the promise it makes is about specificity, not about guessing.
+	for _, ahead := range []string{"abs", "rel", "other"} {
+		if place(bare, ahead) > place(bare, "base") {
+			t.Errorf("bare name: %s came after the bare mention: %v", ahead, bare)
+		}
+	}
+	// And the deepest path wins over a shallower one.
+	if place(bare, "abs") > place(bare, "rel") || place(bare, "abs") > place(bare, "other") {
+		t.Errorf("bare name: the fullest path did not come first: %v", bare)
+	}
+	// And the same when the caller names the path: the session that spells it
+	// out in full is not pushed down by a newer one that says less.
+	full := order(BlameTarget{FullPath: "/work/api/internal/index/ingest.go", Base: "ingest.go", Stem: "ingest"})
+	if place(full, "other") < place(full, "rel") || place(full, "other") < place(full, "abs") {
+		t.Errorf("a file in another tree outranked the path asked about: %v", full)
+	}
+}

--- a/internal/search/blame_specificity_test.go
+++ b/internal/search/blame_specificity_test.go
@@ -36,7 +36,10 @@ func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
 		}
 		return out
 	}
-	bare := order(BlameTarget{Base: "ingest.go", Stem: "ingest"})
+	// The shape ResolveBlamePath builds: it always makes the path absolute, so
+	// a target with an empty FullPath is one production cannot produce and a
+	// test written against it proves nothing.
+	bare := order(BlameTarget{FullPath: "/work/api/ingest.go", Base: "ingest.go", Stem: "ingest"})
 	if len(bare) < 4 {
 		t.Fatalf("every session names the file: %v", bare)
 	}

--- a/internal/search/blame_specificity_test.go
+++ b/internal/search/blame_specificity_test.go
@@ -22,8 +22,10 @@ func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
 	ss := []model.Session{
 		session("abs", "we edited /work/api/internal/index/ingest.go and fixed the watermark", day(10)),
 		session("rel", "the change went into internal/index/ingest.go, one function", day(11)),
-		session("base", "ingest.go needed a second pass, nothing else", day(12)),
-		session("other", "we touched cmd/tools/ingest.go in the other repo entirely", day(13)),
+		// The bare mention is the newest and says the name most often, so only
+		// the rule about naming a path keeps it behind the others.
+		session("base", "ingest.go ingest.go ingest.go needed a second pass, nothing else about ingest.go", day(13)),
+		session("other", "we touched cmd/tools/ingest.go in the other repo entirely", day(12)),
 	}
 
 	order := func(target BlameTarget) []string {
@@ -57,14 +59,45 @@ func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
 			t.Errorf("bare name: %s came after the bare mention: %v", ahead, bare)
 		}
 	}
-	// And the deepest path wins over a shallower one.
-	if place(bare, "abs") > place(bare, "rel") || place(bare, "abs") > place(bare, "other") {
-		t.Errorf("bare name: the fullest path did not come first: %v", bare)
-	}
+	// Among the sessions that wrote a path, the answer is still what it was —
+	// how much each one has to say about the file. Ordering on how deep the
+	// path is instead put one mention of an unrelated file above a session
+	// that had worked on this one all week.
 	// And the same when the caller names the path: the session that spells it
 	// out in full is not pushed down by a newer one that says less.
 	full := order(BlameTarget{FullPath: "/work/api/internal/index/ingest.go", Base: "ingest.go", Stem: "ingest"})
 	if place(full, "other") < place(full, "rel") || place(full, "other") < place(full, "abs") {
 		t.Errorf("a file in another tree outranked the path asked about: %v", full)
+	}
+}
+
+// Measured on a real store: counting the directories a session wrote made a
+// deeply nested file of the same name in another project the most specific
+// mention there is, and every session that had actually worked on the file
+// fell off the first page (#2840).
+func TestBlameDoesNotPreferADeepUnrelatedPath(t *testing.T) {
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	worked := model.Session{
+		Harness: "claude", ID: "worked", Project: "api", Updated: now.Add(-72 * time.Hour),
+		Messages: []model.Message{{
+			Role: "assistant", Time: now.Add(-72 * time.Hour),
+			Text: "internal/index/ingest.go again: ingest.go holds the watermark, ingest.go stamps it, and ingest.go is where the pass ends",
+		}},
+	}
+	elsewhere := model.Session{
+		Harness: "opencode", ID: "elsewhere", Project: "other", Updated: now,
+		Messages: []model.Message{{
+			Role: "user", Time: now,
+			Text: "/var/folders/jn/T/opencode/d3fvxl/apps/image2video/cmd/dfprocessing/ingest.go failed to build",
+		}},
+	}
+	hits := Blame([]model.Session{worked, elsewhere},
+		BlameTarget{FullPath: "/work/api/internal/index/ingest.go", Base: "ingest.go", Stem: "ingest"},
+		BlameOptions{All: true})
+	if len(hits) != 2 {
+		t.Fatalf("both sessions name the file: %d hits", len(hits))
+	}
+	if hits[0].Session.ID != "worked" {
+		t.Errorf("a deeper path in another project outranked the session that worked on the file: %s first", hits[0].Session.ID)
 	}
 }

--- a/internal/search/blame_specificity_test.go
+++ b/internal/search/blame_specificity_test.go
@@ -36,15 +36,14 @@ func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
 		}
 		return out
 	}
-	// The shape ResolveBlamePath builds: it always makes the path absolute, so
-	// a target with an empty FullPath is one production cannot produce and a
-	// test written against it proves nothing.
+	// Asked by a bare filename deja has no tree to prefer, so the rule sits
+	// out and nothing moves: crediting whatever directories a session happened
+	// to write handed `blame Makefile` to three other projects, measured on a
+	// real store. What follows is the query that carries a path.
 	bare := order(BlameTarget{FullPath: "/work/api/ingest.go", Base: "ingest.go", Stem: "ingest"})
 	if len(bare) < 4 {
 		t.Fatalf("every session names the file: %v", bare)
 	}
-	// The two that name the path asked about come before the bare mention and
-	// before the file in another tree.
 	place := func(list []string, id string) int {
 		for i, got := range list {
 			if got == id {
@@ -53,24 +52,19 @@ func TestBlameOrdersBySpecificityBeforeRecency(t *testing.T) {
 		}
 		return -1
 	}
-	// Every session that wrote a path around the name says more about which
-	// file it means than the one that wrote the name alone, whichever tree it
-	// names — with only a base name to go on, deja cannot prefer a tree, and
-	// the promise it makes is about specificity, not about guessing.
-	for _, ahead := range []string{"abs", "rel", "other"} {
-		if place(bare, ahead) > place(bare, "base") {
-			t.Errorf("bare name: %s came after the bare mention: %v", ahead, bare)
-		}
-	}
-	// Among the sessions that wrote a path, the answer is still what it was —
-	// how much each one has to say about the file. Ordering on how deep the
-	// path is instead put one mention of an unrelated file above a session
-	// that had worked on this one all week.
+
 	// And the same when the caller names the path: the session that spells it
 	// out in full is not pushed down by a newer one that says less.
 	full := order(BlameTarget{FullPath: "/work/api/internal/index/ingest.go", Base: "ingest.go", Stem: "ingest"})
-	if place(full, "other") < place(full, "rel") || place(full, "other") < place(full, "abs") {
-		t.Errorf("a file in another tree outranked the path asked about: %v", full)
+	// The two that wrote the path asked about come first, however new or
+	// talkative the others are: the bare mention says the name four times and
+	// is the newest, and the file in another tree wrote a path of its own.
+	for _, ahead := range []string{"abs", "rel"} {
+		for _, behind := range []string{"base", "other"} {
+			if place(full, ahead) > place(full, behind) {
+				t.Errorf("%s came after %s: %v", ahead, behind, full)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #2840. blame's description tells every agent "most specific mentions come first"; the order was recency, so a session that wrote the file's path lost to a newer one that only mentioned the filename.

A session that names the path the caller asked about now outranks one that names only the file, whatever the dates say; among those, the score decides as before. The basename no longer counts as a path — it matched inside a path too, which is why the first version of this changed nothing — and only the target's own directories count, so a query about a file that lives at the project root leaves every mention equal and the rule sits out.

Measured by the reviewer on a real store of ~1580 sessions, 36 paths, three rounds. The first two versions were worse than base and were thrown away: crediting how deep a path was put an unrelated `…/apps/image2video/cmd/dfprocessing/main.go` above every session that had worked on the file, and crediting any directory at all handed `blame Makefile` to three other projects. This version moves nothing except bare-name-only sessions down, and improves 45 quoted snippets — `blame main.go` now quotes `cmd/deja/main.go:371` where it quoted an elided path out of a JSON transcript.