### PR TITLE
ci: ask for a rebase where the base moved on the same files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,29 @@ jobs:
       - name: Every scripts/ binary is ignored
         run: go run ./scripts/ignorecheck
 
+  stale:
+    name: not behind on what it touches
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # merge-base needs the history of both sides.
+          fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+      # A squash merge applies the branch's own diff, so a branch cut before
+      # another PR landed silently restores that PR's old lines — mergeable,
+      # green, reviewed, and a revert (#2911). Requiring every branch to be up
+      # to date prevents it and costs a rebase per PR; this asks for one only
+      # where the base has moved on a file the branch also touches.
+      - name: Rebase needed on the files this branch changes
+        run: |
+          git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+          go run ./scripts/staleoverlap -base "origin/${{ github.event.pull_request.base.ref }}" -head HEAD
+
   vuln:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ deja-stats.svg
 /relnotes
 /reusebench
 /searchbench
+/staleoverlap
 
 # Where story.py drops the film's frames when it is run without --out. Three
 # hundred and twenty PNGs, one run.

--- a/scripts/staleoverlap/main.go
+++ b/scripts/staleoverlap/main.go
@@ -1,0 +1,91 @@
+// Command staleoverlap fails when a pull request would silently revert what
+// landed on its base while it was open.
+//
+// A squash merge applies the branch's own diff. If something merged ahead of
+// it rewrote the same region, the diff still applies — GitHub calls the PR
+// mergeable, both PRs are green, and the second merge restores the first one's
+// old lines along with dropping its tests. That happened here: #2875 made the
+// goose filter a deny-list at 09:34 and #2877, branched before it, put the
+// allow-list back at 09:44 (#2911).
+//
+// Requiring every branch to be up to date would prevent it and costs a rebase
+// per PR on a busy day. This is the narrow version of the same rule: a rebase
+// is demanded only where the base has moved on a file the branch also touches,
+// which is the only case that can revert anything.
+//
+//	go run ./scripts/staleoverlap -base origin/main
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+func main() {
+	base := flag.String("base", "origin/main", "the branch this one will be merged into")
+	head := flag.String("head", "HEAD", "the branch to check")
+	flag.Parse()
+
+	mergeBase, err := git("merge-base", *base, *head)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "staleoverlap:", err)
+		os.Exit(2)
+	}
+	mine, err := changedFiles(mergeBase, *head)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "staleoverlap:", err)
+		os.Exit(2)
+	}
+	theirs, err := changedFiles(mergeBase, *base)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "staleoverlap:", err)
+		os.Exit(2)
+	}
+	var overlap []string
+	for f := range mine {
+		if theirs[f] {
+			overlap = append(overlap, f)
+		}
+	}
+	if len(overlap) == 0 {
+		fmt.Printf("nothing on %s has touched the %d file(s) this branch changes\n", *base, len(mine))
+		return
+	}
+	sort.Strings(overlap)
+	fmt.Fprintf(os.Stderr, "this branch changes %d file(s) that %s has changed since it was cut:\n", len(overlap), *base)
+	for _, f := range overlap {
+		fmt.Fprintln(os.Stderr, "  "+f)
+	}
+	fmt.Fprintf(os.Stderr, "rebase on %s and push again — merging as it stands would apply this branch's\n"+
+		"version of those files over the newer one, which is a revert no check can see (#2911)\n", *base)
+	os.Exit(1)
+}
+
+func changedFiles(from, to string) (map[string]bool, error) {
+	out, err := git("diff", "--name-only", from, to)
+	if err != nil {
+		return nil, err
+	}
+	files := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		if f := strings.TrimSpace(line); f != "" {
+			files[f] = true
+		}
+	}
+	return files, nil
+}
+
+func git(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %v: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
#2911's failure, in one line: a squash merge applies the branch's own diff, so a branch cut before another PR landed restores that PR's old lines — mergeable, green, reviewed, and a revert. It shipped once already (goose's filter, ten minutes apart).

The setting that prevents it, "require branches to be up to date", costs a rebase on every PR whenever anything lands. This is the narrow form of the same rule: a rebase is asked for only where the base has moved on a file this branch also touches, which is the only case that can revert anything. On a day of a dozen merges to different parts of the tree, it asks for nothing.

`scripts/staleoverlap` is the check (merge-base, two `--name-only` diffs, intersect), and a `pull_request`-only job runs it. It names the files and says why.

Two things it does not do, both deliberate: it cannot see a semantic revert in files neither side changed, and it does not replace the branch-protection setting — that trade is yours to make on the repository.

Refs #2911.

Checked while here: none of today's fifteen merges into this branch reverted an earlier one — every change is present on the branch head (index version 34, the freshness floor, the Thai bigrams, the edit pairs, both reworded leads, the near-duplicate collapse) and the full suite is green on it.