### PR TITLE
fix(mcp): blame says why it found nothing on an empty store

### DIFF
--- a/cmd/deja/blame_empty_answer_test.go
+++ b/cmd/deja/blame_empty_answer_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// blame is the tool an agent calls before it edits a file, and on a machine
+// with no history it answered a bare `[]` — no note, nothing. The empty array
+// is the whole answer, so an agent has no way to tell "nobody ever touched this
+// file" from "deja has nothing indexed at all", which is the distinction #2862
+// drew for recall.
+func TestBlameSaysWhyItFoundNothing(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := callMCPTool(dir, "blame", json.RawMessage(`{"path":"main.go"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "no indexed history") {
+		t.Errorf("an empty store answers with nothing at all:\n%s", text)
+	}
+	// Still JSON, still an array: an agent parses this.
+	var out []map[string]any
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("the answer stopped being a JSON array (%v):\n%s", err, text)
+	}
+}
+
+// A store that holds sessions, asked about a file none of them touched, keeps
+// its own answer: nothing was indexed is not true there.
+func TestBlameOnAStoreWithHistoryDoesNotCallItEmpty(t *testing.T) {
+	dir := manySessionStore(t, 3)
+	text, err := callMCPTool(dir, "blame", json.RawMessage(`{"path":"nowhere-near-this-store.go"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(text, "no indexed history") {
+		t.Errorf("a store with sessions in it was called empty:\n%s", text)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -597,6 +597,16 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 	// dropped to make room for a sentence about the index. The answer can end
 	// up the note's length over the budget, which is about a hundred bytes and
 	// worth more than the session it would otherwise cost.
+	if len(hits) == 0 {
+		// A bare `[]` is the whole answer, so an agent cannot tell "nobody
+		// touched this file" from "deja has nothing indexed at all" — the
+		// distinction #2862 drew for recall, on the tool that is called before
+		// an edit. Said in the shape this payload already says everything else.
+		if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
+			return string(mustMarshalBlameNote(
+				"this machine has no indexed history yet, so nothing can be found — `deja sources` shows where deja looked")), 0, nil
+		}
+	}
 	body := mustMarshalBlame(hits, 0, false)
 	for len(body) > blameMCPBudget && len(hits) > 1 {
 		hits = hits[:max(len(hits)*3/4, 1)]
@@ -714,6 +724,16 @@ func (s blameSessionJSON) MarshalJSON() ([]byte, error) {
 		out.Updated = &s.Updated
 	}
 	return json.Marshal(out)
+}
+
+// mustMarshalBlameNote answers with one note and no sessions, in the array
+// shape this tool always answers in.
+func mustMarshalBlameNote(note string) []byte {
+	b, err := json.Marshal([]any{map[string]any{"note": note}})
+	if err != nil {
+		return []byte("[]")
+	}
+	return b
 }
 
 func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []byte {


### PR DESCRIPTION
The first of the two leftovers I listed in #2862. `blame` is the tool called *before* an edit, and on a machine with no history its whole answer was `[]` — an agent cannot tell "nobody ever touched this file" from "deja has nothing indexed at all", which is the distinction that PR drew for recall.

It now answers with the note, in the array shape this tool already uses for everything it has to say — the untrusted-data sentence and the mid-refresh warning are both notes in that array. So the payload stays a JSON array an agent parses, and the test asserts that as well as the wording.

A store that holds sessions and simply has none for that path keeps its own answer; there is a mutation for that.

**One mutation does not go red, and it should not.** Removing the outer `len(hits) == 0` changes no behaviour — the `AllMeta` check inside covers it — so no test can see it. It is there to keep the common path from reading the manifest on every blame, which is a cost guard rather than a behaviour guard. Saying so rather than deleting a line that earns its place, or pretending a test covers it.

Still open from that list: `how` and `fix` say "on this machine", which is honest but still does not separate an empty store from a real absence.