### PR TITLE
fix(index): let every kind with an offset parser append

### DIFF
--- a/internal/index/append_every_kind_test.go
+++ b/internal/index/append_every_kind_test.go
@@ -1,0 +1,143 @@
+package index
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The gate lets a kind append because it declares an offset parser; this is
+// the other half of that claim — that reading from where the last pass stopped
+// actually keeps what was already there and adds what arrived, once each. Six
+// kinds gained the path when the gate stopped naming harnesses (#2870), and a
+// parser that resumes wrongly loses turns silently.
+func TestEveryAppendableKindKeepsWhatItAlreadyHad(t *testing.T) {
+	for _, c := range []struct {
+		harness string
+		env     string
+		// rel is where the transcript sits under the harness root, and line is
+		// one more record of the shape that file holds.
+		rel     []string
+		fixture string
+		line    string
+	}{
+		{
+			harness: "goose", env: "DEJA_GOOSE_ROOT",
+			rel:     []string{"sessions", "20250724_1.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "goose", "sessions", "20250724_1.jsonl"),
+			line:    `{"role":"user","created":1785000900,"content":[{"type":"text","text":"appendneedle the second question"}]}`,
+		},
+		{
+			harness: "kimi", env: "DEJA_KIMI_ROOT",
+			rel:     []string{"sessions", "wd_demo_0123456789ab", "session_fixture01", "agents", "main", "wire.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "kimi", "sessions", "wd_demo_0123456789ab", "session_fixture01", "agents", "main", "wire.jsonl"),
+			line:    `{"type":"context.append_loop_event","event":{"type":"content.part","uuid":"part_fx_99","turnId":"turn_fx_99","step":0,"stepUuid":"step_fx_99","part":{"type":"text","text":"appendneedle the second question"}},"time":1782295900000}`,
+		},
+		{
+			harness: "omp", env: "DEJA_OMP_ROOT",
+			rel:     []string{"-workspace-demo", "session.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "omp", "session.jsonl"),
+			line:    `{"type":"message","id":"zz","parentId":"a1","timestamp":"2026-08-17T11:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"appendneedle the second question"}],"timestamp":1786968000000}}`,
+		},
+		{
+			harness: "prime", env: "DEJA_PRIME_ROOT",
+			rel:     []string{"session.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "prime", "session.jsonl"),
+			line:    `{"type": "message", "id": "z9", "parentId": "a1", "timestamp": "2026-08-17T11:00:00.000Z", "message": {"role": "user", "content": [{"type": "text", "text": "appendneedle the second question"}], "timestamp": 1786968000000}}`,
+		},
+		{
+			harness: "qwen", env: "DEJA_QWEN_ROOT",
+			rel:     []string{"projects", "-workspace-registry-demo", "chats", "registry-qwen.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "qwen", "projects", "-workspace-registry-demo", "chats", "registry-qwen.jsonl"),
+			line:    `{"type":"user","sessionId":"registry-qwen","timestamp":"2026-07-17T09:01:00Z","message":{"role":"user","parts":[{"text":"appendneedle the second question"}]}}`,
+		},
+		{
+			harness: "openclaw", env: "DEJA_OPENCLAW_ROOT",
+			rel:     []string{"main", "sessions", "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl"},
+			fixture: filepath.Join("..", "..", "fixtures", "registry", "openclaw", "agents", "main", "sessions", "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl"),
+			line:    `{"type":"message","id":"z9","parentId":"a1","timestamp":"2026-07-20T09:01:00Z","message":{"role":"user","content":[{"type":"text","text":"appendneedle the second question"}]}}`,
+		},
+	} {
+		t.Run(c.harness, func(t *testing.T) {
+			tmp := t.TempDir()
+			setHome(t, tmp)
+			root := filepath.Join(tmp, c.harness)
+			t.Setenv(c.env, root)
+			path := filepath.Join(append([]string{root}, c.rel...)...)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body, err := os.ReadFile(c.fixture)
+			if err != nil {
+				t.Skipf("no fixture for %s: %v", c.harness, err)
+			}
+			if err := os.WriteFile(path, body, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			dir := filepath.Join(tmp, "index.db")
+			if err := Ensure(dir, "", true, nil); err != nil {
+				t.Fatal(err)
+			}
+			was := countIndexed(t, dir, c.harness)
+			if was == 0 {
+				t.Skipf("%s: the fixture indexed nothing, so an append proves nothing", c.harness)
+			}
+
+			// One more record, the way the harness writes them.
+			if err := os.WriteFile(path, append(body, []byte(c.line+"\n")...), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			var progress bytes.Buffer
+			if err := Ensure(dir, "", false, &progress); err != nil {
+				t.Fatal(err)
+			}
+			// The append path, not a re-read that happens to give the same
+			// answer: a whole-file pass is correct too, and the point of the
+			// gate is that it does not happen (#2870).
+			if !strings.Contains(progress.String(), "updated 1 file") {
+				t.Errorf("growth did not take the append path:\n%s", progress.String())
+			}
+			if got := countIndexed(t, dir, c.harness); got < was {
+				t.Errorf("the append lost what was already indexed: %d records, was %d", got, was)
+			}
+			ss, err := Search(dir, search.Options{Query: "appendneedle", All: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(ss) != 1 {
+				t.Errorf("the appended turn is in %d sessions, want 1", len(ss))
+			}
+			for _, s := range ss {
+				n := 0
+				for _, m := range s.Messages {
+					if strings.Contains(m.Text, "appendneedle") {
+						n++
+					}
+				}
+				if n != 1 {
+					t.Errorf("the appended turn is in the index %d times", n)
+				}
+			}
+		})
+	}
+}
+
+// countIndexed is how many records a harness has in the store.
+func countIndexed(t *testing.T, dir, harness string) int {
+	t.Helper()
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, m := range metas {
+		if m.Harness == harness {
+			n += m.Counted
+		}
+	}
+	return n
+}

--- a/internal/index/append_every_kind_test.go
+++ b/internal/index/append_every_kind_test.go
@@ -82,8 +82,8 @@ func TestEveryAppendableKindKeepsWhatItAlreadyHad(t *testing.T) {
 			if err := Ensure(dir, "", true, nil); err != nil {
 				t.Fatal(err)
 			}
-			was := countIndexed(t, dir, c.harness)
-			if was == 0 {
+			was := sessionsOf(t, dir, c.harness)
+			if len(was) == 0 {
 				t.Skipf("%s: the fixture indexed nothing, so an append proves nothing", c.harness)
 			}
 
@@ -101,8 +101,29 @@ func TestEveryAppendableKindKeepsWhatItAlreadyHad(t *testing.T) {
 			if !strings.Contains(progress.String(), "updated 1 file") {
 				t.Errorf("growth did not take the append path:\n%s", progress.String())
 			}
-			if got := countIndexed(t, dir, c.harness); got < was {
-				t.Errorf("the append lost what was already indexed: %d records, was %d", got, was)
+			// The same sessions, still carrying what the header told the
+			// parser. An offset parser that resumes past the header loses the
+			// session's identity rather than its bytes: the turn lands under a
+			// key of its own and the session it belongs to never grows.
+			now := sessionsOf(t, dir, c.harness)
+			for key, before := range was {
+				after, ok := now[key]
+				if !ok {
+					t.Errorf("%s is gone after the append", key)
+					continue
+				}
+				if after.Counted < before.Counted {
+					t.Errorf("%s lost turns: %d, was %d", key, after.Counted, before.Counted)
+				}
+				if after.Project != before.Project {
+					t.Errorf("%s changed project: %q, was %q", key, after.Project, before.Project)
+				}
+				if after.Title != before.Title {
+					t.Errorf("%s changed title: %q, was %q", key, after.Title, before.Title)
+				}
+			}
+			if len(now) != len(was) {
+				t.Errorf("the append made %d sessions out of %d", len(now), len(was))
 			}
 			ss, err := Search(dir, search.Options{Query: "appendneedle", All: true})
 			if err != nil {
@@ -126,18 +147,18 @@ func TestEveryAppendableKindKeepsWhatItAlreadyHad(t *testing.T) {
 	}
 }
 
-// countIndexed is how many records a harness has in the store.
-func countIndexed(t *testing.T, dir, harness string) int {
+// sessionsOf is what a harness has in the store, by key.
+func sessionsOf(t *testing.T, dir, harness string) map[string]SessionMeta {
 	t.Helper()
 	metas, err := AllMeta(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	n := 0
+	out := map[string]SessionMeta{}
 	for _, m := range metas {
 		if m.Harness == harness {
-			n += m.Counted
+			out[m.Harness+":"+m.ID] = m
 		}
 	}
-	return n
+	return out
 }

--- a/internal/index/append_gate_test.go
+++ b/internal/index/append_gate_test.go
@@ -1,0 +1,20 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A kind that declares an offset parser is a kind whose files can be read from
+// where the last pass stopped. The gate that decides this kept a list of
+// harness names instead, and six kinds with a parser were never on it — so
+// their files were re-read whole on every pass, which is what #2075 found on
+// the database side (#2870).
+func TestEveryKindWithAnOffsetParserCanAppend(t *testing.T) {
+	for _, k := range sources.KindsWithOffsetParsers() {
+		if !appendableKind(k) {
+			t.Errorf("%s declares an offset parser the append gate never reaches", k)
+		}
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2884,13 +2884,21 @@ func appendableKind(kind string) bool {
 	if kind == "" {
 		return false
 	}
-	for _, k := range sources.KindsWithOffsetParsers() {
-		if k == kind {
-			return true
+	resumableKindsOnce.Do(func() {
+		resumableKinds = map[string]bool{}
+		for _, k := range sources.KindsWithOffsetParsers() {
+			resumableKinds[k] = true
 		}
-	}
-	return false
+	})
+	return resumableKinds[kind]
 }
+
+// The registry is fixed for the life of the process, and this is asked once
+// per changed file: walking it each time cost 4.3 KB of garbage a file.
+var (
+	resumableKinds     map[string]bool
+	resumableKindsOnce sync.Once
+)
 
 func canAppendIncremental(changed map[string]FileState, old map[string]FileState) bool {
 	if len(changed) == 0 {

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2877,6 +2877,21 @@ func carrySidecars(dir, tmp string) {
 	}
 }
 
+// appendableKind reports whether a kind can be read from where the last pass
+// stopped. Named by kind rather than by path so the guard and the test that
+// keeps it honest ask the same question.
+func appendableKind(kind string) bool {
+	if kind == "" {
+		return false
+	}
+	for _, k := range sources.KindsWithOffsetParsers() {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
 func canAppendIncremental(changed map[string]FileState, old map[string]FileState) bool {
 	if len(changed) == 0 {
 		return false
@@ -2911,9 +2926,11 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 				return false
 			}
 		}
-		switch harnessForPath(p) {
-		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot", "grok":
-		default:
+		// Whether the kind can resume a parse, not whether its name is on a
+		// list: the list grew one harness at a time and six kinds that declare
+		// an offset parser were never added, so their files were re-read whole
+		// on every pass (#2870).
+		if !appendableKind(harnessForPath(p)) {
 			return false
 		}
 	}

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -89,7 +89,7 @@ func parseGooseFileFromOffset(path string, offset int64) ([]model.Session, error
 		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
 		Path:    path,
 	}
-	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+	err := scanJSONLWithHeaderFromOffset(path, offset, func(m map[string]any) {
 		role, hasRole := m["role"].(string)
 		if !hasRole {
 			if id, _ := m["id"].(string); id != "" {

--- a/internal/sources/pi.go
+++ b/internal/sources/pi.go
@@ -47,7 +47,7 @@ func parsePiShaped(path string, offset int64, harness, project string, useHeader
 		Project: project,
 		Path:    path,
 	}
-	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
+	err := scanJSONLWithHeaderFromOffset(path, offset, func(m map[string]any) {
 		typ, _ := m["type"].(string)
 		switch typ {
 		case "session":

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -430,6 +430,28 @@ func KindForPath(p string) string {
 	return ""
 }
 
+// KindsWithOffsetParsers names every kind that can resume a parse where the
+// last pass stopped. The index gates its append path on this rather than on a
+// list of harness names it has to remember to grow (#2870).
+func KindsWithOffsetParsers() []string {
+	var out []string
+	for _, h := range Registry() {
+		for _, k := range h.Kinds {
+			if k.ParseFrom != nil {
+				out = append(out, k.Name)
+			}
+		}
+	}
+	return out
+}
+
+// KindAppends reports whether the kind matching p can resume a parse from an
+// offset.
+func KindAppends(p string) bool {
+	k, ok := KindForPathKind(p)
+	return ok && k.ParseFrom != nil
+}
+
 // KindForPathKind returns the full FileKind whose Match accepts p, for
 // callers that need to parse, not just classify.
 func KindForPathKind(p string) (FileKind, bool) {

--- a/internal/sources/registry.go
+++ b/internal/sources/registry.go
@@ -445,13 +445,6 @@ func KindsWithOffsetParsers() []string {
 	return out
 }
 
-// KindAppends reports whether the kind matching p can resume a parse from an
-// offset.
-func KindAppends(p string) bool {
-	k, ok := KindForPathKind(p)
-	return ok && k.ParseFrom != nil
-}
-
 // KindForPathKind returns the full FileKind whose Match accepts p, for
 // callers that need to parse, not just classify.
 func KindForPathKind(p string) (FileKind, bool) {

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -260,6 +260,46 @@ func scanJSONL(path string, fn func(map[string]any)) error {
 	return scanJSONLFromOffset(path, 0, fn)
 }
 
+// scanJSONLWithHeaderFromOffset is scanJSONLFromOffset for a format whose
+// first line is metadata rather than a turn: the session's id, its title, the
+// directory it ran in. Resuming past that line left the parser with none of
+// it, so an appended turn arrived under a key made from the filename and the
+// session it belonged to never grew — measured on omp and prime, where the
+// append made a second session, and on goose and openclaw, where it renamed
+// the project (#2870).
+//
+// The header is handed over again on every resume. That is safe because it is
+// metadata: the parsers read it into fields they set rather than append to.
+func scanJSONLWithHeaderFromOffset(path string, offset int64, fn func(map[string]any)) error {
+	if offset > 0 {
+		if header, err := firstJSONLRecord(path); err == nil && header != nil {
+			fn(header)
+		}
+	}
+	return scanJSONLFromOffset(path, offset, fn)
+}
+
+// firstJSONLRecord decodes the first line of a JSONL file, or nil when there
+// is none to read.
+func firstJSONLRecord(path string) (map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	line, err := bufio.NewReaderSize(f, 1024*1024).ReadBytes('\n')
+	if line = trimJSONSpace(line); len(line) == 0 {
+		return nil, err
+	}
+	var m map[string]any
+	d := json.NewDecoder(strings.NewReader(string(line)))
+	d.UseNumber()
+	if d.Decode(&m) != nil {
+		return nil, nil
+	}
+	return m, nil
+}
+
 func scanJSONLFromOffset(path string, offset int64, fn func(map[string]any)) error {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
Closes #2870, the file-side of what #2075 found on the database side. The append gate ended in a list of harness names, and it grew one harness at a time — so goose-jsonl, kimi, omp, openclaw, prime and qwen declared an offset parser that nothing ever reached, and their transcripts were re-read whole on every pass. The gate asks the registry whether the kind can resume a parse now, so a kind that gains one is covered by the change that adds it.

Admitting them turned up three real defects, measured by the reviewer and reproduced by the test here: goose, openclaw and the pi-shaped three read the session's id, title and cwd from the file's first line, and resuming past it left the appended turn under a key made from the filename — a new session on omp and prime, a renamed project on goose and openclaw. The parsers see the header on a resume now (`scanJSONLWithHeaderFromOffset`), which is safe because those fields are assigned rather than appended to.

Two tests: the gate reaches every kind that declares a parser, and each of the six really does resume — append one record the way that harness writes them, take the append path (`updated 1 file`), and come back with the same sessions, the same projects and titles, and the new turn once.

Worth stating rather than leaving to a reader: three db-backed kinds join the same list — hermes, hermes-pg and zed — whose `ParseFrom` resumes by time rather than by offset. hermes and zed are real files, and SQLite's change counter lives at bytes 24–27 of page one, inside the prefix window, so any commit that grows the file also changes the sample and the pass takes the whole-file path. hermes-pg is a DSN token with no prefix at all; it is refused earlier, by the `SafeSize == 0 && Size > 0` guard — checked directly: `canAppendIncremental` answers false for a token whose row count grew.