### PR TITLE
fix(mcp): journal what how and fix hand the agent

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -397,9 +397,9 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		// Recorded like blame and the resource reader: `deja log` is what deja
 		// put in front of an agent, and this is the surface that hands one a
 		// command to run (#2858).
-		return recordedMCPAnswer(dir, usage.KindFix, func() (string, error) { return mcpFix(dir, name, raw) })
+		return recordedMCPAnswer(dir, usage.KindFix, func() (string, int, error) { return mcpFix(dir, name, raw) })
 	case "how":
-		return recordedMCPAnswer(dir, usage.KindHow, func() (string, error) { return mcpHow(dir, name, raw) })
+		return recordedMCPAnswer(dir, usage.KindHow, func() (string, int, error) { return mcpHow(dir, name, raw) })
 	case "remember":
 		var a struct {
 			Text    string   `json:"text"`
@@ -563,32 +563,36 @@ const contextMCPBudget = 8192
 // "no session ran a command after that error" is an answer the agent acts on
 // as much as a remedy is, and a log that held only the successful calls
 // understated what deja said (#2858).
-func recordedMCPAnswer(dir, kind string, answer func() (string, error)) (string, error) {
-	text, err := answer()
+func recordedMCPAnswer(dir, kind string, answer func() (string, int, error)) (string, error) {
+	text, found, err := answer()
 	if err == nil {
-		usage.RecordServedSnapshot(dir, kind, text, 0, 0, nil, policy.Load().Describe(policy.ActivationMCP))
+		// The count, not a zero: a row recorded with none is marked as having
+		// found nothing, so the log said "(empty result)" over an answer that
+		// served a command from two sessions — the opposite of what happened,
+		// on the surface this recording exists to make honest (#2858).
+		usage.RecordServedSnapshot(dir, kind, text, found, 0, nil, policy.Load().Describe(policy.ActivationMCP))
 	}
 	return text, err
 }
 
-func mcpFix(dir, name string, raw json.RawMessage) (string, error) {
+func mcpFix(dir, name string, raw json.RawMessage) (string, int, error) {
 	var a struct {
 		Error string    `json:"error"`
 		Limit mcpNumber `json:"limit"`
 	}
 	if err := decodeToolArgs(name, raw, &a); err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if strings.TrimSpace(a.Error) == "" {
-		return "", fmt.Errorf("error text required")
+		return "", 0, fmt.Errorf("error text required")
 	}
 	// Before the read, not after: the rebuild used to happen first and the
 	// guard ran when there was nothing left to report (#1306, #1309).
 	if line := buildingNowForAgent(dir); line != "" {
-		return line, nil
+		return line, 0, nil
 	}
 	if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
-		return "", err
+		return "", 0, err
 	}
 	pol := policy.Load()
 	pairs := index.FixesFor(dir, a.Error, int(a.Limit), func(project string) bool {
@@ -596,16 +600,16 @@ func mcpFix(dir, name string, raw json.RawMessage) (string, error) {
 	})
 	if len(pairs) == 0 {
 		if !index.LooksLikeError(a.Error) {
-			return "That text does not read like an error line - pass the failing output itself.", nil
+			return "That text does not read like an error line - pass the failing output itself.", 0, nil
 		}
 		// Held-but-unconfirmed is not never-seen, and the agent asking is
 		// the one that would otherwise re-derive the remedy (#2282).
 		if index.FixCandidateSeen(dir, a.Error, func(project string) bool {
 			return pol.Allows(policy.ActivationMCP, project)
 		}) {
-			return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", nil
+			return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", 0, nil
 		}
-		return "No session on this machine ran a command after that error.", nil
+		return "No session on this machine ran a command after that error.", 0, nil
 	}
 	var fb strings.Builder
 	for _, p := range pairs {
@@ -620,46 +624,46 @@ func mcpFix(dir, name string, raw json.RawMessage) (string, error) {
 		fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
 			commandListingLine(p.Command))
 	}
-	return strings.TrimRight(fb.String(), "\n"), nil
+	return strings.TrimRight(fb.String(), "\n"), len(pairs), nil
 }
 
-func mcpHow(dir, name string, raw json.RawMessage) (string, error) {
+func mcpHow(dir, name string, raw json.RawMessage) (string, int, error) {
 	var a struct {
 		What    string    `json:"what"`
 		Project string    `json:"project"`
 		Limit   mcpNumber `json:"limit"`
 	}
 	if err := decodeToolArgs(name, raw, &a); err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if strings.TrimSpace(a.What) == "" {
-		return "", fmt.Errorf("what required")
+		return "", 0, fmt.Errorf("what required")
 	}
 	if line := buildingNowForAgent(dir); line != "" {
-		return line, nil
+		return line, 0, nil
 	}
 	if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
-		return "", err
+		return "", 0, err
 	}
 	entries, hidden, ignored, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	if len(entries) == 0 {
 		// The same reasoning one line down, for the other rule: an agent
 		// told nothing exists invents one, and the ignore rule is exactly
 		// the case where something does exist (#2630).
 		if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
-			return strings.TrimSpace(note), nil
+			return strings.TrimSpace(note), 0, nil
 		}
 		// Not a flat negative when the policy is what emptied the answer:
 		// an agent told nothing exists invents one, and here something does
 		// exist. The CLI has said so since the note was written; this
 		// surface was returning the negative regardless.
 		if note := policyHiddenNote(policy.ActivationMCP, hidden); note != "" {
-			return strings.TrimSpace(note), nil
+			return strings.TrimSpace(note), 0, nil
 		}
-		return fmt.Sprintf("No command on this machine mentions %q.", a.What), nil
+		return fmt.Sprintf("No command on this machine mentions %q.", a.What), 0, nil
 	}
 	limit := int(a.Limit)
 	if limit <= 0 {
@@ -676,7 +680,7 @@ func mcpHow(dir, name string, raw json.RawMessage) (string, error) {
 		// travel with the answer rather than to a terminal it never sees.
 		out += "\n\n" + note
 	}
-	return out, nil
+	return out, len(entries), nil
 }
 
 // blameMCPBudget bounds one blame answer. Higher than recall's ~4 KB because a

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -394,109 +394,12 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		}
 		return text, err
 	case "fix":
-		var a struct {
-			Error string    `json:"error"`
-			Limit mcpNumber `json:"limit"`
-		}
-		if err := decodeToolArgs(name, raw, &a); err != nil {
-			return "", err
-		}
-		if strings.TrimSpace(a.Error) == "" {
-			return "", fmt.Errorf("error text required")
-		}
-		// Before the read, not after: the rebuild used to happen first and the
-		// guard ran when there was nothing left to report (#1306, #1309).
-		if line := buildingNowForAgent(dir); line != "" {
-			return line, nil
-		}
-		if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
-			return "", err
-		}
-		pol := policy.Load()
-		pairs := index.FixesFor(dir, a.Error, int(a.Limit), func(project string) bool {
-			return pol.Allows(policy.ActivationMCP, project)
-		})
-		if len(pairs) == 0 {
-			if !index.LooksLikeError(a.Error) {
-				return "That text does not read like an error line - pass the failing output itself.", nil
-			}
-			// Held-but-unconfirmed is not never-seen, and the agent asking is
-			// the one that would otherwise re-derive the remedy (#2282).
-			if index.FixCandidateSeen(dir, a.Error, func(project string) bool {
-				return pol.Allows(policy.ActivationMCP, project)
-			}) {
-				return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", nil
-			}
-			return "No session on this machine ran a command after that error.", nil
-		}
-		var fb strings.Builder
-		for _, p := range pairs {
-			when := ""
-			if !p.When.IsZero() {
-				when = " (" + p.When.Local().Format("2006-01-02") + ")"
-			}
-			ran := "ran next"
-			if p.Candidate {
-				ran = "ran next, unconfirmed"
-			}
-			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
-				commandListingLine(p.Command))
-		}
-		return strings.TrimRight(fb.String(), "\n"), nil
+		// Recorded like blame and the resource reader: `deja log` is what deja
+		// put in front of an agent, and this is the surface that hands one a
+		// command to run (#2858).
+		return recordedMCPAnswer(dir, usage.KindFix, func() (string, error) { return mcpFix(dir, name, raw) })
 	case "how":
-		var a struct {
-			What    string    `json:"what"`
-			Project string    `json:"project"`
-			Limit   mcpNumber `json:"limit"`
-		}
-		if err := decodeToolArgs(name, raw, &a); err != nil {
-			return "", err
-		}
-		if strings.TrimSpace(a.What) == "" {
-			return "", fmt.Errorf("what required")
-		}
-		if line := buildingNowForAgent(dir); line != "" {
-			return line, nil
-		}
-		if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
-			return "", err
-		}
-		entries, hidden, ignored, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
-		if err != nil {
-			return "", err
-		}
-		if len(entries) == 0 {
-			// The same reasoning one line down, for the other rule: an agent
-			// told nothing exists invents one, and the ignore rule is exactly
-			// the case where something does exist (#2630).
-			if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
-				return strings.TrimSpace(note), nil
-			}
-			// Not a flat negative when the policy is what emptied the answer:
-			// an agent told nothing exists invents one, and here something does
-			// exist. The CLI has said so since the note was written; this
-			// surface was returning the negative regardless.
-			if note := policyHiddenNote(policy.ActivationMCP, hidden); note != "" {
-				return strings.TrimSpace(note), nil
-			}
-			return fmt.Sprintf("No command on this machine mentions %q.", a.What), nil
-		}
-		limit := int(a.Limit)
-		if limit <= 0 {
-			limit = 8
-		}
-		var hb strings.Builder
-		// The same lines the CLI prints, from the same writer: this tool used
-		// to keep its own copy of the loop, so a note the CLI learned never
-		// reached the agent (#1634).
-		writeHowEntries(&hb, entries, limit, ", last ")
-		out := strings.TrimRight(hb.String(), "\n")
-		if note := howCapNote(len(entries), limit, "call again with a higher limit for the rest"); note != "" {
-			// The agent cannot ask a follow-up of its own, so the cut has to
-			// travel with the answer rather than to a terminal it never sees.
-			out += "\n\n" + note
-		}
-		return out, nil
+		return recordedMCPAnswer(dir, usage.KindHow, func() (string, error) { return mcpHow(dir, name, raw) })
 	case "remember":
 		var a struct {
 			Text    string   `json:"text"`
@@ -655,6 +558,126 @@ func keepsQuery(shorter, longer, query string) bool {
 // them bounded — pushed an ordinary reply to 8221 bytes and a long-named one to
 // 8335 (#1797).
 const contextMCPBudget = 8192
+
+// recordedMCPAnswer journals what a tool handed the agent, whatever it was:
+// "no session ran a command after that error" is an answer the agent acts on
+// as much as a remedy is, and a log that held only the successful calls
+// understated what deja said (#2858).
+func recordedMCPAnswer(dir, kind string, answer func() (string, error)) (string, error) {
+	text, err := answer()
+	if err == nil {
+		usage.RecordServedSnapshot(dir, kind, text, 0, 0, nil, policy.Load().Describe(policy.ActivationMCP))
+	}
+	return text, err
+}
+
+func mcpFix(dir, name string, raw json.RawMessage) (string, error) {
+	var a struct {
+		Error string    `json:"error"`
+		Limit mcpNumber `json:"limit"`
+	}
+	if err := decodeToolArgs(name, raw, &a); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(a.Error) == "" {
+		return "", fmt.Errorf("error text required")
+	}
+	// Before the read, not after: the rebuild used to happen first and the
+	// guard ran when there was nothing left to report (#1306, #1309).
+	if line := buildingNowForAgent(dir); line != "" {
+		return line, nil
+	}
+	if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
+		return "", err
+	}
+	pol := policy.Load()
+	pairs := index.FixesFor(dir, a.Error, int(a.Limit), func(project string) bool {
+		return pol.Allows(policy.ActivationMCP, project)
+	})
+	if len(pairs) == 0 {
+		if !index.LooksLikeError(a.Error) {
+			return "That text does not read like an error line - pass the failing output itself.", nil
+		}
+		// Held-but-unconfirmed is not never-seen, and the agent asking is
+		// the one that would otherwise re-derive the remedy (#2282).
+		if index.FixCandidateSeen(dir, a.Error, func(project string) bool {
+			return pol.Allows(policy.ActivationMCP, project)
+		}) {
+			return "One session ran something after that error, and nothing has confirmed it worked - deja waits for a second sighting before naming a remedy.", nil
+		}
+		return "No session on this machine ran a command after that error.", nil
+	}
+	var fb strings.Builder
+	for _, p := range pairs {
+		when := ""
+		if !p.When.IsZero() {
+			when = " (" + p.When.Local().Format("2006-01-02") + ")"
+		}
+		ran := "ran next"
+		if p.Candidate {
+			ran = "ran next, unconfirmed"
+		}
+		fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
+			commandListingLine(p.Command))
+	}
+	return strings.TrimRight(fb.String(), "\n"), nil
+}
+
+func mcpHow(dir, name string, raw json.RawMessage) (string, error) {
+	var a struct {
+		What    string    `json:"what"`
+		Project string    `json:"project"`
+		Limit   mcpNumber `json:"limit"`
+	}
+	if err := decodeToolArgs(name, raw, &a); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(a.What) == "" {
+		return "", fmt.Errorf("what required")
+	}
+	if line := buildingNowForAgent(dir); line != "" {
+		return line, nil
+	}
+	if _, err := index.EnsureForSearchStale(dir, search.Options{}, mcpProgress()); err != nil {
+		return "", err
+	}
+	entries, hidden, ignored, err := howEntries(dir, strings.Fields(a.What), a.Project, policy.ActivationMCP)
+	if err != nil {
+		return "", err
+	}
+	if len(entries) == 0 {
+		// The same reasoning one line down, for the other rule: an agent
+		// told nothing exists invents one, and the ignore rule is exactly
+		// the case where something does exist (#2630).
+		if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
+			return strings.TrimSpace(note), nil
+		}
+		// Not a flat negative when the policy is what emptied the answer:
+		// an agent told nothing exists invents one, and here something does
+		// exist. The CLI has said so since the note was written; this
+		// surface was returning the negative regardless.
+		if note := policyHiddenNote(policy.ActivationMCP, hidden); note != "" {
+			return strings.TrimSpace(note), nil
+		}
+		return fmt.Sprintf("No command on this machine mentions %q.", a.What), nil
+	}
+	limit := int(a.Limit)
+	if limit <= 0 {
+		limit = 8
+	}
+	var hb strings.Builder
+	// The same lines the CLI prints, from the same writer: this tool used
+	// to keep its own copy of the loop, so a note the CLI learned never
+	// reached the agent (#1634).
+	writeHowEntries(&hb, entries, limit, ", last ")
+	out := strings.TrimRight(hb.String(), "\n")
+	if note := howCapNote(len(entries), limit, "call again with a higher limit for the rest"); note != "" {
+		// The agent cannot ask a follow-up of its own, so the cut has to
+		// travel with the answer rather than to a terminal it never sees.
+		out += "\n\n" + note
+	}
+	return out, nil
+}
 
 // blameMCPBudget bounds one blame answer. Higher than recall's ~4 KB because a
 // hit is a whole session rather than a snippet, and well under what an agent

--- a/cmd/deja/mcp_how_fix_log_test.go
+++ b/cmd/deja/mcp_how_fix_log_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja log` is the record of what an agent was handed, and the two tools that
+// hand over commands left no trace in it — the argument #682 made for blame,
+// unapplied to the surfaces that answer with something to run (#2858).
+func TestHowAndFixOverMCPAreRecorded(t *testing.T) {
+	dir := seedHowFixIndex(t)
+	for _, c := range []struct {
+		tool string
+		args string
+		kind string
+	}{
+		{"how", `{"what":"pytest"}`, usage.KindHow},
+		{"fix", `{"error":"zsh:1: command not found: timeout"}`, usage.KindFix},
+	} {
+		t.Run(c.tool, func(t *testing.T) {
+			before := len(usage.Snapshots(dir, 100))
+			text, err := callMCPTool(dir, c.tool, json.RawMessage(c.args))
+			if err != nil {
+				t.Fatal(err)
+			}
+			after := usage.Snapshots(dir, 100)
+			if len(after) != before+1 {
+				t.Fatalf("snapshots %d -> %d, want one more", before, len(after))
+			}
+			last := after[0]
+			if last.Kind != c.kind {
+				t.Errorf("kind = %q, want %q", last.Kind, c.kind)
+			}
+			if last.Bytes != len(text) {
+				t.Errorf("recorded %d bytes, handed over %d", last.Bytes, len(text))
+			}
+			if last.Digest != text {
+				t.Errorf("digest is not what was handed over:\n%q\n%q", last.Digest, text)
+			}
+		})
+	}
+}
+
+// seedHowFixIndex is a store where both tools have something to answer with: a
+// command run in two sessions, and an error a later command settled.
+func seedHowFixIndex(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	store := filepath.Join(root, "-work-api")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"s1", "s2"} {
+		lines := []string{
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
+				id[1:2] + `T10:00:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"pytest -q tests/"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
+				id[1:2] + `T10:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"zsh:1: command not found: timeout"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
+				id[1:2] + `T10:00:02Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"curl --max-time 5 example.internal"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
+				id[1:2] + `T10:00:03Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"200 OK"}]}}`,
+		}
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/cmd/deja/mcp_how_fix_log_test.go
+++ b/cmd/deja/mcp_how_fix_log_test.go
@@ -44,6 +44,19 @@ func TestHowAndFixOverMCPAreRecorded(t *testing.T) {
 			if last.Digest != text {
 				t.Errorf("digest is not what was handed over:\n%q\n%q", last.Digest, text)
 			}
+			// The count, because a row with none is marked as having found
+			// nothing — and these answers served a command.
+			if last.Sessions == 0 {
+				t.Errorf("an answer that served a command was recorded as finding nothing: %#v", last)
+			}
+			// And the log agrees with itself: the event a reader sees must
+			// not say "(empty result)" over an answer that served something.
+			for _, e := range usage.Events(dir, 100) {
+				if e.Kind == c.kind && e.FoundNothing() {
+					t.Errorf("the log says the answer found nothing: %#v", e)
+					break
+				}
+			}
 		})
 	}
 }
@@ -65,9 +78,9 @@ func seedHowFixIndex(t *testing.T) string {
 			`{"type":"user","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
 				id[1:2] + `T10:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"zsh:1: command not found: timeout"}]}}`,
 			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
-				id[1:2] + `T10:00:02Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"curl --max-time 5 example.internal"}}]}}`,
+				id[1:2] + `T10:00:02Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"brew install coreutils"}}]}}`,
 			`{"type":"user","sessionId":"` + id + `","cwd":"/work/api","timestamp":"2026-07-0` +
-				id[1:2] + `T10:00:03Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"200 OK"}]}}`,
+				id[1:2] + `T10:00:03Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t2","content":"==> Installing coreutils"}]}}`,
 		}
 		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 			t.Fatal(err)

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -529,8 +529,8 @@ A top-level array, so no `schema_version`, on the same terms as `blame`. It is
 `[]` and never `null` when there is nothing to report: this is the output a
 script polls, and `null` raises where an empty list iterates zero times.
 
-`t` is when it happened and `kind` is what deja did — `recall`, `recall_context`
-and `blame` are answers to an agent that asked; `hook`, `dejavu` and `tool` are
+`t` is when it happened and `kind` is what deja did — `recall`, `recall_context`,
+`blame`, `how` and `fix` are answers to an agent that asked; `hook`, `dejavu` and `tool` are
 memory offered unasked; `resource` is a read of `deja://session/…`; `remember`
 writes rather than serves; `search` and `handoff` are the reader's own commands.
 A kind this list does not name may still appear: another version of deja may

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -36,6 +36,12 @@ const (
 	// same way blame did before #682.
 	KindResource = "resource"
 	KindHandoff  = "handoff"
+	// KindHow and KindFix are the two MCP tools that answer with something to
+	// run. The reasoning KindBlame and KindResource were added on applies to
+	// them twice over: they hand the agent a command, and `deja log` — the
+	// record of what deja put in front of an agent — showed neither (#2858).
+	KindHow = "how"
+	KindFix = "fix"
 	// KindRemember is the MCP remember tool — the one tool that writes to the
 	// store. #682 covered the read tools only, so an agent could add a note
 	// that showed up nowhere in the journal the user reads.

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -58,8 +58,11 @@ const (
 
 // servedKinds are the events that hand an agent memory it asked for: the two
 // recall tools, a blame — "the largest thing the server hands over", which is
-// why #682 gave it a kind of its own — and a read of deja://session/…, which
-// hands over a whole session in the same frame recall_context uses.
+// why #682 gave it a kind of its own — a read of deja://session/…, which hands
+// over a whole session in the same frame recall_context uses, and the two
+// tools that answer with a command to run (#2858). A kind counted on one
+// screen and not another is the drift below, so a kind added to the log
+// belongs here or nowhere.
 //
 // Named once because the counters drifted: #1569 aligned five of them and left
 // Impact behind, so a blame was a recall on `deja stats` and nothing on
@@ -67,7 +70,7 @@ const (
 // (#1907).
 func servedKind(kind string) bool {
 	switch kind {
-	case KindRecall, KindContext, KindBlame, KindResource:
+	case KindRecall, KindContext, KindBlame, KindResource, KindHow, KindFix:
 		return true
 	}
 	return false


### PR DESCRIPTION
Closes #2858. `deja log` is the record of what deja put in front of an agent, and the two MCP tools that answer with something to run left no trace in it — the argument #682 made for blame and the resource reader, unapplied to the surfaces where it matters most.

Both go through one recorder now, which journals whatever they returned: "no session on this machine ran a command after that error" is an answer the agent acts on as much as a remedy is, and a log holding only the successful calls understates what deja said. The two bodies moved into functions of their own so the diff is the recording rather than a rewrite.