### PR TITLE
fix(notes): a hand-written project must not put a path in the session id

### DIFF
--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -260,10 +260,10 @@ func LoadNotes() []model.Session {
 func noteIDProject(project string) string {
 	var b strings.Builder
 	for _, r := range project {
-		switch {
-		case r == '/' || r == '\\' || r == ':':
+		switch r {
+		case '/', '\\', ':':
 			b.WriteByte('-')
-		case r == '.':
+		case '.':
 			// A dot is ordinary inside a name ("api.v2") and a way out of the
 			// tree in a run of them.
 			if strings.HasSuffix(b.String(), ".") {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -254,6 +254,33 @@ func LoadNotes() []model.Session {
 	return ss
 }
 
+// noteIDProject is the project name as a session id can carry it. An id is
+// what every other surface keys on, and a project of "../../etc" put a path
+// inside one.
+func noteIDProject(project string) string {
+	var b strings.Builder
+	for _, r := range project {
+		switch {
+		case r == '/' || r == '\\' || r == ':':
+			b.WriteByte('-')
+		case r == '.':
+			// A dot is ordinary inside a name ("api.v2") and a way out of the
+			// tree in a run of them.
+			if strings.HasSuffix(b.String(), ".") {
+				continue
+			}
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if out == "" {
+		return "notes"
+	}
+	return out
+}
+
 func ParseNotesFile(path string) ([]model.Session, error) {
 	return ParseNotesFileFromOffset(path, 0)
 }
@@ -281,6 +308,7 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		if project == "" {
 			project = "notes"
 		}
+		idProject := noteIDProject(project)
 		if kind, _ := m["kind"].(string); kind == "promoted" {
 			// One session per promoted source session; corrections append as
 			// further messages and the title tracks the latest state.
@@ -341,7 +369,7 @@ func ParseNotesFileFromOffset(path string, offset int64) ([]model.Session, error
 		key := project + "\x00" + day
 		s := byDay[key]
 		if s == nil {
-			s = &model.Session{ID: "deja-" + day + "-" + project, Harness: "deja", Project: project, Path: path}
+			s = &model.Session{ID: "deja-" + day + "-" + idProject, Harness: "deja", Project: project, Path: path}
 			byDay[key] = s
 		}
 		s.Touch(t)

--- a/internal/sources/notes_hand_written_test.go
+++ b/internal/sources/notes_hand_written_test.go
@@ -1,0 +1,31 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A session id is what every other surface keys on, so it must not carry a
+// path that climbs out of the tree.
+func TestANotesProjectCannotClimbOutOfTheTree(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	body := `{"ts":"` + at + `","project":"../../etc","text":"a note filed against a path"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseNotesFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("got %d sessions, want the note", len(ss))
+	}
+	if strings.Contains(ss[0].ID, "..") || strings.Contains(ss[0].ID, "/") {
+		t.Errorf("session id carries a path: %q", ss[0].ID)
+	}
+}


### PR DESCRIPTION
From the survey in #2063. `{"project":"../../etc"}` in the notes file produced the session id `deja-2026-01-02-../../etc`. Nothing today takes a session id to the filesystem outside `bench`, so this is not an escape — but an id is what every other surface keys on, and it should not carry a path.

Separators and runs of dots collapse; `api.v2` keeps its dot. The project name itself is untouched, so the note still displays and searches under what the person wrote.

The other finding in that survey — a note dated next year keeping the top of `deja last` — is deliberately left alone: clamping it broke the three tests that exist to report it (`doctor` and `last` have named sessions stamped ahead since #2106), and deja telling the user their stamp is wrong beats deja quietly rewriting it.

Closes #2063.