### PR TITLE
perf(search): answer a short ASCII query without reading the catalog

### DIFF
--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -177,3 +177,26 @@ func TestAVariationSelectorIsNotPartOfTheWord(t *testing.T) {
 		t.Fatal("no tokens")
 	}
 }
+
+// A query of short ASCII terms is below the fuzzy floor and cannot reach a
+// marked form either — a mark strips to a non-ASCII base — so it must answer
+// without reading the catalog. Reading it is what #338's floor was avoiding
+// (#2898).
+func TestAShortAsciiQueryDoesNotReadTheCatalog(t *testing.T) {
+	dir := seedOneWord(t, "\u0643\u064e\u062a\u064e\u0628\u064e")
+	before := catalogReads.Load()
+	if _, _, err := fuzzyPostings(dir, []string{"abc", "xyz"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := catalogReads.Load() - before; got != 0 {
+		t.Errorf("the catalog was read %d times for a query that cannot match anything", got)
+	}
+	// A short non-ASCII term does reach it, which is what the exemption is for.
+	before = catalogReads.Load()
+	if _, _, err := fuzzyPostings(dir, []string{"\u0643\u062a\u0628"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if catalogReads.Load() == before {
+		t.Error("a marked word's plain form never consulted the catalog")
+	}
+}

--- a/internal/index/manifest_cache.go
+++ b/internal/index/manifest_cache.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 )
@@ -216,7 +217,13 @@ func tokenCatalogCached(dir string) (map[string]bool, error) {
 	return idx.set, nil
 }
 
+// catalogReads counts how often the token catalog was consulted, for the test
+// that pins the fuzzy tier's early exit (#2898). Reading it is the only way to
+// tell "answered no without looking" from "looked, then answered no".
+var catalogReads atomic.Int64
+
 func tokenIndexCached(dir string) (*tokenIndex, error) {
+	catalogReads.Add(1)
 	sig, err := bucketsSignature(dir)
 	if err != nil {
 		c, cerr := tokenCatalog(dir)

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -2983,9 +2983,14 @@ func fuzzyPostings(dir string, terms, phrases []string) ([]posting, map[string][
 	if !hasFuzzyToken(terms, nil) {
 		// Every term is below the length floor. One of them may still be a
 		// word whose marked form is in the index, which only the catalog can
-		// say; a catalog that will not read means no, the same answer this
-		// path gave before it asked.
+		// say — but a mark strips to a non-ASCII base, so an ASCII term has
+		// none and the catalog stays unread. That keeps the answer this path
+		// gave before it asked, and keeps it free (#2898).
+		if !anyNonASCII(terms) {
+			return nil, nil, nil
+		}
 		cat, err := tokenIndexCached(dir)
+		// A catalog that will not read means no, as it did before.
 		if err != nil || !hasFuzzyToken(terms, cat) {
 			return nil, nil, nil
 		}
@@ -3544,6 +3549,16 @@ func oneSuffixStep(word string) []string {
 	return out
 }
 
+// anyNonASCII reports whether any term could carry or shed a combining mark.
+func anyNonASCII(terms []string) bool {
+	for _, term := range terms {
+		if !isASCIIString(term) {
+			return true
+		}
+	}
+	return false
+}
+
 func hasFuzzyToken(terms []string, idx *tokenIndex) bool {
 	for _, term := range terms {
 		// The 4-rune floor also keeps CJK bigrams (always 2 runes) out of
@@ -3691,10 +3706,13 @@ func damerauDistance(a, b string, max int) int {
 }
 
 func damerauDistanceRunes(a, b string, max int) int {
-	ar, br := []rune(a), []rune(b)
-	if abs(len(ar)-len(br)) > max {
+	// Before the conversion: an edit changes the length by one, so a pair too
+	// far apart in runes cannot match however it is spelled, and counting
+	// costs no allocation.
+	if abs(utf8.RuneCountInString(a)-utf8.RuneCountInString(b)) > max {
 		return max + 1
 	}
+	ar, br := []rune(a), []rune(b)
 	prev := make([]int, len(br)+1)
 	for j := range prev {
 		prev[j] = j


### PR DESCRIPTION
Two from the #2883 review.

Reaching a word's marked forms means asking the catalog, so #2883 made every below-the-floor query load it just to be told no — the early exit #338 relies on. A mark strips to a non-ASCII base, so an ASCII term has nothing to look up and the catalog stays unread. A short non-ASCII term still consults it, which is the whole point of the exemption.

`damerauDistanceRunes` also converted both strings to rune slices before the length bail that rejects the pair. Counting runes settles it without allocating.

The counter the test reads is the only way to tell "answered no without looking" from "looked, then answered no". The bail reorder is not mutation-detectable — same result, fewer allocations — and is stated as such rather than pinned.

Closes #2898.