### PR TITLE
fix(search): a combining mark continues the word it sits on

### DIFF
--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -95,6 +95,8 @@ func TestAMarkContinuesTheWordItSitsOn(t *testing.T) {
 	}{
 		{"arabic harakat", "\u0643\u064e\u062a\u064e\u0628\u064e", "\u0643\u064e\u062a\u064e\u0628\u064e"},
 		{"hebrew niqqud", "\u05e9\u05b8\u05dc\u05d5\u05b9\u05dd", "\u05e9\u05b8\u05dc\u05d5\u05b9\u05dd"},
+		{"thai vowel signs", "\u0e01\u0e34\u0e19", "\u0e01\u0e34\u0e19"},
+		{"devanagari matras", "\u0939\u093f\u0928\u094d\u0926\u0940", "\u0939\u093f\u0928\u094d\u0926\u0940"},
 	} {
 		got := tokens(c.text)
 		if len(got) != 1 || got[0] != c.want {

--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -43,15 +43,13 @@ func seedOneWord(t *testing.T, word string) string {
 // word from the same one written without them. Nothing on the exact tier joins
 // them.
 //
-// What does join them, for Latin, is the close tier: café and cafe are one edit
-// apart, inside its limit of one for a short word. The Arabic pair is out of
-// reach twice over — the candidate walk only visits tokens within the limit of
-// the query's length, so a three-rune query never sees the six-rune stored form,
-// and even if it did the two are three edits apart. One rule, two outcomes.
-//
-// This records which is which. Note what it cannot tell you: raising the tier's
-// edit limit alone would not change the Arabic rows, because the length bucket
-// excludes the candidate before any distance is computed.
+// The close tier does, in every script. For Latin that fell out of the edit
+// limit — café and cafe are one edit apart. Arabic is normally typed without
+// harakat, and each mark is a rune of its own, so the same pair sat three edits
+// apart and outside the length window besides: one rule, two outcomes, and the
+// reader who got nothing was the one whose script writes its vowels as marks
+// (#1941). A combining mark is now free on this tier, which is what makes the
+// two Arabic rows below the same shape as the two Latin ones.
 func TestWhichTierJoinsAWordToItsMarkedForm(t *testing.T) {
 	const (
 		vowelled = "\u0643\u064e\u062a\u064e\u0628\u064e" // a fatha on each letter
@@ -68,8 +66,8 @@ func TestWhichTierJoinsAWordToItsMarkedForm(t *testing.T) {
 		tier                string
 	}{
 		{"arabic, same form", vowelled, vowelled, 1, query.TierExact},
-		{"arabic, marks dropped from the query", vowelled, plain, 0, ""},
-		{"arabic, marks added to the query", plain, vowelled, 0, ""},
+		{"arabic, marks dropped from the query", vowelled, plain, 1, query.TierClose},
+		{"arabic, marks added to the query", plain, vowelled, 1, query.TierClose},
 		{"latin, same form", accented, accented, 1, query.TierExact},
 		{"latin, accent dropped from the query", accented, bare, 1, query.TierClose},
 		{"latin, accent added to the query", bare, accented, 1, query.TierClose},
@@ -85,5 +83,27 @@ func TestWhichTierJoinsAWordToItsMarkedForm(t *testing.T) {
 		if c.hits > 0 && res.Tier != c.tier {
 			t.Errorf("%s: answered on the %q tier, want %q", c.name, res.Tier, c.tier)
 		}
+	}
+}
+
+// The tokenizer is where the Arabic pair was lost before the tier ever ran: a
+// mark is not a letter, so it ended the word and the index held single letters
+// instead of the word. Hebrew with niqqud is the same shape.
+func TestAMarkContinuesTheWordItSitsOn(t *testing.T) {
+	for _, c := range []struct {
+		name, text, want string
+	}{
+		{"arabic harakat", "\u0643\u064e\u062a\u064e\u0628\u064e", "\u0643\u064e\u062a\u064e\u0628\u064e"},
+		{"hebrew niqqud", "\u05e9\u05b8\u05dc\u05d5\u05b9\u05dd", "\u05e9\u05b8\u05dc\u05d5\u05b9\u05dd"},
+	} {
+		got := tokens(c.text)
+		if len(got) != 1 || got[0] != c.want {
+			t.Errorf("%s: tokens(%q) = %q, want the one word", c.name, c.text, got)
+		}
+	}
+	// A mark with no letter in front of it still separates, so a stray one
+	// cannot glue two words together.
+	if got := tokens("alpha \u064e beta"); len(got) != 2 {
+		t.Errorf("a leading mark joined words: %q", got)
 	}
 }

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -85,11 +85,12 @@ import (
 // since its watermark, so without the bump they stay missing until each is
 // used again — the same shape as 21, 22 and 23 (#2873).
 // 33: a combining mark continues the word it sits on. Latin NFD was composed
-// away already, but Arabic harakat and Hebrew niqqud have no precomposed form,
-// so the mark ended the token and كَتَبَ was indexed as three one-letter tokens
-// — the word itself was never in the index, and no query could reach it. A
-// store built under the old rules holds the letters rather than the words, and
-// nothing re-derives them without the bump (#1941).
+// away already, but Arabic harakat, Hebrew niqqud, Thai vowel signs and the
+// Indic matras have no precomposed form, so the mark ended the token: كَتَبَ was
+// indexed as three one-letter tokens and हिन्दी as two, and the words
+// themselves were never in the index for any query to reach. A store built
+// under the old rules holds the letters rather than the words, and nothing
+// re-derives them without the bump (#1941).
 const version = 33
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -84,7 +84,13 @@ import (
 // missing those sessions, and the db path only re-reads what has been touched
 // since its watermark, so without the bump they stay missing until each is
 // used again — the same shape as 21, 22 and 23 (#2873).
-const version = 32
+// 33: a combining mark continues the word it sits on. Latin NFD was composed
+// away already, but Arabic harakat and Hebrew niqqud have no precomposed form,
+// so the mark ended the token and كَتَبَ was indexed as three one-letter tokens
+// — the word itself was never in the index, and no query could reach it. A
+// store built under the old rules holds the letters rather than the words, and
+// nothing re-derives them without the bump (#1941).
+const version = 33
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -78,23 +78,47 @@ var catalogCache struct {
 type tokenIndex struct {
 	set   map[string]bool
 	byLen [][]string
+	// Tokens carrying a combining mark, bucketed by the length they have
+	// without it. The close tier treats a mark as free, and a marked token is
+	// as many runes longer than its unmarked form as it has marks, so the
+	// ordinary length window never reaches it (#1941). Marked tokens are a
+	// small minority of any corpus, so this second bucket list costs little.
+	markedByLen [][]string
 }
 
 const maxIndexedTokenLen = 64
 
 func newTokenIndex(set map[string]bool) *tokenIndex {
-	idx := &tokenIndex{set: set, byLen: make([][]string, maxIndexedTokenLen+2)}
+	idx := &tokenIndex{
+		set:         set,
+		byLen:       make([][]string, maxIndexedTokenLen+2),
+		markedByLen: make([][]string, maxIndexedTokenLen+2),
+	}
 	for tok := range set {
 		n := len(tok)
-		if !isASCIIString(tok) {
+		ascii := isASCIIString(tok)
+		if !ascii {
 			n = utf8.RuneCountInString(tok)
 		}
-		if n > maxIndexedTokenLen {
-			n = maxIndexedTokenLen + 1 // one overflow bucket, always scanned
+		idx.byLen[bucketFor(n)] = append(idx.byLen[bucketFor(n)], tok)
+		if ascii {
+			continue // no ASCII byte is a combining mark
 		}
-		idx.byLen[n] = append(idx.byLen[n], tok)
+		if bare, marked := unmarked(tok); marked {
+			b := bucketFor(utf8.RuneCountInString(bare))
+			idx.markedByLen[b] = append(idx.markedByLen[b], tok)
+		}
 	}
 	return idx
+}
+
+// bucketFor clamps a rune length to the bucket that holds it; anything longer
+// than maxIndexedTokenLen shares one overflow bucket, which is always scanned.
+func bucketFor(n int) int {
+	if n > maxIndexedTokenLen {
+		return maxIndexedTokenLen + 1
+	}
+	return n
 }
 
 // candidates visits the tokens whose rune length is within limit of n, plus
@@ -115,6 +139,47 @@ func (t *tokenIndex) candidates(n, limit int, fn func(string)) {
 	for _, tok := range t.byLen[maxIndexedTokenLen+1] {
 		fn(tok)
 	}
+}
+
+// markedCandidates visits the tokens whose length without their combining
+// marks is within limit of n. The close tier compares those in the same
+// unmarked form, so a query typed without marks reaches the word written with
+// them however many marks it carries.
+func (t *tokenIndex) markedCandidates(n, limit int, fn func(string)) {
+	lo, hi := n-limit, n+limit
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > maxIndexedTokenLen {
+		hi = maxIndexedTokenLen
+	}
+	for l := lo; l <= hi && l < len(t.markedByLen); l++ {
+		for _, tok := range t.markedByLen[l] {
+			fn(tok)
+		}
+	}
+	for _, tok := range t.markedByLen[maxIndexedTokenLen+1] {
+		fn(tok)
+	}
+}
+
+// hasMarkedNear reports whether any token carrying a combining mark has an
+// unmarked length within limit of n. Cheap enough to ask before deciding
+// whether a short term is worth the candidate walk.
+func (t *tokenIndex) hasMarkedNear(n, limit int) bool {
+	lo, hi := n-limit, n+limit
+	if lo < 0 {
+		lo = 0
+	}
+	if hi > maxIndexedTokenLen {
+		hi = maxIndexedTokenLen
+	}
+	for l := lo; l <= hi && l < len(t.markedByLen); l++ {
+		if len(t.markedByLen[l]) > 0 {
+			return true
+		}
+	}
+	return len(t.markedByLen[maxIndexedTokenLen+1]) > 0
 }
 
 // bucketsSignature changes whenever any bucket file is added, removed, resized

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2979,12 +2979,24 @@ func intersectSubstringPostingsDetailed(dir string, bare []string) ([]posting, m
 const commonTokenPostings = 200
 
 func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][]string, error) {
-	if !hasFuzzyToken(terms) {
-		return nil, nil, nil
+	var idx *tokenIndex
+	if !hasFuzzyToken(terms, nil) {
+		// Every term is below the length floor. One of them may still be a
+		// word whose marked form is in the index, which only the catalog can
+		// say; a catalog that will not read means no, the same answer this
+		// path gave before it asked.
+		cat, err := tokenIndexCached(dir)
+		if err != nil || !hasFuzzyToken(terms, cat) {
+			return nil, nil, nil
+		}
+		idx = cat
 	}
-	idx, err := tokenIndexCached(dir)
-	if err != nil {
-		return nil, nil, err
+	if idx == nil {
+		cat, err := tokenIndexCached(dir)
+		if err != nil {
+			return nil, nil, err
+		}
+		idx = cat
 	}
 	perToken := make([]map[int64]posting, len(terms))
 	variants := map[string][]string{}
@@ -3532,11 +3544,20 @@ func oneSuffixStep(word string) []string {
 	return out
 }
 
-func hasFuzzyToken(terms []string) bool {
+func hasFuzzyToken(terms []string, idx *tokenIndex) bool {
 	for _, term := range terms {
+		n := len([]rune(term))
 		// The 4-rune floor also keeps CJK bigrams (always 2 runes) out of
 		// fuzzy variant generation entirely — no variant-space blowup (#338).
-		if len([]rune(term)) >= 4 {
+		if n >= 4 {
+			return true
+		}
+		// A shorter word is let in only to reach its own marked form. Arabic
+		// writes its vowels as combining marks, so كتب is three runes and the
+		// written-out كَتَبَ is six: the word a reader types is below the floor
+		// while the word in the index is above it (#1941). This costs nothing
+		// where no such token exists, and bigrams stay out.
+		if n == 3 && idx != nil && idx.hasMarkedNear(n, 1) {
 			return true
 		}
 	}
@@ -3579,15 +3600,41 @@ func closeTokens(query string, idx *tokenIndex) []string {
 	if qr >= 8 {
 		limit = 2
 	}
+	bareQuery, queryMarked := unmarked(query)
+	bareLen := len([]rune(bareQuery))
+	seen := make(map[string]bool)
+	consider := func(token string) {
+		if seen[token] {
+			return
+		}
+		d := damerauDistance(query, token, limit)
+		if d > limit {
+			// A combining mark is free here. Arabic is normally typed without
+			// harakat and each mark is a rune of its own, so كتب sat three
+			// edits from كَتَبَ while café sat one from cafe: one rule, two
+			// outcomes, and the reader who got nothing was the one whose
+			// script writes its vowels as marks (#1941).
+			if bareToken, tokenMarked := unmarked(token); queryMarked || tokenMarked {
+				d = damerauDistance(bareQuery, bareToken, limit)
+			}
+		}
+		if d > limit {
+			return
+		}
+		seen[token] = true
+		matches = append(matches, match{token: token, distance: d})
+	}
 	// An edit changes the length by at most one and a transposition not at
 	// all, so only tokens within the limit of the query's length can match.
 	// Walking those buckets replaces a Damerau-Levenshtein run against every
 	// token in the corpus — ~200k of them — with a few short slices.
-	idx.candidates(qr, limit, func(token string) {
-		if d := damerauDistance(query, token, limit); d <= limit {
-			matches = append(matches, match{token: token, distance: d})
-		}
-	})
+	idx.candidates(qr, limit, consider)
+	// Marks are free, so a marked token is reached by the length it has
+	// without them, and a marked query reaches unmarked tokens by its own.
+	idx.markedCandidates(bareLen, limit, consider)
+	if queryMarked {
+		idx.candidates(bareLen, limit, consider)
+	}
 	sort.Slice(matches, func(i, j int) bool {
 		if matches[i].distance == matches[j].distance {
 			return matches[i].token < matches[j].token
@@ -3668,6 +3715,31 @@ func damerauDistanceRunes(a, b string, max int) int {
 	return prev[len(br)]
 }
 
+// unmarked strips combining marks from s, reporting whether any were there.
+// Category Mn is what a mark is: Arabic harakat, Hebrew niqqud, Vietnamese and
+// Greek tone marks in their decomposed form. A string without one is returned
+// untouched, so ordinary text pays one scan and no allocation.
+func unmarked(s string) (string, bool) {
+	has := false
+	for _, r := range s {
+		if r >= 0x0300 && unicode.Is(unicode.Mn, r) {
+			has = true
+			break
+		}
+	}
+	if !has {
+		return s, false
+	}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r >= 0x0300 && unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out), true
+}
+
 func abs(n int) int {
 	if n < 0 {
 		return -n
@@ -3717,7 +3789,14 @@ func tokens(s string) []string {
 		b.Reset()
 	}
 	for _, r := range strings.ToLower(s) {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
+		// A combining mark continues the word it sits on. Latin NFD is already
+		// composed away above, but Arabic harakat and Hebrew niqqud have no
+		// precomposed form, so the mark ended the token and كَتَبَ was indexed
+		// as three one-letter tokens — the word itself was not in the index at
+		// all (#1941). A mark cannot start a token, so a stray one still
+		// separates.
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' ||
+			(b.Len() > 0 && r >= 0x0300 && unicode.Is(unicode.Mn, r)) {
 			b.WriteRune(r)
 			if b.Len() > 64 {
 				flush()

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -3715,14 +3715,23 @@ func damerauDistanceRunes(a, b string, max int) int {
 	return prev[len(br)]
 }
 
-// unmarked strips combining marks from s, reporting whether any were there.
-// Category Mn is what a mark is: Arabic harakat, Hebrew niqqud, Vietnamese and
-// Greek tone marks in their decomposed form. A string without one is returned
-// untouched, so ordinary text pays one scan and no allocation.
+// isMark reports whether r is a combining mark: Mn covers Arabic harakat,
+// Hebrew niqqud, Thai vowel signs and the Greek and Vietnamese tone marks in
+// their decomposed form, and Mc the spacing matras of the Indic scripts, which
+// are as much part of their word as any of those. The range test in front
+// keeps ordinary text to one comparison per rune — every mark sits above
+// U+0300.
+func isMark(r rune) bool {
+	return r >= 0x0300 && (unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Mc, r))
+}
+
+// unmarked strips combining marks from s, reporting whether any were there. A
+// string without one is returned untouched, so ordinary text pays one scan and
+// no allocation.
 func unmarked(s string) (string, bool) {
 	has := false
 	for _, r := range s {
-		if r >= 0x0300 && unicode.Is(unicode.Mn, r) {
+		if isMark(r) {
 			has = true
 			break
 		}
@@ -3732,7 +3741,7 @@ func unmarked(s string) (string, bool) {
 	}
 	out := make([]rune, 0, len(s))
 	for _, r := range s {
-		if r >= 0x0300 && unicode.Is(unicode.Mn, r) {
+		if isMark(r) {
 			continue
 		}
 		out = append(out, r)
@@ -3790,13 +3799,14 @@ func tokens(s string) []string {
 	}
 	for _, r := range strings.ToLower(s) {
 		// A combining mark continues the word it sits on. Latin NFD is already
-		// composed away above, but Arabic harakat and Hebrew niqqud have no
-		// precomposed form, so the mark ended the token and كَتَبَ was indexed
-		// as three one-letter tokens — the word itself was not in the index at
-		// all (#1941). A mark cannot start a token, so a stray one still
+		// composed away above, but Arabic harakat, Hebrew niqqud, Thai vowel
+		// signs and the Indic matras have no precomposed form, so the mark
+		// ended the token: كَتَبَ was indexed as three one-letter tokens and
+		// हिन्दी as two, and the words themselves were not in the index at all
+		// (#1941). A mark cannot start a token, so a stray one still
 		// separates.
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' ||
-			(b.Len() > 0 && r >= 0x0300 && unicode.Is(unicode.Mn, r)) {
+			(b.Len() > 0 && isMark(r)) {
 			b.WriteRune(r)
 			if b.Len() > 64 {
 				flush()


### PR DESCRIPTION
`كَتَبَ` was indexed as three one-letter tokens: a harakat is category Mn, not a letter, so it ended the word and the word itself was never in the index. Latin never showed this because NFD is composed back to NFC first, and Arabic has no precomposed form.

So the tokenizer keeps a mark that follows a letter (a stray one still separates), and the close tier treats a mark as a free edit, which is what joins `كتب` to `كَتَبَ` in both directions — the same second chance `cafe` already had at `café`. Marked tokens get their own length buckets, since a marked word is as many runes longer as it has marks; a three-rune query is let past the fuzzy floor only when such a token exists, so CJK bigrams stay out.

Index version 33: a store built under the old rules holds the letters rather than the words.

Closes #1941.