### PR TITLE
fix(digest): a code fence must not take the slot from the conclusion

### DIFF
--- a/internal/digest/concluding_first_test.go
+++ b/internal/digest/concluding_first_test.go
@@ -1,0 +1,72 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func assistantSession(texts ...string) model.Session {
+	s := model.Session{Harness: "claude", Project: "p", ID: "s1"}
+	for _, t := range texts {
+		s.Messages = append(s.Messages, model.Message{Role: "assistant", Text: t})
+	}
+	return s
+}
+
+// selectConclusions keeps a message for three different reasons — it carries a
+// decision marker, it contains a code fence, or it is the last one — and only
+// the first is about concluding anything. The walk is newest-first, so a
+// message kept for its code fence took the slot from the one that settled the
+// question: 28 of the 62 sessions whose block still missed it (#2243).
+func TestACodeFenceDoesNotTakeTheSlotFromTheConclusion(t *testing.T) {
+	long := strings.Repeat("filler words that pad the message out. ", 12)
+	got := Conclusions(assistantSession(
+		"Starting on the pool timeouts now. "+long,
+		"The fix was raising pgbouncer default_pool_size to 40. "+long,
+		"Here is the config as it stands:\n```ini\ndefault_pool_size = 40\nmax_client_conn = 200\n```\n"+long,
+		"Left the notes in the README. "+long,
+	), 320, 1)
+	if len(got) == 0 {
+		t.Fatal("nothing was quoted")
+	}
+	if !strings.Contains(got[0], "raising pgbouncer default_pool_size to 40") {
+		t.Errorf("the block quoted something else and the conclusion never fit:\n%s", got[0])
+	}
+}
+
+// Order inside each group is untouched: among messages that concluded
+// something, the last one still wins.
+func TestAmongConclusionsTheNewestStillWins(t *testing.T) {
+	long := strings.Repeat("filler words that pad the message out. ", 12)
+	// A plain message in the mix, or the two groups never get sorted at all
+	// and this asserts nothing about their internal order.
+	got := Conclusions(assistantSession(
+		"The fix was pinning pgx to 5.4.3. "+long,
+		"That turned out to be wrong; the fix was raising default_pool_size instead. "+long,
+		"Left the notes in the README. "+long,
+	), 320, 1)
+	if len(got) == 0 {
+		t.Fatal("nothing was quoted")
+	}
+	if !strings.Contains(got[0], "raising default_pool_size instead") {
+		t.Errorf("an earlier conclusion outranked the one that superseded it:\n%s", got[0])
+	}
+}
+
+// A session where nothing concludes must be unchanged: the last message is
+// still what the block quotes.
+func TestWithNoConclusionTheOrderIsLeftAlone(t *testing.T) {
+	long := strings.Repeat("filler words that pad the message out. ", 12)
+	got := Conclusions(assistantSession(
+		"Looking at the pool metrics. "+long,
+		"Still reading the replica logs. "+long,
+	), 320, 1)
+	if len(got) == 0 {
+		t.Fatal("nothing was quoted")
+	}
+	if !strings.Contains(got[0], "Still reading the replica logs") {
+		t.Errorf("the newest message stopped being the default:\n%s", got[0])
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -952,7 +952,7 @@ func Conclusions(s model.Session, budget int, max int) []string {
 	if len(assistants) == 0 {
 		return nil
 	}
-	picked := dedupeStatus(selectConclusions(assistants))
+	picked := concludingFirst(dedupeStatus(selectConclusions(assistants)))
 	// Newest first: the last thing concluded outranks the first thing tried.
 	var out []string
 	spent := 0
@@ -991,6 +991,34 @@ func Conclusions(s model.Session, budget int, max int) []string {
 		}
 	}
 	return out
+}
+
+// concludingFirst puts the messages that settle something last, so the
+// newest-first walk reaches them before the budget is gone.
+//
+// selectConclusions keeps a message for carrying a decision marker, for
+// containing a code fence, or for being the last one — three reasons, and only
+// the first is about concluding anything. A message kept for its code fence
+// that happens to be newer than the real conclusion took the slot: on a real
+// store that was 28 of the 62 sessions whose block still missed what they
+// settled (#2243).
+//
+// Order within each group is untouched, so "the last thing concluded outranks
+// the first thing tried" still holds — among the messages that concluded
+// anything, and then among the rest.
+func concludingFirst(ms []model.Message) []model.Message {
+	var plain, concluding []model.Message
+	for _, m := range ms {
+		if CarriesDecision(MessageText(m.Text)) {
+			concluding = append(concluding, m)
+			continue
+		}
+		plain = append(plain, m)
+	}
+	// No guard for the all-one-group cases: appending an empty half leaves the
+	// order exactly as it was, and a guard that cannot change an answer is a
+	// line no test can hold.
+	return append(plain, concluding...)
 }
 
 // decisionLead is the part of a picked message the block quotes: its opening


### PR DESCRIPTION
Follows #2906, which left 62 of 490 sessions handing over a block that did not read as a conclusion. Attributed those rather than guessing, and they are two different things:

```
misses                                        62
  the marker lives only in text the block strips   34
  the block picked a message that settles nothing  28
```

The 34 are the block being right — the marker is inside a code block or an artifact `MessageText` removes, which is the caveat #2243's own follow-up put on this measurement. Left alone.

The 28 are a selection bug. `selectConclusions` keeps a message for three unrelated reasons — it carries a decision marker, it contains a code fence, or it is the last one — and the walk is newest-first, so a message kept for its fence that happens to be newer took the slot and the budget. `concludingFirst` moves the ones that settle something to the end of the list the walk reads backwards, leaving the order inside each group alone, so "the last thing concluded outranks the first thing tried" still holds.

```
sessions that settled something   490
  the block carries it            421  ->  445
  the block misses it              62  ->   35
```

Three benches unchanged: prompt 13/13 with 6 cross-paired false fires, recall@5 1.00, context median 294 tokens.

Two of the four mutations were blind at first, and one of those was my code rather than my test: the early-return guard for the all-one-group cases could not change an answer, since appending an empty half leaves the order as it was, so it is gone rather than papered over with a test. The newest-still-wins fixture had no plain message in it, which meant the grouping never ran and the assertion was about nothing. Three mutations now, all red.
