### PR TITLE
fix(search): the snippet path did not know what a listing is

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -319,6 +319,13 @@ func isStructureLine(l string) bool {
 	return false
 }
 
+// IsListingDump reports whether a line is a listing rather than a sentence.
+// Exported for the snippet path, which had its own smaller pair of filters —
+// a numbered-line check and a tool-dump check — and no notion of a listing at
+// all, so `wc -l` output and a run of paths were quoted as the passage that
+// explains a file.
+func IsListingDump(line string) bool { return looksLikeListingDump(line) }
+
 func looksLikeListingDump(line string) bool {
 	fields := strings.Fields(line)
 	if len(fields) < 8 {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/query"
@@ -2199,7 +2200,7 @@ func proseForSnippet(s string) string {
 	var keep []string
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || looksNumbered(line) || looksToolDump(line) {
+		if line == "" || looksNumbered(line) || looksToolDump(line) || digest.IsListingDump(line) {
 			continue
 		}
 		keep = append(keep, line)

--- a/internal/search/snippet_listing_test.go
+++ b/internal/search/snippet_listing_test.go
@@ -1,0 +1,52 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// The snippet path had its own two filters — a numbered-line check and a
+// tool-dump check — and no notion of a listing, so `wc -l` output and a run of
+// paths were quoted as the passage that explains a file. The digest side has
+// had the rule all along; this is the same question asked on the other path.
+//
+// On a real store, 29 of the 60 most-worked-on files got a different blame
+// answer once the rule was shared.
+func TestASnippetDoesNotQuoteALineCount(t *testing.T) {
+	text := "Counted the package:\n" +
+		"128 domain/apiaccess/apiaccess_test.go 210 domain/apiaccess/apiaccess.go 51 domain/apiaccess/errors.go 70 domain/apiaccess/ledger.go 35 domain/apiaccess/ports.go\n" +
+		"The split is fine, so I left the layout alone."
+	got := proseForSnippet(text)
+	if strings.Contains(got, "apiaccess_test.go") {
+		t.Errorf("a wc -l dump was kept as prose:\n%s", got)
+	}
+	if !strings.Contains(got, "The split is fine") {
+		t.Errorf("the sentence around it was dropped too:\n%s", got)
+	}
+}
+
+// The filters it already had still do their work, and a sentence is still a
+// sentence — the listing rule must not start eating prose on this path either.
+func TestTheSnippetPathKeepsItsOtherFilters(t *testing.T) {
+	got := proseForSnippet(
+		"42:  func main() {\n" +
+			"Raised pgbouncer default_pool_size to 40 and the timeouts stopped.\n" +
+			"12 зелёных. Жду ревьюера перед мержем.")
+	if strings.Contains(got, "func main") {
+		t.Errorf("a numbered source line was kept:\n%s", got)
+	}
+	for _, want := range []string{"default_pool_size to 40", "Жду ревьюера"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prose was dropped, %q is gone:\n%s", want, got)
+		}
+	}
+}
+
+// Everything filtered leaves the old fallback standing: a snippet of the raw
+// text beats an empty one.
+func TestASnippetOfNothingButAListingIsStillSomething(t *testing.T) {
+	got := proseForSnippet("main.go util.go parser.go writer.go reader.go index.go search.go digest.go")
+	if strings.TrimSpace(got) == "" {
+		t.Error("a record that is only a listing produced no snippet at all")
+	}
+}


### PR DESCRIPTION
Ran `deja blame` against the 60 most-worked-on files of a real store and read what it answered. The passage said to explain the file was, repeatedly, a dump:

```
128 domain/apiaccess/apiaccess_test.go 210 domain/apiaccess/apiaccess.go 51 domain/apiaccess/errors.go …
… types.go apps/image2video/internal/domain/partner/ports.go apps/image2video/internal/domain/partner/errors.go …
```

There are two filter sets in the tree and they do not know the same things. `MessageText` runs a line past `noiseLine`, which includes the listing rule. `proseForSnippet` — blame, and the search excerpts — has its own smaller pair: a numbered-line check and a tool-dump check, and no notion of a listing at all. `wc -l` output slips through both of its filters: the number is followed by a space rather than the `:` or `|` `looksNumbered` wants, and it is nobody's tool banner.

So the rule is shared rather than copied — `digest.IsListingDump` is the existing one, exported. Nothing about what counts as a listing changes.

```
blame answers that change   29 of 60
  the snippet got shorter   11
  the snippet got longer    18
```

Eighteen got longer, which is the point: dropping the dump let the prose around it into the window.

Three benches unchanged: prompt 13/13 with 6 cross-paired false fires, recall@5 1.00, context median 294 tokens. Four mutations, all red — including inverting the exported wrapper, so the two sides cannot quietly disagree about the rule.

**What it does not fix.** A path run that happens to contain one stopword still survives, because `looksLikeListingDump` bails on the first stopword it sees. That exit is what keeps an ordinary sentence about files from being read as a list of them, and I would rather leave a dump through than start eating sentences on a second path — the trade #2916 already made once.
