### PR TITLE
probe: what the red Windows leg sees (#2808)

### DIFF
--- a/cmd/deja/windows_red_probe_test.go
+++ b/cmd/deja/windows_red_probe_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -19,7 +20,10 @@ func TestWindowsRedProbe(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("the probe is about Windows")
 	}
-	tmp := hermeticEnv(t)
+	// Exactly the statusline tests' own setup: they pin the index directory
+	// and nothing else, so what they see is the runner's own home — which is
+	// what a hermetic probe cannot show.
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
 
 	// The statusline family: five tests, all reporting "the index cannot
 	// answer", which needs indexNeedsRebuild and history to be true together.
@@ -34,14 +38,22 @@ func TestWindowsRedProbe(t *testing.T) {
 	t.Errorf("probe statusline: needsRebuild=%v history=%v stores=%v",
 		indexNeedsRebuild(index.DefaultDir()), !noAgentHistoryFound(), stores)
 
-	// The install family: what a writer sees for a config it is about to
-	// touch, and whether the paths it derives are where the test put them.
-	t.Errorf("probe install: home=%q claude=%q appdata=%q openclaw=%q zed=%q",
-		sources.Home(), os.Getenv("DEJA_CLAUDE_ROOT"), os.Getenv("APPDATA"),
-		sources.OpenClawStateDir(), sources.ZedSettingsPath())
+	// Every store the history check walks, with how many files it found in
+	// each: the hermetic run said "no history", so the answer is in the
+	// runner's own home.
+	var walked []string
+	for _, check := range doctorStoreChecks() {
+		walked = append(walked, fmt.Sprintf("%s=%d", check.name, len(check.files)))
+	}
+	t.Errorf("probe stores: %v", walked)
+
+	// And what the install family derives, since those paths are the other
+	// thing that differs here.
+	t.Errorf("probe install: home=%q appdata=%q openclaw=%q zed=%q",
+		sources.Home(), os.Getenv("APPDATA"), sources.OpenClawStateDir(), sources.ZedSettingsPath())
 
 	// The ignore-rule family: eight tests, all about what a rule withholds.
 	// The rule is a path pattern, and paths are what differ here.
-	t.Errorf("probe paths: tmp=%q sep=%q index=%q notes=%q",
-		tmp, string(filepath.Separator), index.DefaultDir(), sources.NotesFile())
+	t.Errorf("probe paths: home=%q sep=%q index=%q notes=%q",
+		sources.Home(), string(filepath.Separator), index.DefaultDir(), sources.NotesFile())
 }

--- a/cmd/deja/windows_red_probe_test.go
+++ b/cmd/deja/windows_red_probe_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A measurement, not a guard. The Windows leg has been red on main for 35
+// tests across six areas (#2808), and the whole set has never been looked at
+// from inside the runner. This reports what each family's decisive value
+// actually is there. It fails on purpose — a passing test prints nothing — and
+// does not belong on a long-lived branch.
+func TestWindowsRedProbe(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("the probe is about Windows")
+	}
+	tmp := hermeticEnv(t)
+
+	// The statusline family: five tests, all reporting "the index cannot
+	// answer", which needs indexNeedsRebuild and history to be true together.
+	var stores []string
+	for _, check := range doctorStoreChecks() {
+		for _, f := range check.files {
+			if fi, err := os.Stat(f); err == nil && fi.Size() > 0 {
+				stores = append(stores, check.name+":"+f)
+			}
+		}
+	}
+	t.Errorf("probe statusline: needsRebuild=%v history=%v stores=%v",
+		indexNeedsRebuild(index.DefaultDir()), !noAgentHistoryFound(), stores)
+
+	// The install family: what a writer sees for a config it is about to
+	// touch, and whether the paths it derives are where the test put them.
+	t.Errorf("probe install: home=%q claude=%q appdata=%q openclaw=%q zed=%q",
+		sources.Home(), os.Getenv("DEJA_CLAUDE_ROOT"), os.Getenv("APPDATA"),
+		sources.OpenClawStateDir(), sources.ZedSettingsPath())
+
+	// The ignore-rule family: eight tests, all about what a rule withholds.
+	// The rule is a path pattern, and paths are what differ here.
+	t.Errorf("probe paths: tmp=%q sep=%q index=%q notes=%q",
+		tmp, string(filepath.Separator), index.DefaultDir(), sources.NotesFile())
+}


### PR DESCRIPTION
Measurement only, not for merge. The leg has been red on main for 35 tests across six areas and none of it has been looked at from inside the runner. One Windows-only test reports the decisive value for the three largest families — the statusline's two conditions and which store it finds history in, the paths the install writers derive, and the separator and roots the ignore-rule tests build patterns from. Fails on purpose so the run prints it. Needs the `windows` label.