### PR TITLE
fix(search): bound the freshness decay

### DIFF
--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -66,7 +66,10 @@ of these commands is run:
 
 - `deja update` connects to GitHub over HTTPS to read release metadata and
   download the selected archive and `checksums.txt`. It verifies the archive's
-  SHA-256 checksum before replacing the binary.
+  SHA-256 checksum before replacing the binary. It does not check the cosign
+  signature over `checksums.txt`, so the check catches a corrupt download but
+  not a tampered release; verify the signature yourself (below) if you need
+  that guarantee.
 - `deja sync ssh <host>` runs the system `ssh` and `scp` clients against the
   host supplied by the user. The remote peer receives redacted JSONL sync
   batches and imports them into its own index. `--pull` reverses that flow.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -752,6 +752,16 @@ func isLocalProject(project string) bool {
 	return !strings.HasPrefix(project, "imported:")
 }
 
+// freshnessFloor bounds how much a session's age can cost it. The decay used
+// to be 1/(1+age), which keeps 3% of a score after a month and 0.3% after a
+// year; BM25 does not span three orders of magnitude, so the exact tier
+// ordered by date and let topicality break the ties, the opposite of what it
+// says it does (#1269). At a floor of 0.5 age can halve a score, not erase it:
+// recency still leads between answers that say the same thing, and a session
+// that answers the question outranks a newer one that only mentions it.
+const freshnessFloor = 0.5
+
+// freshnessDecay weighs a session's age between freshnessFloor and 1.
 func freshnessDecay(updated, now time.Time) float64 {
 	if updated.IsZero() {
 		return 0
@@ -760,7 +770,7 @@ func freshnessDecay(updated, now time.Time) float64 {
 	if age <= 0 {
 		return 1
 	}
-	return 1 / (1 + age)
+	return freshnessFloor + (1-freshnessFloor)/(1+age)
 }
 
 // windowScanLimit bounds how many places of one token are enumerated when

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strings"
@@ -96,8 +97,11 @@ func TestBM25HelperSignals(t *testing.T) {
 	if got := freshnessDecay(now.Add(time.Hour), now); got != 1 {
 		t.Fatalf("future decay=%v", got)
 	}
-	if got := freshnessDecay(now.Add(-24*time.Hour), now); got != 0.5 {
+	if got := freshnessDecay(now.Add(-24*time.Hour), now); math.Abs(got-0.75) > 1e-9 {
 		t.Fatalf("one-day decay=%v", got)
+	}
+	if got := freshnessDecay(now.Add(-3650*24*time.Hour), now); got < freshnessFloor {
+		t.Fatalf("decay fell through its floor: %v", got)
 	}
 	counts := make([]int, 2)
 	userCounts := make([]int, 2)
@@ -756,5 +760,44 @@ func TestProjectMatchesHandlesImportedPrefix(t *testing.T) {
 		if got := projectMatches(c.project, names); got != c.want {
 			t.Errorf("projectMatches(%q, %v) = %v, want %v", c.project, names, got, c.want)
 		}
+	}
+}
+
+// The exact tier states that it weighs freshness. With a hyperbolic decay it
+// ordered by date instead: a month-old session keeps 3% of its score, which is
+// more than BM25 spans, so topicality only broke ties (#1269).
+func TestASharpOldMatchOutranksAVagueNewOne(t *testing.T) {
+	now := time.Now()
+	at := now.Add(-30 * 24 * time.Hour)
+	old := model.Session{ID: "old", Harness: "claude", Project: "p", Updated: at,
+		Messages: []model.Message{{Role: "user", Time: at,
+			Text: "the pgbouncer pool ran out of connections; pgbouncer pool_mode transaction fixed the connections, pgbouncer pool connections settled"}}}
+	fresh := model.Session{ID: "fresh", Harness: "claude", Project: "p", Updated: now,
+		Messages: []model.Message{{Role: "user", Time: now,
+			Text: "notes on the reporting worker " + strings.Repeat("queues dashboards retries batches ", 20) + " the pgbouncer pool connections were fine here"}}}
+	hits, err := Run([]model.Session{fresh, old}, Options{Query: "pgbouncer pool connections"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "old" {
+		t.Fatalf("the sharper match lost to the newer one: %#v", hits)
+	}
+}
+
+// And age still counts: between two sessions that say the same thing, the
+// recent one leads.
+func TestBetweenEqualMatchesTheRecentOneLeads(t *testing.T) {
+	now := time.Now()
+	text := "the pgbouncer pool ran out of connections"
+	old := model.Session{ID: "old", Harness: "claude", Project: "p", Updated: now.Add(-30 * 24 * time.Hour),
+		Messages: []model.Message{{Role: "user", Text: text, Time: now.Add(-30 * 24 * time.Hour)}}}
+	fresh := model.Session{ID: "fresh", Harness: "claude", Project: "p", Updated: now,
+		Messages: []model.Message{{Role: "user", Text: text, Time: now}}}
+	hits, err := Run([]model.Session{old, fresh}, Options{Query: "pgbouncer pool connections"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 || hits[0].Session.ID != "fresh" {
+		t.Fatalf("age stopped counting: %#v", hits)
 	}
 }


### PR DESCRIPTION
The exact tier multiplied every score by `1/(1+age in days)`: 13% after a week, 3% after a month, 0.3% after a year. BM25 does not span that, so the tier ordered by date and topicality only broke ties, which is the opposite of what the code says it does.

Floor at 0.5, so age can halve a score but not erase it. longmemeval (200 questions) is byte-identical before and after — it is answered by the relevance path, which never consulted the decay, which is #1269's other half. The new test pins the exact tier's own ordering, and a second one keeps recency deciding between equal answers.

Closes #1269.