### PR TITLE
fix(goose): keep a session unless goose wrote it for itself

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -77,7 +77,13 @@ import (
 // re-derives them — `deja friction` reads the records and sees the difference,
 // while `hook-tool-after` and the environment block read the manifest and stay
 // silent, which is the state this bump exists to end (#2444).
-const version = 31
+// 32: goose sessions are kept unless goose says it wrote them for itself. The
+// filter was an allow-list, so a way of reaching goose that it did not name
+// was dropped. A store built under the old rules is missing those sessions,
+// and the db path only re-reads what has been touched since its watermark, so
+// without the bump they stay missing until each is used again — the same shape
+// as 21, 22 and 23 (#2873).
+const version = 32
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -178,19 +178,39 @@ func gooseText(v any) string {
 	}
 }
 
-// gooseTypeFilter keeps subagent turns, cron-recipe runs and gateway traffic
-// out of recall: Goose stores them in the same table as the user's own
-// sessions. The user-visible session types (user, acp and terminal) belong in
-// recall, while gateway, hidden, subagent and scheduled remain excluded. The
-// column exists only on newer stores, and naming it on an older one fails the
-// whole query, so it is probed rather than assumed.
+// gooseTypeFilter keeps out of recall what goose wrote for itself: Goose
+// stores subagent turns and scheduled runs in the same table as the reader's
+// own sessions. The column exists only on newer stores, and naming it on an
+// older one fails the whole query, so it is probed rather than assumed.
+//
+// Stated as what to exclude rather than what to keep. #2874 named the three
+// types a person reaches goose through today, which fixed the report; written
+// that way round, a type goose adds next is dropped silently and nothing says
+// why — the failure that produced #2873 in the first place. So: a type is a
+// person's work until goose is known to write it for itself.
 func gooseTypeFilter(db string) string {
 	out, err := exec.Command("sqlite3", "-readonly", sqliteTarget(db), ".timeout 5000", "pragma table_info(sessions)").Output()
 	if err != nil || !bytes.Contains(out, []byte("session_type")) {
 		return ""
 	}
-	return " and (s.session_type is null or s.session_type = '' or s.session_type in ('user','acp','terminal'))"
+	quoted := make([]string, 0, len(gooseMachineTypes))
+	for _, t := range gooseMachineTypes {
+		quoted = append(quoted, "'"+t+"'")
+	}
+	return " and (s.session_type is null or s.session_type not in (" + strings.Join(quoted, ",") + "))"
 }
+
+// gooseMachineTypes are the session types goose writes for its own work rather
+// than the reader's: a subagent it spawned, spelled both ways across versions,
+// and a run its scheduler started.
+//
+// Read off goose's own enum — user, scheduled, sub_agent, hidden, terminal,
+// gateway, acp — rather than guessed. `hidden` is not on this list although
+// the name suggests it: goose writes it for `goose run --no-session`, the
+// reader working without keeping a session, and for two wizards that store no
+// conversation and fall out of the role join anyway. `gateway` is a person
+// reaching goose from a chat app. Both are history someone made.
+var gooseMachineTypes = []string{"subagent", "sub_agent", "scheduled"}
 
 func ParseGooseDB(db string) ([]model.Session, error) {
 	return parseGooseDBWhere(db, "", 0)

--- a/internal/sources/goose_test.go
+++ b/internal/sources/goose_test.go
@@ -170,6 +170,8 @@ insert into sessions values ('s_term','n','terminal','/w','2026-07-24T11:00:00Z'
 insert into sessions values ('s_gw','n','gateway','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','gateway');
 insert into sessions values ('s_sub','n','subagent','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','subagent');
 insert into sessions values ('s_cron','n','cron','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','scheduled');
+insert into sessions values ('s_hidden','n','no-session','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','hidden');
+insert into sessions values ('s_new','n','a type goose adds later','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z','somethingnew');
 insert into sessions values ('s_old','n','legacy','/w','2026-07-24T11:00:00Z','2026-07-24T11:00:02Z',null);
 insert into messages values (1,'s_user','user','[{"type":"text","text":"mine"}]',1784282401);
 insert into messages values (2,'s_acp','user','[{"type":"text","text":"acp sessions"}]',1784282401);
@@ -177,7 +179,9 @@ insert into messages values (3,'s_term','user','[{"type":"text","text":"terminal
 insert into messages values (4,'s_gw','user','[{"type":"text","text":"gateway noise"}]',1784282401);
 insert into messages values (5,'s_sub','user','[{"type":"text","text":"subagent noise"}]',1784282401);
 insert into messages values (6,'s_cron','user','[{"type":"text","text":"cron noise"}]',1784282401);
-insert into messages values (7,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);`
+insert into messages values (7,'s_old','user','[{"type":"text","text":"legacy"}]',1784282401);
+insert into messages values (8,'s_hidden','user','[{"type":"text","text":"a run that kept no session"}]',1784282401);
+insert into messages values (9,'s_new','user','[{"type":"text","text":"a type goose has not shipped yet"}]',1784282401);`
 	if out, err := exec.Command("sqlite3", db, sql).CombinedOutput(); err != nil {
 		t.Fatalf("create db: %v: %s", err, out)
 	}
@@ -189,10 +193,16 @@ insert into messages values (7,'s_old','user','[{"type":"text","text":"legacy"}]
 	for _, s := range ss {
 		got[s.ID] = true
 	}
-	if !got["s_user"] || !got["s_old"] || !got["s_acp"] || !got["s_term"] {
-		t.Fatalf("dropped sessions that belong in recall: %v", got)
+	// `hidden` is `goose run --no-session` and `gateway` is a person reaching
+	// goose from a chat app: both are somebody's work, so both are in. And a
+	// type goose has not shipped yet is in too — the allow-list dropped one
+	// silently, which is how #2873 happened.
+	for _, id := range []string{"s_user", "s_old", "s_acp", "s_term", "s_gw", "s_hidden", "s_new"} {
+		if !got[id] {
+			t.Errorf("%s belongs in recall and was dropped: %v", id, got)
+		}
 	}
-	if got["s_sub"] || got["s_cron"] || got["s_gw"] {
-		t.Fatalf("subagent, scheduled or gateway runs leaked into recall: %v", got)
+	if got["s_sub"] || got["s_cron"] {
+		t.Fatalf("subagent or scheduled runs leaked into recall: %v", got)
 	}
 }


### PR DESCRIPTION
On top of #2874, which fixed the report. Two things it left, plus the index bump.

`hidden` and `gateway` are still dropped. Reading goose's enum (`session_manager.rs`: user, scheduled, sub_agent, hidden, terminal, gateway, acp), `hidden` is `goose run --no-session` — a person working without keeping a session — and `gateway` is a person reaching goose from a chat app. Both are somebody's work.

And the filter stays an allow-list, which is the shape that produced #2873: a type goose ships next is dropped silently and nothing says why. Turned round, it excludes what goose writes for its own work — a subagent it spawned, both spellings, and a scheduled run — and keeps everything else. The test now seeds a `somethingnew` type and asserts it survives.

Index version 32: the db path re-reads only what has been touched since its watermark, so a store built under the old filter keeps missing those sessions until each is used again.

**Why this is a re-land.** #2875 did this and was merged at 09:34. #2877 was branched before it, touched the same file, and its squash took `gooseTypeFilter` back to `= 'user'` at 09:44 — so main lost the fix ten minutes after getting it, with every check green on both. #2874 is what put the ACP half back. Worth a repo setting rather than more care: "require branches to be up to date before merging" would have made #2877 rebase first.

Five mutations, all red: back to the allow-list, excluding gateway, excluding hidden, dropping either subagent spelling, and dropping the filter entirely.
