### PR TITLE
fix(friction): sanitise the recorded error line before printing it

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
 )
 
 // `deja friction` names what this machine keeps tripping over.
@@ -226,10 +227,16 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 }
 
 func trimFriction(l string) string {
+	// Sanitised first. A wall is text out of a transcript deja did not write,
+	// and this was the one surface printing it as recorded: an ANSI escape
+	// recoloured the rest of the screen and U+202E reversed the reading order
+	// of everything after it. Every other place a recorded line is shown runs
+	// it through SafeLine; this now does too.
+	//
 	// Rune-safe: a wall recorded in Russian or Chinese was cut mid-character
 	// and printed as a broken byte (#1319). The bound includes the mark, so a
 	// line loses one character rather than gaining one.
-	return truncatePlanBytes(l, 79)
+	return truncatePlanBytes(search.SafeLine(l), 79)
 }
 
 // emptiedBy names the rule that leaves a path nothing to read. Both can be in

--- a/cmd/deja/friction_safe_test.go
+++ b/cmd/deja/friction_safe_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A recorded error line is untrusted text — it came out of a transcript deja
+// did not write. Every surface that prints one runs it through search.SafeLine
+// first; friction was the exception, and printed the bytes as recorded.
+//
+// Found while reviewing #2895, whose JSON path inherited the same line. The
+// terminal obeys what it is sent: an ANSI escape recolours the rest of the
+// screen, and U+202E reverses the reading order of everything after it, so a
+// command in a wall can be made to read as something else.
+func TestFrictionDoesNotPrintWhatATerminalWouldObey(t *testing.T) {
+	root := frictionEnv(t)
+	writeEscapedFriction(t, root)
+
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "shellcheck") {
+		t.Fatalf("the wall was not reported at all, so this asserts nothing:\n%s", out)
+	}
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("an ANSI escape reached the terminal:\n%q", out)
+	}
+	if strings.Contains(out, "\u202e") {
+		t.Errorf("a bidi override reached the terminal:\n%q", out)
+	}
+}
+
+func writeEscapedFriction(t *testing.T, root string) {
+	t.Helper()
+	proj := filepath.Join(root, "projects", "repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bad := "command not found: \x1b[31mshellcheck\x1b[0m\u202eevil"
+	for i := 0; i < index.FrictionMinSessions; i++ {
+		sid := fmt.Sprintf("esc%02d", i)
+		payload, err := json.Marshal(bad + "\nexit status 127")
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := `{"type":"user","sessionId":"` + sid + `","cwd":"/repo",` +
+			`"timestamp":"2026-07-30T03:05:05Z","message":{"role":"user","content":` +
+			`[{"type":"tool_result","content":` + string(payload) + `}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(row), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Found while reviewing #2895, and it is ours rather than theirs — the JSON path in that PR only inherited it.

`deja friction` printed the recorded error line as recorded. Every other surface that shows a line out of a transcript runs it through `search.SafeLine` first; `trimFriction` truncates to 79 bytes and sanitises nothing, and nothing upstream does either — `index.FrictionLine` only normalises the shell prefix.

What that prints, before:

```
 3 sessions  command not found: \x1b[31mshellcheck\x1b[0m‮evil
```

The terminal obeys both. The escape recolours the rest of the screen, and U+202E reverses the reading order of everything after it, so a command inside a wall can be made to read as something else. The text comes out of a transcript deja did not write, which is the whole reason `SafeLine` exists.

Sanitise, then truncate — that order, so the 79-byte bound is over what is actually printed rather than over bytes that vanish.

Two mutations, both red: printing the line as recorded, and dropping the truncation.
