### PR TITLE
fix(index): stop mining remedies that point at a scratch file

### DIFF
--- a/internal/index/fix_ephemeral_test.go
+++ b/internal/index/fix_ephemeral_test.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A remedy that names a file under a temp directory cannot be run by anyone,
+// including the session that ran it: the file is gone by the time deja serves
+// the pair. On this machine 38 of 186 confirmed pairs stored one — an agent
+// scripts an edit into a scratch file, runs it, then re-runs the suite, and
+// the whole line is mined as the fix for the failing test.
+//
+// Handing that back at the moment an agent is stuck is worse than silence,
+// which is the bar the miner already holds itself to for a command that
+// failed (#2163).
+func TestARemedyUnderATempDirectoryIsNotMined(t *testing.T) {
+	gone := []string{
+		"$ python3 /Users/x/.claude/jobs/9f0aa059/tmp/edit38.py; go test ./internal/index/",
+		"$ sh /tmp/patch.sh",
+		"$ bash /var/folders/2b/T/scratch/apply.sh && go build ./...",
+		"$ python3 $TMPDIR/fixture.py",
+	}
+	for _, cmd := range gone {
+		if !namesAnEphemeralPath(cmd) {
+			t.Errorf("kept as a remedy, and the file it names is gone: %s", cmd)
+		}
+	}
+
+	kept := []string{
+		"$ go mod tidy",
+		"$ python3 scripts/gen.py",
+		"$ brew install pgbouncer",
+		// The word appears, the path does not: a flag or a package name that
+		// merely spells it is not a scratch file.
+		"$ go test ./internal/tmp/",
+		"$ kubectl get pods --request-timeout=20s",
+		"$ git commit -m 'drop the /tmp fallback'",
+	}
+	for _, cmd := range kept {
+		if namesAnEphemeralPath(cmd) {
+			t.Errorf("dropped a runnable remedy: %s", cmd)
+		}
+	}
+}
+
+// End to end through the miner, so the rule is wired and not merely present.
+func TestTheMinerSkipsAScratchScriptAndTakesTheRealRemedy(t *testing.T) {
+	ms := []model.Message{
+		{Role: roleToolOutput, Text: "--- FAIL: TestPoolTimeout"},
+		{Role: roleCommand, Text: "$ python3 /tmp/edit.py; go test ./..."},
+		{Role: roleToolOutput, Text: "ok"},
+		{Role: roleCommand, Text: "$ go mod tidy"},
+		{Role: roleToolOutput, Text: "ok"},
+	}
+	pairs := fixPairsIn(ms, "k", "proj")
+	if len(pairs) != 1 {
+		t.Fatalf("want one pair, got %d: %#v", len(pairs), pairs)
+	}
+	if pairs[0].Command != "$ go mod tidy" {
+		t.Errorf("remedy = %q, want the command that can still be run", pairs[0].Command)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -357,11 +357,33 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			if investigationCommand(cmd) {
 				continue
 			}
+			// A command that names a scratch file is not a remedy anyone can
+			// run, including the session that ran it: an agent scripts an edit
+			// into a temp file, runs it, then re-runs the suite, and the whole
+			// line reads as the fix for the failing test. On a real store that
+			// was 38 of 186 confirmed pairs (#2163). Keep scanning — the
+			// durable command usually follows.
+			if namesAnEphemeralPath(cmd) {
+				continue
+			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
 			break
 		}
 	}
 	return out
+}
+
+// ephemeralPathRE matches a path under a directory whose contents do not
+// survive: the system temp roots, and the per-session scratch directories an
+// agent harness hands its tools. Anchored on a boundary and on the separator
+// that follows, so a package path like ./internal/tmp/ and the word inside a
+// commit message are left alone.
+var ephemeralPathRE = regexp.MustCompile(`(^|[\s"'=(])(/tmp/|/var/folders/|/private/tmp/|\$TMPDIR/|\${TMPDIR}/)|/\.claude/jobs/[^/]+/tmp/`)
+
+// namesAnEphemeralPath reports whether the command reaches for a file that is
+// gone by the time deja would serve it.
+func namesAnEphemeralPath(cmd string) bool {
+	return ephemeralPathRE.MatchString(cmd)
 }
 
 // firstFrictionLine returns the first line of a record that names something


### PR DESCRIPTION
Read the confirmed pairs a real store holds today, the way #2163 read them. 186 pairs, and **38 of them name a file under a temp directory** — `python3 /Users/…/tmp/edit38.py; go test ./…` stored as the remedy for `--- FAIL: TestX`.

The shape is consistent: an agent scripts an edit into a scratch file, runs it, then re-runs the suite, and the whole compound line is mined as the fix. `investigationCommand` does not catch it because it requires every part of the command to be an investigation, and the `python3 …` part is a real edit — it just names a file that is gone by the time anyone reads the pair.

Handing an agent a command it cannot run, at the moment it is stuck, is the case the miner already refuses for a command that failed. Same reason, same treatment: skip it and keep scanning the window, because the durable command usually follows.

Rebuild of the same store, before and after:

```
confirmed pairs            186  ->  147
naming a scratch path       38  ->    0
```

Matched on a path boundary and the separator that follows, so `./internal/tmp/` and a commit message that mentions `/tmp` are left alone. Four mutations, all red: dropping the rule, breaking out of the window instead of scanning on, dropping the boundary, and dropping the harness scratch root.

This is one of the two things #2163 points at and does not close it — the larger question there, what to do with test-failure pairs whose remedy is an edit rather than a command, is untouched.
