### PR TITLE
perf: a growing goose session appends, keeping the project its header names

### DIFF
--- a/internal/index/goose_append_test.go
+++ b/internal/index/goose_append_test.go
@@ -1,0 +1,132 @@
+package index
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+func gooseHeaderLine() string {
+	b, _ := json.Marshal(map[string]any{
+		"id": "g1", "description": "the ingest watermark work",
+		"working_dir": "/work/app",
+		"created_at":  "2026-08-30T09:00:00Z", "updated_at": "2026-08-30T09:00:00Z",
+	})
+	return string(b)
+}
+
+func gooseTurn(i int, text string) string {
+	role := "user"
+	if i%2 == 1 {
+		role = "assistant"
+	}
+	b, _ := json.Marshal(map[string]any{"role": role, "content": text, "created": "2026-08-30T09:00:00Z"})
+	return string(b)
+}
+
+// goose's JSONL sessions declare an offset parser the append gate never
+// reached, so every pass re-read them whole (#2870). Adding them needs one
+// thing first: goose writes the session's project in a header line, and an
+// offset parse starts past it — measured before this, appending a turn moved
+// the session from project "app" to the literal "goose".
+func TestAGrowingGooseSessionKeepsItsProject(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	for k, v := range map[string]string{
+		"DEJA_CLAUDE_ROOT": "none-claude", "DEJA_CODEX_ROOT": "none-codex",
+		"DEJA_GOOSE_DB": "none-goose.db", "DEJA_OPENCODE_DB": "none-opencode.db",
+		"DEJA_GROK_DB": "none-grok.db", "DEJA_HERMES_HOME": "none-hermes",
+		"DEJA_ZED_DB": "none-zed.db", "DEJA_QWEN_ROOT": "none-qwen",
+		"DEJA_NOTES_FILE": "notes.jsonl",
+	} {
+		t.Setenv(k, filepath.Join(tmp, v))
+	}
+	root := filepath.Join(tmp, "goose")
+	t.Setenv("DEJA_GOOSE_ROOT", root)
+	if err := os.MkdirAll(filepath.Join(root, "sessions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(root, "sessions", "g1.jsonl")
+	write := func(lines []string) {
+		t.Helper()
+		if err := os.WriteFile(file, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seed := []string{gooseHeaderLine()}
+	for i := 0; i < 6; i++ {
+		seed = append(seed, gooseTurn(i, fmt.Sprintf("seed %d zonkomatic", i)))
+	}
+	write(seed)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	found := func(term string) []string {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: term, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var projects []string
+		for _, s := range got {
+			projects = append(projects, s.Project)
+		}
+		return projects
+	}
+	hits := func(term string) int {
+		t.Helper()
+		got, err := Search(dir, search.Options{Query: term, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		for _, s := range got {
+			for _, m := range s.Messages {
+				if strings.Contains(m.Text, term) {
+					n++
+				}
+			}
+		}
+		return n
+	}
+	if p := found("zonkomatic"); len(p) != 1 || p[0] != "app" {
+		t.Fatalf("the fixture did not index under its working_dir: %v", p)
+	}
+
+	write(append(append([]string{}, seed...), gooseTurn(6, "appended vantorquell")))
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if p := found("zonkomatic"); len(p) != 1 || p[0] != "app" {
+		t.Errorf("appending a turn moved the session's project: %v", p)
+	}
+	if n := hits("appended vantorquell"); n != 1 {
+		t.Errorf("the appended turn is not indexed: %d", n)
+	}
+	if n := hits("seed 0 "); n != 1 {
+		t.Errorf("an earlier turn is held %d times", n)
+	}
+
+	// The rewind the prefix comparison exists for.
+	rewritten := []string{gooseHeaderLine()}
+	for i := 0; i < 9; i++ {
+		rewritten = append(rewritten, gooseTurn(i, fmt.Sprintf("rewritten %d zonkomatic", i)))
+	}
+	write(rewritten)
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if n := hits("seed 0 "); n != 0 {
+		t.Errorf("text from before the rewrite survived: %d", n)
+	}
+	if n := hits("rewritten 8 "); n != 1 {
+		t.Errorf("the rewritten tail is not indexed: %d", n)
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2876,7 +2876,7 @@ func canAppendIncremental(changed map[string]FileState, old map[string]FileState
 			}
 		}
 		switch harnessForPath(p) {
-		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot", "grok", "qwen":
+		case "claude", "codex", "codex-history", "opencode", "cursor-db", "goose-db", "deja", "pi", "copilot", "grok", "qwen", "goose-jsonl":
 		default:
 			return false
 		}

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -89,20 +90,20 @@ func parseGooseFileFromOffset(path string, offset int64) ([]model.Session, error
 		ID:      strings.TrimSuffix(filepath.Base(path), ".jsonl"),
 		Path:    path,
 	}
+	// The first line is the session's header — id, description, working_dir —
+	// and an offset parse starts past it, so a resumed read fell back to the
+	// filename and to the project literal "goose". Read it whatever the
+	// offset: it is one line, and without it appending a turn renamed the
+	// session's project (#2870).
+	if offset > 0 {
+		if head, herr := firstJSONLObject(path); herr == nil {
+			applyGooseHeader(&s, head)
+		}
+	}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		role, hasRole := m["role"].(string)
 		if !hasRole {
-			if id, _ := m["id"].(string); id != "" {
-				s.ID = id
-			}
-			if desc, _ := m["description"].(string); strings.TrimSpace(desc) != "" {
-				s.Title = strings.TrimSpace(desc)
-			}
-			if wd, _ := m["working_dir"].(string); wd != "" {
-				s.Project = projectName(wd)
-			}
-			s.Touch(parseTimeAny(m["created_at"]))
-			s.Touch(parseTimeAny(m["updated_at"]))
+			applyGooseHeader(&s, m)
 			return
 		}
 		if role != "user" && role != "assistant" {
@@ -125,6 +126,43 @@ func parseGooseFileFromOffset(path string, offset int64) ([]model.Session, error
 		return nil, err
 	}
 	return []model.Session{s}, err
+}
+
+// firstJSONLObject decodes the first line of a .jsonl file, which is where a
+// store that writes a header puts it.
+func firstJSONLObject(path string) (map[string]any, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	// The same reader size the offset scanner uses, so a long header line is
+	// read here exactly where it would be read there.
+	line, err := bufio.NewReaderSize(f, 1024*1024).ReadBytes('\n')
+	if err != nil && len(line) == 0 {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(line, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// applyGooseHeader reads the session's own line: the header goose writes first,
+// carrying the id, the description and the directory the work happened in.
+func applyGooseHeader(s *model.Session, m map[string]any) {
+	if id, _ := m["id"].(string); id != "" {
+		s.ID = id
+	}
+	if desc, _ := m["description"].(string); strings.TrimSpace(desc) != "" {
+		s.Title = strings.TrimSpace(desc)
+	}
+	if wd, _ := m["working_dir"].(string); wd != "" {
+		s.Project = projectName(wd)
+	}
+	s.Touch(parseTimeAny(m["created_at"]))
+	s.Touch(parseTimeAny(m["updated_at"]))
 }
 
 func gooseText(v any) string {


### PR DESCRIPTION
Second of the six from #2870, after qwen in #2876 — and this one could not be a one-line change, which is the useful part.

Measured on a stand, best of three, one turn appended between passes:

    1.8 MB session   218 ms -> 54 ms
    5.3 MB session   549 ms -> 116 ms

**The gate was right to exclude it.** goose writes the session's own line first — id, description, `working_dir` — and an offset parse starts past it, so a resumed read fell back to the filename and to the project literal `"goose"`. Measured on the stand before any fix:

    first index    project='app'
    after append   project='goose'

A session that grows quietly changes project, which moves it out of every project-scoped answer: the session-start block, `deja how --project`, the pre-action hook. So this PR reads the header line whatever the offset — one line, and the same reader size the offset scanner uses — and only then joins goose to the append list.

The header reading is now one function used by both paths rather than two copies that could drift, which is what the mutation on it shows: removing it turns the test red at the project assertion, not at the message count.

Three mutations, and the split is the honest one: dropping the header read or the prefix comparison turns the test red; taking goose-jsonl back off the append list leaves it green, because that half is a perf change and the behaviour is identical either way.

Four kinds left on #2870 — kimi, omp, openclaw, prime — each needing the same treatment: a fixture that proves what a resumed parse loses, before it is trusted to resume.
