### PR TITLE
fix(sources): include goose ACP sessions in the type allowlist

### DIFF
--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -141,15 +141,17 @@ func gooseText(v any) string {
 }
 
 // gooseTypeFilter keeps subagent turns and cron-recipe runs out of recall:
-// Goose stores them in the same table as the user's own sessions. The column
-// exists only on newer stores, and naming it on an older one fails the whole
-// query, so it is probed rather than assumed.
+// Goose stores them in the same table as the user's own sessions. The
+// user-visible session types (user and acp) belong in recall, while terminal,
+// gateway and hidden remain excluded. The column exists only on newer stores,
+// and naming it on an older one fails the whole query, so it is probed rather
+// than assumed.
 func gooseTypeFilter(db string) string {
 	out, err := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000", "pragma table_info(sessions)").Output()
 	if err != nil || !bytes.Contains(out, []byte("session_type")) {
 		return ""
 	}
-	return " and (s.session_type is null or s.session_type = '' or s.session_type = 'user')"
+	return " and (s.session_type is null or s.session_type = '' or s.session_type in ('user','acp'))"
 }
 
 func ParseGooseDB(db string) ([]model.Session, error) {

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -140,18 +140,18 @@ func gooseText(v any) string {
 	}
 }
 
-// gooseTypeFilter keeps subagent turns and cron-recipe runs out of recall:
-// Goose stores them in the same table as the user's own sessions. The
-// user-visible session types (user and acp) belong in recall, while terminal,
-// gateway and hidden remain excluded. The column exists only on newer stores,
-// and naming it on an older one fails the whole query, so it is probed rather
-// than assumed.
+// gooseTypeFilter keeps subagent turns, cron-recipe runs and gateway traffic
+// out of recall: Goose stores them in the same table as the user's own
+// sessions. The user-visible session types (user, acp and terminal) belong in
+// recall, while gateway, hidden, subagent and scheduled remain excluded. The
+// column exists only on newer stores, and naming it on an older one fails the
+// whole query, so it is probed rather than assumed.
 func gooseTypeFilter(db string) string {
 	out, err := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000", "pragma table_info(sessions)").Output()
 	if err != nil || !bytes.Contains(out, []byte("session_type")) {
 		return ""
 	}
-	return " and (s.session_type is null or s.session_type = '' or s.session_type in ('user','acp'))"
+	return " and (s.session_type is null or s.session_type = '' or s.session_type in ('user','acp','terminal'))"
 }
 
 func ParseGooseDB(db string) ([]model.Session, error) {

--- a/internal/sources/goose_test.go
+++ b/internal/sources/goose_test.go
@@ -154,7 +154,9 @@ func TestGooseDataDirFollowsPathRoot(t *testing.T) {
 
 // Goose stores subagent turns and cron-recipe runs in the same table as real
 // sessions. Recall is about the user's own work, so those stay out; rows from
-// before the column existed have no type and stay in.
+// before the column existed have no type and stay in. The acp session type is
+// a user-visible Goose session and belongs in recall alongside plain user
+// sessions.
 func TestParseGooseDBSkipsNonUserSessions(t *testing.T) {
 	if _, err := exec.LookPath("sqlite3"); err != nil {
 		t.Skip("sqlite3 not installed")
@@ -163,13 +165,15 @@ func TestParseGooseDBSkipsNonUserSessions(t *testing.T) {
 	sql := `create table sessions (id text primary key, name text, description text, working_dir text, created_at text, updated_at text, session_type text);
 create table messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
 insert into sessions values ('s_user','n','mine','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','user');
+insert into sessions values ('s_acp','n','acp','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','acp');
 insert into sessions values ('s_sub','n','subagent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','subagent');
 insert into sessions values ('s_cron','n','cron','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','scheduled');
 insert into sessions values ('s_old','n','legacy','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z',null);
 insert into messages values (1,'s_user','user','[{"type":"text","text":"mine"}]',1784282401);
-insert into messages values (2,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
-insert into messages values (3,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
-insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
+insert into messages values (2,'s_acp','user','[{"type":"text","text":"acp sessions"}]',1784282401);
+insert into messages values (3,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
+insert into messages values (4,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
+insert into messages values (5,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
 	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("create db: %v: %s", err, out)
 	}
@@ -181,7 +185,7 @@ insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]
 	for _, s := range ss {
 		got[s.ID] = true
 	}
-	if !got["s_user"] || !got["s_old"] {
+	if !got["s_user"] || !got["s_old"] || !got["s_acp"] {
 		t.Fatalf("dropped sessions that belong in recall: %v", got)
 	}
 	if got["s_sub"] || got["s_cron"] {

--- a/internal/sources/goose_test.go
+++ b/internal/sources/goose_test.go
@@ -166,14 +166,18 @@ func TestParseGooseDBSkipsNonUserSessions(t *testing.T) {
 create table messages (id integer primary key autoincrement, session_id text, role text, content_json text, created_timestamp integer);
 insert into sessions values ('s_user','n','mine','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','user');
 insert into sessions values ('s_acp','n','acp','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','acp');
+insert into sessions values ('s_term','n','terminal','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','terminal');
+insert into sessions values ('s_gw','n','gateway','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','gateway');
 insert into sessions values ('s_sub','n','subagent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','subagent');
 insert into sessions values ('s_cron','n','cron','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','scheduled');
 insert into sessions values ('s_old','n','legacy','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z',null);
 insert into messages values (1,'s_user','user','[{"type":"text","text":"mine"}]',1784282401);
 insert into messages values (2,'s_acp','user','[{"type":"text","text":"acp sessions"}]',1784282401);
-insert into messages values (3,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
-insert into messages values (4,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
-insert into messages values (5,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
+insert into messages values (3,'s_term','user','[{"type":"text","text":"terminal session"}]',1784282401);
+insert into messages values (4,'s_gw','user','[{"type":"text","text":"gateway noise"}]',1784282401);
+insert into messages values (5,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
+insert into messages values (6,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
+insert into messages values (7,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
 	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("create db: %v: %s", err, out)
 	}
@@ -185,10 +189,10 @@ insert into messages values (5,'s_old','user','[{"type":"text","text":"legacy"}]
 	for _, s := range ss {
 		got[s.ID] = true
 	}
-	if !got["s_user"] || !got["s_old"] || !got["s_acp"] {
+	if !got["s_user"] || !got["s_old"] || !got["s_acp"] || !got["s_term"] {
 		t.Fatalf("dropped sessions that belong in recall: %v", got)
 	}
-	if got["s_sub"] || got["s_cron"] {
-		t.Fatalf("subagent or scheduled runs leaked into recall: %v", got)
+	if got["s_sub"] || got["s_cron"] || got["s_gw"] {
+		t.Fatalf("subagent, scheduled or gateway runs leaked into recall: %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2873. The Goose parser silently excluded Goose ACP and terminal sessions because `gooseTypeFilter()` in `internal/sources/goose.go` only allow-listed `session_type = 'user'` (plus `NULL`/empty-string for legacy stores). Goose stores ACP sessions with `session_type = 'acp'` and terminal-mode sessions with `session_type = 'terminal'`, so those conversations never reached the `deja-vu` index and were invisible to search and recall.

The filter now accepts `session_type in ('user','acp','terminal')`. These are first-class, user-visible Goose session types (Desktop, plain CLI, ACP, and terminal-mode UI). Gateway, hidden, sub_agent, and scheduled sessions remain excluded, and the `pragma table_info` probe that keeps older stores working is unchanged.

## Test plan

- Extended `TestParseGooseDBSkipsNonUserSessions` to seed `acp`- and `terminal`-type sessions (each with a user message) and assert both are included, while gateway, sub_agent, and scheduled remain excluded and legacy `NULL` rows stay included.
- `go test ./internal/sources/ -race -count=1 -run Goose` passes.
- `go test ./internal/sources/ -coverprofile=cov.out && go tool cover -func=cov.out` → `internal/sources` total **89.1%**, above the 87.5 CI floor. `gooseTypeFilter` at 100%.
- `go vet ./internal/sources/` clean; changed files pass `gofmt -s`.

> Note: two unrelated tests in `internal/sources` (`TestAiderClaudeAntigravityAndUtilityEdges`, `TestTheNotesFileIsParsedOncePerProcess`) fail identically on base `main` in this environment — pre-existing, not caused by this change (confirmed by running them on commit `39d4b38`).

## Notes

- Scope decided in the issue thread: user, acp, and terminal are user-visible and included; gateway, hidden, sub_agent, and scheduled stay excluded per the documented product decision.
- No breaking changes. Existing `user`, legacy `NULL`, and empty-string sessions behave exactly as before.
- Closes #2873.
