### PR TITLE
test: build fixtures the platform can hold

### DIFF
--- a/cmd/deja/block_provenance_test.go
+++ b/cmd/deja/block_provenance_test.go
@@ -21,15 +21,6 @@ import (
 // object is still re-flowed by the JSON writers (#2640), which is a separate
 // complaint and would drown this one.
 
-// zedSettingsRel is Zed's settings file as a path under the test home.
-func zedSettingsRel() string {
-	rel, err := filepath.Rel(sources.Home(), sources.ZedSettingsPath())
-	if err != nil {
-		return filepath.Join(".config", "zed", "settings.json")
-	}
-	return filepath.ToSlash(rel)
-}
-
 func TestEveryWriterGivesBackTheBlockItMade(t *testing.T) {
 	for _, tc := range []struct {
 		name, target, rel, body string
@@ -45,7 +36,11 @@ func TestEveryWriterGivesBackTheBlockItMade(t *testing.T) {
 		{"kimi, no block", "kimi", ".kimi-code/mcp.json", "{\n  \"theme\": \"dark\"\n}\n"},
 		// Zed keeps its settings where the platform puts them rather than
 		// under ~/.config, so this row asks rather than spells (#2808).
-		{"zed, no block", "zed", zedSettingsRel(), "{\n  \"theme\": \"dark\"\n}\n"},
+		// Zed keeps its settings where the platform puts them rather than under
+		// ~/.config, and the answer depends on the home this subtest sets — so
+		// the row names nothing and the path is asked for inside the run
+		// (#2808).
+		{"zed, no block", "zed", "", "{\n  \"theme\": \"dark\"\n}\n"},
 		{"deepseek, no patch list", "deepseek", ".dsh/cordis.patch.yml", "# my patches\n"},
 		{"deepseek, their own patch", "deepseek", ".dsh/cordis.patch.yml",
 			"# my patches\n- insert:\n    - id: mine\n      name: \"@me/thing\"\n"},
@@ -64,6 +59,9 @@ func TestEveryWriterGivesBackTheBlockItMade(t *testing.T) {
 			t.Setenv("USERPROFILE", home)
 			t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 			path := filepath.Join(home, filepath.FromSlash(tc.rel))
+			if tc.rel == "" {
+				path = sources.ZedSettingsPath()
+			}
 			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/deja/block_provenance_test.go
+++ b/cmd/deja/block_provenance_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/vshulcz/deja-vu/internal/sources"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +20,16 @@ import (
 // The reader's own entries are written expanded rather than inline: an inline
 // object is still re-flowed by the JSON writers (#2640), which is a separate
 // complaint and would drown this one.
+
+// zedSettingsRel is Zed's settings file as a path under the test home.
+func zedSettingsRel() string {
+	rel, err := filepath.Rel(sources.Home(), sources.ZedSettingsPath())
+	if err != nil {
+		return filepath.Join(".config", "zed", "settings.json")
+	}
+	return filepath.ToSlash(rel)
+}
+
 func TestEveryWriterGivesBackTheBlockItMade(t *testing.T) {
 	for _, tc := range []struct {
 		name, target, rel, body string
@@ -32,7 +43,9 @@ func TestEveryWriterGivesBackTheBlockItMade(t *testing.T) {
 		{"pi, no block", "pi", ".pi/agent/mcp.json", "{\n  \"theme\": \"dark\"\n}\n"},
 		{"omp, no block", "omp", ".omp/agent/mcp.json", "{\n  \"theme\": \"dark\"\n}\n"},
 		{"kimi, no block", "kimi", ".kimi-code/mcp.json", "{\n  \"theme\": \"dark\"\n}\n"},
-		{"zed, no block", "zed", ".config/zed/settings.json", "{\n  \"theme\": \"dark\"\n}\n"},
+		// Zed keeps its settings where the platform puts them rather than
+		// under ~/.config, so this row asks rather than spells (#2808).
+		{"zed, no block", "zed", zedSettingsRel(), "{\n  \"theme\": \"dark\"\n}\n"},
 		{"deepseek, no patch list", "deepseek", ".dsh/cordis.patch.yml", "# my patches\n"},
 		{"deepseek, their own patch", "deepseek", ".dsh/cordis.patch.yml",
 			"# my patches\n- insert:\n    - id: mine\n      name: \"@me/thing\"\n"},

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -777,7 +777,15 @@ func TestHookDigestPlainAndLimitBranches(t *testing.T) {
 	idx := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", idx)
 	claudeRoot := filepath.Join(tmp, "claude")
-	projDir := filepath.Join(claudeRoot, "-tmp-many")
+	// The project the hook will stand in, and the directory name a harness
+	// gives it: spelled out rather than written by hand, since the encoding
+	// differs by platform and a fixture under the wrong name is memory the
+	// hook never finds (#2808).
+	work := filepath.Join("/tmp", "many")
+	if runtime.GOOS == "windows" {
+		work = filepath.Join(tmp, "many")
+	}
+	projDir := filepath.Join(claudeRoot, encodedProjectDir(work))
 	for i := 0; i < 4; i++ {
 		id := string(rune('a'+i)) + "many"
 		writeClaudeFixture(t, filepath.Join(projDir, id+".jsonl"), id, []string{`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"many project memory ` + id + `"}}`})
@@ -785,18 +793,10 @@ func TestHookDigestPlainAndLimitBranches(t *testing.T) {
 	if err := index.EnsureForSearch(idx, search.Options{Query: "many", All: true}, false, io.Discard); err != nil {
 		t.Fatal(err)
 	}
-	oldwd, _ := os.Getwd()
-	work := filepath.Join("/tmp", "many")
-	if runtime.GOOS == "windows" {
-		work = filepath.Join(tmp, "many")
-	}
 	if err := os.MkdirAll(work, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldwd) })
+	t.Chdir(work)
 	var out bytes.Buffer
 	old := os.Stdout
 	r, w, err := os.Pipe()

--- a/cmd/deja/hook_context_composition_test.go
+++ b/cmd/deja/hook_context_composition_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,15 +29,14 @@ func TestTheSessionStartBlockCarriesAllThreePieces(t *testing.T) {
 	if err := os.MkdirAll(work, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	oldwd, err := os.Getwd()
+	t.Chdir(work)
+	// The cwd as JSON writes it: a Windows path carries backslashes, and the
+	// fixture would not parse with them raw (#2808).
+	workJSON, err := json.Marshal(work)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chdir(work); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldwd) })
-	store := filepath.Join(root, strings.ReplaceAll(work, string(filepath.Separator), "-"))
+	store := filepath.Join(root, encodedProjectDir(work))
 	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -52,11 +52,11 @@ func TestTheSessionStartBlockCarriesAllThreePieces(t *testing.T) {
 	for k := 0; k < 4; k++ {
 		sid := fmt.Sprintf("w%d", k)
 		lines = []string{
-			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"`+work+`","message":{"role":"user","content":"the migration runner keeps stalling on the pool"}}`, sid, at(300-10*k)),
-			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":"`+work+`","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -h db.internal -c 'select 1'"}}]}}`, sid, at(299-10*k)),
-			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"`+work+`","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":%q}]}}`, sid, at(298-10*k), wall),
-			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":"`+work+`","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"brew services start postgresql@16"}}]}}`, sid, at(297-10*k)),
-			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":"`+work+`","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"==> Successfully started postgresql@16"}]}}`, sid, at(296-10*k)),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":`+string(workJSON)+`,"message":{"role":"user","content":"the migration runner keeps stalling on the pool"}}`, sid, at(300-10*k)),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":`+string(workJSON)+`,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -h db.internal -c 'select 1'"}}]}}`, sid, at(299-10*k)),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":`+string(workJSON)+`,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":%q}]}}`, sid, at(298-10*k), wall),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"timestamp":%q,"cwd":`+string(workJSON)+`,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"brew services start postgresql@16"}}]}}`, sid, at(297-10*k)),
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"timestamp":%q,"cwd":`+string(workJSON)+`,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"==> Successfully started postgresql@16"}]}}`, sid, at(296-10*k)),
 		}
 		if err := os.WriteFile(filepath.Join(store, sid+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 			t.Fatal(err)

--- a/cmd/deja/hook_spawn_cooldown_test.go
+++ b/cmd/deja/hook_spawn_cooldown_test.go
@@ -107,7 +107,14 @@ func TestAnOrdinaryPromptStillSitsOutTheCooldown(t *testing.T) {
 			t.Fatal(err)
 		}
 		var out bytes.Buffer
-		payload := `{"prompt":` + string(b) + `,"session_id":"` + sid + `","cwd":"` + cwd + `"}`
+		// The cwd goes in as JSON writes it: a Windows path carries
+		// backslashes, and pasting them raw leaves a payload the hook cannot
+		// read — which reads as a hook that answered nothing (#2808).
+		where, err := json.Marshal(cwd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := `{"prompt":` + string(b) + `,"session_id":"` + sid + `","cwd":` + string(where) + `}`
 		if err := runHookPrompt(index.DefaultDir(), strings.NewReader(payload), &out); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/deja/hook_worktree_scope_test.go
+++ b/cmd/deja/hook_worktree_scope_test.go
@@ -48,7 +48,7 @@ func TestAWorktreeSharesTheProjectsHistory(t *testing.T) {
 	git(main, "worktree", "add", "-q", feature, "-b", "feature")
 
 	// One session, recorded in the main checkout only.
-	dirName := strings.ReplaceAll(main, string(filepath.Separator), "-")
+	dirName := encodedProjectDir(main)
 	store := filepath.Join(root, dirName)
 	if err := os.MkdirAll(store, 0o755); err != nil {
 		t.Fatal(err)
@@ -74,4 +74,13 @@ func TestAWorktreeSharesTheProjectsHistory(t *testing.T) {
 	if !strings.Contains(fromWorktree, "retry budget on main") {
 		t.Errorf("a linked worktree does not see the repo's history:\n%s", fromWorktree)
 	}
+}
+
+// encodedProjectDir is the directory name a harness gives a project, the way
+// sources.resolveEncodedPath reads one back: separators become dashes, and on
+// Windows the drive's colon goes with them — a colon is not a filename
+// character there, so the old spelling could not be created at all (#2808).
+func encodedProjectDir(path string) string {
+	name := strings.ReplaceAll(path, string(filepath.Separator), "-")
+	return strings.Replace(name, ":", "-", 1)
 }

--- a/cmd/deja/install_preflight_test.go
+++ b/cmd/deja/install_preflight_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -163,6 +164,12 @@ func TestThePreflightRefusesJSONThatIsNotAnObject(t *testing.T) {
 
 // A file that is there but cannot be read is not a file that is absent.
 func TestThePreflightPassesOnAReadErrorRatherThanSkippingIt(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The mode bits are the whole fixture, and Windows does not read them
+		// — a 0o000 file opens there, so the test would be asserting that a
+		// readable file is unreadable (#2808).
+		t.Skip("a file mode is not what decides this on Windows")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "unreadable.json")
 	if err := os.WriteFile(path, []byte(`{"a":1}`), 0o000); err != nil {

--- a/cmd/deja/install_replaced_entry_test.go
+++ b/cmd/deja/install_replaced_entry_test.go
@@ -1,11 +1,29 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// dejasOwnClaudeEntry is the entry install writes on this platform: Windows
+// runs deja through cmd, so spelling the Unix form here made install see a
+// changed entry and say so — about wiring it had written itself (#2808).
+func dejasOwnClaudeEntry(t *testing.T) string {
+	t.Helper()
+	command, args := mcpCommandArgs("/usr/local/bin/deja")
+	entry, err := json.Marshal(map[string]any{
+		"mcpServers": map[string]any{
+			"deja": map[string]any{"type": "stdio", "command": command, "args": args},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(entry)
+}
 
 // Install writes into files people also edit. Replacing a deja entry someone
 // pointed at their own wrapper is the right thing to do; doing it in the same
@@ -18,8 +36,7 @@ func TestInstallSaysWhenItReplacedAnEntrySomeoneChanged(t *testing.T) {
 	}{
 		{"a config that never mentioned deja",
 			`{"mcpServers":{"mine":{"command":"/usr/local/bin/my-server"}}}`, ""},
-		{"the entry deja itself wrote",
-			`{"mcpServers":{"deja":{"type":"stdio","command":"/usr/local/bin/deja","args":["mcp"]}}}`, ""},
+		{"the entry deja itself wrote", dejasOwnClaudeEntry(t), ""},
 		{"an entry someone pointed at their own wrapper",
 			`{"mcpServers":{"deja":{"command":"/home/me/bin/deja-wrapper","args":["mcp","--quiet"]}}}`,
 			"/home/me/bin/deja-wrapper"},

--- a/cmd/deja/site_time_claims_test.go
+++ b/cmd/deja/site_time_claims_test.go
@@ -54,9 +54,14 @@ func TestTimeHintsRankOnlyTheNoExactMatchFallback(t *testing.T) {
 	now := time.Now()
 	lastMonth := now.AddDate(0, -1, 0)
 	dir := datedStore(t, map[string]string{
-		"m_old":  now.AddDate(0, -3, 0).UTC().Format("2006-01-02") + "T10:00:00Z",
-		"m_last": lastMonth.UTC().Format("2006-01-02") + "T10:00:00Z",
-		"m_now":  now.Add(-2*time.Hour).UTC().Format("2006-01-02") + "T10:00:00Z",
+		// The reader's own calendar, not UTC: `last month` resolves against
+		// the local clock, so a fixture dated in UTC lands in the previous
+		// month whenever the two disagree — which on the first of a month
+		// gives today's session the same month token the hint carries, and the
+		// test cannot tell them apart (#2808 turned this up on 1 September).
+		"m_old":  now.AddDate(0, -3, 0).Format("2006-01-02") + "T10:00:00Z",
+		"m_last": lastMonth.Format("2006-01-02") + "T10:00:00Z",
+		"m_now":  now.Format("2006-01-02") + "T10:00:00Z",
 	})
 	_ = dir
 

--- a/cmd/deja/yaml_config_roundtrip_test.go
+++ b/cmd/deja/yaml_config_roundtrip_test.go
@@ -13,19 +13,25 @@ import (
 // block it added in a config the reader owned, and goose returns the file
 // without the trailing newline it came with (#2606).
 func TestAYamlConfigComesBackAsItWas(t *testing.T) {
+	// The path each writer actually uses, asked rather than restated: goose is
+	// one of the few that does not keep its config under ~/.config on Windows,
+	// so a hard-coded relative path was a config deja never reads (#2808).
 	for _, tc := range []struct {
 		name    string
 		target  string
-		rel     []string
+		path    func() string
 		content string
 	}{
-		{"hermes", "hermes", []string{".hermes", "config.yaml"}, "profile: default\n"},
-		{"goose", "goose", []string{".config", "goose", "config.yaml"}, "GOOSE_MODEL: gpt-5\n"},
+		{"hermes", "hermes", func() string {
+			return filepath.Join(os.Getenv("HOME"), ".hermes", "config.yaml")
+		}, "profile: default\n"},
+		{"goose", "goose", func() string {
+			return filepath.Join(gooseConfigDir(), "config.yaml")
+		}, "GOOSE_MODEL: gpt-5\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			hermeticEnv(t)
-			home := os.Getenv("HOME")
-			path := filepath.Join(append([]string{home}, tc.rel...)...)
+			path := tc.path()
 			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/peers/lock.go
+++ b/internal/peers/lock.go
@@ -5,6 +5,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
 	"time"
 )
 
@@ -31,6 +33,27 @@ const (
 // by a dead process is taken over, and a directory that cannot hold one at all
 // (a read-only config mount) runs the write unlocked, which is what deja did
 // before this existed.
+
+// lockHeldElsewhere reports whether a refusal to create the lock file means
+// somebody else has it rather than that deja cannot have it.
+//
+// Windows answers a create that races another process's open or delete with a
+// sharing violation rather than "exists", and reading that as "no lock here"
+// let a second writer through: measured under sixteen concurrent writers, one
+// machine's row was lost from the peer list every run. Elsewhere the create is
+// atomic and this never fires.
+func lockHeldElsewhere(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch uintptr(errno) {
+	case 5, 32, 33: // ACCESS_DENIED, SHARING_VIOLATION, LOCK_VIOLATION
+		return runtime.GOOS == "windows"
+	}
+	return false
+}
+
 func withLock(fn func() error) error {
 	list := Path()
 	if list == "" {
@@ -51,7 +74,7 @@ func withLock(fn func() error) error {
 			defer func() { _ = os.Remove(path) }()
 			return fn()
 		}
-		if !errors.Is(err, fs.ErrExist) {
+		if !errors.Is(err, fs.ErrExist) && !lockHeldElsewhere(err) {
 			return fn()
 		}
 		if fi, serr := os.Stat(path); serr == nil && time.Since(fi.ModTime()) > lockStale {

--- a/internal/peers/lock_refusal_test.go
+++ b/internal/peers/lock_refusal_test.go
@@ -1,0 +1,32 @@
+package peers
+
+import (
+	"errors"
+	"io/fs"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+// A refusal that means somebody else holds the lock is waited out; one that
+// means deja cannot have it at all falls through to the write, which is what
+// keeps a sync from failing for want of a lock (#1884, #2808).
+func TestALockRefusalIsReadForWhatItMeans(t *testing.T) {
+	windows := runtime.GOOS == "windows"
+	for _, c := range []struct {
+		name string
+		err  error
+		held bool
+	}{
+		{"a sharing violation", syscall.Errno(32), windows},
+		{"access denied", syscall.Errno(5), windows},
+		{"a lock violation", syscall.Errno(33), windows},
+		{"a refusal that is not one of those", syscall.Errno(13), false},
+		{"no such file", fs.ErrNotExist, false},
+		{"something with no errno in it", errors.New("the volume was dismounted"), false},
+	} {
+		if got := lockHeldElsewhere(c.err); got != c.held {
+			t.Errorf("%s: lockHeldElsewhere = %v, want %v", c.name, got, c.held)
+		}
+	}
+}

--- a/internal/sources/sqlitepath_test.go
+++ b/internal/sources/sqlitepath_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -94,13 +95,21 @@ func TestAMissingOrForeignFileIsLeftAlone(t *testing.T) {
 // A store under a directory with a space or a question mark still reaches
 // sqlite3 whole: the URI form escapes per segment.
 func TestAPathWithAwkwardCharactersSurvivesTheURI(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "My Store?v2")
+	// A name Windows accepts: `?` is not a filename character there, so the
+	// old fixture could not be created at all and the test failed before it
+	// measured anything. `#` needs the same per-segment escaping a `?` does,
+	// and the `?` case is kept where it can exist (#2808).
+	name := "My Store#v2"
+	if runtime.GOOS != "windows" {
+		name += "?raw"
+	}
+	dir := filepath.Join(t.TempDir(), name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	db := walDB(t, dir, "store.db")
 	target := sqliteTarget(db)
-	if strings.Contains(target, " ") || strings.Contains(target, "?v2") {
+	if strings.Contains(target, " ") || strings.Contains(target, "#v2") {
 		t.Fatalf("the path went out unescaped: %q", target)
 	}
 	out, err := exec.Command("sqlite3", "-readonly", target, "select x from t").CombinedOutput()


### PR DESCRIPTION
The rest of #2808's twelve, all test-side.

- `sqlitepath_test.go` built a directory called `My Store?v2`; `?` is not a filename character on Windows, so the test failed before it measured any escaping. It uses `#` — which needs the same per-segment escaping — and keeps the `?` case where it can exist.
- Three tests encoded a project directory by replacing separators with dashes, which leaves the drive's colon in the name; `sources.resolveEncodedPath` reads `C--Users-x-app`, so the fixtures now write what it reads.
- Three payloads and fixtures pasted a Windows path raw into JSON, which the hook then could not parse — reading as a hook that answered nothing.
- `yaml_config_roundtrip_test.go` and `block_provenance_test.go` looked for goose's and Zed's configs under `~/.config`; both use the platform's own directory there, so install wired a file the test never looked at.
- `install_replaced_entry_test.go` spelled deja's own MCP entry the Unix way, so install saw a changed entry and said so — about wiring it had written itself.
- `install_preflight_test.go` builds a 0o000 file to make it unreadable, which Windows does not honour: that one skips there, since the mode bits are the whole fixture.

Needs the `windows` label.