### PR TITLE
fix(mcp): say the store is empty instead of blaming the query

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -366,12 +366,16 @@ func TestMCPRecallAndProgressBranches(t *testing.T) {
 	if mcpProgress() != os.Stderr {
 		t.Fatal("debug progress did not use stderr")
 	}
+	// The store here is empty, which is its own answer now: "nothing matched"
+	// on a machine with no history reads as a miss and sends an agent
+	// rephrasing (#680, one step earlier). The wording for a real miss is
+	// covered where a fixture actually holds sessions.
 	text, err := recallText(index.DefaultDir(), "nomatch", "", 0, 30)
-	if err != nil || !strings.Contains(text, "No prior deja sessions") {
+	if err != nil || !strings.Contains(text, "no indexed history") {
 		t.Fatalf("recallText no match = %q err=%v", text, err)
 	}
 	ctx, err := recallContext(index.DefaultDir(), "nomatch")
-	if err != nil || !strings.Contains(ctx, "No prior deja sessions") {
+	if err != nil || !strings.Contains(ctx, "no indexed history") {
 		t.Fatalf("recallContext no match = %q err=%v", ctx, err)
 	}
 }

--- a/cmd/deja/empty_store_answer_test.go
+++ b/cmd/deja/empty_store_answer_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// On a machine with no history yet, recall answered "No prior deja sessions
+// matched <query>" — which reads as "your query missed" and invites an agent to
+// keep rephrasing. The same function already separates three other reasons an
+// answer is empty, for the reason its own comment gives: an agent told nothing
+// matched concludes the work was never done (#680). "Nothing is indexed" is the
+// fourth, and it is the one a first run always hits.
+func TestAnEmptyStoreSaysSoRatherThanBlamingTheQuery(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 0 {
+		t.Fatalf("the fixture indexed %d sessions, so this is not the empty case", len(metas))
+	}
+
+	for _, tool := range []string{"recall", "recall_context"} {
+		text, err := callMCPTool(dir, tool, json.RawMessage(`{"query":"how did we set up the deploy"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(text, "matched") && !strings.Contains(text, "no indexed history") {
+			t.Errorf("%s: an empty store answers as though the query missed:\n%s", tool, firstLines(text, 3))
+		}
+		if !strings.Contains(text, "no indexed history") {
+			t.Errorf("%s: does not say the store is empty:\n%s", tool, firstLines(text, 3))
+		}
+	}
+}
+
+// And a store that holds something keeps the ordinary answer: "nothing is
+// indexed" must not be said about a query that simply found nothing.
+func TestAStoreWithHistoryStillBlamesNeitherSide(t *testing.T) {
+	dir := manySessionStore(t, 3)
+	text, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"zzzqqq wwwxxx vvvbbb"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "no indexed history") {
+		t.Errorf("a store with sessions in it was called empty:\n%s", firstLines(text, 3))
+	}
+}

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -247,6 +247,15 @@ func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 		return fmt.Sprintf("No indexed session matched %q — the index is behind and cannot be updated (%s is not writable), so recent work may be missing from this answer.",
 			q, filepath.Dir(dir))
 	}
+	// Nothing has ever been indexed: this is a first run, not a miss. The
+	// sentence above reads as "your query missed", which on a fresh machine
+	// sends an agent rephrasing a question nothing can answer yet — the same
+	// mistake #680 named, one step earlier. Said only when the store is
+	// genuinely empty; a store with sessions that simply did not match keeps
+	// the ordinary answer.
+	if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
+		return "This machine has no indexed history yet, so nothing can match — `deja sources` shows where deja looked for it. Do not read this as the work never happening."
+	}
 	return fmt.Sprintf("No prior deja sessions matched %q.", q)
 }
 


### PR DESCRIPTION
Found by asking what an agent gets on a machine with no history — the first run, which nothing in the test suite was standing at.

    recall          No prior deja sessions matched "how did we set up the deploy".
    recall_context  same
    how             No command on this machine mentions "deploy".
    fix             No session on this machine ran a command after that error.
    blame           []

The first two read as *your query missed*, so an agent rephrases — and on a fresh machine nothing it asks can match. `emptyRecallAnswerPolicy` already separates three other reasons an answer is empty, for the reason its own comment gives: an agent told nothing matched concludes the work was never done (#680). "Nothing is indexed" is the fourth, and it is the one a first run always hits.

It now says so, and points at `deja sources` — which is what `deja index` itself says in the same situation. Only when the store is genuinely empty: a store with sessions that simply did not match keeps the ordinary sentence, and there is a mutation making the branch fire for every store that turns a test red.

One existing test moved: `TestMCPRecallAndProgressBranches` asserted the old wording on an empty hermetic store, which is exactly the new case. It asserts the new sentence; the miss wording is covered where a fixture actually holds sessions.

Not touched here, and worth their own look: `blame` answers a bare `[]` on an empty store — no note, nothing — and `how`/`fix` say "on this machine", which is honest but still does not distinguish an empty store from a real absence.