### PR TITLE
fix(mcp): how and fix say the store is empty rather than reporting an absence

### DIFF
--- a/cmd/deja/how_fix_empty_answer_test.go
+++ b/cmd/deja/how_fix_empty_answer_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The last two surfaces from #2862's list. "No command on this machine mentions
+// X" and "No session on this machine ran a command after that error" are honest
+// about the machine and silent about the store: on a first run they read as a
+// real absence, and an agent concludes the work was never done — the mistake
+// #680 named and #2862 and #2863 fixed for recall and blame.
+func TestHowAndFixSayTheStoreIsEmpty(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ tool, args string }{
+		{"how", `{"what":"deploy"}`},
+		{"fix", `{"error":"ld: symbol(s) not found for architecture arm64"}`},
+	} {
+		text, err := callMCPTool(dir, tc.tool, json.RawMessage(tc.args))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(text, "no indexed history") {
+			t.Errorf("%s: an empty store answers as though the thing was never done:\n%s", tc.tool, text)
+		}
+	}
+}
+
+// A store with sessions keeps its own answer: it is a real absence there.
+func TestHowAndFixOnAStoreWithHistoryDoNotCallItEmpty(t *testing.T) {
+	dir := manySessionStore(t, 3)
+	for _, tc := range []struct{ tool, args string }{
+		{"how", `{"what":"nothing-like-this-was-ever-run"}`},
+		{"fix", `{"error":"ld: symbol(s) not found for architecture arm64"}`},
+	} {
+		text, err := callMCPTool(dir, tc.tool, json.RawMessage(tc.args))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(text, "no indexed history") {
+			t.Errorf("%s: a store with sessions in it was called empty:\n%s", tc.tool, text)
+		}
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -427,7 +427,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			}) {
 				return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", nil
 			}
-			return "No session on this machine ran a command after that error.", nil
+			return "No session on this machine ran a command after that error." + emptyStoreNote(dir), nil
 		}
 		var fb strings.Builder
 		for _, p := range pairs {
@@ -484,7 +484,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			if note := policyHiddenNote(policy.ActivationMCP, hidden); note != "" {
 				return strings.TrimSpace(note), nil
 			}
-			return fmt.Sprintf("No command on this machine mentions %q.", a.What), nil
+			return fmt.Sprintf("No command on this machine mentions %q.", a.What) + emptyStoreNote(dir), nil
 		}
 		limit := int(a.Limit)
 		if limit <= 0 {
@@ -1512,6 +1512,19 @@ func contextIgnoredWords(result index.SearchResult) string {
 		what = "close spellings"
 	}
 	return fmt.Sprintf("No exact match; using %s: %s\n", what, strings.Join(summary, ", "))
+}
+
+// emptyStoreNote is what a tool says when the store holds nothing at all,
+// rather than reporting a real absence. An agent told a thing was never done
+// concludes exactly that and starts over (#680); on a first run every tool is
+// in this state, and recall and blame already say so (#2862, #2863).
+//
+// Empty when the store has something in it, so a caller can append it blind.
+func emptyStoreNote(dir string) string {
+	if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
+		return " This machine has no indexed history yet, so nothing can be found — `deja sources` shows where deja looked."
+	}
+	return ""
 }
 
 // nothingIsAboutThis is the half both surfaces share. The wording was tuned in


### PR DESCRIPTION
The last two surfaces from the list in #2862, after blame in #2863.

    how   No command on this machine mentions "deploy".
    fix   No session on this machine ran a command after that error.

Both are honest about the machine and silent about the store, so on a first run they read as a real absence and an agent concludes the work was never done — the mistake #680 named. They now append the same sentence recall and blame say, from one helper, so the four cannot drift apart the way the framing did.

The note is empty when the store holds anything, so the callers append it blind and a real absence keeps its own answer. Three mutations: each tool dropping the note, and the helper firing for every store.

**A pre-existing failure surfaced while running the suite for this**, fixed separately in #2864 so it would not ride along: `TestTimeHintsRankOnlyTheNoExactMatchFallback` goes red on the first of a month in a positive UTC offset, because its newest session was dated through `.UTC()` two hours back and landed in the previous month. I stashed my changes and ran it on clean main before assuming it was mine.