### PR TITLE
fix(mcp): tell an unheld subject from a rephrased question

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
 	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -1085,6 +1086,11 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 	if stale {
 		fmt.Fprintln(&b, "(index refresh running in the background — the very newest sessions may not appear yet)")
 	}
+	// Whether the question named something the store does not hold. The word
+	// forms line already says which word was dropped; what it did not say is
+	// that dropping the subject leaves an answer about the rest of the
+	// sentence, which is the shape #657 measured on twenty invented subjects.
+	absent := namedSomethingAbsent(result.Variants)
 	if result.Stemmed {
 		fmt.Fprintf(&b, "No exact match; using word forms: %s\n", strings.Join(fuzzySummary(result.Variants), ", "))
 	} else if result.Fuzzy {
@@ -1098,6 +1104,27 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 		// questions about subjects this machine has never held — eight of
 		// eight came back with sessions rather than nothing, and the tool
 		// description promises an empty result means no record (#2074).
+		//
+		// But only where it is true. The tier is reached whenever the exact
+		// AND misses, which a real question does all the time: measured on
+		// this store, four of five questions about work done that same day
+		// were headed "No session is about this" while the session below was
+		// exactly about it (#657). A session that speaks one of the question's
+		// identifying words is about it as far as deja can tell, and saying
+		// otherwise teaches the reader to ignore the line that matters.
+		// The query's own words, not the stem forms the ranking also tries:
+		// the idf map is keyed by what the reader typed.
+		asked, _ := query.QueryParts(q)
+		if !absent && relevanceHitsAreAboutIt(hits, asked, result.TermIDF) {
+			fmt.Fprintln(&b, "No exact match; the sessions below are ranked by relevance — check that one describes what is happening now before acting on it.")
+		} else {
+			fmt.Fprintln(&b, nothingIsAboutThis+" so the sessions below are the nearest by wording — treat them as leads to check, not as a record, and say plainly if none of them answers.")
+		}
+	}
+	if absent && result.Tier != search.TierRelevance {
+		// The tier below relevance already says which word it dropped; this
+		// says what dropping it means, in the words the relevance tier uses
+		// for the same situation.
 		fmt.Fprintln(&b, nothingIsAboutThis+" so the sessions below are the nearest by wording — treat them as leads to check, not as a record, and say plainly if none of them answers.")
 	}
 	if note := demotedNote(hits, demoted); note != "" {
@@ -1457,6 +1484,69 @@ func recallContextResultFrom(dir, q, harness string) (string, int, int64, []stri
 		// The search path reaches a promoted note as often as the id path
 		// does — the note carries the id in its own text.
 		forgottenSourceNote(whole, q, false), nil
+}
+
+// relevanceHitsAreAboutIt reports whether some session being served is about
+// the question, or whether the page is only the nearest wording to it.
+//
+// The test is whether one session holds the whole question. The tier is
+// reached whenever the exact AND misses, which happens both when the store has
+// never held the subject and when it holds it and the reader phrased it
+// differently — and the strong warning was printed over both: measured on this
+// store, four of five questions about that same day's work were headed "No
+// session is about this" while the session below was exactly about it (#657).
+//
+// A session that speaks every word of the question the store knows is about it
+// as far as deja can tell. A page where the words are spread across different
+// sessions — one holds half, another the other half — is not, and keeps the
+// warning it earned in #2074.
+func relevanceHitsAreAboutIt(hits []search.Hit, terms []string, idf map[string]float64) bool {
+	if len(hits) == 0 || len(terms) == 0 || idf == nil {
+		return false
+	}
+	known := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if _, ok := idf[t]; ok {
+			known = append(known, t)
+		}
+	}
+	// A word the store does not hold at all is the #657 case and is decided by
+	// the caller before this; here it only means the question is not fully
+	// known, so nothing can hold all of it.
+	if len(known) == 0 || len(known) != len(terms) {
+		return false
+	}
+	for _, h := range hits {
+		if sessionSpeaksEvery(h.Session, known) {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionSpeaksEvery reports whether one session says every one of these words
+// somewhere in what a person or the agent said.
+func sessionSpeaksEvery(s model.Session, terms []string) bool {
+	for _, t := range terms {
+		if !search.SpeechCarriesAnyTerm(s, []string{t}) {
+			return false
+		}
+	}
+	return true
+}
+
+// namedSomethingAbsent reports whether a word of the question was dropped for
+// having nothing in the store: the recovery tiers record such a term with an
+// empty variant, which is how the "ignored" note is written.
+func namedSomethingAbsent(variants map[string][]string) bool {
+	for _, values := range variants {
+		for _, v := range values {
+			if v == "" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // nothingIsAboutThis is the half both surfaces share. The wording was tuned in

--- a/cmd/deja/mcp_relevance_lead_test.go
+++ b/cmd/deja/mcp_relevance_lead_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The relevance tier is reached whenever the exact match misses, which a real
+// question does all the time — so heading every such answer "No session is
+// about this" says it about sessions that are exactly about it. The line has
+// to tell the two apart: a question whose subject this store has never held,
+// and a question it holds and did not match word for word (#657).
+func TestTheRelevanceLeadSaysWhichKindOfMissItIs(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 40; i++ {
+		at := time.Now().Add(-time.Duration(i+1) * time.Hour).UTC().Format(time.RFC3339)
+		id := fmt.Sprintf("s%02d", i)
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"the checkout throttle kept tripping under load on shard ` + fmt.Sprint(i) + `"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":"we raised the throttle window and the checkout queue drained"}}`,
+		})
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Every word of this one is in the store; the exact AND still misses.
+	held := mcpRecallText(t, "checkout throttle load queue window")
+	if strings.Contains(held, "No session is about this") {
+		t.Errorf("a question the store holds every word of was headed as unheld:\n%s", head(held))
+	}
+	if !strings.Contains(held, "ranked by relevance") {
+		t.Errorf("the relevance answer did not say what it is:\n%s", head(held))
+	}
+
+	// This one names something the store has never held.
+	unheld := mcpRecallText(t, "grimwald checkout throttle")
+	if !strings.Contains(unheld, "No session is about this") {
+		t.Errorf("a question about an unheld subject read as an answer:\n%s", head(unheld))
+	}
+}
+
+func head(s string) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > 6 {
+		lines = lines[:6]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func mcpRecallText(t *testing.T, query string) string {
+	t.Helper()
+	req, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": "recall", "arguments": map[string]any{"query": query, "limit": 3}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := driveMCP(t, string(req))
+	res, ok := resp[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("recall %q returned no result: %#v", query, resp[0])
+	}
+	content, ok := res["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("recall %q returned no content: %#v", query, res)
+	}
+	first, _ := content[0].(map[string]any)
+	text, _ := first["text"].(string)
+	return text
+}

--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -89,6 +89,23 @@ func HasIdentifierTermKnown(terms []string, known map[string]float64) bool {
 	return HasIdentifierTerm(kept)
 }
 
+// IdentifyingTerms is the question's words that are rare enough in this store
+// to say what a session is about. The caller that has the ranking's own idf
+// gets that verdict; without it there is nothing to judge by and the whole
+// question stands.
+func IdentifyingTerms(terms []string, known map[string]float64) []string {
+	if known == nil {
+		return terms
+	}
+	kept := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if v, ok := known[t]; ok && v >= identifierIDFFloor {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
 // HasIdentifierTerm reports whether the question contains a word specific
 // enough to carry a match on its own. In a small corpus even "file" clears the
 // informativeness bar, so a single hit is only trusted when the question named


### PR DESCRIPTION
#657 asked whether an unknown-term query should answer weakly-with-annotation or stay silent. The product had already chosen the first — `recall` heads such an answer with "No session is about this. Nothing matched the query, so the sessions below are the nearest by wording" — but it printed that line over every relevance answer, and the relevance tier is reached whenever the exact AND misses.

Measured on this machine's store, four of five questions about work done that same day were headed as unheld while the session below was exactly about it. A warning that fires on the true case as often as the false one is one an agent learns to ignore.

Two shapes, told apart by what the store holds:

- **the question named something the store has never held** — the recovery tiers already record such a word as ignored, and that verdict now carries the "No session is about this" framing on the stemmed and close tiers too, where it was previously only annotated as a dropped word while the count line said "matched";
- **the store holds every word and one session says them all** — headed "No exact match; the sessions below are ranked by relevance — check that one describes what is happening now before acting on it."

A page where the words are spread across different sessions keeps the strong warning it earned in #2074, which is what its tests pin.

New test seeds a store, asks one question of each shape, and asserts the two leads. Full suite green.

Closes #657.