### PR TITLE
fix(digest): a sentence with no stopword is not a listing dump

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -271,12 +271,35 @@ func looksLikeListingDump(line string) bool {
 	if len(fields) < 8 {
 		return false
 	}
-	slashes := 0
+	words := 0
 	for _, f := range fields {
-		if strings.ContainsRune(f, '/') {
-			slashes++
+		if plainWordField(f) {
+			words++
 		}
 		if shareStopwords[strings.ToLower(strings.Trim(f, ".,!?:;"))] {
+			return false
+		}
+	}
+	// Most of a sentence is words; most of a dump is not. The path count this
+	// used to keep was never read, so the rule degenerated into "eight fields
+	// and none of them a stopword" — which is an ordinary sentence in any
+	// language the stopword list does not cover, and the list has eighteen
+	// English words against twelve Russian. Measured over 277375 prose lines
+	// of a real store, it dropped 20294 of them; 55 were listings.
+	return words*2 < len(fields)
+}
+
+// plainWordField reports whether a token is an ordinary word: letters only,
+// once the punctuation a sentence puts around one is off. A path, a filename,
+// a mode string, a size and a timestamp are all not — which is what an `ls`
+// line is made of, and what a sentence is not.
+func plainWordField(f string) bool {
+	f = strings.Trim(f, "`\"'()[]{},;:.!?—–-*_#")
+	if utf8.RuneCountInString(f) < 2 {
+		return false
+	}
+	for _, r := range f {
+		if !unicode.IsLetter(r) {
 			return false
 		}
 	}

--- a/internal/digest/listing_dump_test.go
+++ b/internal/digest/listing_dump_test.go
@@ -1,0 +1,76 @@
+package digest
+
+import "testing"
+
+// looksLikeListingDump counted path-shaped fields and never read the count, so
+// the rule it actually applied was "eight or more words, none of them a
+// stopword" — which is an ordinary sentence in any language the stopword list
+// does not cover. The list has eighteen English words and twelve Russian ones,
+// and half this store is Russian.
+//
+// Measured over 277375 prose lines of a real store: 20294 dropped, 55 of them
+// listings.
+func TestASentenceIsNotAListingDump(t *testing.T) {
+	prose := []string{
+		// Russian, eight or more words, none of them in the stopword list.
+		"Монорепа смержена (#1562). Оба внешних PR перенацелены, жду их проверки.",
+		"Оба утверждения теперь острее: тест первого запуска слово «forgotten» прямо запрещает.",
+		"Хорошо — XDG уважается, значит живой тест изолируется. Пишу защиту.",
+		// English written without any of the eighteen: still a sentence.
+		"Raised pgbouncer default_pool_size from twenty up through forty, timeouts stopped afterwards.",
+	}
+	for _, l := range prose {
+		if looksLikeListingDump(l) {
+			t.Errorf("a sentence was dropped as a listing: %q", l)
+		}
+	}
+}
+
+// The rule still has to do its job. A listing is what it was written for, and
+// `ls` inside a directory prints no slashes at all — so bare filenames count.
+func TestAListingIsStillARejected(t *testing.T) {
+	listings := []string{
+		"internal/index/ingest.go internal/index/manifest.go internal/search/recall.go cmd/deja/mcp.go cmd/deja/fix.go cmd/deja/how.go internal/digest/digest.go internal/model/model.go",
+		"main.go util.go parser.go writer.go reader.go index.go search.go digest.go",
+		"- Repositories (`order_repository.go`, `payment_repository.go`, `profile_repository.go`, `dftype_repository.go`, `wallet_repository.go`, `audit_repository.go`, `session_repository.go`)",
+	}
+	for _, l := range listings {
+		if !looksLikeListingDump(l) {
+			t.Errorf("a listing dump got through: %q", l)
+		}
+	}
+}
+
+// The short-line and stopword exits are unchanged, and are what keeps an
+// ordinary sentence about files from being read as a list of them.
+func TestTheListingRuleKeepsItsEarlierExits(t *testing.T) {
+	if looksLikeListingDump("main.go util.go parser.go") {
+		t.Error("a three-field line is not a listing")
+	}
+	if looksLikeListingDump("the files are main.go util.go parser.go writer.go reader.go index.go search.go") {
+		t.Error("a sentence with a stopword in it was read as a listing")
+	}
+}
+
+// A word is letters once the punctuation a sentence puts around one is off.
+// Everything an `ls` line is made of is not.
+func TestPlainWordFieldNamesOnlyWords(t *testing.T) {
+	for _, f := range []string{"pgbouncer", "перенацелены", "(смержена)", "root", "**Домены**"} {
+		if !plainWordField(f) {
+			t.Errorf("%q is a word", f)
+		}
+	}
+	for _, f := range []string{"internal/index/ingest.go", "main.go", "v5.4.3", "4096", "drwxr-xr-x", "00:00", "a"} {
+		if plainWordField(f) {
+			t.Errorf("%q is not a word", f)
+		}
+	}
+}
+
+// The shape this regressed on first: `ls -l` output is three words and six
+// fields that are not, and the old rule caught it only by accident.
+func TestAnLsLineIsStillAListing(t *testing.T) {
+	if !looksLikeListingDump("drwxr-xr-x 5 root root 4096 Jan 1 00:00 /usr/lib/x86_64-linux-gnu/libfoo.so.1.2.3") {
+		t.Error("an ls -l line got through")
+	}
+}


### PR DESCRIPTION
`looksLikeListingDump` counted path-shaped fields and never read the count. What it actually applied was *eight or more fields, none of them a stopword* — which is an ordinary sentence in any language the stopword list does not cover, and the list is eighteen English words against twelve Russian.

`MessageText` runs every line through it, so this is upstream of every digest: recall, the session-start block, `share`, the conclusions.

Measured over 277375 prose lines of a real store, classifying a drop as a genuine listing when most of its fields are paths:

```
dropped as a listing   20294  ->  4048
of those, listings        55        55
```

The rule now asks what a sentence is made of rather than what it is missing: most of a sentence is plain words, most of a dump is not. That also fixes the shape the path count would have missed — `ls` inside a directory prints no slashes, and `ls -l` is three words and six fields that are not.

`plainWordField` is letters only, two or more, after stripping the punctuation a sentence puts around a word. A version number, a size, a timestamp, a mode string and a path are all not words.

**What it still drops, and I am leaving it.** The 4048 are markdown table rows and lines dense with backticked identifiers — `**80 \`[index-empty-store]\`** закрыт — #1738 → PR #1739 смержен`. Making those pass means treating code spans and dashes as neutral rather than as non-words, and at that point I am tuning a ratio against samples I picked. It wants an instrument that can judge whether a line is worth quoting, which is #2243's subject, not a third threshold here.

Three benches unchanged: prompt 13/13 with 6 cross-paired false fires, recall@5 1.00, context median 294 tokens.

Eight mutations, all red — including the first version of this fix, which used a path count and let `ls -l` through; `TestPastedDumpsAreStillNotProse` caught it, which is the test doing exactly its job.
