### PR TITLE
fix(index): Thai gets the bigrams the other unspaced scripts have

### DIFF
--- a/internal/cjkfold/fold.go
+++ b/internal/cjkfold/fold.go
@@ -66,8 +66,24 @@ func String(s string) string {
 	return string(runes)
 }
 
+// Unspaced reports whether r belongs to a script that writes without spaces
+// between words. Everything IsCJK covers, plus Thai: a Thai sentence is one
+// run of letters, so a tokenizer that splits on spaces keys the sentence and
+// never the word (#2897). The bigram path is what makes such a script
+// searchable, and it asks this rather than IsCJK.
+func Unspaced(r rune) bool {
+	return IsCJK(r) || IsThai(r)
+}
+
+// IsThai reports whether r is a Thai letter, digit or sign. The block is
+// contiguous and holds nothing else, so the range is the test.
+func IsThai(r rune) bool {
+	return r >= 0x0E00 && r <= 0x0E7F
+}
+
 // IsCJK reports whether r is a Han, Hiragana, Katakana or Hangul rune — the
-// scripts this package folds, and the ones written without spaces between words.
+// scripts this package folds. Use Unspaced for the wider question of whether a
+// script writes its words apart.
 func IsCJK(r rune) bool {
 	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
 		unicode.Is(unicode.Katakana, r) || unicode.Is(unicode.Hangul, r) ||
@@ -192,7 +208,7 @@ func Bigrams(s string) []string {
 		run = run[:0]
 	}
 	for _, r := range s {
-		if IsCJK(r) {
+		if Unspaced(r) {
 			run = append(run, r)
 			continue
 		}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -171,7 +171,7 @@ func looksLikeProse(line string) bool {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r >= 0x80 {
 			letters++
 		}
-		if cjkfold.IsCJK(r) {
+		if cjkfold.Unspaced(r) {
 			spaceless++
 		}
 	}

--- a/internal/index/cjkindex.go
+++ b/internal/index/cjkindex.go
@@ -147,7 +147,7 @@ func cjkIndexKeys(s string, emit func(tok string)) {
 	}
 
 	for _, r := range s {
-		if !cjkfold.IsCJK(r) {
+		if !cjkfold.Unspaced(r) {
 			flush()
 			continue
 		}

--- a/internal/index/diacritics_test.go
+++ b/internal/index/diacritics_test.go
@@ -200,3 +200,33 @@ func TestAShortAsciiQueryDoesNotReadTheCatalog(t *testing.T) {
 		t.Error("a marked word's plain form never consulted the catalog")
 	}
 }
+
+// Thai writes without spaces, so a sentence is one run of letters: the
+// tokenizer keys the sentence and the reader searching for a word in it got
+// nothing. Bigrams are what makes an unspaced script searchable, and Thai now
+// gets the ones CJK has had (#2897).
+func TestAThaiWordIsFoundInsideASentence(t *testing.T) {
+	const sentence = "\u0e09\u0e31\u0e19\u0e0a\u0e2d\u0e1a\u0e01\u0e34\u0e19\u0e02\u0e49\u0e32\u0e27\u0e40\u0e0a\u0e49\u0e32\u0e17\u0e38\u0e01\u0e27\u0e31\u0e19"
+	dir := seedOneWord(t, sentence)
+	for _, word := range []string{
+		"\u0e02\u0e49\u0e32\u0e27",             // rice
+		"\u0e40\u0e0a\u0e49\u0e32",             // morning
+		"\u0e17\u0e38\u0e01\u0e27\u0e31\u0e19", // every day
+	} {
+		res, err := SearchDetailed(dir, query.Options{Query: word, All: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Sessions) != 1 {
+			t.Errorf("%q: %d hits, want the sentence that contains it", word, len(res.Sessions))
+		}
+	}
+	// A Thai word the sentence does not contain is still not in it.
+	res, err := SearchDetailed(dir, query.Options{Query: "\u0e2a\u0e38\u0e19\u0e31\u0e02", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 0 {
+		t.Errorf("an absent word matched the sentence: %d hits", len(res.Sessions))
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -93,7 +93,12 @@ import (
 // re-derives them without the bump (#1941). A variation selector is category
 // Mn but says how to draw the rune in front of it, so it is not one of those
 // marks and does not join the word (#2896).
-const version = 33
+// 34: Thai is indexed the way the other unspaced scripts are. Thai writes
+// without spaces between words, so a sentence was one token cut at the byte
+// cap and no query reached the words inside it; it now emits the overlapping
+// bigrams CJK has had since 21. A store built before this holds the sentences
+// and nothing re-derives the bigrams without the bump (#2897).
+const version = 34
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/query/cjk.go
+++ b/internal/query/cjk.go
@@ -25,7 +25,7 @@ func ExpandCJKTokens(toks []string) []string {
 		hasCJK := false
 		allCJK := true
 		for _, r := range runes {
-			if cjkfold.IsCJK(r) {
+			if cjkfold.Unspaced(r) {
 				hasCJK = true
 			} else {
 				allCJK = false
@@ -42,12 +42,12 @@ func ExpandCJKTokens(toks []string) []string {
 		}
 		i := 0
 		for i < len(runes) {
-			if !cjkfold.IsCJK(runes[i]) {
+			if !cjkfold.Unspaced(runes[i]) {
 				i++
 				continue
 			}
 			j := i
-			for j < len(runes) && cjkfold.IsCJK(runes[j]) {
+			for j < len(runes) && cjkfold.Unspaced(runes[j]) {
 				j++
 			}
 			out = append(out, cjkfold.Bigrams(string(runes[i:j]))...)

--- a/internal/query/terms.go
+++ b/internal/query/terms.go
@@ -27,7 +27,7 @@ func RelevanceTerms(q string) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, f := range fields {
-		if len([]rune(f)) < 2 || (len(f) < 3 && !cjkfold.IsCJK([]rune(f)[0])) || IsStopWord(f) || seen[f] {
+		if len([]rune(f)) < 2 || (len(f) < 3 && !cjkfold.Unspaced([]rune(f)[0])) || IsStopWord(f) || seen[f] {
 			continue
 		}
 		if CJKFunctionBigram(f) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1083,7 +1083,7 @@ func countDocumentWords(s string, terms []string, variants map[string][]string, 
 			size = n
 			isWord = unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
 			if isWord {
-				if cjkfold.IsCJK(r) {
+				if cjkfold.Unspaced(r) {
 					cjk++
 				} else {
 					other++


### PR DESCRIPTION
Thai writes without spaces, so `ฉันชอบกินข้าวเช้าทุกวัน` is one run of letters: the tokenizer keyed the sentence, cut it at the 64-byte cap mid-syllable, and no query for a word inside it reached anything. CJK has had overlapping bigrams for this since index version 21; Thai was simply not in the script test.

`cjkfold.Unspaced` is that test — everything `IsCJK` covers plus the Thai block — and the sites that meant "written without spaces" now ask it: the bigram emitter on both the index and the query side, the digest's prose check, the search word count, and the query term floor. `IsCJK` keeps its name and its meaning for the folding table and the Chinese function-rune list.

Index version 34.

The tone-mark test from #2896 still holds: ขาว, ข่าว and ข้าว each answer their own query and none answers another's, because the bigram AND keeps them apart.

Closes #2897.