### PR TITLE
fix(handoff): sanitise the digest --exec hands to the next agent

### DIFF
--- a/cmd/deja/handoff.go
+++ b/cmd/deja/handoff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/redact"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
@@ -121,18 +122,41 @@ func runHandoff(dir string, args []string, stdout io.Writer) error {
 		}
 		return nil
 	}
-	// A prompt can never start with "-" today, but keep the invariant explicit
-	// so a future digest change cannot turn the prompt into a flag.
-	if strings.HasPrefix(digest, "-") {
-		digest = " " + digest
-	}
-	argv, _ := handoffCommand(target, digest)
+	argv, _ := handoffArgv(target, digest)
 	if _, err := exec.LookPath(argv[0]); err != nil {
 		return fmt.Errorf("handoff: %s is not installed (looked for %q in PATH)", target, argv[0])
 	}
 	c := exec.Command(argv[0], argv[1:]...)
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
 	return c.Run()
+}
+
+// handoffArgv is the command that opens the target with this digest as its
+// first prompt. One seam, so the sanitising below cannot be wired past: the
+// exec path used to build the argv from the raw digest a few lines from the
+// printed path that sanitised it.
+func handoffArgv(target, digest string) ([]string, bool) {
+	return handoffCommand(target, handoffPrompt(digest))
+}
+
+// handoffPrompt is the digest as it leaves for another agent's command line.
+//
+// The printed handoff has always gone through printSanitized — secrets
+// redacted, bidi and zero-width characters stripped — and --exec passed the
+// digest raw, so one session left this machine clean when pasted and unclean
+// when handed over directly. The two differ in how the text leaves, not in
+// what it is.
+//
+// The leading-dash guard rides here too: a prompt can never start with "-"
+// today, but a future digest change must not be able to turn the prompt into
+// a flag for the target.
+func handoffPrompt(digest string) string {
+	redacted, _ := redact.Text(digest)
+	out := stripBidiAndInvisible(redacted)
+	if strings.HasPrefix(out, "-") {
+		out = " " + out
+	}
+	return out
 }
 
 func humanAge(d time.Duration) string {

--- a/cmd/deja/handoff_exec_sanitised_test.go
+++ b/cmd/deja/handoff_exec_sanitised_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The printed handoff goes through printSanitized — secrets redacted, bidi and
+// zero-width characters stripped. The --exec handoff passed the digest to the
+// next agent's command line raw, so the same session left the machine clean
+// when pasted and unclean when handed over directly.
+//
+// The two paths differ in how the text leaves, not in what it is, so they have
+// to sanitise alike.
+func TestTheExecHandoffSanitisesLikeThePrintedOne(t *testing.T) {
+	// A bidi override and a zero-width space, which no index-time pass removes
+	// because they are a display concern, and a token shaped like a secret.
+	raw := "continue the work‮reversed​ here: ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+
+	got := handoffPrompt(raw)
+	for _, bad := range []string{"‮", "​"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("an invisible character survived into the prompt: %q", got)
+		}
+	}
+	if strings.Contains(got, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
+		t.Errorf("a secret-shaped token was handed over verbatim: %q", got)
+	}
+	if !strings.Contains(got, "continue the work") {
+		t.Errorf("the digest itself was lost: %q", got)
+	}
+}
+
+// The wiring, not just the helper: the argv the exec path builds carries the
+// sanitised prompt. Before this the two sat a few lines apart and the exec one
+// took the raw digest.
+func TestTheExecArgvCarriesTheSanitisedPrompt(t *testing.T) {
+	argv, ok := handoffArgv("claude", "work‮reversed here ghp_0123456789abcdefghijklmnopqrstuvwxyzAB")
+	if !ok || len(argv) < 2 {
+		t.Fatalf("no argv for a known target: %v", argv)
+	}
+	joined := strings.Join(argv, " ")
+	if strings.Contains(joined, "‮") || strings.Contains(joined, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
+		t.Errorf("the command line carries what the printed handoff would have removed: %q", joined)
+	}
+}
+
+// And the invariant the exec path already had: a prompt cannot start with a
+// dash, or the target reads it as a flag.
+func TestTheExecHandoffPromptNeverStartsWithADash(t *testing.T) {
+	if got := handoffPrompt("-rf /"); strings.HasPrefix(got, "-") {
+		t.Errorf("the prompt starts with a dash: %q", got)
+	}
+}

--- a/cmd/deja/handoff_exec_sanitised_test.go
+++ b/cmd/deja/handoff_exec_sanitised_test.go
@@ -15,10 +15,10 @@ import (
 func TestTheExecHandoffSanitisesLikeThePrintedOne(t *testing.T) {
 	// A bidi override and a zero-width space, which no index-time pass removes
 	// because they are a display concern, and a token shaped like a secret.
-	raw := "continue the work‮reversed​ here: ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	raw := "continue the work\u202ereversed\u200b here: ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
 
 	got := handoffPrompt(raw)
-	for _, bad := range []string{"‮", "​"} {
+	for _, bad := range []string{"\u202e", "\u200b"} {
 		if strings.Contains(got, bad) {
 			t.Errorf("an invisible character survived into the prompt: %q", got)
 		}
@@ -35,12 +35,12 @@ func TestTheExecHandoffSanitisesLikeThePrintedOne(t *testing.T) {
 // sanitised prompt. Before this the two sat a few lines apart and the exec one
 // took the raw digest.
 func TestTheExecArgvCarriesTheSanitisedPrompt(t *testing.T) {
-	argv, ok := handoffArgv("claude", "work‮reversed here ghp_0123456789abcdefghijklmnopqrstuvwxyzAB")
+	argv, ok := handoffArgv("claude", "work\u202ereversed here ghp_0123456789abcdefghijklmnopqrstuvwxyzAB")
 	if !ok || len(argv) < 2 {
 		t.Fatalf("no argv for a known target: %v", argv)
 	}
 	joined := strings.Join(argv, " ")
-	if strings.Contains(joined, "‮") || strings.Contains(joined, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
+	if strings.Contains(joined, "\u202e") || strings.Contains(joined, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
 		t.Errorf("the command line carries what the printed handoff would have removed: %q", joined)
 	}
 }


### PR DESCRIPTION
Found while reading `handoff.go` for #2866, and unlike that one this needs no product judgement: the same digest left the machine two ways and only one was cleaned.

    printed   printSanitized(stdout, digest)   secrets redacted, bidi and zero-width stripped
    --exec    handoffCommand(target, digest)   raw

So a session handed over directly carried the secret-shaped tokens and the invisible characters that the pasted form would have removed — into another agent's command line, as its first prompt.

Both paths now go through `handoffPrompt`, and the exec path builds its argv through a single seam (`handoffArgv`) so the sanitising cannot be wired past again — which is exactly what happened here, with the two calls a dozen lines apart. The leading-dash guard moved into the same helper rather than being left behind at the old call site.

Four mutations, one per property: dropping the redaction, dropping the invisible-character strip, dropping the dash guard, and wiring the seam past. The last one is why the seam exists — my first version of the test called the helper directly and could not see the wiring, and the mutation stayed green until the argv itself was asserted.

Secrets are redacted at index time too, so in most stores this pass finds little. "Most" is why the printed path has it, and now so does the other.