### PR TITLE
fix(hook): keep the projects a cached digest was built from

### DIFF
--- a/cmd/deja/hook_cache_projects_test.go
+++ b/cmd/deja/hook_cache_projects_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The injection log records which projects a digest was built from, and the
+// cache is the path almost every session takes: a miss happens once per
+// project, a hit happens every time after. Dropping the names on the way in
+// made every one of those hits read as an injection from no project at all
+// (#2889).
+func TestTheHookCacheKeepsTheProjectsBehindTheDigest(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(tmp, "proj")
+	writeHookCache(dir, cwd, "a digest", 2, 10, nil, 0, []string{"claude:s1"}, []string{"acme-api"})
+
+	_, _, _, _, _, ids, projects := cachedHookDigestFor(dir, cwd)
+	if len(ids) != 1 || ids[0] != "claude:s1" {
+		t.Fatalf("session ids came back as %v", ids)
+	}
+	if len(projects) != 1 || projects[0] != "acme-api" {
+		t.Fatalf("projects came back as %v, want the name the digest was built from", projects)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -741,7 +741,7 @@ func writeHookCache(dir, cwd, digest string, sessions int, raw int64, taskMatche
 	if digest == "" {
 		return
 	}
-	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld, IDs: ids}); err == nil {
+	if b, err := json.Marshal(hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: digest, Sessions: sessions, Raw: raw, TaskMatched: taskMatched, Withheld: withheld, IDs: ids, Projects: projects}); err == nil {
 		_ = os.WriteFile(hookCachePath(dir, cwd), b, 0o600)
 	}
 }


### PR DESCRIPTION
`writeHookCache` took `projects` and never marshalled it, while the reader pulls `e.Projects` back out. The miss path logged the names once per project; every cache hit after it — the common path — logged an injection from nowhere. One field, plus a test that writes the cache and reads it back.

Closes #2889.