### PR TITLE
feat(cli): --json for fix and friction

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -23,9 +25,15 @@ import (
 
 func runFix(dir string, args []string, stdout io.Writer) error {
 	limit := 3
+	asJSON := false
 	var parts []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--json":
+			// Rejected outright until now. The comment below records an earlier bug where
+			// `--json` was swallowed into the search text, so the flag has been on this
+			// command's mind since without ever being answered (#1932).
+			asJSON = true
 		case "--limit":
 			if i+1 >= len(args) {
 				return fmt.Errorf("fix: --limit wants a number")
@@ -72,6 +80,9 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 	pairs := index.FixesFor(dir, text, limit, func(project string) bool {
 		return pol.Allows(policy.ActivationSearch, project)
 	})
+	if asJSON {
+		return writeFixJSON(stdout, pairs)
+	}
 	if len(pairs) == 0 {
 		// One honest line. The old code tried to tell "not an error" apart from
 		// "never seen it", but the test it used rejects `Error: …`, `npm ERR!`
@@ -148,4 +159,45 @@ func nearestRecordedError(dir, text string, allow func(string) bool) string {
 		}
 	}
 	return search.SafeLine(best)
+}
+
+// fixJSON is the `deja fix --json` envelope. See docs/json-output.md.
+//
+// Object-shaped and versioned, because a consumer parses it on a schedule. The
+// empty case is the same shape with an empty array rather than a different one:
+// the prose path answers "nothing recorded" three different ways depending on
+// what the store holds, and a script cannot branch on prose.
+type fixJSON struct {
+	SchemaVersion int          `json:"schema_version"`
+	Fixes         []fixRowJSON `json:"fixes"`
+}
+
+type fixRowJSON struct {
+	Error   string `json:"error"`
+	Command string `json:"command"`
+	// Candidate is the half-evidence flag the prose renders as "ran next,
+	// unconfirmed": one session ran this after the error and nothing has
+	// confirmed it worked. A caller acting on a fix needs to know which it has.
+	Candidate bool `json:"candidate"`
+	// When is omitted rather than zero-valued: an absent timestamp is a real
+	// state here, and "0001-01-01" is not a date anybody should read.
+	When string `json:"when,omitempty"`
+}
+
+func writeFixJSON(stdout io.Writer, pairs []index.FixPair) error {
+	rows := make([]fixRowJSON, 0, len(pairs))
+	for _, p := range pairs {
+		row := fixRowJSON{
+			Error:     search.SafeLine(p.Error),
+			Command:   search.SafeCommand(p.Command),
+			Candidate: p.Candidate,
+		}
+		if !p.When.IsZero() {
+			row.When = p.When.UTC().Format(time.RFC3339)
+		}
+		rows = append(rows, row)
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(fixJSON{SchemaVersion: jsonout.Version, Fixes: rows})
 }

--- a/cmd/deja/fix_cli_test.go
+++ b/cmd/deja/fix_cli_test.go
@@ -15,8 +15,18 @@ func TestFixRejectsFlagMistakes(t *testing.T) {
 	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "p", "s.jsonl"), "s", []string{
 		`{"type":"user","sessionId":"s","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"hi"}}`,
 	})
-	if _, err := captureRun(t, "fix", "boom", "--json"); err == nil {
-		t.Error("unknown flag --json was accepted and folded into the query")
+	// --json is answered now rather than refused (#1932). What must not come back is
+	// the bug this test was written for: the flag being folded into the searched text.
+	// So it is asserted as a flag on both counts - accepted beside a query, and NOT
+	// treated as one when it stands alone.
+	if _, err := captureRun(t, "fix", "boom", "--json"); err != nil {
+		t.Errorf("fix --json refused: %v", err)
+	}
+	if _, err := captureRun(t, "fix", "--json"); err == nil {
+		t.Error("--json alone was accepted; the flag became the query")
+	}
+	if _, err := captureRun(t, "fix", "boom", "--jsonn"); err == nil {
+		t.Error("unknown flag --jsonn was accepted and folded into the query")
 	}
 	if _, err := captureRun(t, "fix", "boom", "--limit"); err == nil {
 		t.Error("--limit with no value was accepted")

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // `deja friction` names what this machine keeps tripping over.
@@ -292,10 +293,11 @@ func writeFrictionJSON(stdout io.Writer, rows []frictionRow, sessionsRead, limit
 	out := make([]frictionRowJSON, 0, len(rows))
 	for _, r := range rows {
 		row := frictionRowJSON{
-			// Same sanitiser the prose path uses. A recorded error line is
-			// untrusted text, and a JSON consumer pasting it into a shell is
-			// no safer than a human reading it.
-			Error:     trimFriction(r.line),
+			// Sanitised, but not truncated. trimFriction bounds the line to 79
+			// bytes because that is what fits a terminal row; a JSON consumer
+			// has no such row, and a clipped error can no longer be matched
+			// against the error it came from or passed back to `deja fix`.
+			Error:     search.SafeLine(r.line),
 			Sessions:  r.n,
 			Harnesses: r.harnesses,
 		}

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
@@ -27,12 +29,18 @@ import (
 
 func runFriction(dir string, args []string, stdout io.Writer) error {
 	limit := 10
+	asJSON := false
 	for i := 0; i < len(args); i++ {
+		if args[i] == "--json" {
+			asJSON = true
+			continue
+		}
 		// Anything else used to be dropped on the floor, so `deja friction
 		// --json` and `--limt 3` answered in prose and exited 0 as though they
-		// had been understood (#2253).
+		// had been understood (#2253). --json is answered now rather than
+		// refused (#1932); anything else still refuses.
 		if args[i] != "--limit" {
-			return fmt.Errorf("friction: unknown flag %q — it takes --limit n", args[i])
+			return fmt.Errorf("friction: unknown flag %q — it takes --limit n and --json", args[i])
 		}
 		if i+1 >= len(args) {
 			return fmt.Errorf("friction: --limit needs value")
@@ -115,13 +123,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprint(os.Stderr, note)
 	}
 
-	type row struct {
-		line      string
-		when      time.Time
-		n         int
-		harnesses []string
-	}
-	var rows []row
+	var rows []frictionRow
 	for _, s := range found {
 		line := s.text
 		if len(s.sessions) < index.FrictionMinSessions {
@@ -132,7 +134,7 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			hs = append(hs, h)
 		}
 		sort.Strings(hs)
-		rows = append(rows, row{line, s.last, len(s.sessions), hs})
+		rows = append(rows, frictionRow{line, s.last, len(s.sessions), hs})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].n != rows[j].n {
@@ -140,6 +142,9 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		}
 		return rows[i].line < rows[j].line
 	})
+	if asJSON {
+		return writeFrictionJSON(stdout, rows, len(sessions), limit)
+	}
 	if len(rows) == 0 {
 		// The count is sessions-with-tool-output, and it reads as
 		// sessions-indexed: a store with six conversations reported zero,
@@ -240,4 +245,73 @@ func emptiedBy(pol policy.Policy) string {
 		return "the ignore rule (" + strings.Join(pol.IgnorePatterns(), ", ") + ")"
 	}
 	return "the trust policy (" + policy.ActivationSearch + ": " + pol.Describe(policy.ActivationSearch) + ")"
+}
+
+// frictionRow is one recurring error, shared by the prose and JSON renderers so
+// they cannot disagree about what a row is.
+type frictionRow struct {
+	line      string
+	when      time.Time
+	n         int
+	harnesses []string
+}
+
+// frictionJSON is the `deja friction --json` envelope. See docs/json-output.md.
+//
+// Carries the two counts a caller cannot recover from the rows, on the same
+// reasoning as the v2 search envelope: how many recurring errors there were
+// before the cap, and whether the cap hid any. Reading len(rows) answers
+// neither once --limit is in play.
+//
+// sessions_read is the denominator the prose header states, and min_sessions is
+// the threshold a row had to clear — without it a consumer cannot tell an empty
+// result meaning "nothing recurs" from one meaning "nothing recurred twice".
+type frictionJSON struct {
+	SchemaVersion int               `json:"schema_version"`
+	SessionsRead  int               `json:"sessions_read"`
+	MinSessions   int               `json:"min_sessions"`
+	Total         int               `json:"total"`
+	Truncated     bool              `json:"truncated"`
+	Rows          []frictionRowJSON `json:"rows"`
+}
+
+type frictionRowJSON struct {
+	Error     string   `json:"error"`
+	Sessions  int      `json:"sessions"`
+	Harnesses []string `json:"harnesses"`
+	// Omitted rather than zero-valued, like the fix envelope: a row with no
+	// recorded time is a real state and "0001-01-01" is not a date.
+	Last string `json:"last,omitempty"`
+}
+
+func writeFrictionJSON(stdout io.Writer, rows []frictionRow, sessionsRead, limit int) error {
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]frictionRowJSON, 0, len(rows))
+	for _, r := range rows {
+		row := frictionRowJSON{
+			// Same sanitiser the prose path uses. A recorded error line is
+			// untrusted text, and a JSON consumer pasting it into a shell is
+			// no safer than a human reading it.
+			Error:     trimFriction(r.line),
+			Sessions:  r.n,
+			Harnesses: r.harnesses,
+		}
+		if !r.when.IsZero() {
+			row.Last = r.when.UTC().Format(time.RFC3339)
+		}
+		out = append(out, row)
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(frictionJSON{
+		SchemaVersion: jsonout.Version,
+		SessionsRead:  sessionsRead,
+		MinSessions:   index.FrictionMinSessions,
+		Total:         total,
+		Truncated:     total > len(rows),
+		Rows:          out,
+	})
 }

--- a/cmd/deja/friction_json_full_line_test.go
+++ b/cmd/deja/friction_json_full_line_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The JSON row carries the recorded error, not the terminal's view of it.
+// trimFriction bounds a line to 79 bytes because that is what fits a row; a
+// consumer has no row, and a clipped error can no longer be matched against
+// the error it came from or handed back to `deja fix`.
+func TestFrictionJSONCarriesTheWholeErrorLine(t *testing.T) {
+	root := frictionEnv(t)
+	// With an escape in it, so the row is pinned as sanitised as well as whole.
+	long := "psql: error: \x1b[31mconnection\x1b[0m to server at \"db-primary-replica-eu-central.internal.example.com\" (192.0.2.14), port 5432 failed: Connection refused"
+	if len(long) <= 79 {
+		t.Fatalf("the fixture is %d bytes, so it never reaches the cut", len(long))
+	}
+	proj := filepath.Join(root, "projects", "repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < index.FrictionMinSessions; i++ {
+		sid := fmt.Sprintf("long%02d", i)
+		payload, err := json.Marshal(long + "\nexit status 2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := `{"type":"user","sessionId":"` + sid + `","cwd":"/repo",` +
+			`"timestamp":"2026-07-30T03:05:05Z","message":{"role":"user","content":` +
+			`[{"type":"tool_result","content":` + string(payload) + `}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(row), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--json"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got frictionJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Rows) == 0 {
+		t.Fatalf("nothing was reported, so this asserts nothing:\n%s", buf.String())
+	}
+	if !strings.Contains(got.Rows[0].Error, "Connection refused") {
+		t.Errorf("the row was cut before the end of the error:\n%q", got.Rows[0].Error)
+	}
+	if strings.HasSuffix(got.Rows[0].Error, "…") {
+		t.Errorf("the row carries the terminal's ellipsis:\n%q", got.Rows[0].Error)
+	}
+	if strings.Contains(got.Rows[0].Error, "\x1b[") {
+		t.Errorf("an ANSI escape reached the row:\n%q", got.Rows[0].Error)
+	}
+}
+
+// The prose path keeps its bound: a terminal row is still a terminal row.
+func TestFrictionProseStillFitsARow(t *testing.T) {
+	long := strings.Repeat("connection refused on the replica ", 6)
+	if got := trimFriction(long); len(got) > 79 {
+		t.Errorf("the prose line is %d bytes, over the row bound", len(got))
+	}
+}

--- a/cmd/deja/json_flag_test.go
+++ b/cmd/deja/json_flag_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
+)
+
+// `deja fix --json` was refused and `deja friction --json` was accepted, ignored
+// and answered in prose (#1932). The second is the worse of the two: a script
+// reading it gets no error and no JSON either.
+//
+// friction's silent-ignore was closed separately by its unknown-flag guard, which
+// turned it into a refusal. These pin the answer both commands now give.
+
+func TestFrictionJSONIsAVersionedEnvelope(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--json"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got frictionJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version = %d, want %d", got.SchemaVersion, jsonout.Version)
+	}
+	if len(got.Rows) == 0 {
+		t.Fatalf("no rows:\n%s", buf.String())
+	}
+	if got.Rows[0].Sessions != index.FrictionMinSessions {
+		t.Fatalf("sessions = %d, want %d", got.Rows[0].Sessions, index.FrictionMinSessions)
+	}
+	// The threshold a row had to clear. Without it a consumer cannot tell an
+	// empty result meaning "nothing recurs" from one meaning "nothing twice".
+	if got.MinSessions != index.FrictionMinSessions {
+		t.Fatalf("min_sessions = %d, want %d", got.MinSessions, index.FrictionMinSessions)
+	}
+}
+
+// The empty case must be the SAME shape, not a different one. The prose path
+// answers "nothing recurring" five different ways depending on what the store
+// holds and which rule emptied it; a script cannot branch on prose.
+func TestFrictionJSONKeepsItsShapeWhenEmpty(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions-1)
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--json"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	_ = root
+	var got frictionJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.Rows == nil {
+		t.Fatal("rows is null; an empty result must still be an array")
+	}
+	if len(got.Rows) != 0 || got.Total != 0 {
+		t.Fatalf("want an empty result, got %+v", got)
+	}
+}
+
+// `--limit` caps the rows; `total` and `truncated` are how a caller learns the
+// cap hid something. Reading len(rows) answers neither.
+func TestFrictionJSONReportsWhatTheLimitHid(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--json", "--limit", "1"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got frictionJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Rows) > 1 {
+		t.Fatalf("--limit 1 returned %d rows", len(got.Rows))
+	}
+	if got.Total < len(got.Rows) {
+		t.Fatalf("total %d is below the rows returned %d", got.Total, len(got.Rows))
+	}
+	if got.Truncated != (got.Total > len(got.Rows)) {
+		t.Fatalf("truncated=%v disagrees with total=%d rows=%d", got.Truncated, got.Total, len(got.Rows))
+	}
+}
+
+// The flag was rejected outright, and the comment in fix.go records an earlier
+// bug where it was swallowed into the searched text instead.
+func TestFixAcceptsJSON(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	var buf bytes.Buffer
+	if err := runFix(index.DefaultDir(), []string{"some error text", "--json"}, &buf); err != nil {
+		t.Fatalf("fix --json refused: %v", err)
+	}
+	var got fixJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version = %d, want %d", got.SchemaVersion, jsonout.Version)
+	}
+	if got.Fixes == nil {
+		t.Fatal("fixes is null; an empty result must still be an array")
+	}
+}
+
+// --json must not become the error text. That is the bug fix.go's comment
+// describes, and the reason the flag was refused rather than parsed.
+func TestFixJSONIsNotSearchedFor(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runFix(index.DefaultDir(), []string{"--json"}, &buf); err == nil {
+		t.Fatal("fix --json with no error text was accepted; the flag became the query")
+	}
+}
+
+// Everything else still refuses. Answering one flag must not reopen the
+// dropped-on-the-floor behaviour the unknown-flag guard closed.
+func TestBothStillRefuseAnUnknownFlag(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), []string{"--jsonn"}, &buf); err == nil {
+		t.Fatal("friction accepted --jsonn")
+	}
+	if err := runFix(index.DefaultDir(), []string{"err", "--jsonn"}, &buf); err == nil {
+		t.Fatal("fix accepted --jsonn")
+	}
+}

--- a/cmd/deja/silent_flag_test.go
+++ b/cmd/deja/silent_flag_test.go
@@ -11,6 +11,11 @@ import (
 // Every command in this family refuses a flag it does not take. friction and
 // restore dropped one on the floor and answered as though nothing was wrong, so
 // a script asking either for --json got prose on stdout and exit 0 (#2253).
+//
+// friction ANSWERS --json now (#1932), so it has moved to the accepted list
+// below. The property this test exists for is unchanged: a flag the command
+// cannot honour must be refused, never ignored. --limt keeps that covered, and
+// restore still refuses --json because it does not implement one.
 func TestFrictionAndRestoreRefuseAFlagTheyDoNotTake(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, "home")
@@ -27,9 +32,9 @@ func TestFrictionAndRestoreRefuseAFlagTheyDoNotTake(t *testing.T) {
 
 	var out bytes.Buffer
 	for _, args := range [][]string{
-		{"--json"},
 		{"--limt", "3"},
 		{"--limit"},
+		{"--jsonn"},
 	} {
 		out.Reset()
 		err := runFriction(dir, args, &out)
@@ -45,6 +50,10 @@ func TestFrictionAndRestoreRefuseAFlagTheyDoNotTake(t *testing.T) {
 	out.Reset()
 	if err := runFriction(dir, []string{"--limit", "3"}, &out); err != nil {
 		t.Errorf("friction --limit 3: %v", err)
+	}
+	out.Reset()
+	if err := runFriction(dir, []string{"--json"}, &out); err != nil {
+		t.Errorf("friction --json: %v", err)
 	}
 
 	for _, args := range [][]string{

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -459,6 +459,73 @@ from a machine a moment ahead — or an NTP step landing between the write and t
 read — is not a clock worth reporting, while a session's stamp comes from a
 transcript deja did not write.
 
+## `deja friction --json`
+
+What this machine keeps tripping over, machine-readable:
+
+```json
+{
+  "schema_version": 2,
+  "sessions_read": 506,
+  "min_sessions": 3,
+  "total": 8,
+  "truncated": true,
+  "rows": [
+    {
+      "error": "command not found: shellcheck",
+      "sessions": 11,
+      "harnesses": ["claude", "codex"],
+      "last": "2026-08-30T09:14:02Z"
+    }
+  ]
+}
+```
+
+`sessions_read` is the denominator the prose header states — sessions that
+recorded tool output, after the trust policy and ignore rules have taken theirs.
+`min_sessions` is the threshold a row had to clear: without it a consumer cannot
+tell an empty result meaning "nothing recurs here" from one meaning "nothing
+recurred *twice*", which are different facts about the same store.
+
+`total` counts the recurring errors found before `--limit` was applied and
+`truncated` says whether the cap hid any, on the same reasoning as the version 2
+search envelope: reading `rows.length` answers neither question once a limit is
+in play.
+
+The empty result is the same shape with an empty `rows` array, never a different
+one. The prose path answers "nothing recurring" five ways depending on which
+rule emptied the store, and a script cannot branch on prose.
+
+`last` is omitted rather than zero-valued when a row carries no recorded time.
+
+## `deja fix <error> --json`
+
+The commands sessions on this machine ran after that error:
+
+```json
+{
+  "schema_version": 2,
+  "fixes": [
+    {
+      "error": "command not found: shellcheck",
+      "command": "brew install shellcheck",
+      "candidate": false,
+      "when": "2026-08-29T18:02:44Z"
+    }
+  ]
+}
+```
+
+`candidate` is the half-evidence flag the prose renders as *"ran next,
+unconfirmed"*: one session ran this after the error and nothing has confirmed it
+worked. A caller acting on a fix automatically needs to know which half it is
+holding, so it is a field rather than a wording difference.
+
+As with `friction`, an empty result keeps the envelope and returns `fixes: []`.
+The prose path distinguishes "held but unconfirmed", "nothing recorded for that
+line" and "no session ran a command after that error" in three different
+sentences; the JSON says only that there is nothing to act on.
+
 ## `deja stats --impact --json`
 
 What deja has actually served on this machine, measured from the usage log:


### PR DESCRIPTION
## What

Both commands answer `--json`, in the shape `docs/json-output.md` describes.

Fixes #1932, taking the option you list first.

## State when I picked this up

The issue describes `friction` accepting `--json`, ignoring it and printing prose. That half is already closed — its unknown-flag guard (#2253) turned the silent ignore into a refusal. So what was left was two commands refusing the same flag, and the issue's own preference: implement it rather than document the refusal.

## The envelopes

Object-shaped, `schema_version` 2, per the stability policy.

```json
{ "schema_version": 2, "sessions_read": 506, "min_sessions": 3,
  "total": 8, "truncated": true, "rows": [ … ] }
```

**The empty result keeps the shape.** That is most of the value here: the prose paths answer "nothing recurring" **five** different ways and "nothing to fix" three, depending on which rule emptied the store — trust policy, ignore rule, no tool output, below threshold. Every one of those is a good sentence for a human and unparseable for a script.

`friction` carries `total` and `truncated` for the reason version 2 gave the search envelope its counts: reading `rows.length` cannot tell you what `--limit` hid. And `min_sessions` because without it a consumer cannot separate *"nothing recurs on this machine"* from *"nothing recurred **twice**"* — different facts about the same store.

`fix` carries `candidate`, the half-evidence flag the prose renders as *"ran next, unconfirmed"*. A caller acting on a fix automatically needs to know which half it is holding, so it is a field rather than a wording difference.

Both use the same `search.SafeLine` / `SafeCommand` sanitisers as the prose path. A recorded error line is untrusted text, and a JSON consumer pasting it into a shell is no safer than a human reading it.

`friction`'s row struct is hoisted to a package-level type so the two renderers cannot disagree about what a row is.

## Two existing tests changed

`TestFixRejectsFlagMistakes` and `TestFrictionAndRestoreRefuseAFlagTheyDoNotTake` pinned the refusals. Updated, not deleted — their property is unchanged and still covered: **a flag a command cannot honour must be refused, never ignored**, now asserted with `--limt` and `--jsonn`. `restore` still refuses `--json` because it does not implement one.

`fix` keeps a case pinning that **`--json` alone is not swallowed into the query** — that is the bug the comment in `fix.go` records, and the reason the flag was refused rather than parsed. It would have been easy to reintroduce while adding the flag.

## Gates

- [x] `go build ./...`
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] `go test ./cmd/deja/` — ok, 88s
- [x] Driven by hand: `deja friction --json` and `deja fix "some error" --json` on an empty store both return the envelope

Documented in `docs/json-output.md` beside the other surfaces, including why each field is there.