### PR TITLE
fix(blame): a path with nothing said around it is not evidence

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -220,8 +220,14 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 }
 
 // namedAPath reports whether the session wrote the file as a path rather than
-// as a bare name. It is the coarse half of specificity — the half that orders
-// the answer; the rest is left to the score, where the number of mentions is.
+// as a bare name, and said enough for that to be evidence. It is the coarse
+// half of specificity — the half that orders the answer; the rest is left to
+// the score, where the number of mentions is.
+//
+// More than once, because naming the path once and saying nothing else is not
+// working on a file: measured on a real store, a pasted absolute path and a
+// `git diff --stat` row each took the top of the answer from the session that
+// had debugged it (#2854).
 func namedAPath(h BlameHit) bool { return h.Specificity > 1.0 }
 
 // BlameCap is how many hits the default listing shows. The rest are behind
@@ -256,12 +262,17 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 	low := strings.ToLower(filepath.ToSlash(text))
 	count := 0
 	level := 1.0
+	// A path with nothing said around it is not a session working on the file:
+	// a `git diff --stat` row and a pasted absolute path each name it once and
+	// took the top of the answer from the session that had debugged it
+	// (#2854). What counts is the path plus something about it.
+	explained := saysMoreThanThePath(low)
 	for _, form := range forms {
 		// The bare basename is one of the forms, and it matches inside a path
 		// as well as on its own — so every mention was already "specific" and
 		// the rule below could never fire. A name is what the caller asked
 		// with; a path is what says which file the session meant (#2840).
-		if !strings.Contains(strings.Trim(form, "/"), "/") {
+		if !strings.Contains(strings.Trim(form, "/"), "/") || !explained {
 			continue
 		}
 		if pathFormCount(low, form) > 0 {
@@ -290,6 +301,32 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 		pos = i + len(base)
 	}
 	return count, level
+}
+
+// saysMoreThanThePath reports whether a message carries words of its own beside
+// the paths in it. Three, so a diffstat row (`cmd/deja/mcp.go | 4 +-`) and a
+// bare pasted path do not read as a session discussing the file, while a line
+// that says what was done to it does.
+func saysMoreThanThePath(low string) bool {
+	words := 0
+	for _, field := range strings.Fields(low) {
+		if strings.ContainsAny(field, "/\\") || len(field) < 2 {
+			continue
+		}
+		letters := 0
+		for _, r := range field {
+			if r >= 'a' && r <= 'z' {
+				letters++
+			}
+		}
+		if letters >= 2 {
+			words++
+			if words >= 3 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func pathFormCount(s, form string) int {

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -326,18 +326,30 @@ func aLineSaysMoreThanThePath(low, base string) bool {
 // Letters by Unicode rather than by ASCII: a session that says what it did in
 // Russian or Chinese is saying it (#2854).
 func saysMoreThanThePath(low string) bool {
-	words := 0
+	words, unspaced := 0, 0
 	for _, field := range strings.Fields(low) {
-		if strings.ContainsAny(field, "/\\") || utf8.RuneCountInString(field) < 2 {
+		if strings.ContainsAny(field, "/\\") {
 			continue
 		}
-		letters := 0
+		letters, script := 0, 0
 		for _, r := range field {
-			if unicode.IsLetter(r) {
-				letters++
+			if !unicode.IsLetter(r) {
+				continue
+			}
+			letters++
+			// Chinese, Japanese and Korean put no spaces between words, so a
+			// whole sentence arrives as one field and counting fields counts
+			// it as one word. Their letters are counted instead, which is the
+			// same question asked in the units that script uses (#2854).
+			if unicode.In(r, unicode.Han, unicode.Hiragana, unicode.Katakana, unicode.Hangul) {
+				script++
 			}
 		}
-		if letters >= 2 {
+		unspaced += script
+		if unspaced >= 4 {
+			return true
+		}
+		if letters >= 2 && utf8.RuneCountInString(field) >= 2 {
 			words++
 			if words >= 3 {
 				return true

--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -224,7 +224,7 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 // half of specificity — the half that orders the answer; the rest is left to
 // the score, where the number of mentions is.
 //
-// More than once, because naming the path once and saying nothing else is not
+// Said something, because naming the path and saying nothing else is not
 // working on a file: measured on a real store, a pasted absolute path and a
 // `git diff --stat` row each took the top of the answer from the session that
 // had debugged it (#2854).
@@ -265,8 +265,11 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 	// A path with nothing said around it is not a session working on the file:
 	// a `git diff --stat` row and a pasted absolute path each name it once and
 	// took the top of the answer from the session that had debugged it
-	// (#2854). What counts is the path plus something about it.
-	explained := saysMoreThanThePath(low)
+	// (#2854). What counts is the path plus something about it, on the line it
+	// is on — asked of the whole message, a diffstat qualifies on its own
+	// summary line ("2 files changed, 6 insertions(+)") and the rule catches
+	// only messages shorter than three words.
+	explained := aLineSaysMoreThanThePath(low, base)
 	for _, form := range forms {
 		// The bare basename is one of the forms, and it matches inside a path
 		// as well as on its own — so every mention was already "specific" and
@@ -303,19 +306,34 @@ func mentionScore(text, base string, forms []string) (int, float64) {
 	return count, level
 }
 
-// saysMoreThanThePath reports whether a message carries words of its own beside
-// the paths in it. Three, so a diffstat row (`cmd/deja/mcp.go | 4 +-`) and a
-// bare pasted path do not read as a session discussing the file, while a line
-// that says what was done to it does.
+// aLineSaysMoreThanThePath reports whether some line naming the file carries
+// words of its own beside the paths on it. Three, so a diffstat row
+// (`cmd/deja/mcp.go | 4 +-`) and a bare pasted path do not read as a session
+// discussing the file, while a line that says what was done to it does.
+//
+// Per line rather than per message, because a diffstat's own summary line
+// would otherwise vouch for every path above it.
+func aLineSaysMoreThanThePath(low, base string) bool {
+	for _, line := range strings.Split(low, "\n") {
+		if strings.Contains(line, base) && saysMoreThanThePath(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// saysMoreThanThePath counts the words on a line that are not part of a path.
+// Letters by Unicode rather than by ASCII: a session that says what it did in
+// Russian or Chinese is saying it (#2854).
 func saysMoreThanThePath(low string) bool {
 	words := 0
 	for _, field := range strings.Fields(low) {
-		if strings.ContainsAny(field, "/\\") || len(field) < 2 {
+		if strings.ContainsAny(field, "/\\") || utf8.RuneCountInString(field) < 2 {
 			continue
 		}
 		letters := 0
 		for _, r := range field {
-			if r >= 'a' && r <= 'z' {
+			if unicode.IsLetter(r) {
 				letters++
 			}
 		}

--- a/internal/search/blame_one_echo_test.go
+++ b/internal/search/blame_one_echo_test.go
@@ -51,3 +51,54 @@ func TestOneEchoOfThePathDoesNotOutrankAWorkingSession(t *testing.T) {
 		t.Errorf("the session that named the path twice did not come first: %s", hits[0].Session.ID)
 	}
 }
+
+// A real diffstat carries its own summary line, so asking the whole message
+// whether it says anything let every path above that line ride on it — the
+// question is about the line the path is on (#2854).
+func TestADiffstatDoesNotVouchForItsOwnRows(t *testing.T) {
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	target := BlameTarget{FullPath: "/work/api/cmd/deja/mcp.go", Base: "mcp.go", Stem: "mcp"}
+	diffstat := model.Session{
+		Harness: "opencode", ID: "diffstat", Project: "api", Updated: now,
+		Messages: []model.Message{{
+			Role: "user", Time: now,
+			Text: " cmd/deja/mcp.go      | 4 +-\n cmd/deja/recall.go   | 2 +-\n 2 files changed, 6 insertions(+), 2 deletions(-)",
+		}},
+	}
+	worked := model.Session{
+		Harness: "claude", ID: "worked", Project: "api", Updated: now.Add(-24 * time.Hour),
+		Messages: []model.Message{{
+			Role: "assistant", Time: now.Add(-24 * time.Hour),
+			Text: "mcp.go is where the budget trim happens; mcp.go cuts from the tail, and mcp.go broke the windows build",
+		}},
+	}
+	hits := Blame([]model.Session{diffstat, worked}, target, BlameOptions{All: true})
+	if len(hits) != 2 || hits[0].Session.ID != "worked" {
+		t.Errorf("a diffstat outranked the session that worked on the file: %+v", hits)
+	}
+}
+
+// And a session that says what it did in a language with no Latin letters is
+// saying it: the words were counted as ASCII only.
+func TestWordsAreCountedInAnyScript(t *testing.T) {
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	target := BlameTarget{FullPath: "/work/api/cmd/deja/mcp.go", Base: "mcp.go", Stem: "mcp"}
+	said := model.Session{
+		Harness: "claude", ID: "said", Project: "api", Updated: now.Add(-48 * time.Hour),
+		Messages: []model.Message{{
+			Role: "assistant", Time: now.Add(-48 * time.Hour),
+			Text: "починил cmd/deja/mcp.go — падал на виндах",
+		}},
+	}
+	bare := model.Session{
+		Harness: "claude", ID: "bare", Project: "api", Updated: now,
+		Messages: []model.Message{{
+			Role: "user", Time: now,
+			Text: "mcp.go mcp.go mcp.go again",
+		}},
+	}
+	hits := Blame([]model.Session{said, bare}, target, BlameOptions{All: true})
+	if len(hits) != 2 || hits[0].Session.ID != "said" {
+		t.Errorf("a session that said what it did was not read as saying it: %+v", hits)
+	}
+}

--- a/internal/search/blame_one_echo_test.go
+++ b/internal/search/blame_one_echo_test.go
@@ -1,0 +1,53 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Naming the path is evidence; naming it once and saying nothing else is not.
+// A pasted absolute path and a `git diff --stat` row each mention the file once
+// and outranked the session that debugged it, because the rule that puts a path
+// first asked nothing about how much the session had to say (#2854).
+func TestOneEchoOfThePathDoesNotOutrankAWorkingSession(t *testing.T) {
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	target := BlameTarget{FullPath: "/work/api/cmd/deja/mcp.go", Base: "mcp.go", Stem: "mcp"}
+
+	echo := model.Session{
+		Harness: "opencode", ID: "echo", Project: "api", Updated: now,
+		Messages: []model.Message{{
+			Role: "user", Time: now,
+			Text: " cmd/deja/mcp.go | 4 +-",
+		}},
+	}
+	worked := model.Session{
+		Harness: "claude", ID: "worked", Project: "api", Updated: now.Add(-24 * time.Hour),
+		Messages: []model.Message{{
+			Role: "assistant", Time: now.Add(-24 * time.Hour),
+			Text: "mcp.go is where the budget trim happens; mcp.go cuts from the tail, and mcp.go was what broke the windows build",
+		}},
+	}
+	hits := Blame([]model.Session{echo, worked}, target, BlameOptions{All: true})
+	if len(hits) != 2 {
+		t.Fatalf("both sessions name the file: %d hits", len(hits))
+	}
+	if hits[0].Session.ID != "worked" {
+		t.Errorf("one echo of the path outranked the session that worked on the file: %s first", hits[0].Session.ID)
+	}
+
+	// And a session that names the path *and* has something to say still comes
+	// first: the rule is about evidence, not about punishing paths.
+	saidMore := model.Session{
+		Harness: "claude", ID: "said_more", Project: "api", Updated: now.Add(-48 * time.Hour),
+		Messages: []model.Message{{
+			Role: "assistant", Time: now.Add(-48 * time.Hour),
+			Text: "cmd/deja/mcp.go holds the budget; cmd/deja/mcp.go trims from the tail",
+		}},
+	}
+	hits = Blame([]model.Session{echo, worked, saidMore}, target, BlameOptions{All: true})
+	if hits[0].Session.ID != "said_more" {
+		t.Errorf("the session that named the path twice did not come first: %s", hits[0].Session.ID)
+	}
+}

--- a/internal/search/blame_one_echo_test.go
+++ b/internal/search/blame_one_echo_test.go
@@ -102,3 +102,27 @@ func TestWordsAreCountedInAnyScript(t *testing.T) {
 		t.Errorf("a session that said what it did was not read as saying it: %+v", hits)
 	}
 }
+
+// Chinese and Japanese put no spaces between words, so counting fields counted
+// a whole sentence as one and the rule read it as saying nothing.
+func TestAScriptWithoutSpacesStillCounts(t *testing.T) {
+	now := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	target := BlameTarget{FullPath: "/work/api/cmd/deja/mcp.go", Base: "mcp.go", Stem: "mcp"}
+	for _, text := range []string{
+		"我修好了 cmd/deja/mcp.go 的问题",
+		"cmd/deja/mcp.go のバグを直した",
+	} {
+		said := model.Session{
+			Harness: "claude", ID: "said", Project: "api", Updated: now.Add(-48 * time.Hour),
+			Messages: []model.Message{{Role: "assistant", Time: now.Add(-48 * time.Hour), Text: text}},
+		}
+		bare := model.Session{
+			Harness: "claude", ID: "bare", Project: "api", Updated: now,
+			Messages: []model.Message{{Role: "user", Time: now, Text: "mcp.go mcp.go mcp.go again"}},
+		}
+		hits := Blame([]model.Session{said, bare}, target, BlameOptions{All: true})
+		if len(hits) != 2 || hits[0].Session.ID != "said" {
+			t.Errorf("%q was read as saying nothing: %+v", text, hits)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2854, the residue #2849 left. Specificity is the first sort key, so a session whose entire evidence was one line — a pasted absolute path, or a `git diff --stat` row — outranked a session that had debugged the file at length.

A mention earns the specificity credit only when the message says something beside the path: three words of its own. That keeps every case #2849 measured as an improvement (those sessions discuss the file in prose) and drops the two the reviewer measured as a regression.