### PR TITLE
fix(digest): a sentence that starts with a number is not a numbered dump

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -143,7 +143,7 @@ func MessageText(s string) string {
 }
 
 var (
-	shareLineNumRE = regexp.MustCompile(`^\s*\d{1,6}\s`)            // "1 diff --git", numbered dumps
+	shareLineNumRE = regexp.MustCompile(`^\s*\d{1,6}[ \t]`)         // "1\tdiff --git", numbered dumps
 	shareGrepRE    = regexp.MustCompile(`^\S+\.[a-z]{1,5}:\d+[:)]`) // path/file.go:18: grep output
 	shareShellRE   = regexp.MustCompile(`^\((eval|\w*sh)\):\d*:?`)  // zsh/bash error prefixes
 	shareDigitsRE  = regexp.MustCompile(`^[\d\s.,%-]+$`)            // bare number sequences
@@ -193,9 +193,62 @@ func looksLikeProse(line string) bool {
 }
 
 func noiseLine(line string) bool {
-	return shareLineNumRE.MatchString(line) || shareGrepRE.MatchString(line) ||
+	return numberedDumpLine(line) || shareGrepRE.MatchString(line) ||
 		shareShellRE.MatchString(line) || shareDigitsRE.MatchString(line) ||
 		looksLikeListingDump(line)
+}
+
+// numberedDumpLine reports whether a line that opens with a number is a line
+// out of a numbered listing rather than a sentence that starts with one.
+//
+// The rule used to be the number alone, which dropped every sentence opening
+// with a count — "12 зелёных. Жду ревьюера перед мержем.", "505 отказов записи
+// за 16 часов". Measured on a real store: of the lines it matched in assistant
+// text, 917 were sentences and none was a listing, because a numbered listing
+// arrives inside a code fence and MessageText returns those whole.
+//
+// What separates them, read off the same store rather than guessed: `cat -n`
+// and the file readers put a tab after the number, and the dumps that use a
+// space — `3 files changed, 9 insertions(+)`, `300 index.js` — are fragments
+// with no sentence in them. So a space-separated line survives only if it
+// reads as one.
+func numberedDumpLine(line string) bool {
+	if !shareLineNumRE.MatchString(line) {
+		return false
+	}
+	rest := strings.TrimLeft(line, " ")
+	i := 0
+	for i < len(rest) && rest[i] >= '0' && rest[i] <= '9' {
+		i++
+	}
+	if i < len(rest) && rest[i] == '\t' {
+		return true
+	}
+	body := strings.TrimSpace(rest[i:])
+	// A pipe opens a table row, which is what the numbered rows of a rendered
+	// listing look like.
+	if strings.HasPrefix(body, "|") {
+		return true
+	}
+	return !hasSentenceEnd(body)
+}
+
+// hasSentenceEnd reports whether the text closes a sentence anywhere, by the
+// same rule firstSentences counts them: a stop with a space after it, or one
+// of the CJK stops, which take no space.
+func hasSentenceEnd(s string) bool {
+	for i, r := range s {
+		switch {
+		case r == '.' || r == '!' || r == '?':
+			next := i + utf8.RuneLen(r)
+			if next >= len(s) || s[next] == ' ' {
+				return true
+			}
+		case isCJKSentenceEnd(r):
+			return true
+		}
+	}
+	return false
 }
 
 // shareStopwords: a line of 8+ tokens with none of these is a path listing or

--- a/internal/digest/numbered_line_test.go
+++ b/internal/digest/numbered_line_test.go
@@ -1,0 +1,69 @@
+package digest
+
+import "testing"
+
+// The rule was the number alone — `^\s*\d{1,6}\s` — so every sentence that
+// opens with a count was dropped from every digest. Measured on a real store,
+// 916 of the assistant lines it matched are sentences.
+func TestASentenceThatStartsWithANumberIsKept(t *testing.T) {
+	prose := []string{
+		"12 зелёных. Жду ревьюера перед мержем.",
+		"505 отказов записи шаблонов за 16 часов — это то, что я вчера «починил» ретраем. Проверяю в первую очередь.",
+		"21 стора, 1.26 мс и 0.39 мс. Локально дёшево — но проверяю утверждение про сетевой стор.",
+		"3 sessions read it before the fix. None of them saw the pair.",
+		"已修复 3 个测试。现在全部通过。",
+	}
+	for _, l := range prose {
+		if numberedDumpLine(l) {
+			t.Errorf("a sentence was dropped as a numbered dump: %q", l)
+		}
+	}
+}
+
+// And the dumps it exists for are still dumps. `cat -n` and the file readers
+// put a tab after the number; the space-separated ones are fragments with no
+// sentence in them.
+func TestANumberedDumpLineIsStillDropped(t *testing.T) {
+	dumps := []string{
+		"1\tdiff --git a/internal/index/ingest.go b/internal/index/ingest.go",
+		// A numbered source line whose content is a sentence: the tab is what
+		// says it is a listing, and without it the sentence test would keep it.
+		"   42\t// Raised the pool to 40. It held.",
+		"3 files changed, 9 insertions(+)",
+		"1 file changed, 1 insertion(+), 1 deletion(-)",
+		"300 index.js",
+		"1564 nonpass=0",
+		// A rendered table row that happens to contain a sentence end. The
+		// pipe is what says it is a row.
+		"61 |            [claude] goprojects/d3fvxl · today · Summary: 1. done",
+	}
+	for _, l := range dumps {
+		if !numberedDumpLine(l) {
+			t.Errorf("a numbered dump got through: %q", l)
+		}
+	}
+}
+
+// A line that does not open with a number is not this rule's business.
+func TestTheNumberedRuleOnlyLooksAtNumberedLines(t *testing.T) {
+	for _, l := range []string{"raised the pool to 40", "\tindented but no number", ""} {
+		if numberedDumpLine(l) {
+			t.Errorf("matched a line with no leading number: %q", l)
+		}
+	}
+}
+
+// hasSentenceEnd follows firstSentences: a stop needs a space after it, so a
+// version number does not end a sentence, and the CJK stops take none.
+func TestHasSentenceEndAgreesWithTheSentenceSplitter(t *testing.T) {
+	for _, s := range []string{"pinned pgx. it held", "done.", "готово! дальше", "已修复。"} {
+		if !hasSentenceEnd(s) {
+			t.Errorf("%q ends a sentence", s)
+		}
+	}
+	for _, s := range []string{"v5.4.3 held", "300 index.js", "files changed, 9 insertions(+)", ""} {
+		if hasSentenceEnd(s) {
+			t.Errorf("%q does not end a sentence", s)
+		}
+	}
+}


### PR DESCRIPTION
Same sweep as #2916, next gate along. `shareLineNumRE` was `^\s*\d{1,6}\s` — the number alone — so `MessageText` dropped every sentence that opens with a count.

```
12 зелёных. Жду ревьюера перед мержем.
505 отказов записи шаблонов за 16 часов — это то, что я вчера «починил» ретраем.
21 стора, 1.26 мс и 0.39 мс. Локально дёшево — но проверяю утверждение про сетевой стор.
```

Measured on a real store rather than argued: of the assistant lines the rule matched, **916 are sentences and none is a listing**. The reason there are none is structural — a numbered listing arrives inside a code fence, and `MessageText` returns a fenced message whole without running any gate over it.

It does earn its place on tool output, where the same rule catches 111451 lines. So the rule stays and gets a discriminator, read off the store rather than guessed: `cat -n` and the file readers put a **tab** after the number, and the space-separated dumps — `3 files changed, 9 insertions(+)`, `300 index.js`, `1564 nonpass=0` — are fragments with no sentence in them. A space-separated line now survives only if it reads as one, by the same stop-plus-space rule `firstSentences` already uses, plus the CJK stops that take no space.

```
assistant lines:  916 sentences recovered, 616 still dropped
tool output:      111451 dumps still caught, 1386 through (was 1485)
```

A pipe opens a rendered table row, which is the shape most of the remainder had.

Three benches unchanged: prompt 13/13 with 6 cross-paired false fires, recall@5 1.00, context median 294 tokens.

Two of the seven mutations were blind at first — both dump fixtures happened to have no sentence in them, so removing the tab and pipe checks changed nothing. They now carry one each: a numbered source line whose content is a sentence, and a table row ending in one. Seven mutations, all red.
