### PR TITLE
feat(cli): --json for how

### DIFF
--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -142,7 +142,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprint(os.Stderr, note)
 	}
 	if asJSON {
-		return writeHowJSON(stdout, entries, limit)
+		return writeHowJSON(stdout, entries, limit, hidden, ignored)
 	}
 	if len(entries) == 0 {
 		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
@@ -373,10 +373,19 @@ func isCommandWordRune(r rune) bool {
 // the cap note lives on stderr, so a caller reading stdout alone cannot otherwise tell
 // eight ways to run the tests from thirteen.
 type howJSON struct {
-	SchemaVersion int          `json:"schema_version"`
-	Found         int          `json:"found"`
-	Truncated     bool         `json:"truncated"`
-	Commands      []howRowJSON `json:"commands"`
+	SchemaVersion int  `json:"schema_version"`
+	Found         int  `json:"found"`
+	Truncated     bool `json:"truncated"`
+	// Withheld and Ignored are what the two rules took out before any of this
+	// was counted. howEntries carries them for a stated reason — filtering on
+	// its own turns a leak into a confident "no command mentions that" over
+	// records a rule hid — and the prose path says so in a sentence. Without
+	// them here the envelope reintroduces exactly what the counts exist to
+	// prevent: `commands: []` reads as "nothing matched" when it can mean
+	// "everything that matched was withheld".
+	Withheld int          `json:"withheld"`
+	Ignored  int          `json:"ignored"`
+	Commands []howRowJSON `json:"commands"`
 }
 
 type howRowJSON struct {
@@ -398,7 +407,7 @@ type howRowJSON struct {
 	ExitCode *int `json:"exit_code,omitempty"`
 }
 
-func writeHowJSON(stdout io.Writer, entries []howEntry, limit int) error {
+func writeHowJSON(stdout io.Writer, entries []howEntry, limit, withheld, ignored int) error {
 	found := len(entries)
 	if len(entries) > limit {
 		entries = entries[:limit]
@@ -430,6 +439,8 @@ func writeHowJSON(stdout io.Writer, entries []howEntry, limit int) error {
 		SchemaVersion: jsonout.Version,
 		Found:         found,
 		Truncated:     found > len(rows),
+		Withheld:      withheld,
+		Ignored:       ignored,
 		Commands:      rows,
 	})
 }

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
@@ -88,9 +90,12 @@ func (e howEntry) failureNote() string {
 func runHow(dir string, args []string, stdout io.Writer) error {
 	limit := 8
 	project := ""
+	asJSON := false
 	var terms []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--json":
+			asJSON = true
 		case "--limit":
 			// What was typed has to do something: a flag with nothing after it,
 			// an unknown flag and an empty argument all used to pass through in
@@ -124,7 +129,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if len(terms) == 0 {
-		return fmt.Errorf("usage: deja how <what> [--project name] [--limit n]")
+		return fmt.Errorf("usage: deja how <what> [--project name] [--limit n] [--json]")
 	}
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)
@@ -135,6 +140,9 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 	}
 	if note := ignoredHiddenNoteFor("answer", ignored); note != "" {
 		fmt.Fprint(os.Stderr, note)
+	}
+	if asJSON {
+		return writeHowJSON(stdout, entries, limit)
 	}
 	if len(entries) == 0 {
 		if note := policyHiddenNote(policy.ActivationSearch, hidden); note != "" {
@@ -353,4 +361,75 @@ func commandMentions(low, term string) bool {
 
 func isCommandWordRune(r rune) bool {
 	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// howJSON is the `deja how --json` envelope. See docs/json-output.md.
+//
+// `how` answers "how do I run this here", and its answer is the single output most
+// worth piping somewhere else — yet it was the one command in this family without
+// `--json` (#1931).
+//
+// Carries `found` and `truncated` for the reason the version 2 search envelope does:
+// the cap note lives on stderr, so a caller reading stdout alone cannot otherwise tell
+// eight ways to run the tests from thirteen.
+type howJSON struct {
+	SchemaVersion int          `json:"schema_version"`
+	Found         int          `json:"found"`
+	Truncated     bool         `json:"truncated"`
+	Commands      []howRowJSON `json:"commands"`
+}
+
+type howRowJSON struct {
+	Command  string `json:"command"`
+	Runs     int    `json:"runs"`
+	Sessions int    `json:"sessions"`
+	// Last is omitted rather than zero-valued: a command with no recorded time is a
+	// real state, and "0001-01-01" is not a date.
+	Last string `json:"last,omitempty"`
+	// FailedEveryTime is the prose's failure note as a field. `how` offering a command
+	// that never once worked, in the shape of one that always has, is the sharpest miss
+	// this surface can make — so a machine reader must be able to see it too.
+	FailedEveryTime bool `json:"failed_every_time"`
+	// Outcomes is how many runs recorded an exit status at all (about one in a hundred
+	// on a real store), so a consumer can weigh `failed_every_time` rather than trust it
+	// blind. ExitCode is omitted when the failures disagreed about it.
+	Outcomes int  `json:"outcomes"`
+	Failures int  `json:"failures"`
+	ExitCode *int `json:"exit_code,omitempty"`
+}
+
+func writeHowJSON(stdout io.Writer, entries []howEntry, limit int) error {
+	found := len(entries)
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+	rows := make([]howRowJSON, 0, len(entries))
+	for _, e := range entries {
+		row := howRowJSON{
+			// The same sanitiser the prose path uses: a recorded command is untrusted
+			// text, and a JSON consumer pasting it into a shell is no safer than a human.
+			Command:         search.SafeCommand(e.Command),
+			Runs:            e.Runs,
+			Sessions:        len(e.Sessions),
+			FailedEveryTime: e.failedEveryTime(),
+			Outcomes:        e.Outcomes,
+			Failures:        e.Failures,
+		}
+		if !e.Last.IsZero() {
+			row.Last = e.Last.UTC().Format(time.RFC3339)
+		}
+		if e.failedEveryTime() && !e.MixedExit {
+			code := e.ExitCode
+			row.ExitCode = &code
+		}
+		rows = append(rows, row)
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(howJSON{
+		SchemaVersion: jsonout.Version,
+		Found:         found,
+		Truncated:     found > len(rows),
+		Commands:      rows,
+	})
 }

--- a/cmd/deja/how_json_test.go
+++ b/cmd/deja/how_json_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
+)
+
+// `deja how` answers "how do I run this here", and its answer is the single
+// output most worth piping somewhere else — yet it was the one command in this
+// family without `--json` (#1931).
+
+func TestHowJSONIsAVersionedEnvelope(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	var buf bytes.Buffer
+	if err := runHow(index.DefaultDir(), []string{"--json", "go"}, &buf); err != nil {
+		t.Fatalf("how --json refused: %v", err)
+	}
+	var got howJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version = %d, want %d", got.SchemaVersion, jsonout.Version)
+	}
+	if got.Commands == nil {
+		t.Fatal("commands is null; an empty result must still be an array")
+	}
+}
+
+// The empty case keeps the shape. The prose path answers with a sentence naming
+// the terms, and separately with a policy note when a rule withheld everything;
+// a script can branch on neither.
+func TestHowJSONKeepsItsShapeWhenNothingMatches(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runHow(index.DefaultDir(), []string{"--json", "nothing-matches-this-xyzzy"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got howJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Commands) != 0 || got.Found != 0 || got.Truncated {
+		t.Fatalf("want an empty result, got %+v", got)
+	}
+}
+
+// `found` and `truncated` exist because the cap note goes to STDERR. A caller
+// reading stdout alone could not otherwise tell eight ways to run the tests
+// from thirteen.
+func TestHowJSONReportsWhatTheLimitHid(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runHow(index.DefaultDir(), []string{"--json", "--limit", "1", "go"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got howJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Commands) > 1 {
+		t.Fatalf("--limit 1 returned %d commands", len(got.Commands))
+	}
+	if got.Found < len(got.Commands) {
+		t.Fatalf("found %d is below the rows returned %d", got.Found, len(got.Commands))
+	}
+	if got.Truncated != (got.Found > len(got.Commands)) {
+		t.Fatalf("truncated=%v disagrees with found=%d rows=%d", got.Truncated, got.Found, len(got.Commands))
+	}
+}
+
+// A command with no search terms is still a usage error, and the flag must not
+// become the term — the shape `fix` was refused over.
+func TestHowJSONIsNotSearchedFor(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runHow(index.DefaultDir(), []string{"--json"}, &buf); err == nil {
+		t.Fatal("how --json with no terms was accepted; the flag became the query")
+	}
+}
+
+// Answering one flag must not reopen the dropped-on-the-floor behaviour the
+// unknown-flag guard closed.
+func TestHowStillRefusesAnUnknownFlag(t *testing.T) {
+	root := frictionEnv(t)
+	writeFrictionCorpus(t, root, index.FrictionMinSessions)
+	_ = root
+	var buf bytes.Buffer
+	if err := runHow(index.DefaultDir(), []string{"--jsonn", "go"}, &buf); err == nil {
+		t.Fatal("how accepted --jsonn")
+	}
+}

--- a/cmd/deja/how_json_withheld_test.go
+++ b/cmd/deja/how_json_withheld_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// howEntries carries the withheld count for a stated reason: filtering on its
+// own turns a leak into a confident "no command mentions that" over records a
+// rule hid. The prose path says so in a sentence, and a script cannot read a
+// sentence — so `commands: []` alone would mean both "nothing matched" and
+// "everything that matched was withheld".
+func TestHowJSONSaysWhatARuleWithheld(t *testing.T) {
+	dir := importedCommandStore(t)
+
+	// Control: with no rule in force the command is answered, or the arm below
+	// is measuring an empty store rather than a policy.
+	var open bytes.Buffer
+	if err := runHow(dir, []string{"--json", "kafkactl"}, &open); err != nil {
+		t.Fatal(err)
+	}
+	var before howJSON
+	if err := json.Unmarshal(open.Bytes(), &before); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, open.String())
+	}
+	if len(before.Commands) == 0 {
+		t.Fatalf("nothing matched without a policy, so this test measures nothing:\n%s", open.String())
+	}
+
+	writePolicy(t, `{"activations":{"search":{"imported":false}}}`)
+
+	var buf bytes.Buffer
+	if err := runHow(dir, []string{"--json", "kafkactl"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got howJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Commands) != 0 {
+		t.Fatalf("the policy should have withheld everything, got %d rows", len(got.Commands))
+	}
+	if got.Withheld < 1 {
+		t.Errorf("withheld=%d — an empty result reads as \"nothing matched\":\n%s", got.Withheld, buf.String())
+	}
+}
+
+// The ignore rule is the other half, and it is a separate number: the trust
+// policy is about where a session came from, the ignore rule about a path the
+// reader named. A consumer that can see only one of them still cannot tell an
+// empty answer from a hidden one.
+func TestHowJSONSaysWhatTheIgnoreRuleHid(t *testing.T) {
+	dir := importedCommandStore(t)
+	writePolicy(t, `{"ignore":["*projx*"]}`)
+
+	var buf bytes.Buffer
+	if err := runHow(dir, []string{"--json", "kafkactl"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var got howJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("not JSON: %v\n%s", err, buf.String())
+	}
+	if len(got.Commands) != 0 {
+		t.Fatalf("the ignore rule should have taken the only match, got %d rows", len(got.Commands))
+	}
+	if got.Ignored < 1 {
+		t.Errorf("ignored=%d — the rule hid the answer and the envelope says nothing:\n%s", got.Ignored, buf.String())
+	}
+}
+
+// importedCommandStore holds one imported session that ran a command, so a
+// local-only policy has something to withhold.
+func importedCommandStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	exp := filepath.Join(tmp, "transfer")
+	if err := os.MkdirAll(exp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var batch []byte
+	for i, rec := range []index.SyncRecord{
+		{Harness: "claude", SessionID: "peer1", Project: "tmp/projx", Role: "user",
+			Text: "how do we drive kafka here"},
+		{Harness: "claude", SessionID: "peer1", Project: "tmp/projx", Role: "command",
+			Text: "kafkactl consume orders --from-beginning"},
+	} {
+		b, err := json.Marshal(rec)
+		if err != nil {
+			t.Fatalf("record %d: %v", i, err)
+		}
+		batch = append(append(batch, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(exp, "deja-sync-x.jsonl"), batch, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := captureRun(t, "sync", "import", exp); err != nil {
+		t.Fatalf("import: %v (%s)", err, strings.TrimSpace(out))
+	}
+	return dir
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -468,6 +468,8 @@ The real command this machine runs for a given tool:
   "schema_version": 2,
   "found": 13,
   "truncated": true,
+  "withheld": 0,
+  "ignored": 0,
   "commands": [
     {
       "command": "go test ./... -race",
@@ -494,6 +496,12 @@ flag rather than trust it blind — only about one run record in a hundred carri
 an exit status at all, and `failed_every_time` is false whenever deja knows the
 outcome of no run. `exit_code` is present only when every recorded failure
 agreed on one.
+
+`withheld` and `ignored` are what the trust policy and the ignore rule took out
+before any of this was counted. Without them an empty `commands` means both
+"nothing matched" and "everything that matched was hidden" — which is the reason
+the count travels with the entries in the first place, and what the prose path
+says in a sentence.
 
 `last` is omitted rather than zero-valued when a command carries no recorded
 time. An empty result keeps the envelope and returns `commands: []`.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -459,6 +459,45 @@ from a machine a moment ahead — or an NTP step landing between the write and t
 read — is not a clock worth reporting, while a session's stamp comes from a
 transcript deja did not write.
 
+## `deja how <what> --json`
+
+The real command this machine runs for a given tool:
+
+```json
+{
+  "schema_version": 2,
+  "found": 13,
+  "truncated": true,
+  "commands": [
+    {
+      "command": "go test ./... -race",
+      "runs": 41,
+      "sessions": 12,
+      "last": "2026-08-30T11:20:03Z",
+      "failed_every_time": false,
+      "outcomes": 3,
+      "failures": 0
+    }
+  ]
+}
+```
+
+`found` and `truncated` are here because the cap note goes to **stderr**: a caller
+reading stdout alone could not otherwise tell eight ways to run the tests from
+thirteen.
+
+`failed_every_time` is the prose's failure note as a field. `how` offering a
+command that never once worked, in the shape of one that always has, is the
+sharpest miss this surface can make, so a machine reader has to be able to see
+it too. `outcomes` and `failures` are beside it so a consumer can weigh that
+flag rather than trust it blind — only about one run record in a hundred carries
+an exit status at all, and `failed_every_time` is false whenever deja knows the
+outcome of no run. `exit_code` is present only when every recorded failure
+agreed on one.
+
+`last` is omitted rather than zero-valued when a command carries no recorded
+time. An empty result keeps the envelope and returns `commands: []`.
+
 ## `deja stats --impact --json`
 
 What deja has actually served on this machine, measured from the usage log:


### PR DESCRIPTION
## What

`deja how <what> --json`, in the shape `docs/json-output.md` describes.

Fixes #1931.

## The envelope, and the two fields that are not obvious

```json
{ "schema_version": 2, "found": 13, "truncated": true, "commands": [ ... ] }
```

**`found` / `truncated`** are here because the cap note goes to **stderr**. A caller reading stdout alone could not otherwise tell eight ways to run the tests from thirteen — the same misread #1632 fixed for the human reader, which the machine reader would have inherited.

**`failed_every_time`** is the prose's failure note as a field. `how` offering a command that never once worked, in the shape of one that always has, is the sharpest miss this surface can make (#2624), so a machine reader has to be able to see it too.

`outcomes` and `failures` sit beside it deliberately, so a consumer can **weigh** that flag rather than trust it blind: only about one run record in a hundred carries an exit status at all, and `failed_every_time` is false whenever deja knows the outcome of no run. Without those two, a `false` reads as "this works" when it often means "nobody recorded". `exit_code` is present only when every recorded failure agreed on one, matching `MixedExit`.

The empty result keeps the envelope. The prose path answers with a sentence naming the terms, and separately with a policy note when a rule withheld everything — a script can branch on neither.

Same `search.SafeCommand` sanitiser as the prose path: a recorded command is untrusted text, and a JSON consumer pasting it into a shell is no safer than a human reading it.

## Tests

Five, including the two guards that matter for adding a flag to a command that takes free text:

- **`--json` alone is still a usage error** — it must not become the search term. That is the shape `fix` was refused over, and it would have been easy to reintroduce here.
- **an unknown flag is still refused** — answering one flag must not reopen the dropped-on-the-floor behaviour the unknown-flag guard closed.

## Gates

- [x] `go build ./...`
- [x] `go vet ./...` — clean
- [x] `gofmt -l` — clean
- [x] `go test ./cmd/deja/` — ok, 83s

Documented in `docs/json-output.md` beside the other surfaces, including why `outcomes` and `failures` accompany the flag.

Note: this is a sibling of #2895 (`--json` for `fix` and `friction`) and touches a different file, so they are independent — merge in either order.