### PR TITLE
test(hooks): cover the pre-action hook in the framing property

### DIFF
--- a/cmd/deja/hook_frame_invariant_test.go
+++ b/cmd/deja/hook_frame_invariant_test.go
@@ -43,6 +43,24 @@ func TestEveryHookInjectionSaysItIsUntrusted(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// The pre-action hook speaks about a file several sessions have worked on:
+	// one edit is not a history worth interrupting for, so the fixture has to
+	// carry the shape that surface actually answers to.
+	for k := 0; k < 6; k++ {
+		sid := fmt.Sprintf("e%d", k)
+		at := base.Add(time.Duration(k) * time.Hour)
+		rows := []string{
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"cwd":"/work/api","timestamp":%q,"message":{"role":"user","content":"work on the ingest watermark"}}`,
+				sid, at.Format(time.RFC3339)),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"cwd":"/work/api","timestamp":%q,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/work/api/internal/index/ingest.go","old_string":"x","new_string":"y"}}]}}`,
+				sid, at.Add(time.Minute).Format(time.RFC3339)),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"cwd":"/work/api","timestamp":%q,"message":{"role":"assistant","content":"the watermark stays grok-only (%d)"}}`,
+				sid, at.Add(2*time.Minute).Format(time.RFC3339), k),
+		}
+		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 	dir := index.DefaultDir()
 	if err := index.Ensure(dir, "", true, nil); err != nil {
 		t.Fatal(err)
@@ -68,13 +86,27 @@ func TestEveryHookInjectionSaysItIsUntrusted(t *testing.T) {
 	}
 
 	withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "ses_hooks", "cwd": cwd}))
-	check("hook-context", captureStdout(t, func() { runHookContextPlain(t) }), "transaction mode")
+	// The block leads with what the project has been busy with, which the
+	// edit sessions above now are — either half of the fixture proves the
+	// text came from it.
+	check("hook-context", captureStdout(t, func() { runHookContextPlain(t) }), "watermark")
 
 	var prompt bytes.Buffer
 	if err := runHookPromptMode(dir, strings.NewReader(`{"prompt":"what did we settle about pgbouncer prepared statements","session_id":"ses_hooks"}`), &prompt, true); err != nil {
 		t.Fatal(err)
 	}
 	check("hook-prompt", prompt.String(), "transaction mode")
+
+	// hook-tool speaks before an action rather than after one: an Edit of a
+	// file the store has seen brings back what was decided about it.
+	var before bytes.Buffer
+	editPayload := fmt.Sprintf(`{"hook_event_name":"PreToolUse","tool_name":"Edit",`+
+		`"tool_input":{"file_path":%q},"cwd":%q,"session_id":"ses_hooks_edit"}`,
+		"/work/api/internal/index/ingest.go", "/work/api")
+	if err := runHookTool(dir, strings.NewReader(editPayload), &before); err != nil {
+		t.Fatal(err)
+	}
+	check("hook-tool", before.String(), "ingest.go")
 
 	var after bytes.Buffer
 	payload := fmt.Sprintf(`{"hook_event_name":"PostToolUse","tool_name":"Bash","tool_input":{"command":"go build ./..."},`+


### PR DESCRIPTION
Closes the gap #2850 named: `hook-tool` was the one surface the property left out, because I could not make it speak with the fixture that was there.

It turns out to want a shape of its own. `fileHookLine` answers about a file **several** sessions have worked on — one edit is not a history worth interrupting for — so the fixture now carries six sessions that edit the same path, alongside the two that hold the error and the command after it. Probed that first rather than guessing: with two sessions the line is empty, with six it reads "ingest.go has been worked on in 6 sessions… last session on it ended: …".

Two consequences worth naming, both visible in the diff:

- the pre-action hook takes the cwd from its payload, so its case passes `/work/api` — the sessions' own directory — where the other hooks use the temp project dir;
- with six edit sessions in the store, the session-start block leads with them rather than with the pgbouncer prose, so that check now looks for a string those sessions carry. Both halves of the fixture are the fixture; what matters is that the text is provably from it.

Mutations: framing neutered in each of the four hook files in turn — two call sites in `hook_context.go`, one each in the others — turns it red every time. That is the whole point of adding this one: before, `hook_tool.go` could lose its frame with nothing noticing.