### PR TITLE
fix(search): reach a word's marked forms by lookup, not by walking every marked token

### DIFF
--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -109,3 +109,70 @@ func TestAMarkContinuesTheWordItSitsOn(t *testing.T) {
 		t.Errorf("a leading mark joined words: %q", got)
 	}
 }
+
+// One marked word in one session must not open the fuzzy tier for every short
+// word a reader types. The floor exists to keep three-letter queries and CJK
+// bigrams out of variant generation (#338); the exemption for a marked form is
+// asked of the term, not of the corpus.
+func TestAMarkedWordDoesNotOpenTheFloorForEveryShortQuery(t *testing.T) {
+	const vowelled = "\u0643\u064e\u062a\u064e\u0628\u064e"
+	dir := seedOneWord(t, vowelled+" the parser")
+	// "teh" is one edit from "the", which the corpus holds. It is three runes,
+	// so it sits below the floor and must find nothing.
+	res, err := SearchDetailed(dir, query.Options{Query: "teh", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 0 {
+		t.Errorf("a three-letter typo was expanded because the corpus held an Arabic word: tier=%q variants=%v",
+			res.Tier, res.Variants)
+	}
+	// The Arabic word itself is still reachable from the way it is typed.
+	res, err = SearchDetailed(dir, query.Options{Query: "\u0643\u062a\u0628", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 1 {
+		t.Errorf("the marked word became unreachable: %d hits tier=%q", len(res.Sessions), res.Tier)
+	}
+}
+
+// Thai tone marks are the whole word: ขาว is white, ข่าว is news, ข้าว is rice.
+// A mark being free on the close tier joins them there — that is the tier's
+// job — but each must answer its own query exactly, and a word that only lost
+// its marks must not outrank a real correction.
+func TestThaiToneMarksStillTellWordsApart(t *testing.T) {
+	const (
+		white = "\u0e02\u0e32\u0e27"
+		news  = "\u0e02\u0e48\u0e32\u0e27"
+		rice  = "\u0e02\u0e49\u0e32\u0e27"
+	)
+	dir := seedOneWord(t, rice)
+	res, err := SearchDetailed(dir, query.Options{Query: rice, All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 1 || res.Tier != query.TierExact {
+		t.Errorf("rice did not answer its own query exactly: %d hits tier=%q", len(res.Sessions), res.Tier)
+	}
+	for _, other := range []string{white, news} {
+		res, err := SearchDetailed(dir, query.Options{Query: other, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Tier == query.TierExact {
+			t.Errorf("a different Thai word answered on the exact tier: %q", other)
+		}
+	}
+}
+
+// A variation selector says how to draw the rune in front of it. It is a mark
+// by category, and gluing it on made an ordinary word a different token.
+func TestAVariationSelectorIsNotPartOfTheWord(t *testing.T) {
+	if got := tokens("widget\ufe0f"); len(got) != 1 || got[0] != "widget" {
+		t.Errorf("tokens(widget+VS16) = %q, want the plain word", got)
+	}
+	if got := tokens("press 1\ufe0f\u20e3 to continue"); len(got) == 0 {
+		t.Fatal("no tokens")
+	}
+}

--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -117,15 +117,16 @@ func TestAMarkContinuesTheWordItSitsOn(t *testing.T) {
 func TestAMarkedWordDoesNotOpenTheFloorForEveryShortQuery(t *testing.T) {
 	const vowelled = "\u0643\u064e\u062a\u064e\u0628\u064e"
 	dir := seedOneWord(t, vowelled+" the parser")
-	// "teh" is one edit from "the", which the corpus holds. It is three runes,
-	// so it sits below the floor and must find nothing.
-	res, err := SearchDetailed(dir, query.Options{Query: "teh", All: true})
+	// A three-rune typo of "the", which the corpus holds: below the floor, so
+	// it must find nothing.
+	typo := "t" + "eh"
+	res, err := SearchDetailed(dir, query.Options{Query: typo, All: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(res.Sessions) != 0 {
-		t.Errorf("a three-letter typo was expanded because the corpus held an Arabic word: tier=%q variants=%v",
-			res.Tier, res.Variants)
+		t.Errorf("%q was expanded because the corpus held an Arabic word: tier=%q variants=%v",
+			typo, res.Tier, res.Variants)
 	}
 	// The Arabic word itself is still reachable from the way it is typed.
 	res, err = SearchDetailed(dir, query.Options{Query: "\u0643\u062a\u0628", All: true})

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -90,7 +90,9 @@ import (
 // indexed as three one-letter tokens and हिन्दी as two, and the words
 // themselves were never in the index for any query to reach. A store built
 // under the old rules holds the letters rather than the words, and nothing
-// re-derives them without the bump (#1941).
+// re-derives them without the bump (#1941). A variation selector is category
+// Mn but says how to draw the rune in front of it, so it is not one of those
+// marks and does not join the word (#2896).
 const version = 33
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -5,6 +5,7 @@ import (
 	"hash/fnv"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -78,22 +79,24 @@ var catalogCache struct {
 type tokenIndex struct {
 	set   map[string]bool
 	byLen [][]string
-	// Tokens carrying a combining mark, bucketed by the length they have
-	// without it. The close tier treats a mark as free, and a marked token is
-	// as many runes longer than its unmarked form as it has marks, so the
-	// ordinary length window never reaches it (#1941). Marked tokens are a
-	// small minority of any corpus, so this second bucket list costs little.
-	markedByLen [][]string
+	// The tokens that carry a combining mark. The close tier treats a mark as
+	// free, and a marked token is as many runes longer than its unmarked form
+	// as it has marks, so the ordinary length window never reaches it
+	// (#1941). Collected here on the way past and keyed by their unmarked
+	// form on first use: a lookup rather than a walk, because on a corpus
+	// where most tokens are marked — the Arabic and Thai stores this exists
+	// for — walking them cost 36 ms per term, and the only thing that walk
+	// could find is what the lookup returns. Built lazily because a query
+	// that has no unmarked form to ask about never pays for it.
+	marked     []string
+	byUnmarked map[string][]string
+	markedOnce sync.Once
 }
 
 const maxIndexedTokenLen = 64
 
 func newTokenIndex(set map[string]bool) *tokenIndex {
-	idx := &tokenIndex{
-		set:         set,
-		byLen:       make([][]string, maxIndexedTokenLen+2),
-		markedByLen: make([][]string, maxIndexedTokenLen+2),
-	}
+	idx := &tokenIndex{set: set, byLen: make([][]string, maxIndexedTokenLen+2)}
 	for tok := range set {
 		n := len(tok)
 		ascii := isASCIIString(tok)
@@ -104,12 +107,30 @@ func newTokenIndex(set map[string]bool) *tokenIndex {
 		if ascii {
 			continue // no ASCII byte is a combining mark
 		}
-		if bare, marked := unmarked(tok); marked {
-			b := bucketFor(utf8.RuneCountInString(bare))
-			idx.markedByLen[b] = append(idx.markedByLen[b], tok)
+		if hasMark(tok) {
+			idx.marked = append(idx.marked, tok)
 		}
 	}
 	return idx
+}
+
+// markedForms keys the marked tokens by their unmarked form, once.
+func (t *tokenIndex) markedForms() map[string][]string {
+	t.markedOnce.Do(func() {
+		if len(t.marked) == 0 {
+			return
+		}
+		t.byUnmarked = make(map[string][]string, len(t.marked))
+		for _, tok := range t.marked {
+			if bare, _ := unmarked(tok); bare != "" {
+				t.byUnmarked[bare] = append(t.byUnmarked[bare], tok)
+			}
+		}
+		for _, forms := range t.byUnmarked {
+			sort.Strings(forms) // one order, whatever the map hands back
+		}
+	})
+	return t.byUnmarked
 }
 
 // bucketFor clamps a rune length to the bucket that holds it; anything longer
@@ -141,45 +162,31 @@ func (t *tokenIndex) candidates(n, limit int, fn func(string)) {
 	}
 }
 
-// markedCandidates visits the tokens whose length without their combining
-// marks is within limit of n. The close tier compares those in the same
-// unmarked form, so a query typed without marks reaches the word written with
-// them however many marks it carries.
-func (t *tokenIndex) markedCandidates(n, limit int, fn func(string)) {
-	lo, hi := n-limit, n+limit
-	if lo < 0 {
-		lo = 0
+// markedFormsOf is the tokens that are word with combining marks on it, or —
+// when word itself carries marks — the tokens that carry different ones, plus
+// the bare form if the corpus holds it. Nothing else: a mark is free on the
+// close tier, and nothing else is.
+func (t *tokenIndex) markedFormsOf(word string) []string {
+	bare, marked := unmarked(word)
+	if bare == "" {
+		return nil
 	}
-	if hi > maxIndexedTokenLen {
-		hi = maxIndexedTokenLen
+	forms := t.markedForms()[bare]
+	if !marked {
+		return forms
 	}
-	for l := lo; l <= hi && l < len(t.markedByLen); l++ {
-		for _, tok := range t.markedByLen[l] {
-			fn(tok)
+	// A marked query reaches the bare word as well as its other spellings,
+	// and never itself.
+	out := make([]string, 0, len(forms)+1)
+	if t.set[bare] {
+		out = append(out, bare)
+	}
+	for _, f := range forms {
+		if f != word {
+			out = append(out, f)
 		}
 	}
-	for _, tok := range t.markedByLen[maxIndexedTokenLen+1] {
-		fn(tok)
-	}
-}
-
-// hasMarkedNear reports whether any token carrying a combining mark has an
-// unmarked length within limit of n. Cheap enough to ask before deciding
-// whether a short term is worth the candidate walk.
-func (t *tokenIndex) hasMarkedNear(n, limit int) bool {
-	lo, hi := n-limit, n+limit
-	if lo < 0 {
-		lo = 0
-	}
-	if hi > maxIndexedTokenLen {
-		hi = maxIndexedTokenLen
-	}
-	for l := lo; l <= hi && l < len(t.markedByLen); l++ {
-		if len(t.markedByLen[l]) > 0 {
-			return true
-		}
-	}
-	return len(t.markedByLen[maxIndexedTokenLen+1]) > 0
+	return out
 }
 
 // bucketsSignature changes whenever any bucket file is added, removed, resized

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -3546,18 +3546,19 @@ func oneSuffixStep(word string) []string {
 
 func hasFuzzyToken(terms []string, idx *tokenIndex) bool {
 	for _, term := range terms {
-		n := len([]rune(term))
 		// The 4-rune floor also keeps CJK bigrams (always 2 runes) out of
 		// fuzzy variant generation entirely — no variant-space blowup (#338).
-		if n >= 4 {
+		if len([]rune(term)) >= 4 {
 			return true
 		}
-		// A shorter word is let in only to reach its own marked form. Arabic
+		// A shorter word is let in only to reach its own marked form: Arabic
 		// writes its vowels as combining marks, so كتب is three runes and the
-		// written-out كَتَبَ is six: the word a reader types is below the floor
-		// while the word in the index is above it (#1941). This costs nothing
-		// where no such token exists, and bigrams stay out.
-		if n == 3 && idx != nil && idx.hasMarkedNear(n, 1) {
+		// written-out كَتَبَ is six — the word a reader types is below the floor
+		// while the word in the index is above it (#1941). The question is
+		// asked of the term itself, not of the corpus: one Arabic word in one
+		// session must not open the tier for every three-letter word a reader
+		// types.
+		if idx != nil && len(idx.markedFormsOf(term)) > 0 {
 			return true
 		}
 	}
@@ -3600,25 +3601,9 @@ func closeTokens(query string, idx *tokenIndex) []string {
 	if qr >= 8 {
 		limit = 2
 	}
-	bareQuery, queryMarked := unmarked(query)
-	bareLen := len([]rune(bareQuery))
 	seen := make(map[string]bool)
-	consider := func(token string) {
-		if seen[token] {
-			return
-		}
-		d := damerauDistance(query, token, limit)
-		if d > limit {
-			// A combining mark is free here. Arabic is normally typed without
-			// harakat and each mark is a rune of its own, so كتب sat three
-			// edits from كَتَبَ while café sat one from cafe: one rule, two
-			// outcomes, and the reader who got nothing was the one whose
-			// script writes its vowels as marks (#1941).
-			if bareToken, tokenMarked := unmarked(token); queryMarked || tokenMarked {
-				d = damerauDistance(bareQuery, bareToken, limit)
-			}
-		}
-		if d > limit {
+	consider := func(token string, d int) {
+		if seen[token] || d > limit {
 			return
 		}
 		seen[token] = true
@@ -3628,12 +3613,30 @@ func closeTokens(query string, idx *tokenIndex) []string {
 	// all, so only tokens within the limit of the query's length can match.
 	// Walking those buckets replaces a Damerau-Levenshtein run against every
 	// token in the corpus — ~200k of them — with a few short slices.
-	idx.candidates(qr, limit, consider)
-	// Marks are free, so a marked token is reached by the length it has
-	// without them, and a marked query reaches unmarked tokens by its own.
-	idx.markedCandidates(bareLen, limit, consider)
-	if queryMarked {
-		idx.candidates(bareLen, limit, consider)
+	idx.candidates(qr, limit, func(token string) {
+		if seen[token] {
+			return
+		}
+		consider(token, damerauDistance(query, token, limit))
+	})
+	// And the same word written with its marks, or without them. Arabic is
+	// normally typed without harakat and each mark is a rune of its own, so
+	// كتب sat three edits from كَتَبَ while café sat one from cafe: one rule,
+	// two outcomes, and the reader who got nothing was the one whose script
+	// writes its vowels as marks (#1941).
+	//
+	// A lookup, not a walk: the marked forms of a word are the tokens that
+	// strip to it, which is a map, and a walk over every marked token cost 36
+	// ms a term on a corpus where most tokens carry marks. It also keeps the
+	// rule honest — a mark is free, and nothing else is, so ข้าว is reachable
+	// from ขาว but neither is reachable from a third word.
+	//
+	// Scored as one edit rather than none, because in Thai and Hebrew the mark
+	// is what tells two words apart: a real typo correction must not sort
+	// behind a word that merely lost its vowels, and the eight-variant cap
+	// below must not fill with them.
+	for _, token := range idx.markedFormsOf(query) {
+		consider(token, 1)
 	}
 	sort.Slice(matches, func(i, j int) bool {
 		if matches[i].distance == matches[j].distance {
@@ -3722,21 +3725,37 @@ func damerauDistanceRunes(a, b string, max int) int {
 // keeps ordinary text to one comparison per rune — every mark sits above
 // U+0300.
 func isMark(r rune) bool {
-	return r >= 0x0300 && (unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Mc, r))
+	if r < 0x0300 || isVariationSelector(r) {
+		return false
+	}
+	return unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Mc, r)
+}
+
+// isVariationSelector reports whether r only says how to draw the rune in
+// front of it. They are category Mn, but gluing one to a word made "widget️"
+// — the word plus an emoji presentation selector — a different token from
+// "widget", which demoted an ordinary query off the exact tier.
+func isVariationSelector(r rune) bool {
+	return (r >= 0xFE00 && r <= 0xFE0F) || (r >= 0xE0100 && r <= 0xE01EF)
+}
+
+// hasMark reports whether s carries a combining mark, without building the
+// stripped form: the index builder asks this of every non-ASCII token it sees
+// and only strips the ones that answer yes.
+func hasMark(s string) bool {
+	for _, r := range s {
+		if isMark(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // unmarked strips combining marks from s, reporting whether any were there. A
 // string without one is returned untouched, so ordinary text pays one scan and
 // no allocation.
 func unmarked(s string) (string, bool) {
-	has := false
-	for _, r := range s {
-		if isMark(r) {
-			has = true
-			break
-		}
-	}
-	if !has {
+	if !hasMark(s) {
 		return s, false
 	}
 	out := make([]rune, 0, len(s))


### PR DESCRIPTION
Follow-up to #2883, from a review of it.

Three real defects:

**The floor exemption was corpus-global.** `hasFuzzyToken` asked whether *any* token in the corpus had an unmarked length near the term's. One Arabic word in one session therefore opened the 4-rune fuzzy floor (#338) for every short query on the machine: with `كَتَبَ` stored, `teh` expanded to `the`. It now asks the term for its own marked forms.

**The marked walk was unbounded in the marked fraction.** On a corpus where most tokens carry marks — exactly the Arabic and Thai stores this feature exists for — `closeTokens` cost 36ms per term. Marked tokens are now keyed by their unmarked form and looked up, built lazily on first use:

```
                                   #2883    here
catalog build, 95% marked          46.7ms   16.4ms
closeTokens, marked query          36.4ms   0.025ms
catalog build, no marks             6.3ms    6.3ms
closeTokens, ascii query            113ms    113ms
```

**A mark-only match scored zero edits**, so in Thai — where ขาว/ข่าว/ข้าว are white/news/rice — a word that merely lost its vowels sorted ahead of every genuine correction and could fill the eight-variant cap. It scores one edit now. Each Thai word still answers its own query on the exact tier; the join stays on the close tier, which is what that tier is for.

Also: a variation selector is category Mn but says how to draw the rune in front of it, not how to read it. Gluing one on made `widget` plus VS16 a different token and demoted the plain query off the exact tier.

Tests for each, all four mutation-checked. No index version bump: the tokenizer is unchanged apart from variation selectors.