### PR TITLE
test: date the time-hint fixture in the calendar the hint is read in

### DIFF
--- a/cmd/deja/site_time_claims_test.go
+++ b/cmd/deja/site_time_claims_test.go
@@ -54,9 +54,14 @@ func TestTimeHintsRankOnlyTheNoExactMatchFallback(t *testing.T) {
 	now := time.Now()
 	lastMonth := now.AddDate(0, -1, 0)
 	dir := datedStore(t, map[string]string{
-		"m_old":  now.AddDate(0, -3, 0).UTC().Format("2006-01-02") + "T10:00:00Z",
-		"m_last": lastMonth.UTC().Format("2006-01-02") + "T10:00:00Z",
-		"m_now":  now.Add(-2*time.Hour).UTC().Format("2006-01-02") + "T10:00:00Z",
+		// Dated in the same calendar deja reads "last month" in — the local
+		// one. Formatted through UTC and taken two hours back, the newest
+		// session landed in the previous month whenever the run happened early
+		// on the first of a month, so "last month" matched it too and the hint
+		// had nothing to tell apart. It failed that way on 2026-09-01.
+		"m_old":  now.AddDate(0, -3, 0).Format("2006-01-02") + "T10:00:00Z",
+		"m_last": lastMonth.Format("2006-01-02") + "T10:00:00Z",
+		"m_now":  now.Format("2006-01-02") + "T10:00:00Z",
 	})
 	_ = dir
 


### PR DESCRIPTION
`TestTimeHintsRankOnlyTheNoExactMatchFallback` fails on main today, and it is the date rather than anything in the product:

    `last month` did not rank last month's session first (got m_now):
    [claude] tmp/projm · 1d ago · m_now — 0 matches · relevance

The fixture built its newest session as `time.Now().Add(-2h).UTC()` and kept only the date part. This machine is UTC+3, so at 00:00–03:00 local on the first of a month that lands on the last day of the *previous* month — the newest session becomes "last month's" too, and the hint has nothing to tell apart. It ranks by recency and picks it, correctly.

Confirmed it is not mine before touching it: stashed my working changes, ran the test on clean main, still red.

Dated in the local calendar now — the one deja reads "last month" in — and without the two-hour step, which only ever moved the date string. The other two sessions go through the same change so all three are compared in one calendar.

Windows and Linux CI run in UTC, so this was invisible there and would have stayed invisible until someone ran the suite in a positive offset early on a first of the month.