### PR TITLE
feat(mcp): recall_context says how many other sessions matched

### DIFF
--- a/cmd/deja/context_others_test.go
+++ b/cmd/deja/context_others_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// recall_context serves one session and said nothing about the rest, so a
+// digest chosen from forty candidates read exactly like the only thing deja
+// held. That is the misread #1308 fixed for the counted page — "(5 match(es))"
+// reads as five exist — and blame already names what it left out.
+//
+// The tool returns one digest on purpose; what was missing is the number the
+// agent needs to decide whether one is enough.
+func TestTheContextDigestSaysHowManyItChoseFrom(t *testing.T) {
+	dir := manySessionStore(t, 40)
+
+	text, err := callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"pipeline stalled retry"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "# deja context:") {
+		t.Fatalf("nothing was served, so there is nothing to count:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "other sessions matched") {
+		t.Errorf("the digest does not say it was chosen from several:\n%s", firstLines(text, 5))
+	}
+	if !strings.Contains(text, "recall") {
+		t.Errorf("nothing points at the tool that lists the others:\n%s", firstLines(text, 5))
+	}
+}
+
+// The number itself, on a store where it is known: three sessions say
+// "pipeline … stalled on retry", so the one served leaves two behind. Asserting
+// only the sentence let an off-by-one through — the count is the whole point of
+// the line.
+func TestTheContextDigestCountsTheOthersCorrectly(t *testing.T) {
+	dir := manySessionStore(t, 3)
+
+	text, err := callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"pipeline stalled retry"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "# deja context:") {
+		t.Fatalf("nothing was served, so there is nothing to count:\n%s", firstLines(text, 4))
+	}
+	if !strings.Contains(text, "2 other sessions matched") {
+		t.Errorf("the count is wrong — three sessions match and one was served:\n%s", firstLines(text, 6))
+	}
+}
+
+// One match is one match: a sentence about others would be a lie, and an agent
+// told to go looking wastes a call.
+func TestTheContextDigestIsQuietWhenItWasTheOnlyMatch(t *testing.T) {
+	dir := manySessionStore(t, 1)
+
+	text, err := callMCPTool(dir, "recall_context", json.RawMessage(`{"query":"quibblesnatch"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "# deja context:") {
+		t.Fatalf("nothing was served, so this guards nothing:\n%s", firstLines(text, 4))
+	}
+	if strings.Contains(text, "other sessions matched") {
+		t.Errorf("the only match was reported as one of several:\n%s", firstLines(text, 5))
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1480,7 +1480,7 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 	}
 	var b bytes.Buffer
 	search.PrintContext(&b, whole, q)
-	text := b.String()
+	text := b.String() + contextOthersNote(len(hits))
 	if hits[0].Tier != search.TierExact {
 		text = contextTierLead(hits[0].Tier, sessionNamesTheAsked(whole, q, result.TermIDF)) +
 			contextIgnoredWords(result) + text
@@ -1548,6 +1548,24 @@ func pluralHave(n int) string {
 		return "has"
 	}
 	return "have"
+}
+
+// contextOthersNote says how many other sessions matched the question this
+// digest answers.
+//
+// The tool returns one session on purpose. What it did not say is how many it
+// chose from, so a digest picked out of forty read exactly like the only thing
+// deja held — the misread #1308 fixed for the counted page, where "(5
+// match(es))" reads as five exist. blame already names what it left out.
+//
+// Silent on a single match: a sentence about others would be untrue, and an
+// agent told to go looking spends a call finding nothing.
+func contextOthersNote(hits int) string {
+	if hits < 2 {
+		return ""
+	}
+	return fmt.Sprintf("\n%d other session%s matched this question — call recall for the list if this one does not answer it.\n",
+		hits-1, pluralS(hits-1))
 }
 
 // nothingIsAboutThis is the half both surfaces share. The wording was tuned in


### PR DESCRIPTION
`recall_context` returns one session on purpose — the description says so, and that is not what changes here. What it never said is how many it chose from, so a digest picked out of forty read exactly like the only thing deja held.

That is the misread #1308 fixed for the counted page: "(5 match(es))" reads as five exist, when the useful answer is *five of sixteen thousand*. `blame` already names what it left out ("N more sessions touch this path…"). This is the same sentence for the surface that returns the most text and counted nothing.

    2 other sessions matched this question — call recall for the list if this one does not answer it.

Silent on a single match: a sentence about others would be untrue, and an agent told to go looking spends a call finding nothing.

**The off-by-one mutation was blind at first** — the test asserted the phrase and not the number, so `hits` instead of `hits-1` passed. There is now a fixture where the count is known: three sessions match, one is served, the line says two. All three mutations go red.