### PR TITLE
fix(policy): read an ignore rule against a Windows path too

### DIFF
--- a/internal/policy/ignore.go
+++ b/internal/policy/ignore.go
@@ -52,6 +52,14 @@ func matchesAnywhere(pattern, s string) bool {
 	if s == "" {
 		return false
 	}
+	// Both sides in the one spelling. A rule is a directory rule and is
+	// written with forward slashes; a session path on Windows carries
+	// backslashes, and compared as they are the rule matched nothing there —
+	// so a tree deja was told not to recall was recalled on every surface
+	// (#2808). Normalising the rule too means someone who writes it the
+	// Windows way is understood as well.
+	pattern = strings.ReplaceAll(pattern, `\`, "/")
+	s = strings.ReplaceAll(s, `\`, "/")
 	if ok, err := path.Match(pattern, s); err == nil && ok {
 		return true
 	}

--- a/internal/policy/ignore_separator_test.go
+++ b/internal/policy/ignore_separator_test.go
@@ -1,0 +1,28 @@
+package policy
+
+import "testing"
+
+// An ignore rule is written with forward slashes — it is a directory rule, and
+// that is how a person writes one — while a session path on Windows carries
+// backslashes. Compared as they are, the rule matched nothing there and the
+// tree it names was recalled on every surface (#2808).
+func TestAnIgnoreRuleReadsAPathWithEitherSeparator(t *testing.T) {
+	var p Policy
+	for _, path := range []string{
+		`/home/me/.claude/jobs/abc/projects/-w-app/scratch.jsonl`,
+		`C:\Users\me\.claude\jobs\abc\projects\-w-app\scratch.jsonl`,
+		`C:/Users/me/.claude/jobs/abc/projects/-w-app/scratch.jsonl`,
+	} {
+		if !p.Ignored(path, "") {
+			t.Errorf("the default rule does not reach %q", path)
+		}
+	}
+	if p.Ignored(`C:\Users\me\.claude\projects\-w-app\real.jsonl`, "") {
+		t.Error("an ordinary session was ignored")
+	}
+	// A rule someone writes in the Windows spelling reaches the same tree.
+	win := Policy{Ignore: []string{`*\.claude\jobs\*`}}
+	if !win.Ignored(`C:\Users\me\.claude\jobs\abc\s.jsonl`, "") {
+		t.Error("a rule written with backslashes does not match its own tree")
+	}
+}


### PR DESCRIPTION
Eight of the 30 remaining failures in #2808, and not a test problem: an ignore rule is a directory rule and is written with forward slashes, while a session path on Windows carries backslashes. Compared as they are the rule matched nothing there — so a tree deja was told not to recall was recalled from every surface, which is what the eight tests are about.

Reproduces on any platform, since the path is just a string: the new test fails on macOS before the fix. Both sides are normalised, so a rule someone writes in the Windows spelling is understood as well.

Needs the `windows` label to show the eight going green.