### PR TITLE
fix(recall): let a repository root find the work done inside it

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -814,6 +814,25 @@ func hookDigestResult(dir string) (string, int, int64, []string, int, []string, 
 // project the call is about, rather than one reading it back out of the
 // environment, where a project deja itself had written stayed for every later
 // call in the process (#2182, #2185).
+
+// withProjectsOf adds the projects of sessions already chosen to a name list,
+// without disturbing its order: the names the caller guessed come first, and
+// what the store answered with follows.
+func withProjectsOf(names []string, ss []model.Session) []string {
+	have := make(map[string]bool, len(names))
+	for _, n := range names {
+		have[strings.ToLower(n)] = true
+	}
+	out := names
+	for _, s := range ss {
+		if p := strings.ToLower(s.Project); p != "" && !have[p] {
+			have[p] = true
+			out = append(out, s.Project)
+		}
+	}
+	return out
+}
+
 func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string, int, []string, []string) {
 	withheld := 0
 	defer func() { _ = recover() }()
@@ -889,7 +908,10 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	if len(taskFiles) > 0 {
 		perName = 12
 	}
-	if got, err := index.RecentProjects(dir, lookupNames, perName); err == nil {
+	// The cwd as well as the names it can guess: a session started in a
+	// subdirectory keeps that directory's name, and no list of names reaches
+	// down to it (#2040).
+	if got, err := index.RecentProjectsUnder(dir, lookupNames, cwd, perName); err == nil {
 		for _, s := range got {
 			if !pol.Allows(policy.ActivationAuto, s.Project) {
 				withheld++
@@ -939,7 +961,13 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	// corrects unmarked (#761).
 	ss, rejectedWarning := orderForInjection(ss)
 	ss = leadWithUnseen(dir, names, ss)
-	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: mode, ProjectNames: names, TaskScores: scores})
+	// A session found by where its work happened carries the name of the
+	// directory it was started in, which is not one the cwd can guess — the
+	// safe-mode filter is a name list, so the evidence that admitted the
+	// session admits its name with it (#2040). The trust policy has already
+	// had its say on each of these, one session at a time, above.
+	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{
+		Mode: mode, ProjectNames: withProjectsOf(names, ss), TaskScores: scores})
 	mark("build-digest")
 	if result.Sessions == 0 {
 		matched = nil

--- a/cmd/deja/hook_subdirectory_test.go
+++ b/cmd/deja/hook_subdirectory_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A session started in a subdirectory of a repository belongs to that
+// repository: #2039 taught the subdirectory to find the repo, and standing at
+// the root still found nothing of what happened inside it — the name is
+// guessed from the cwd, and guessing downward is what no list of names can do
+// (#2040). What the session touched says where the work was, and those paths
+// are already in the index.
+func TestTheRepositoryRootRecallsWorkFromItsSubdirectories(t *testing.T) {
+	tmp := hermeticEnv(t)
+	repo := filepath.Join(tmp, "src", "app")
+	sub := filepath.Join(repo, "cmd", "deja")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A short session, started in the subdirectory, that touched a file under
+	// the repository — too little for projectFromPaths to re-project it, which
+	// is the case the issue measured.
+	at := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), encodedProjectDir(sub))
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"user","sessionId":"insub","timestamp":"` + at + `","cwd":` + mustJSON(t, sub) +
+			`,"message":{"role":"user","content":"the connection pool keeps running dry under load"}}`,
+		`{"type":"assistant","sessionId":"insub","timestamp":"` + at + `","cwd":` + mustJSON(t, sub) +
+			`,"message":{"role":"assistant","content":"we raised the pool size to 32 and it held"}}`,
+		`{"type":"assistant","sessionId":"insub","timestamp":"` + at + `","cwd":` + mustJSON(t, sub) +
+			`,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"t1","input":{"file_path":` +
+			mustJSON(t, filepath.Join(sub, "pool.go")) + `,"old_string":"16","new_string":"32"}}]}}`,
+	}
+	if err := os.WriteFile(filepath.Join(store, "insub.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Standing in the subdirectory: the session is its own project and the
+	// hook finds it. This is the half #2039 fixed, and it has to keep working.
+	if out := hookDigestAt(t, sub); !strings.Contains(out, "pool") {
+		t.Fatalf("the subdirectory does not recall its own session:\n%s", out)
+	}
+	// Standing at the repository root.
+	if out := hookDigestAt(t, repo); !strings.Contains(out, "pool") {
+		t.Errorf("the repository root recalls nothing that happened inside it:\n%s", out)
+	}
+}
+
+func hookDigestAt(t *testing.T, cwd string) string {
+	t.Helper()
+	t.Setenv("CLAUDE_PROJECT_DIR", cwd)
+	withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "s", "cwd": cwd}))
+	return captureStdout(t, func() { runHookContextPlain(t) })
+}

--- a/cmd/deja/hook_subdirectory_test.go
+++ b/cmd/deja/hook_subdirectory_test.go
@@ -67,3 +67,42 @@ func hookDigestAt(t *testing.T, cwd string) string {
 	withHookStdin(t, hookPayload(t, map[string]string{"source": "startup", "session_id": "s", "cwd": cwd}))
 	return captureStdout(t, func() { runHookContextPlain(t) })
 }
+
+// And only inside a checkout. Measured on a real store, standing in a home
+// directory admitted 697 of 768 sessions with touched files — every project on
+// the machine, under a line that says the sessions are from this project
+// (#2040, and #2343 for what that line promises).
+func TestAnUmbrellaDirectoryDoesNotRecallEverythingUnderIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	// No .git anywhere above: an ordinary directory holding two projects.
+	work := filepath.Join(tmp, "work")
+	other := filepath.Join(work, "someone-elses-project")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), encodedProjectDir(other))
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := []string{
+		`{"type":"user","sessionId":"theirs","timestamp":"` + at + `","cwd":` + mustJSON(t, other) +
+			`,"message":{"role":"user","content":"the frobnicator keeps dropping its widgets"}}`,
+		`{"type":"assistant","sessionId":"theirs","timestamp":"` + at + `","cwd":` + mustJSON(t, other) +
+			`,"message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"t1","input":{"file_path":` +
+			mustJSON(t, filepath.Join(other, "frob.go")) + `,"old_string":"a","new_string":"b"}}]}}`,
+	}
+	if err := os.WriteFile(filepath.Join(store, "theirs.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if out := hookDigestAt(t, work); strings.Contains(out, "frobnicator") {
+		t.Errorf("a directory that is not a checkout recalled what is under it:\n%s", out)
+	}
+	// The project itself still recalls its own work.
+	if out := hookDigestAt(t, other); !strings.Contains(out, "frobnicator") {
+		t.Errorf("the project stopped recalling its own session:\n%s", out)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1759,6 +1759,20 @@ func sessionsForMetas(dir string, metas []SessionMeta) ([]model.Session, error) 
 // RecentProjects is RecentProject for several project names at once: one
 // manifest read and one records pass instead of names × sessions scans.
 func RecentProjects(dir string, projects []string, perName int) ([]model.Session, error) {
+	return RecentProjectsUnder(dir, projects, "", perName)
+}
+
+// RecentProjectsUnder is RecentProjects plus the sessions whose work happened
+// inside root, whatever they are called.
+//
+// A project is a name derived from where a session was started, and a caller
+// can guess the names above it — a subdirectory finds its repository (#2039).
+// Downward it cannot: there is no list of the names a repository's
+// subdirectories might have produced, so standing at the root found nothing of
+// what happened inside it (#2040). The files a session touched are already in
+// the manifest and say where the work was, so the root asks that instead of
+// guessing.
+func RecentProjectsUnder(dir string, projects []string, root string, perName int) ([]model.Session, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -1799,7 +1813,48 @@ func RecentProjects(dir string, projects []string, perName int) ([]model.Session
 			}
 		}
 	}
+	// And what happened under the caller's own directory, however it was
+	// named. Ranked among themselves by recency and held to the same per-name
+	// cap, so a repository with many subdirectories cannot crowd out the
+	// sessions recorded against it directly.
+	if under := metasWorkingUnder(m, root, seen); len(under) > 0 {
+		sort.Slice(under, func(i, j int) bool { return newestFirstMeta(under[i], under[j]) })
+		if perName > 0 && len(under) > perName {
+			under = under[:perName]
+		}
+		metas = append(metas, under...)
+	}
 	return sessionsForMetas(dir, metas)
+}
+
+// metasWorkingUnder is the sessions whose touched files sit under root and
+// which no name has already claimed. Nothing when root is empty, so a caller
+// that does not know where it stands is unaffected.
+func metasWorkingUnder(m Manifest, root string, seen map[string]bool) []SessionMeta {
+	if strings.TrimSpace(root) == "" {
+		return nil
+	}
+	prefix := strings.ToLower(filepath.ToSlash(filepath.Clean(root)))
+	if prefix == "" || prefix == "/" || prefix == "." {
+		// Every path is under "/" and none is meaningfully under it.
+		return nil
+	}
+	prefix += "/"
+	var out []SessionMeta
+	for _, meta := range m.Sessions {
+		k := meta.Harness + ":" + meta.ID
+		if seen[k] {
+			continue
+		}
+		for _, p := range meta.Touched {
+			if strings.HasPrefix(strings.ToLower(filepath.ToSlash(p)), prefix) {
+				seen[k] = true
+				out = append(out, meta)
+				break
+			}
+		}
+	}
+	return metasNotIgnored(out)
 }
 
 func FindByPrefix(dir, p string) (model.Session, bool, error) {

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
 func Search(dir string, o query.Options) ([]model.Session, error) {
@@ -1813,10 +1814,11 @@ func RecentProjectsUnder(dir string, projects []string, root string, perName int
 			}
 		}
 	}
-	// And what happened under the caller's own directory, however it was
-	// named. Ranked among themselves by recency and held to the same per-name
-	// cap, so a repository with many subdirectories cannot crowd out the
-	// sessions recorded against it directly.
+	// And what happened under the caller's own checkout, however it was named.
+	// Ranked among themselves by recency and cut to the same per-name cap, so
+	// a repository with many subdirectories contributes as much as any one
+	// name does; from there they compete with the rest on the caller's own
+	// score and recency rule.
 	if under := metasWorkingUnder(m, root, seen); len(under) > 0 {
 		sort.Slice(under, func(i, j int) bool { return newestFirstMeta(under[i], under[j]) })
 		if perName > 0 && len(under) > perName {
@@ -1830,13 +1832,26 @@ func RecentProjectsUnder(dir string, projects []string, root string, perName int
 // metasWorkingUnder is the sessions whose touched files sit under root and
 // which no name has already claimed. Nothing when root is empty, so a caller
 // that does not know where it stands is unaffected.
+//
+// A repository, not any directory: measured on a real store, standing in a
+// home directory admitted 697 of 768 sessions with touched files — every
+// project on the machine, injected under a line that says "from this project's
+// recent history" (#2343's shape). The checkout is the boundary a person means
+// by "this project", so anything that is not one answers with nothing.
 func metasWorkingUnder(m Manifest, root string, seen map[string]bool) []SessionMeta {
-	if strings.TrimSpace(root) == "" {
+	root = strings.TrimSpace(root)
+	if root == "" {
 		return nil
 	}
-	prefix := strings.ToLower(filepath.ToSlash(filepath.Clean(root)))
+	repo := sources.RepoRoot(root)
+	if repo == "" || sameDir(repo, homeDir()) {
+		// A checkout at the home directory — a dotfiles repo — is a repository
+		// whose "work" is the whole machine. Everything under it keeps its own
+		// name, as before.
+		return nil
+	}
+	prefix := filepath.ToSlash(filepath.Clean(root))
 	if prefix == "" || prefix == "/" || prefix == "." {
-		// Every path is under "/" and none is meaningfully under it.
 		return nil
 	}
 	prefix += "/"
@@ -1847,14 +1862,41 @@ func metasWorkingUnder(m Manifest, root string, seen map[string]bool) []SessionM
 			continue
 		}
 		for _, p := range meta.Touched {
-			if strings.HasPrefix(strings.ToLower(filepath.ToSlash(p)), prefix) {
-				seen[k] = true
-				out = append(out, meta)
-				break
+			if !underDir(p, prefix) {
+				continue
 			}
+			seen[k] = true
+			out = append(out, meta)
+			break
 		}
 	}
 	return metasNotIgnored(out)
+}
+
+// underDir reports whether p sits under a slash-terminated directory prefix,
+// without lowering either side into a new string: this runs over every touched
+// path of every session in the manifest, on the session-start hook, and the
+// lowering alone was 12 MB of garbage on a large store.
+func underDir(p, prefix string) bool {
+	p = filepath.ToSlash(p)
+	if len(p) <= len(prefix) {
+		return false
+	}
+	return strings.EqualFold(p[:len(prefix)], prefix)
+}
+
+// sameDir compares two directories the way the filesystem would for this
+// purpose: case-insensitively, since the callers are a cwd and a home.
+func sameDir(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}
+
+func homeDir() string {
+	h, _ := os.UserHomeDir()
+	return h
 }
 
 func FindByPrefix(dir, p string) (model.Session, bool, error) {

--- a/internal/sources/project_paths.go
+++ b/internal/sources/project_paths.go
@@ -87,6 +87,12 @@ func agentScratch(p string) bool {
 
 var repoRootCache sync.Map
 
+// RepoRoot is the checkout dir sits in, or "" when it is not in one. Exported
+// for the index, which needs to know whether a caller's directory is a
+// repository before treating everything under it as one project's work
+// (#2040).
+func RepoRoot(dir string) string { return repoRoot(dir) }
+
 // repoRoot walks up until it finds a .git, which is what makes a directory a
 // project rather than a folder. Cached because one session touches the same few
 // directories hundreds of times.


### PR DESCRIPTION
Closes #2040, the half #2039 left. A project is a name derived from where a session was started, and the hook guesses the names it can reach from the cwd — upward, which is cheap. Downward there is nothing to guess with: a session started in `<repo>/cmd/deja` keeps that name, and standing at the repository root found none of it.

The files a session touched are already in the manifest and say where the work actually was, so the root asks that instead of guessing names. A session admitted that way carries its own project name into the safe-mode filter — the filter is a name list, and the evidence that admitted the session admits its name with it. The trust policy still has its say per session, before any of this.

What it deliberately does not do is option 2 from the issue: re-projecting every short session onto its repository root would take `cmd/deja` away as a project of its own, which is a real loss in a monorepo where the subdirectories are the projects.