### PR TITLE
fix(mcp): how and fix reach the journal, without moving the stats ratios

### DIFF
--- a/cmd/deja/how_fix_journal_test.go
+++ b/cmd/deja/how_fix_journal_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// `deja log` is the record of what an agent was handed, and the two tools that
+// serve commands were the two it never mentioned (#2858). The kind list already
+// argues the case twice — blame and the resource read were added because
+// leaving them out "understated what the agent was given" (#682), and remember
+// because a write "showed up nowhere in the journal the user reads".
+//
+// Recorded, and deliberately not counted as memory served: `servedKind` decides
+// the ratios `deja stats` publishes, and a one-line command is not the store's
+// text handed over. That half is asserted below too, because the last time
+// these drifted a blame was a recall on one screen and nothing on the other
+// (#1907).
+func TestHowAndFixReachTheJournal(t *testing.T) {
+	tmp := hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const errLine = "ld: symbol(s) not found for architecture arm64"
+	for i, sid := range []string{"s1", "s2"} {
+		day := string(rune('1' + i))
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + day + `T09:00:00Z","message":{"role":"user","content":"deploying the zonkomatic"}}
+{"type":"user","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + day + `T09:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"` + errLine + `"}]}}
+{"type":"assistant","sessionId":"` + sid + `","cwd":"/app","timestamp":"2026-08-0` + day + `T09:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"helm upgrade zonkomatic --set replicas=9"}}]}}
+`
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	kinds := func() map[string]int {
+		t.Helper()
+		out := map[string]int{}
+		b, err := os.ReadFile(usage.Path(dir))
+		if err != nil {
+			return out
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			var ev struct {
+				Kind string `json:"kind"`
+			}
+			if json.Unmarshal([]byte(line), &ev) == nil {
+				out[ev.Kind]++
+			}
+		}
+		return out
+	}
+	// The number `deja stats` publishes: recalls counted as memory served.
+	served := func() int {
+		t.Helper()
+		n, _, _ := usage.TodayWithInjections(dir)
+		return n
+	}
+
+	before := served()
+	text, err := callMCPTool(dir, "how", json.RawMessage(`{"what":"zonkomatic"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "helm upgrade") {
+		t.Fatalf("how served nothing, so there is nothing to journal:\n%s", text)
+	}
+	text, err = callMCPTool(dir, "fix", json.RawMessage(`{"error":"`+errLine+`"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "helm upgrade") {
+		t.Fatalf("fix served nothing, so there is nothing to journal:\n%s", text)
+	}
+
+	got := kinds()
+	if got[usage.KindHow] != 1 {
+		t.Errorf("how is not in the journal: %v", got)
+	}
+	if got[usage.KindFix] != 1 {
+		t.Errorf("fix is not in the journal: %v", got)
+	}
+	// And the number deja publishes has not moved: a command offered is not
+	// the store's text served.
+	if after := served(); after != before {
+		t.Errorf("the served count moved from %d to %d — the ratios in `deja stats` changed with it", before, after)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -442,6 +442,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
 				commandListingLine(p.Command))
 		}
+		usage.RecordResult(dir, usage.KindFix, fb.Len(), len(pairs), false)
 		// Framed like `how` (#2844) and for a sharper reason: this hands an
 		// agent a command at the moment it has just hit an error, which is
 		// the moment it is most likely to run it without reading. The
@@ -501,6 +502,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			// travel with the answer rather than to a terminal it never sees.
 			out += "\n\n" + note
 		}
+		usage.RecordResult(dir, usage.KindHow, len(out), len(entries), false)
 		// Framed like every other agent-facing recall: these are command lines
 		// lifted out of transcripts, which recall_frame.go names as data an
 		// attacker may have influenced — and they are the most directly

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -43,6 +43,18 @@ const (
 	// KindDejaVu marks a per-prompt recall: the user asked something their
 	// own history already answers — the product's namesake moment.
 	KindDejaVu = "dejavu"
+	// KindHow and KindFix are the two MCP tools that hand an agent a command
+	// to run. They were the only answers missing from the journal, which is
+	// the record of what the agent was given — the same argument KindBlame and
+	// KindResource were added on (#682), and sharper: what these serve is the
+	// most directly actionable thing deja has (#2858).
+	//
+	// Recorded, and deliberately not in servedKind. That classifier decides
+	// the ratios `deja stats` publishes, and what it counts is the store's
+	// text handed over; a one-line command is not that. Keeping them out means
+	// every number published before and after this stays comparable.
+	KindHow = "how"
+	KindFix = "fix"
 	// KindTool is the PreToolUse hook injection — one line about a command or
 	// file the agent is acting on. It is deduped per session, so it counts a
 	// distinct fact served, not every action. Leaving it out made deja's most


### PR DESCRIPTION
#2858 written out, taking the first of the two options I put there — **the fork is still yours**, and if you want them counted as memory served instead, that is one line in `servedKind` and this PR is the wrong half of it.

`how` and `fix` were the only MCP answers `deja log` never mentioned, and they are the two that hand an agent a command to run. The kind list already makes the argument twice: `KindBlame` and `KindResource` were added because leaving them out "understated what the agent was given" (#682), `KindRemember` because a write "showed up nowhere in the journal the user reads".

**Recorded, and deliberately not counted as served.** `servedKind` decides the ratios `deja stats` and `--impact` publish, and what it counts is the store's *text* handed over; a one-line command is not that. Keeping them out means every number published before and after this stays comparable — which is the failure #1907 records, where a blame was a recall on one screen and nothing on the other.

The test asserts both halves, because only asserting the first would let the ratios move silently: the two events appear in the journal, **and** the count behind `deja stats` is the same before and after the calls. Three mutations — dropping either recorder, or adding the two kinds to `servedKind` — each turn it red.
