### PR TITLE
fix(hook): the lead says what the block is before what to do with it

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -1307,7 +1307,14 @@ func sessionIDs(ss []model.Session) []string {
 	return out
 }
 
-const promptHookLead = "deja found prior sessions matching this request. If one genuinely helps, use it and tell the user in one short line what deja-vu recalled; otherwise ignore silently.\n"
+// promptHookLead says what the block is before it says what to do with it.
+// "deja found prior sessions matching this request" reads as a judgement that
+// they answer it, and an agent acted on that: asked about one service with
+// another's symptom in the prompt, it applied the neighbouring session's
+// decision and said history had settled it — naming the mismatch in the same
+// sentence (#2370). The match is on wording, and the lead now says so and asks
+// for the one check that catches it.
+const promptHookLead = "deja found sessions whose wording matches this request — not a judgement that they answer it. Check that the session describes what is happening now before acting on it. If one genuinely helps, use it and tell the user in one short line what deja-vu recalled; otherwise ignore silently.\n"
 
 // digestBudget is how much room the block gets. A match resting on a single
 // rare word is a weaker claim than one resting on two, and it is where most of


### PR DESCRIPTION
From #2370, which has the failure in the agent's own words: asked about the reporting service with the orders worker's symptom in the prompt, the agent applied the reporting session's decision and said history settled it — *despite pgx prepared-statement errors*, naming the mismatch in the same sentence.

`deja found prior sessions matching this request` reads as a judgement that they answer it. They are matched on wording, and the lead now says so and asks for the check that catches this:

> deja found sessions whose wording matches this request — not a judgement that they answer it. Check that the session describes what is happening now before acting on it.

#2370 stopped short of a PR because a live-model rig could not tell the change from run-to-run variation, and that is still true — this ships on the plainer ground that the old sentence claimed something deja does not know. `bench prompt` is unchanged on every arm (the lead is not part of what it scores).

Refs #2370.