### PR TITLE
fix(digest): quote the sentence that concludes, not only the opening

### DIFF
--- a/internal/digest/decision_lead_test.go
+++ b/internal/digest/decision_lead_test.go
@@ -1,0 +1,89 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func conclusionSession(text string) model.Session {
+	return model.Session{
+		Harness:  "claude",
+		Project:  "p",
+		ID:       "s1",
+		Messages: []model.Message{{Role: "assistant", Text: text}},
+	}
+}
+
+// A reply is diagnosis-first, and the block quoted its opening. When the
+// outcome is further in, that handed an agent the symptom and dropped what the
+// session settled — 211 of 490 sessions on a real store (#2243).
+func TestTheBlockQuotesTheConclusionAndNotOnlyTheDiagnosis(t *testing.T) {
+	got := Conclusions(conclusionSession(
+		"The pool kept dropping connections under load. "+
+			"Both replicas showed the same pattern in the logs. "+
+			"The fix was raising pgbouncer default_pool_size to 40."), 600, 3)
+	if len(got) == 0 {
+		t.Fatal("nothing was quoted")
+	}
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, "raising pgbouncer default_pool_size to 40") {
+		t.Errorf("the outcome is not in the block:\n%s", joined)
+	}
+	if !CarriesDecision(joined) {
+		t.Errorf("the block does not read as a conclusion:\n%s", joined)
+	}
+}
+
+// The opening stays the default. A head that already concludes must not be
+// traded for some later sentence that also happens to carry a marker — the
+// first statement of the outcome is the one worth having.
+func TestAHeadThatAlreadyConcludesIsKept(t *testing.T) {
+	got := Conclusions(conclusionSession(
+		"Connections were dropping under load. "+
+			"The fix was pinning pgx to 5.4.3. "+
+			"Later we also merged the CI image switch."), 600, 3)
+	if len(got) == 0 {
+		t.Fatal("nothing was quoted")
+	}
+	// Both sentences of the head, not the decision sentence lifted out of it:
+	// the opening is what makes the outcome make sense, and a later sentence
+	// carrying a marker of its own must not displace it.
+	for _, want := range []string{"Connections were dropping under load", "pinning pgx to 5.4.3"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("the head was traded for a later sentence, %q is gone:\n%s", want, got[0])
+		}
+	}
+}
+
+// A message that settles nothing must not acquire a conclusion: the fallback
+// is still its opening.
+func TestAMessageWithNoOutcomeStillQuotesItsOpening(t *testing.T) {
+	got := Conclusions(conclusionSession(
+		"Looking at the pool metrics now. "+
+			"The graph covers the last six hours. "+
+			"I will check the replica logs next."), 600, 3)
+	if len(got) == 0 {
+		t.Fatal("a message that settles nothing was dropped entirely; its opening is still the answer")
+	}
+	if !strings.Contains(got[0], "Looking at the pool metrics") {
+		t.Errorf("the opening was dropped for something else:\n%s", got[0])
+	}
+}
+
+// The splitter has to agree with firstSentences on what a sentence is, or the
+// two disagree about where a conclusion starts. A version number is not a
+// sentence end; a CJK stop is, with no space after it.
+func TestSentencesSplitWhereTheDigestAlreadySplits(t *testing.T) {
+	got := sentencesOf("Pinned pgx to v5.4.3 and it held. Left a note.")
+	if len(got) != 2 {
+		t.Fatalf("split into %d sentences, want 2: %q", len(got), got)
+	}
+	if !strings.Contains(got[0], "v5.4.3 and it held") {
+		t.Errorf("the version number was read as a sentence end: %q", got[0])
+	}
+	if n := len(sentencesOf("已固定 pgx 5.4.3。问题消失了。")); n != 2 {
+		t.Errorf("CJK sentences split into %d, want 2", n)
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -957,7 +957,7 @@ func Conclusions(s model.Session, budget int, max int) []string {
 	var out []string
 	spent := 0
 	for i := len(picked) - 1; i >= 0 && len(out) < max; i-- {
-		line := firstSentences(MessageText(picked[i].Text), 2)
+		line := decisionLead(MessageText(picked[i].Text))
 		if line == "" {
 			continue
 		}
@@ -989,6 +989,62 @@ func Conclusions(s model.Session, budget int, max int) []string {
 		if spent >= budget {
 			break
 		}
+	}
+	return out
+}
+
+// decisionLead is the part of a picked message the block quotes: its opening
+// two sentences, unless the words that make it a conclusion are further in.
+//
+// A reply is diagnosis-first, so the opening is the right default and #1336's
+// whole-sentences rule is built on it. But the head is not always where the
+// conclusion lives, and when it is not, the block quoted the diagnosis and
+// dropped the outcome — measured on a real store, 211 of 490 sessions that
+// settled something handed over a block that no longer read as one (#2243).
+//
+// One sentence, not the head plus it: the budget is the reason the conclusion
+// fell off in the first place.
+func decisionLead(text string) string {
+	head := firstSentences(text, 2)
+	if head == "" || CarriesDecision(head) {
+		return head
+	}
+	for _, sent := range sentencesOf(text) {
+		if CarriesDecision(sent) {
+			return sent
+		}
+	}
+	return head
+}
+
+// sentencesOf splits on the same stops firstSentences counts, so the two agree
+// on what a sentence is — including the space-after rule that keeps "v1.2"
+// whole and the CJK stops that have no space after them.
+func sentencesOf(s string) []string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if s == "" {
+		return nil
+	}
+	var out []string
+	start := 0
+	for i, r := range s {
+		switch {
+		case r == '.' || r == '!' || r == '?':
+			if i+1 < len(s) && s[i+1] != ' ' {
+				continue
+			}
+		case isCJKSentenceEnd(r):
+		default:
+			continue
+		}
+		end := i + utf8.RuneLen(r)
+		if sent := strings.TrimSpace(s[start:end]); sent != "" {
+			out = append(out, sent)
+		}
+		start = end
+	}
+	if sent := strings.TrimSpace(s[start:]); sent != "" {
+		out = append(out, sent)
 	}
 	return out
 }


### PR DESCRIPTION
The residual of #2243, and the thing its own follow-up comment names: `CarriesDecision` answers differently for a line and for an excerpt of that line, and 8 of the 12 remaining assistant misses were blocks that *did* carry the conclusion with the marking words cut off.

`Conclusions` quoted `firstSentences(text, 2)`. A reply is diagnosis-first, which is why the opening is the default and why #1336's whole-sentences rule is built on it — but when the outcome lands further in, the block handed over the symptom and dropped what the session settled.

Measured through the real path, one scratch index over this machine's stores, `Conclusions(s, 600, 3)` per session, judged by `CarriesDecision`:

```
sessions that settled something   490     490
  the block carried it            275     421
  the block missed it             211      62
  the block came back empty         4       7
```

The head stays the default: a message that already concludes in its opening keeps both sentences, and a message that settles nothing still quotes its opening. Only when the head does not conclude does the lead move to the first sentence that does — one sentence, not the head plus it, since the budget is why it fell off to begin with.

`sentencesOf` splits on exactly what `firstSentences` counts, including the space-after rule that keeps `v5.4.3` whole and the CJK stops that have no space after them; the two disagreeing about where a sentence starts is its own bug.

Three benches unchanged — prompt 13/13 with 6 cross-paired false fires, recall@5 1.00, context median 294 tokens.

**Two of the five mutations were blind at first.** The head-is-kept fixture concluded in its *first* sentence, so removing the guard produced the same string; it now concludes in the second, and the test asserts both sentences survive. And the no-outcome test skipped itself when nothing came back instead of failing. All five red now.

Does not close #2243 — the tool-output and brief-quoting groups there are unchanged.
