### PR TITLE
test: read and write paths the way the platform does

### DIFF
--- a/cmd/deja/bench_leftovers_test.go
+++ b/cmd/deja/bench_leftovers_test.go
@@ -12,15 +12,12 @@ import (
 // touches the parent. So a ^C leaves megabytes there that nothing ever looks at
 // again, and a clean run still leaves an empty directory behind (#2560).
 func TestBenchSweepsWhatEarlierRunsLeft(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	// t.Chdir rather than a cleanup of our own: cleanups run last-registered
+	// first, so a chdir registered before the temp directory is restored
+	// after it is removed — and on Windows a process's working directory
+	// cannot be removed while it stands there (#2808).
 	work := t.TempDir()
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(work)
 	parent := filepath.Join(work, ".deja-bench")
 	stale := filepath.Join(parent, "run-interrupted")
 	if err := os.MkdirAll(stale, 0o700); err != nil {
@@ -65,15 +62,12 @@ func TestBenchSweepsWhatEarlierRunsLeft(t *testing.T) {
 
 // A parent still holding another run's tree stays where it is.
 func TestBenchKeepsTheParentWhileAnotherRunIsInIt(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	// t.Chdir rather than a cleanup of our own: cleanups run last-registered
+	// first, so a chdir registered before the temp directory is restored
+	// after it is removed — and on Windows a process's working directory
+	// cannot be removed while it stands there (#2808).
 	work := t.TempDir()
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
+	t.Chdir(work)
 	dir, err := benchmarkTempDir()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/deja/doctor_home_path_test.go
+++ b/cmd/deja/doctor_home_path_test.go
@@ -43,7 +43,13 @@ func TestDoctorContractsTheHomePath(t *testing.T) {
 	if err := json.Unmarshal([]byte(raw), &report); err != nil {
 		t.Fatalf("doctor --json is not JSON: %v", err)
 	}
-	if !strings.Contains(raw, home) {
+	// As JSON writes it: a Windows path is escaped in the encoding, so looking
+	// for the raw spelling is looking for something no encoder produces.
+	encoded, err := json.Marshal(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(raw, strings.Trim(string(encoded), `"`)) {
 		t.Errorf("doctor --json lost the real path")
 	}
 }

--- a/cmd/deja/doctor_hook_exe_test.go
+++ b/cmd/deja/doctor_hook_exe_test.go
@@ -77,7 +77,12 @@ func TestDoctorNamesHooksRunningABinaryThatIsGone(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := os.WriteFile(path, bytes.ReplaceAll(b, []byte(gone), []byte(here)), 0o644); err != nil {
+		// Both spellings: a config holds a Windows path escaped, so replacing
+		// the raw one finds nothing and the file still names the binary that
+		// is gone.
+		swapped := bytes.ReplaceAll(b, []byte(gone), []byte(here))
+		swapped = bytes.ReplaceAll(swapped, []byte(jsonEscaped(t, gone)), []byte(jsonEscaped(t, here)))
+		if err := os.WriteFile(path, swapped, 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/deja/doctor_hook_wiring_test.go
+++ b/cmd/deja/doctor_hook_wiring_test.go
@@ -21,8 +21,12 @@ func writeClaudeSettings(t *testing.T, events ...string) {
 	}
 	var entries []string
 	for _, e := range events {
-		entries = append(entries, `"`+e+`":[{"matcher":"","hooks":[{"type":"command","command":"`+exe+` `+
-			subFor(e)+`"}]}]`)
+		// The path goes in as JSON writes it: a Windows exe carries
+		// backslashes, and pasting them raw makes the fixture invalid JSON —
+		// which doctor reports as an unreadable config, not as the wiring the
+		// test is about.
+		entries = append(entries, `"`+e+`":[{"matcher":"","hooks":[{"type":"command","command":"`+
+			jsonEscaped(t, exe)+` `+subFor(e)+`"}]}]`)
 	}
 	body := `{"hooks":{` + strings.Join(entries, ",") + `}}`
 	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")

--- a/cmd/deja/handoff_imported_scope_test.go
+++ b/cmd/deja/handoff_imported_scope_test.go
@@ -55,14 +55,9 @@ func TestHandoffDoesNotPackageASyncedProjectMatchedByDirectoryName(t *testing.T)
 	if err := os.MkdirAll(work, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	// t.Chdir, so the restore happens before the temp directory is removed:
+	// on Windows a directory a process is standing in cannot be deleted.
+	t.Chdir(work)
 
 	out, err := captureRun(t, "handoff")
 	if err != nil {

--- a/cmd/deja/handoff_project_scope_test.go
+++ b/cmd/deja/handoff_project_scope_test.go
@@ -42,14 +42,9 @@ func TestHandoffPicksFromTheCheckoutsOwnProject(t *testing.T) {
 	if err := os.MkdirAll(work, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	// t.Chdir, so the restore happens before the temp directory is removed:
+	// on Windows a directory a process is standing in cannot be deleted.
+	t.Chdir(work)
 
 	out, err := captureRun(t, "handoff")
 	if err != nil {


### PR DESCRIPTION
Five of #2808, all test-side.

Three JSON ones: `doctor_hook_wiring_test.go` pasted the test binary's path into a settings.json it builds by hand, so on Windows the fixture was invalid JSON and doctor reported "unreadable" — which is true of what it was given; `doctor_hook_exe_test.go` swapped a missing binary for a present one with a raw `bytes.ReplaceAll`, which matches nothing in an escaped config; `doctor_home_path_test.go` looked for the raw home path inside `doctor --json`. All three go through the package's existing `jsonEscaped`.

Two working-directory ones: the bench tests registered `os.Chdir(cwd)` before calling `t.TempDir()`, and cleanups run last-registered-first — so the temp directory was removed while the process was still standing in it, which Windows refuses. `t.Chdir` orders it correctly. Two handoff tests had the same shape and went with them.