### PR TITLE
fix(digest): read the English shapes of a decision

### DIFF
--- a/internal/digest/decision_english_test.go
+++ b/internal/digest/decision_english_test.go
@@ -1,0 +1,29 @@
+package digest
+
+import "testing"
+
+// The English half of the marker list was missing the shapes English uses to
+// close something, and the store the list was measured on is Russian-dominant,
+// so the gap read as rare rather than as a hole (#2340).
+func TestEnglishDecisionShapesAreRead(t *testing.T) {
+	for _, line := range []string{
+		"we settled on ninety seconds for the skew window",
+		"in the end we went with the vpn resolver",
+		"we ended up reading the cycle count from ioreg",
+		"opted for noto as the fallback font",
+		"Decision: the ledger rejects a batch over ninety seconds",
+	} {
+		if !CarriesDecision(line) {
+			t.Errorf("not read as a decision: %q", line)
+		}
+	}
+	// And a line that only plans one is still not a decision.
+	for _, line := range []string{
+		"i will look at the skew window later",
+		"what should we do about the resolver",
+	} {
+		if CarriesDecision(line) {
+			t.Errorf("read as a decision: %q", line)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -623,14 +623,14 @@ var decisionMarkers = []string{
 	// live questions turns into a pointer.
 	"теперь ", "стало ", "становится", "лежит в", "работает через",
 	"по умолчанию", "переехал", "now lives", "now goes", "by default",
-	// A decision is as often reported as the state something ended up in as by
-	// the act of deciding. Measured over 4000 assistant lines from a real
-	// store, the list above marks 4% of them, and lines like "прод-пины теперь
-	// ложатся на deploy/prod" or "бывшая ведущая становится ведомой" — plainly
-	// the outcome of a decision — were read as passing mentions. With these the
-	// share is 9%, the benchmark does not move, and one off-topic block of 58
-	// live questions turns into a pointer.
-
+	// The English half was missing the shapes English actually uses to close
+	// something. Counted over 41,084 real messages, the Russian markers fired
+	// 149 times on "решили" and 47 on "в итоге" while their English mirrors —
+	// "we settled on", "in the end we", "Decision:" at the start of a line —
+	// fired once or twice each: the store is Russian-dominant, so the gap read
+	// as rare rather than as a hole (#2340). It is a hole for a reader working
+	// in English, and these are the same shapes as the entries above them.
+	"settled on", "went with", "ended up", "in the end", "opted for",
 }
 
 // CarriesDecision reports whether a line reads as something concluded rather


### PR DESCRIPTION
#2340 counted the markers over 41,084 real messages and found the English half firing once or twice each where the Russian half fired 149 and 47 times. That store is Russian-dominant, so the gap read as rare; for a reader working in English it is a hole, and `we settled on ninety seconds` was a passing mention as far as the block was concerned.

Five shapes added, the same kinds already in the list: settled on, went with, ended up, in the end, opted for.

longmemeval over 200 questions is byte-identical (79.5% hit@1, MRR 0.857), which is what widening a marker list should do to a benchmark whose corpus does not use those phrases. The test pins the five, and pins that a line merely planning something is still not a decision.

Refs #2340, #2243.