### PR TITLE
test: put back the lock-wait callback main() installs

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -518,6 +518,14 @@ func TestAdditionalDispatchAndHelperBranches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// main() installs index.LockWaitNotice, a closure that reads os.Stderr
+	// when it fires. Left installed, it outlives this test: any later test
+	// that swaps os.Stderr while something else waits for the index lock
+	// races with it, which is what `go test -race` caught on Go 1.25
+	// (TestForgetAgainstARebuildDropsOnlyWhatItNamed). The global belongs to
+	// the process main() would own, so it is put back here.
+	oldNotice := index.LockWaitNotice
+	t.Cleanup(func() { index.LockWaitNotice = oldNotice })
 	os.Args = []string{"deja", "version"}
 	os.Stdout = w
 	main()


### PR DESCRIPTION
Unblocks #2887 (setup-go 6.5.0 → 7.0.0), where the macOS leg fails with a data race rather than anything to do with the action itself. The bump brings Go 1.25, whose race detector sees it.

The race, from that run:

```
Read at 0x00010583f3f0 by goroutine 9800:
  cmd/deja.main.func1()               cmd/deja/main.go:36
  index.noteLockWait()                internal/index/index.go:513
  ...
  TestForgetAgainstARebuildDropsOnlyWhatItNamed.func1()

Previous write at 0x00010583f3f0 by goroutine 9765:
  cmd/deja.captureBoth()              cmd/deja/command_hint_with_hits_test.go:25
```

`main()` installs `index.LockWaitNotice` as a closure that reads `os.Stderr` when it fires. One test calls `main()` directly to cover the version path, and the closure stays installed for the rest of the binary. Much later, `TestForgetAgainstARebuild…` runs a rebuild in a goroutine while `captureBoth` swaps `os.Stdout`/`os.Stderr` — the goroutine hits a held lock, the callback fires, and the two touch the same global.

Restoring the callback in the test that installed it is the fix. The global belongs to the process `main()` would own, and no other test calls it.

**I could not reproduce this locally and am not going to claim otherwise.** `noteLockWait` fires at most once per process, so it needs the first lock wait in the binary to land inside a stderr swap; six repeats of the two tests together did not hit it on Go 1.27/arm64. What I have is the report naming both lines and a mechanism that follows from the code. The full `cmd/deja` package passes with `-race` here either way, which is the state the CI run is expected to reach.
