### PR TITLE
fix(mcp): an emptied store is a removal, not a first run

### DIFF
--- a/cmd/deja/empty_store_answer_test.go
+++ b/cmd/deja/empty_store_answer_test.go
@@ -37,8 +37,14 @@ func TestAnEmptyStoreSaysSoRatherThanBlamingTheQuery(t *testing.T) {
 		if strings.Contains(text, "matched") && !strings.Contains(text, "no indexed history") {
 			t.Errorf("%s: an empty store answers as though the query missed:\n%s", tool, firstLines(text, 3))
 		}
-		if !strings.Contains(text, "no indexed history") {
+		if !strings.Contains(text, "no indexed history yet") {
 			t.Errorf("%s: does not say the store is empty:\n%s", tool, firstLines(text, 3))
+		}
+		// A store nobody has forgotten anything from is a first run, and must
+		// not be described as a removal — the two sentences share a prefix, so
+		// the assertion above cannot tell them apart on its own (#2862).
+		if strings.Contains(text, "forgotten") {
+			t.Errorf("%s: a first run was reported as a deliberate removal:\n%s", tool, firstLines(text, 3))
 		}
 	}
 }

--- a/cmd/deja/empty_store_forgotten_test.go
+++ b/cmd/deja/empty_store_forgotten_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// "This machine has no indexed history yet" is the right thing to say on a
+// first run (#2862, #2863, #2865) and the wrong thing to say after the user
+// forgot everything: the history existed, and "yet" claims it never did.
+//
+// deja knows the difference — forgetting leaves tombstones — and the CLI
+// already says so on its own screen: "this machine also has 2 sessions
+// forgotten (`deja forget --list`)".
+func TestAnEmptiedStoreIsNotCalledAFirstRun(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec := `{"type":"user","sessionId":"s1","cwd":"/app","timestamp":"2026-08-01T09:00:00Z","message":{"role":"user","content":"the zonkomatic deploy"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(rec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "forget", "--session", "s1"); err != nil {
+		t.Fatal(err)
+	}
+	metas, err := index.AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 0 {
+		t.Fatalf("the fixture still holds %d sessions, so this is not the emptied case", len(metas))
+	}
+
+	for _, tc := range []struct{ tool, args string }{
+		{"recall", `{"query":"zonkomatic"}`},
+		{"blame", `{"path":"main.go"}`},
+		{"how", `{"what":"zonkomatic"}`},
+		{"fix", `{"error":"ld: symbol(s) not found for architecture arm64"}`},
+	} {
+		text, err := callMCPTool(dir, tc.tool, json.RawMessage(tc.args))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(text, "no indexed history yet") {
+			t.Errorf("%s: an emptied store is reported as a first run:\n%s", tc.tool, text)
+		}
+		if !strings.Contains(text, "forgotten") {
+			t.Errorf("%s: nothing says the history was removed rather than absent:\n%s", tc.tool, text)
+		}
+		// The count, not just the word: "some sessions have been forgotten"
+		// leaves the reader where they started, and a sentence that cannot
+		// say how many is a sentence that never read the tombstones.
+		if !strings.Contains(text, "1 session has been forgotten") {
+			t.Errorf("%s: the sentence does not say how much was removed:\n%s", tc.tool, text)
+		}
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -603,8 +603,7 @@ func blameTextResult(dir string, o search.BlameOptions, path string, limit int) 
 		// distinction #2862 drew for recall, on the tool that is called before
 		// an edit. Said in the shape this payload already says everything else.
 		if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
-			return string(mustMarshalBlameNote(
-				"this machine has no indexed history yet, so nothing can be found — `deja sources` shows where deja looked")), 0, nil
+			return string(mustMarshalBlameNote(emptyStoreSentence("so nothing can be found"))), 0, nil
 		}
 	}
 	body := mustMarshalBlame(hits, 0, false)
@@ -1522,9 +1521,31 @@ func contextIgnoredWords(result index.SearchResult) string {
 // Empty when the store has something in it, so a caller can append it blind.
 func emptyStoreNote(dir string) string {
 	if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
-		return " This machine has no indexed history yet, so nothing can be found — `deja sources` shows where deja looked."
+		return " " + emptyStoreSentence("so nothing can be found")
 	}
 	return ""
+}
+
+// emptyStoreSentence says why an empty store is empty.
+//
+// "No indexed history yet" is right on a first run and wrong after the reader
+// forgot everything: the history existed, and "yet" claims it never did. deja
+// can tell the two apart — forgetting leaves tombstones — and the search screen
+// already separates them on its own output.
+func emptyStoreSentence(because string) string {
+	if n := len(index.Tombstones()); n > 0 {
+		return fmt.Sprintf("This machine has no indexed history left, %s — %d session%s %s been forgotten here (`deja forget --list`). This is a deliberate removal, not an absence of work.",
+			because, n, pluralS(n), pluralHave(n))
+	}
+	return "This machine has no indexed history yet, " + because + " — `deja sources` shows where deja looked for it. Do not read this as the work never happening."
+}
+
+// pluralHave keeps the sentence above readable for one session and for many.
+func pluralHave(n int) string {
+	if n == 1 {
+		return "has"
+	}
+	return "have"
 }
 
 // nothingIsAboutThis is the half both surfaces share. The wording was tuned in

--- a/cmd/deja/warmup_status.go
+++ b/cmd/deja/warmup_status.go
@@ -254,7 +254,7 @@ func emptyRecallAnswerPolicy(dir, q string, hidden int) string {
 	// genuinely empty; a store with sessions that simply did not match keeps
 	// the ordinary answer.
 	if metas, err := index.AllMeta(dir); err == nil && len(metas) == 0 {
-		return "This machine has no indexed history yet, so nothing can match — `deja sources` shows where deja looked for it. Do not read this as the work never happening."
+		return emptyStoreSentence("so nothing can match")
 	}
 	return fmt.Sprintf("No prior deja sessions matched %q.", q)
 }


### PR DESCRIPTION
A defect I introduced earlier today, found by standing where the reader stands after using `deja forget`.

#2862, #2863 and #2865 taught the four MCP surfaces to say "this machine has no indexed history **yet**" instead of blaming the query. That is right on a first run and wrong once the reader has forgotten everything: the history existed, and *yet* claims it never did. An agent reads it as "this was never done" — the exact conclusion #680 is about, reached by the sentence written to prevent it.

deja can tell the two apart: forgetting leaves tombstones, and the search screen already separates them on its own output ("this machine also has 2 sessions forgotten (`deja forget --list`)").

    first run   This machine has no indexed history yet, so nothing can match — `deja sources` shows where deja looked…
    emptied     This machine has no indexed history left, so nothing can match — 1 session has been forgotten here
                (`deja forget --list`). This is a deliberate removal, not an absence of work.

One sentence behind all four surfaces, so they cannot drift the way the framing did.

**Two of the three mutations were blind at first, against my own tests** — which is the lesson of the day arriving on schedule. Calling every empty store a removal passed, because both sentences start with "no indexed history"; dropping the count passed, because the test only looked for the word "forgotten". Both assertions are sharper now: the first-run test rejects the word "forgotten" outright, and the emptied test asks for "1 session has been forgotten". All three mutations go red.
