### PR TITLE
fix(goose): index every way a person reaches goose

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -77,7 +77,14 @@ import (
 // re-derives them — `deja friction` reads the records and sees the difference,
 // while `hook-tool-after` and the environment block read the manifest and stay
 // silent, which is the state this bump exists to end (#2444).
-const version = 31
+// 32: goose sessions are kept unless goose says it wrote them for itself. The
+// filter was an allow-list of `session_type = 'user'`, so the ways people
+// actually reach goose — an editor over ACP, the CLI, a chat gateway, a run
+// that kept no session — were dropped. A store built under the old rules is
+// missing those sessions, and the db path only re-reads what has been touched
+// since its watermark, so without the bump they stay missing until each is
+// used again — the same shape as 21, 22 and 23 (#2873).
+const version = 32
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -165,9 +165,16 @@ func gooseTypeFilter(db string) string {
 }
 
 // gooseMachineTypes are the session types goose writes for its own work rather
-// than the reader's: a subagent it spawned (spelled both ways across versions),
-// a recipe it ran on a schedule, and the sessions it hides from its own list.
-var gooseMachineTypes = []string{"subagent", "sub_agent", "scheduled", "recipe", "hidden"}
+// than the reader's: a subagent it spawned (spelled both ways across versions)
+// and a run its scheduler started.
+//
+// Read off goose's own enum rather than guessed — user, scheduled, sub_agent,
+// hidden, terminal, gateway, acp. `hidden` is not on this list although the
+// name suggests it: goose writes it for `goose run --no-session`, which is the
+// reader working without keeping a session, and for two wizards that store no
+// conversation at all and fall out of the role join anyway. `gateway` is a
+// person reaching goose from a chat app. Both are history someone made.
+var gooseMachineTypes = []string{"subagent", "sub_agent", "scheduled"}
 
 func ParseGooseDB(db string) ([]model.Session, error) {
 	return parseGooseDBWhere(db, "", 0)

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -144,13 +144,30 @@ func gooseText(v any) string {
 // Goose stores them in the same table as the user's own sessions. The column
 // exists only on newer stores, and naming it on an older one fails the whole
 // query, so it is probed rather than assumed.
+//
+// What goose calls its own work is what deja excludes, rather than what it
+// calls the reader's. Written the other way round — everything but `user`
+// dropped — someone whose work reached goose through an editor (`acp`) or the
+// CLI (`terminal`) found none of it in recall, and nothing said why: the store
+// held the sessions and deja had thrown them away for carrying a type it was
+// never told about (#2873). A type goose adds next is a person's work until it
+// is known not to be.
 func gooseTypeFilter(db string) string {
 	out, err := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000", "pragma table_info(sessions)").Output()
 	if err != nil || !bytes.Contains(out, []byte("session_type")) {
 		return ""
 	}
-	return " and (s.session_type is null or s.session_type = '' or s.session_type = 'user')"
+	quoted := make([]string, 0, len(gooseMachineTypes))
+	for _, t := range gooseMachineTypes {
+		quoted = append(quoted, "'"+t+"'")
+	}
+	return " and (s.session_type is null or s.session_type not in (" + strings.Join(quoted, ",") + "))"
 }
+
+// gooseMachineTypes are the session types goose writes for its own work rather
+// than the reader's: a subagent it spawned (spelled both ways across versions),
+// a recipe it ran on a schedule, and the sessions it hides from its own list.
+var gooseMachineTypes = []string{"subagent", "sub_agent", "scheduled", "recipe", "hidden"}
 
 func ParseGooseDB(db string) ([]model.Session, error) {
 	return parseGooseDBWhere(db, "", 0)

--- a/internal/sources/goose_test.go
+++ b/internal/sources/goose_test.go
@@ -171,6 +171,8 @@ insert into sessions values ('s_acp','n','acp','/w','2026-07-24T11:00:00Z','2026
 insert into sessions values ('s_term','n','terminal','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','terminal');
 insert into sessions values ('s_sub2','n','sub_agent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','sub_agent');
 insert into sessions values ('s_hidden','n','hidden','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','hidden');
+insert into sessions values ('s_empty','n','empty','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','');
+insert into sessions values ('s_gateway','n','gateway','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','gateway');
 insert into messages values (1,'s_user','user','[{"type":"text","text":"mine"}]',1784282401);
 insert into messages values (2,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
 insert into messages values (3,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
@@ -178,7 +180,9 @@ insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]
 insert into messages values (5,'s_acp','user','[{"type":"text","text":"through the editor"}]',1784282401);
 insert into messages values (6,'s_term','user','[{"type":"text","text":"through the terminal"}]',1784282401);
 insert into messages values (7,'s_sub2','user','[{"type":"text","text":"subagent noise"}]',1784282401);
-insert into messages values (8,'s_hidden','user','[{"type":"text","text":"hidden noise"}]',1784282401);`
+insert into messages values (8,'s_hidden','user','[{"type":"text","text":"a run kept no session"}]',1784282401);
+insert into messages values (9,'s_empty','user','[{"type":"text","text":"no type at all"}]',1784282401);
+insert into messages values (10,'s_gateway','user','[{"type":"text","text":"through a chat app"}]',1784282401);`
 	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("create db: %v: %s", err, out)
 	}
@@ -195,12 +199,15 @@ insert into messages values (8,'s_hidden','user','[{"type":"text","text":"hidden
 	// Named the other way round — an allow-list of "user" — a type goose added
 	// later was dropped, and a reader's ACP sessions were missing from recall
 	// with nothing saying why (#2873).
-	for _, id := range []string{"s_user", "s_old", "s_acp", "s_term"} {
+	// The empty string and a type this build has never heard of are in the
+	// keep list on purpose: what the filter must never do again is drop work
+	// for carrying a name it was not told about.
+	for _, id := range []string{"s_user", "s_old", "s_acp", "s_term", "s_empty", "s_gateway", "s_hidden"} {
 		if !got[id] {
 			t.Errorf("%s belongs in recall and is not there: %v", id, got)
 		}
 	}
-	for _, id := range []string{"s_sub", "s_sub2", "s_cron", "s_hidden"} {
+	for _, id := range []string{"s_sub", "s_sub2", "s_cron"} {
 		if got[id] {
 			t.Errorf("%s is goose talking to itself and leaked into recall: %v", id, got)
 		}

--- a/internal/sources/goose_test.go
+++ b/internal/sources/goose_test.go
@@ -154,7 +154,8 @@ func TestGooseDataDirFollowsPathRoot(t *testing.T) {
 
 // Goose stores subagent turns and cron-recipe runs in the same table as real
 // sessions. Recall is about the user's own work, so those stay out; rows from
-// before the column existed have no type and stay in.
+// before the column existed have no type and stay in, and so does every way a
+// person reaches goose (#2873).
 func TestParseGooseDBSkipsNonUserSessions(t *testing.T) {
 	if _, err := exec.LookPath("sqlite3"); err != nil {
 		t.Skip("sqlite3 not installed")
@@ -166,10 +167,18 @@ insert into sessions values ('s_user','n','mine','/w','2026-07-24T11:00:00Z','20
 insert into sessions values ('s_sub','n','subagent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','subagent');
 insert into sessions values ('s_cron','n','cron','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','scheduled');
 insert into sessions values ('s_old','n','legacy','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z',null);
+insert into sessions values ('s_acp','n','acp','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','acp');
+insert into sessions values ('s_term','n','terminal','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','terminal');
+insert into sessions values ('s_sub2','n','sub_agent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','sub_agent');
+insert into sessions values ('s_hidden','n','hidden','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','hidden');
 insert into messages values (1,'s_user','user','[{"type":"text","text":"mine"}]',1784282401);
 insert into messages values (2,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
 insert into messages values (3,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
-insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
+insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);
+insert into messages values (5,'s_acp','user','[{"type":"text","text":"through the editor"}]',1784282401);
+insert into messages values (6,'s_term','user','[{"type":"text","text":"through the terminal"}]',1784282401);
+insert into messages values (7,'s_sub2','user','[{"type":"text","text":"subagent noise"}]',1784282401);
+insert into messages values (8,'s_hidden','user','[{"type":"text","text":"hidden noise"}]',1784282401);`
 	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("create db: %v: %s", err, out)
 	}
@@ -181,10 +190,19 @@ insert into messages values (4,'s_old','user','[{"type":"text","text":"legacy"}]
 	for _, s := range ss {
 		got[s.ID] = true
 	}
-	if !got["s_user"] || !got["s_old"] {
-		t.Fatalf("dropped sessions that belong in recall: %v", got)
+	// Everything a person did, whichever way they reached goose: the CLI, the
+	// desktop app, and an editor speaking ACP are all the reader's own work.
+	// Named the other way round — an allow-list of "user" — a type goose added
+	// later was dropped, and a reader's ACP sessions were missing from recall
+	// with nothing saying why (#2873).
+	for _, id := range []string{"s_user", "s_old", "s_acp", "s_term"} {
+		if !got[id] {
+			t.Errorf("%s belongs in recall and is not there: %v", id, got)
+		}
 	}
-	if got["s_sub"] || got["s_cron"] {
-		t.Fatalf("subagent or scheduled runs leaked into recall: %v", got)
+	for _, id := range []string{"s_sub", "s_sub2", "s_cron", "s_hidden"} {
+		if got[id] {
+			t.Errorf("%s is goose talking to itself and leaked into recall: %v", id, got)
+		}
 	}
 }


### PR DESCRIPTION
Closes #2873, reported with a full reproduction against a real store.

The goose filter was an allow-list of `session_type = 'user'`, written to keep subagent turns and scheduled runs out. Goose has since grown types for the ways people actually reach it, and every one of them was dropped silently: the reporter's store holds 96 ACP sessions with 1256 messages and 155 terminal sessions, none of them in recall.

It names what goose writes for itself instead — a subagent it spawned (both spellings) and a run its scheduler started. The list is read off goose's own enum (`session_manager.rs`: user, scheduled, sub_agent, hidden, terminal, gateway, acp) rather than guessed, which also settled two calls I had got wrong: `hidden` is `goose run --no-session`, a person working without keeping a session, and `gateway` is a person reaching goose from a chat app. Both stay. A type goose adds next is a person's work until it is known not to be.

The index version goes to 32: the db path re-reads only what has been touched since its watermark, so without the bump an upgraded store would keep missing those sessions until each was used again.

Thank you for the report — the session-type table with the counts is what made the cause obvious, and the enum check came out of it.