### PR TITLE
feat(fix): answer a failing test with the file the session changed

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -122,6 +122,17 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			when = " · " + p.When.Local().Format("2006-01-02")
 		}
 		fmt.Fprintf(stdout, "%s%s\n", search.SafeLine(p.Error), when)
+		if p.Edit != "" {
+			// An edit is not something to run, so it is not offered as one:
+			// what fixes a failing test is a change to a file, and the useful
+			// half of that is which file (#2163).
+			changed := "changed next"
+			if p.Candidate {
+				changed = "changed next, unconfirmed"
+			}
+			fmt.Fprintf(stdout, "  %s: %s\n", changed, search.SafeLine(p.Edit))
+			continue
+		}
 		ran := "ran next"
 		if p.Candidate {
 			// One session doing something after an error is half the evidence,

--- a/cmd/deja/fix_edit_remedy_test.go
+++ b/cmd/deja/fix_edit_remedy_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A failing test is answered by a change to a file, and deja must hand that
+// over as what it is rather than as a command to paste (#2163).
+func TestFixNamesTheFileTheSessionChanged(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i, id := range []string{"e1", "e2"} {
+		at := time.Now().Add(-time.Duration(i+1) * time.Hour).UTC().Format(time.RFC3339)
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"the pool test keeps failing"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t` + id + `","input":{"command":"go test ./internal/pool"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` + id + `","content":"--- FAIL: TestPoolDrainsOnClose (0.09s)"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/pool/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
+		})
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureRun(t, "fix", "--- FAIL: TestPoolDrainsOnClose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "pool.go") {
+		t.Errorf("fix did not name the file the sessions changed:\n%s", out)
+	}
+	if strings.Contains(out, "ran next") {
+		t.Errorf("an edit was offered as a command to run:\n%s", out)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -67,6 +67,13 @@ type FixPair struct {
 	// Empty on a pair mined before this field existed; the version bump that
 	// ships it forces the rebuild that fills it.
 	Project string
+	// Edit is the file a session changed after the error, for the failures a
+	// command cannot answer. What fixes a failing test is an edit, and the
+	// miner only ever looked for the next command — so the most common failure
+	// an agent sees had no remedy it could record (#2163). Set instead of
+	// Command, never beside it: an edit is evidence of what was changed, not
+	// something a reader can run.
+	Edit string `json:",omitempty"`
 	// Candidate marks a sighting that is not a pair yet: the remedy named
 	// nothing the error named, and no other session has done the same thing
 	// after the same error. Evidence of the second kind accumulates across
@@ -156,7 +163,7 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 // fixKey identifies one remedy for one error, so the same pair arriving from
 // two sessions can be counted as a repeat.
 func fixKey(p FixPair) string {
-	return strconv.FormatUint(p.Sig, 16) + "|" + strings.ToLower(p.Command)
+	return strconv.FormatUint(p.Sig, 16) + "|" + strings.ToLower(p.Command) + "|" + strings.ToLower(p.Edit)
 }
 
 // fixTermRE matches the words worth comparing: identifiers, paths, flags.
@@ -317,7 +324,17 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 		if !ok {
 			continue
 		}
+		// The first file the session changed after the error, kept in case the
+		// window holds no command that answers it.
+		edited := ""
+		paired := false
 		for j := i + 1; j < len(ms) && j <= i+fixLookAhead; j++ {
+			if ms[j].Role == roleEdit {
+				if edited == "" {
+					edited = strings.TrimSpace(firstLineOf(ms[j].Text))
+				}
+				continue
+			}
 			if ms[j].Role != roleCommand {
 				continue
 			}
@@ -355,10 +372,31 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 				continue
 			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
+			paired = true
 			break
+		}
+		// No command answered it, and the session changed a file: that is the
+		// remedy for a failing test, which is what the command window can
+		// never hold.
+		if !paired && edited != "" && looksLikeEditedPath(edited) {
+			out = append(out, FixPair{Sig: sig, Error: line, Edit: edited, Key: key, When: m.Time, Project: project})
 		}
 	}
 	return out
+}
+
+// looksLikeEditedPath keeps the first line of an edit record to what a path can
+// be. The record is "<path>\n<span>", but a span whose file was not recorded
+// would otherwise put a line of source in the table.
+func looksLikeEditedPath(p string) bool {
+	// A path carries no whitespace and none of the punctuation source is
+	// written in. "Makefile" is a path and "\tif err != nil {" is not;
+	// requiring a dot or a slash would have refused the first, which is a real
+	// file at the top of a repository.
+	if p == "" || len(p) > 200 {
+		return false
+	}
+	return !strings.ContainsAny(p, " \t\"'`$(){}[]=;:,*")
 }
 
 // opensMoreInput reports whether a command's first line is only the start of
@@ -411,6 +449,72 @@ func LooksLikeError(text string) bool {
 	return false
 }
 
+// mergeFixPairs folds newly mined pairs into the table on file: a remedy that
+// names what the error named is a pair at once, anything else waits for a
+// second session to do the same thing.
+func mergeFixPairs(kept, fresh []FixPair) []FixPair {
+	seen := map[string]int{}
+	for _, p := range kept {
+		seen[fixKey(p)]++
+	}
+	repeats := map[string]int{}
+	for _, p := range fresh {
+		repeats[fixKey(p)]++
+	}
+	// A candidate already on file is the evidence a later session needs, so it
+	// counts towards the second sighting — and once something is promoted, the
+	// candidate copy of it goes. Not redundant with the deduplication below:
+	// two sessions carrying the same timestamp sort either way, and when the
+	// candidate copy sorts first it is the one that survives, so the pair the
+	// second sighting just earned is never served.
+	promoted := map[string]bool{}
+	for _, p := range fresh {
+		k := fixKey(p)
+		// An edit is never self-evident the way a command that names what the
+		// error named is: the error names a test, the remedy names a file, and
+		// nothing ties them but a second session doing the same thing.
+		selfEvident := p.Edit == "" && sharesTerm(p.Error, p.Command)
+		if selfEvident || repeats[k]+seen[k] >= 2 {
+			p.Candidate = false
+			kept = append(kept, p)
+			promoted[k] = true
+			continue
+		}
+		p.Candidate = true
+		kept = append(kept, p)
+	}
+	for i := range kept {
+		if promoted[fixKey(kept[i])] {
+			kept[i].Candidate = false
+		}
+	}
+	sort.SliceStable(kept, func(i, j int) bool { return kept[i].When.After(kept[j].When) })
+	written := map[string]bool{}
+	out := kept[:0]
+	candidates := 0
+	for _, p := range kept {
+		k := fixKey(p)
+		if written[k] {
+			continue
+		}
+		// Candidates are bounded on their own. They serve nobody until a second
+		// session confirms them, so letting them share the pair budget would
+		// push real answers out of a table that is read whole.
+		if p.Candidate {
+			if candidates >= fixesCandidateMax {
+				continue
+			}
+			candidates++
+		}
+		written[k] = true
+		out = append(out, p)
+		if len(out) >= fixesMax+fixesCandidateMax {
+			break
+		}
+	}
+	return out
+}
+
 // mergeFixes updates the carried pairs with what the sessions in this
 // incremental update contain.
 //
@@ -456,61 +560,7 @@ func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[stri
 	if len(fresh) == 0 && len(kept) == len(carried) && !dirty {
 		return
 	}
-	seen := map[string]int{}
-	for _, p := range kept {
-		seen[fixKey(p)]++
-	}
-	repeats := map[string]int{}
-	for _, p := range fresh {
-		repeats[fixKey(p)]++
-	}
-	// A candidate already on file is the evidence a later session needs, so it
-	// counts towards the second sighting — and once something is promoted, the
-	// candidate copy of it goes. Not redundant with the deduplication below:
-	// two sessions carrying the same timestamp sort either way, and when the
-	// candidate copy sorts first it is the one that survives, so the pair the
-	// second sighting just earned is never served.
-	promoted := map[string]bool{}
-	for _, p := range fresh {
-		k := fixKey(p)
-		if sharesTerm(p.Error, p.Command) || repeats[k]+seen[k] >= 2 {
-			p.Candidate = false
-			kept = append(kept, p)
-			promoted[k] = true
-			continue
-		}
-		p.Candidate = true
-		kept = append(kept, p)
-	}
-	for i := range kept {
-		if promoted[fixKey(kept[i])] {
-			kept[i].Candidate = false
-		}
-	}
-	sort.SliceStable(kept, func(i, j int) bool { return kept[i].When.After(kept[j].When) })
-	written := map[string]bool{}
-	out := kept[:0]
-	candidates := 0
-	for _, p := range kept {
-		k := fixKey(p)
-		if written[k] {
-			continue
-		}
-		// Candidates are bounded on their own. They serve nobody until a second
-		// session confirms them, so letting them share the pair budget would
-		// push real answers out of a table that is read whole.
-		if p.Candidate {
-			if candidates >= fixesCandidateMax {
-				continue
-			}
-			candidates++
-		}
-		written[k] = true
-		out = append(out, p)
-		if len(out) >= fixesMax+fixesCandidateMax {
-			break
-		}
-	}
+	out := mergeFixPairs(kept, fresh)
 	// Atomic, unlike buildFixes above: that one writes into a directory made
 	// moments earlier, where the file cannot exist. This one runs after
 	// carrySidecars has copied the live table into the build directory, and the

--- a/internal/index/fixpair_edit_test.go
+++ b/internal/index/fixpair_edit_test.go
@@ -1,0 +1,84 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// What fixes a failing test is an edit, not a command. The pair miner only
+// ever looked for the next command, so the most common failure an agent sees —
+// 2,318 of 6,744 error lines on a real store — could never have a remedy
+// recorded, and the next session hit it with nothing to show (#2163).
+func TestATestFailureIsPairedWithTheEditThatFollowed(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "--- FAIL: TestPoolDrainsOnClose (0.09s)", Time: now},
+		{Role: "edit", Text: "internal/pool/pool.go\n-\tclose(c)\n+\tc.drain()", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "ok  \tinternal/pool\t0.4s", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 {
+		t.Fatalf("got %d pairs, want the edit: %+v", len(pairs), pairs)
+	}
+	if pairs[0].Edit != "internal/pool/pool.go" {
+		t.Errorf("pair records %q as the edit", pairs[0].Edit)
+	}
+	if pairs[0].Command != "" {
+		t.Errorf("an edit remedy must not be stored as a command to run: %q", pairs[0].Command)
+	}
+}
+
+// A command remedy still wins where there is one: a missing binary is fixed by
+// installing it, and the edit that happens to follow is not the answer.
+func TestACommandRemedyStillBeatsAnEdit(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "tool-output", Text: "zsh: command not found: rg", Time: now},
+		// The edit comes first and is not the answer: the session tried a
+		// change, then installed the thing that was missing.
+		{Role: "edit", Text: "Makefile\n-rg\n+grep", Time: now.Add(time.Minute)},
+		{Role: "command", Text: "brew install ripgrep", Time: now.Add(2 * time.Minute)},
+		{Role: "tool-output", Text: "installed", Time: now.Add(3 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 || pairs[0].Command != "brew install ripgrep" || pairs[0].Edit != "" {
+		t.Fatalf("the command remedy was not kept: %+v", pairs)
+	}
+}
+
+// An edit is one session's doing until a second session does the same after
+// the same failure — the same bar a command remedy that names nothing of the
+// error has to clear.
+func TestAnEditRemedyIsACandidateUntilASecondSessionRepeatsIt(t *testing.T) {
+	now := time.Now()
+	session := func(id string) []FixPair {
+		return fixPairsIn([]model.Message{
+			{Role: "tool-output", Text: "--- FAIL: TestPoolDrainsOnClose (0.09s)", Time: now},
+			{Role: "edit", Text: "internal/pool/pool.go\n-\tclose(c)\n+\tc.drain()", Time: now.Add(time.Minute)},
+		}, "claude:"+id, "p")
+	}
+	first := mergeFixPairs(nil, session("s1"))
+	if len(first) != 1 || !first[0].Candidate {
+		t.Fatalf("one sighting of an edit must be a candidate: %+v", first)
+	}
+	second := mergeFixPairs(first, session("s2"))
+	if len(second) != 1 || second[0].Candidate {
+		t.Fatalf("a second session doing the same edit must confirm it: %+v", second)
+	}
+}
+
+// The first line of an edit record is the file it changed — unless the harness
+// recorded no file, in which case it is a line of source, and a line of source
+// is not a remedy.
+func TestALineOfSourceIsNotAnEditRemedy(t *testing.T) {
+	now := time.Now()
+	pairs := fixPairsIn([]model.Message{
+		{Role: "tool-output", Text: "--- FAIL: TestPoolDrainsOnClose (0.09s)", Time: now},
+		{Role: "edit", Text: "\tif err != nil {\n\t\treturn err", Time: now.Add(time.Minute)},
+	}, "claude:s1", "p")
+	if len(pairs) != 0 {
+		t.Errorf("a line of source was stored as the file that was changed: %+v", pairs)
+	}
+}


### PR DESCRIPTION
#2163's own conclusion: what fixes a failing test is an edit, not a command, and `fixPairsIn` only ever looked for the next `roleCommand`. So the shape that is 2,318 of 6,744 error lines on a real store — a named test failure — could be recognised as friction and still never have a remedy recorded.

An error whose window holds no command remedy is now paired with the first file the session changed. A command still wins wherever there is one, including when an edit came first and the install after it was the answer.

Confirmation is the same bar, minus the shortcut: a command that names what the error named is a pair at once, an edit never is — the error names a test and the remedy names a file, and nothing ties them but a second session doing the same thing. So edits start as candidates and are promoted on the second sighting.

`deja fix` prints an edit as `changed next: <path>`, never as something to run.

On this machine's store: 1,430 pairs, of which 386 are edits and 41 of those are confirmed. A sample of what they say:

```
--- FAIL: TestMergeNamesAnEntryLeftSwitchedOff   -> cmd/deja/install.go
--- FAIL: TestARotationBoundsALogOfNothingButRecentEvents -> internal/usage/usage.go
```

Five mutations, all caught. No index version bump: the table is a sidecar, an older one simply holds no edits, and the next rebuild fills them in.

Closes #2163.