### PR TITLE
perf(index): grammar earns no posting

### DIFF
--- a/internal/index/cjk_grammar_bigrams_test.go
+++ b/internal/index/cjk_grammar_bigrams_test.go
@@ -1,0 +1,70 @@
+package index
+
+import (
+	"strings"
+	"testing"
+
+	query "github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A pair of function runes is the CJK counterpart of a stop word. The query
+// side has dropped it from the term list since it was written; the index kept
+// storing it, so the postings carried the most frequent pairs in the language
+// for nothing (#492).
+func TestGrammarBigramsEarnNoPosting(t *testing.T) {
+	var got []string
+	cjkIndexKeys("这是什么问题", func(tok string) { got = append(got, tok) })
+	joined := strings.Join(got, " ")
+	for _, grammar := range []string{"t这是", "t是什", "t什么"} {
+		if strings.Contains(joined, grammar) {
+			t.Errorf("grammar bigram %q was stored: %v", grammar, got)
+		}
+	}
+	// And the content pairs are still there, including the ones that straddle
+	// grammar and content: 么问 is half a function rune and half a word.
+	for _, content := range []string{"t么问", "t问题"} {
+		if !strings.Contains(joined, content) {
+			t.Errorf("content bigram %q was dropped: %v", content, got)
+		}
+	}
+}
+
+// A single function rune that also carries meaning keeps its pairs: 中 and 个
+// are in the closed class, and 中国 and 个人 are words.
+func TestAFunctionRuneBesideAContentRuneKeepsItsBigram(t *testing.T) {
+	var got []string
+	cjkIndexKeys("中国个人", func(tok string) { got = append(got, tok) })
+	joined := strings.Join(got, " ")
+	for _, want := range []string{"t中国", "t国个", "t个人"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("%q was dropped: %v", want, got)
+		}
+	}
+}
+
+// The two sides ask for the same thing: what the index no longer stores, the
+// query no longer puts in the AND.
+func TestTheQuerySideDropsTheSameBigrams(t *testing.T) {
+	keys := queryKeys("这是什么问题")
+	for _, k := range keys {
+		if query.CJKFunctionBigram(strings.TrimPrefix(k, "t")) {
+			t.Errorf("the query asks for a grammar bigram the index does not hold: %q of %v", k, keys)
+		}
+	}
+	if len(keys) == 0 {
+		t.Error("the query lost every key")
+	}
+}
+
+// A sentence written entirely in the closed class is grammar with no subject;
+// it must not take the whole store with it.
+func TestAGrammarOnlySentenceFindsNothingInParticular(t *testing.T) {
+	dir := seedOneWord(t, "这是什么问题")
+	res, err := SearchDetailed(dir, query.Options{Query: "是的了", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != 0 {
+		t.Errorf("a grammar-only query returned %d sessions", len(res.Sessions))
+	}
+}

--- a/internal/index/cjkindex.go
+++ b/internal/index/cjkindex.go
@@ -5,6 +5,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
+	"github.com/vshulcz/deja-vu/internal/query"
 )
 
 // hexBuckets fixes every shard name in a lookup table. bucket relies on these
@@ -115,6 +116,14 @@ func cjkIndexKeys(s string, emit func(tok string)) {
 
 	seen := map[uint64]struct{}{}
 	emitFolded := func(r1, r2 rune) {
+		// Grammar earns no posting. A pair of function runes — 的了, 在哪,
+		// 什么 — is the CJK counterpart of a stop word: the query side has
+		// dropped it from the term list since it was written, so the postings
+		// were carrying the most frequent pairs in the language for nothing
+		// (#492). queryKeys drops them from the AND for the same reason.
+		if r1 != 0 && query.CJKFunctionRune(r1) && query.CJKFunctionRune(r2) {
+			return
+		}
 		key := (uint64(r1) << 21) | uint64(r2)
 		if _, ok := seen[key]; ok {
 			return

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -98,6 +98,12 @@ import (
 // cap and no query reached the words inside it; it now emits the overlapping
 // bigrams CJK has had since 21. A store built before this holds the sentences
 // and nothing re-derives the bigrams without the bump (#2897).
+//
+// The same bump carries one subtraction: a bigram of two function runes — 的了,
+// 在哪, 什么 — is grammar, the query side has dropped it from the term list
+// since it was written, and the index was storing the most frequent pairs in
+// the language for nothing. Measured on a 42 MB Chinese corpus, buckets 75.5
+// MB to 70.7 MB (#492).
 const version = 34
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -3955,7 +3955,10 @@ func queryKeys(s string) []string {
 	// query is all stop words, keep them (odd results beat none).
 	content := make([]string, 0, len(toks))
 	for _, tok := range toks {
-		if !query.IsStopWord(tok) {
+		// A bigram of two function runes is grammar, and the index no longer
+		// stores one: asking for it would AND the query against a key that
+		// cannot exist (#492).
+		if !query.IsStopWord(tok) && !query.CJKFunctionBigram(tok) {
 			content = append(content, tok)
 		}
 	}

--- a/internal/query/cjk.go
+++ b/internal/query/cjk.go
@@ -65,9 +65,14 @@ func ExpandCJKTokens(toks []string) []string {
 //
 // The test is deliberately "both runes", not "either": 中 and 个 are function
 // runes on their own but carry meaning in 中国 and 个人, and dropping every
-// bigram that merely contains one would delete real words. This filter runs
-// at query time only — the index keeps every bigram, so nothing about
-// ingestion changes.
+// bigram that merely contains one would delete real words.
+//
+// Both sides apply it. It began as a query-time filter with the index keeping
+// every bigram, which meant the postings carried the most frequent pairs in
+// the language for nothing: 的了是在 and their neighbours are what a Chinese
+// text is mostly made of, and #492 measured bigram postings at +68% of the
+// bucket bytes. The index drops them too now, and queryKeys drops them from
+// the AND, so the two sides ask for the same thing.
 //
 // The list covers three scripts of the same closed class. Simplified Mandarin
 // alone is not enough: a Traditional writer's 哪個 and a Cantonese writer's
@@ -98,6 +103,11 @@ var cjkFunctionRunes = map[rune]bool{
 	'點': true, '哋': true, '嗰': true, '啲': true, '樣': true, '冇': true,
 	'嚟': true, '咪': true, '囉': true, '喎': true, '啦': true, '咁': true,
 }
+
+// CJKFunctionRune reports whether r belongs to the closed class above: a
+// particle, pronoun or question word that carries no topic on its own. The
+// index asks this pair by pair, to keep grammar out of the postings.
+func CJKFunctionRune(r rune) bool { return cjkFunctionRunes[r] }
 
 // CJKFunctionBigram reports whether every rune of a CJK token is a function
 // rune, i.e. the token is pure grammar.

--- a/internal/query/cjk_function_rune_test.go
+++ b/internal/query/cjk_function_rune_test.go
@@ -1,0 +1,19 @@
+package query
+
+import "testing"
+
+// The index asks this rune by rune, to keep a pair of them out of the
+// postings, so it is exported and has to say the same thing the bigram test
+// says (#492).
+func TestCJKFunctionRuneNamesTheClosedClass(t *testing.T) {
+	for _, r := range []rune{'的', '了', '什', '么', '嘅'} {
+		if !CJKFunctionRune(r) {
+			t.Errorf("%q is in the closed class and was not named", r)
+		}
+	}
+	for _, r := range []rune{'国', '人', '题', 'a'} {
+		if CJKFunctionRune(r) {
+			t.Errorf("%q carries meaning and was called grammar", r)
+		}
+	}
+}


### PR DESCRIPTION
`cjkFunctionRunes` has said since it was written that a bigram of two function runes — 的了, 在哪, 什么 — is the CJK counterpart of a stop word, and its own comment said the filter runs at query time only, so the index kept every one of them. Those are the most frequent pairs in the language, and #492 measures bigram postings at +68% of the bucket bytes.

Both sides drop them now, so the index and the query ask for the same thing.

Measured on a 42 MB synthetic Chinese corpus (1,200 sessions, 120k messages, a third of the runes drawn from the closed class, which is roughly ordinary prose):

```
                base      here
buckets      75.5 MB   70.7 MB   (-6.4%)
index        103.0 MB   98.2 MB
build          2.68s     2.65s
40 sentence queries   40/40 found either way, same tier
```

Smaller than the issue's headline: most bigrams straddle a function rune and a content rune, and those are kept — 中国 and 个人 are words. This takes the pairs that are only grammar.

No new index version: 34 is unreleased, so the note there carries this too rather than forcing a second rebuild.

Refs #492.