### PR TITLE
fix(search): the neighbour rescue reads a sentence

### DIFF
--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -3,6 +3,7 @@ package index
 import (
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/query"
@@ -191,6 +192,216 @@ func cooccurSearch(dir string, m Manifest, o query.Options) (SearchResult, error
 	if len(terms) < 2 {
 		return SearchResult{}, nil
 	}
+	return cooccurSearchOver(dir, m, o, terms, true)
+}
+
+// cooccurNarrowedSearch is the same rescue asked of a sentence, and it runs
+// last — after the ranked tier has come back empty.
+//
+// The whole-AND rung above can only fire on a query short enough not to need
+// it (#2331). Narrowing the AND to the words that identify something makes it
+// fire on a sentence, and putting that in the ladder where the whole-AND rung
+// sits made things worse: measured on LongMemEval, hit@1 79.5% to 73.5% and
+// MRR .857 to .795, because it answered questions the ranked tier answers
+// better. Below the ranked tier it costs nothing and reaches what nothing else
+// does.
+func cooccurNarrowedSearch(dir string, m Manifest, o query.Options) (SearchResult, error) {
+	terms, _ := query.QueryParts(o.Query)
+	if len(terms) < 2 {
+		return SearchResult{}, nil
+	}
+	neighbors := readCooccur(dir)
+	if neighbors == nil {
+		return SearchResult{}, nil
+	}
+	// A sentence never matches an AND after one substitution: the map holds
+	// the link a reworded question needs and the only query short enough to
+	// read it is one that did not need it (#2331). So ask again over the words
+	// that identify something — a question's ordinary words are what the AND
+	// was failing on, and they are not what the answer is found by.
+	//
+	// Narrower, then narrower still. Three identifying words is already a
+	// sharp question and often one word too many: the session that settled
+	// something says it in its own vocabulary, and every word of the reader's
+	// that it does not use fails the AND on its own.
+	// Every attempt, not the first that lands. The widest subset is the one
+	// the *explaining* session matches — it holds both vocabularies by
+	// definition — while the session that settled something holds the
+	// project's word and little else of the question, so it is found by a
+	// narrower pair. Returning on the first hit therefore returned the
+	// explanation and never the answer, which is what #2331 says this rung
+	// cannot reach.
+	var found []model.Session
+	seen := map[string]bool{}
+	variants := map[string][]string{}
+	for _, narrowed := range narrowedAttempts(dir, m, terms, neighbors) {
+		res, err := cooccurSearchOver(dir, m, o, narrowed, false)
+		if err != nil {
+			return SearchResult{}, err
+		}
+		for _, s := range res.Sessions {
+			key := s.Harness + ":" + s.ID
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			found = append(found, s)
+		}
+		for term, values := range res.Variants {
+			if _, ok := variants[term]; !ok {
+				variants[term] = values
+			}
+		}
+		if len(found) >= cooccurNarrowedMax {
+			break
+		}
+	}
+	if len(found) == 0 {
+		return SearchResult{}, nil
+	}
+	return SearchResult{Sessions: found, Stemmed: true, Neighbour: true, Variants: variants, Tier: query.TierClose}, nil
+}
+
+// cooccurNarrowedMax bounds what the narrowed attempts collect. This is the
+// last rung and the reader is waiting; a handful of sessions is a lead, and
+// more than that is the ranked tier's job.
+const cooccurNarrowedMax = 10
+
+// narrowedAttempts is the identifying subsets worth trying: the widest first,
+// then the pairs.
+//
+// A pair is what usually works, and which pair matters. The session that
+// settled something says it in its own vocabulary — "the pgbouncer pool ran
+// out of connections" — so the reader's word for the subject has to be in the
+// subset (it is what the substitution is made on) and the rest of the subset
+// has to be a word that session also uses. Trying the bridgeable word against
+// each of the other identifying words is a handful of intersections and finds
+// the answering session rather than the sentence that explains the term.
+func narrowedAttempts(dir string, m Manifest, terms []string, neighbours map[string][]string) [][]string {
+	kept := identifyingTerms(dir, m, terms, neighbours)
+	if len(kept) == 0 {
+		return nil
+	}
+	inQueryOrder := func(subset []string) []string {
+		out := append([]string(nil), subset...)
+		sort.Slice(out, func(i, j int) bool { return indexOf(terms, out[i]) < indexOf(terms, out[j]) })
+		return out
+	}
+	var out [][]string
+	seen := map[string]bool{}
+	add := func(subset []string) {
+		subset = inQueryOrder(subset)
+		key := strings.Join(subset, "\x00")
+		if seen[key] || len(subset) > len(terms) {
+			return
+		}
+		seen[key] = true
+		out = append(out, subset)
+	}
+	if len(kept) >= cooccurNarrowTerms {
+		add(kept[:cooccurNarrowTerms])
+	}
+	for i, b := range kept {
+		if len(neighbours[b]) == 0 || i >= cooccurBridgeHeads {
+			continue
+		}
+		for j, other := range kept {
+			if i == j || j >= cooccurPairsPerHead {
+				continue
+			}
+			add([]string{b, other})
+		}
+	}
+	// And the word on its own. A session that settled something in the
+	// project's own vocabulary often shares nothing else with the question —
+	// "quarto was moved to the first of the month" answers "when did we last
+	// change the zephyrine schedule" and holds none of its words. This is the
+	// last rung of the last tier, so the alternative to swapping the subject
+	// and looking for that alone is silence.
+	for i, b := range kept {
+		if len(neighbours[b]) == 0 || i >= cooccurBridgeHeads {
+			continue
+		}
+		add([]string{b})
+	}
+	return out
+}
+
+// cooccurBridgeHeads and cooccurPairsPerHead bound the pairs tried. Each is an
+// intersection of two posting lists, and the reader is waiting: two words to
+// bridge from against the four rarest words of the question is the width at
+// which this stops paying.
+const (
+	cooccurBridgeHeads  = 2
+	cooccurPairsPerHead = 4
+)
+
+// identifyingTerms is the query's words that are rare enough in this store to
+// say what a session is about, bridgeable ones first and then rarest first.
+// The order is what the narrowing cuts against.
+func identifyingTerms(dir string, m Manifest, terms []string, neighbours map[string][]string) []string {
+	type scored struct {
+		term      string
+		df        int
+		bridgable bool
+	}
+	var kept []scored
+	for _, t := range terms {
+		if query.IsStopWord(t) {
+			continue
+		}
+		posts, err := postingsFor(dir, "t"+t)
+		if err != nil || len(posts) == 0 {
+			continue
+		}
+		in := make(map[uint32]bool, len(posts))
+		for _, p := range posts {
+			in[p.Sid] = true
+		}
+		if len(in) > 2 && rankIDF(len(m.Sessions), len(in)) < dejaVuIDFFloor {
+			continue
+		}
+		kept = append(kept, scored{t, len(in), len(neighbours[t]) > 0})
+	}
+	sort.Slice(kept, func(i, j int) bool {
+		if kept[i].bridgable != kept[j].bridgable {
+			return kept[i].bridgable
+		}
+		if kept[i].df == kept[j].df {
+			return kept[i].term < kept[j].term
+		}
+		return kept[i].df < kept[j].df
+	})
+	out := make([]string, 0, len(kept))
+	for _, k := range kept {
+		out = append(out, k.term)
+	}
+	return out
+}
+
+func indexOf(terms []string, want string) int {
+	for i, t := range terms {
+		if t == want {
+			return i
+		}
+	}
+	return len(terms)
+}
+
+// cooccurNarrowTerms is how many identifying words the narrowed AND is built
+// from. Three is the width at which a rephrased question still names one
+// subject; wider and the AND fails for the same reason the sentence did.
+const cooccurNarrowTerms = 3
+
+// cooccurSearchOver tries each neighbour of each term in turn. stopAtFirst is
+// what the whole-AND rung wants — one swap that matches is the answer — while
+// the narrowed rung takes them all, because the first neighbour to match is
+// usually the sentence that explains the word and the one after it is the
+// session that used it.
+func cooccurSearchOver(dir string, m Manifest, o query.Options, terms []string, stopAtFirst bool) (SearchResult, error) {
+	var found []model.Session
+	seen := map[string]bool{}
+	gathered := map[string][]string{}
 	neighbors := readCooccur(dir)
 	if neighbors == nil {
 		return SearchResult{}, nil
@@ -239,12 +450,41 @@ func cooccurSearch(dir string, m Manifest, o query.Options) (SearchResult, error
 			if len(posts) == 0 {
 				continue
 			}
-			ss, serr := scanRecordsWithVariants(dir, m, o, postingOffsets(posts), variants)
+			// Verified against the words this attempt was built from, not
+			// against the whole sentence. The scan re-checks the record
+			// against the query, and a session that settled something says it
+			// in its own words — asking it to also carry "why", "would" and
+			// "exhaust" is the AND this rung was trying to get out from under
+			// (#2331).
+			narrowed := o
+			narrowed.Query = strings.Join(terms, " ")
+			ss, serr := scanRecordsWithVariants(dir, m, narrowed, postingOffsets(posts), variants)
 			if serr != nil || len(ss) == 0 {
 				continue
 			}
-			return SearchResult{Sessions: ss, Stemmed: true, Neighbour: true, Variants: variants, Tier: query.TierClose}, nil
+			if stopAtFirst {
+				return SearchResult{Sessions: ss, Stemmed: true, Neighbour: true, Variants: variants, Tier: query.TierClose}, nil
+			}
+			for _, s := range ss {
+				key := s.Harness + ":" + s.ID
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				found = append(found, s)
+			}
+			for t, values := range variants {
+				if _, ok := gathered[t]; !ok {
+					gathered[t] = values
+				}
+			}
+			if len(found) >= cooccurNarrowedMax {
+				return SearchResult{Sessions: found, Stemmed: true, Neighbour: true, Variants: gathered, Tier: query.TierClose}, nil
+			}
 		}
 	}
-	return SearchResult{}, nil
+	if len(found) == 0 {
+		return SearchResult{}, nil
+	}
+	return SearchResult{Sessions: found, Stemmed: true, Neighbour: true, Variants: gathered, Tier: query.TierClose}, nil
 }

--- a/internal/index/cooccur_sentence_test.go
+++ b/internal/index/cooccur_sentence_test.go
@@ -1,0 +1,163 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// The co-occurrence map holds the link a reworded question needs, and the tier
+// that reads it required the whole AND to match after one substitution — so it
+// could only ever fire on a query short enough not to need it. A sentence,
+// which is what an agent and a person both type, never matched (#2331).
+func TestTheNeighbourRescueFiresOnASentence(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	// Ordinary work, so the question's ordinary words are not rare by accident.
+	for i := 0; i < 60; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("noise%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: fmt.Sprintf("the go service on shard %d was restarted after the weekly deploy", i)}},
+		})
+	}
+	// The sentence that ties the reader's word to the project's, said in three
+	// sessions, which is the evidence the map asks for.
+	for i := 0; i < 3; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("explains%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: "pgbouncer is the connection proxy we put in front of postgres"}},
+		})
+	}
+	// What the question is really after, in the project's own word.
+	sessions = append(sessions, model.Session{
+		ID: "answer", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user",
+			Text: "the pgbouncer pool ran out of connections and the go service could not open one"}},
+	})
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sentence, not two words: the question the issue was written about.
+	// Asked of the tier itself, because the ranked path finds the session by
+	// other means and would hide whether this rung fired at all.
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := query.Options{Query: "why would a go service exhaust its postgres pool behind a connection proxy", All: true}
+	res, err := cooccurNarrowedSearch(dir, m, o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, s := range res.Sessions {
+		ids = append(ids, s.ID)
+	}
+	if !strings.Contains(strings.Join(ids, " "), "answer") {
+		t.Errorf("the neighbour rescue did not fire on a sentence: tier=%q %v", res.Tier, ids)
+	}
+	if res.Variants["proxy"] == nil {
+		t.Errorf("the swap is not narrated: %v", res.Variants)
+	}
+}
+
+// The narrowing takes the words that identify something, not the first three
+// it sees: a question is mostly ordinary words and they are what the AND was
+// failing on.
+func TestTheNarrowedAndKeepsOnlyIdentifyingWords(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	for i := 0; i < 60; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("noise%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: fmt.Sprintf("the service was restarted after the deploy on shard %d", i)}},
+		})
+	}
+	sessions = append(sessions, model.Session{
+		ID: "rare", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user", Text: "the zephyrine quarto ledger was rebuilt"}},
+	})
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := identifyingTerms(dir, m, []string{"the", "service", "was", "restarted", "zephyrine", "quarto"}, nil)
+	for _, ordinary := range []string{"service", "restarted"} {
+		for _, g := range got {
+			if g == ordinary {
+				t.Errorf("an ordinary word was kept: %v", got)
+			}
+		}
+	}
+	if len(got) == 0 {
+		t.Fatalf("every word was dropped: %v", got)
+	}
+}
+
+// And the rung is wired where it belongs: below the ranked tier, which answers
+// better wherever it answers at all. Asked through the ladder, a sentence
+// whose subject the project calls something else comes back with the session
+// that settled it.
+func TestTheLadderReachesTheNeighbourRescue(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	var sessions []model.Session
+	for i := 0; i < 60; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("noise%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: fmt.Sprintf("weekly deploy notes for shard %d, nothing unusual", i)}},
+		})
+	}
+	for i := 0; i < 3; i++ {
+		sessions = append(sessions, model.Session{
+			ID: fmt.Sprintf("explains%02d", i), Harness: "claude", Project: "p", Updated: time.Now(),
+			Messages: []model.Message{{Role: "user",
+				Text: "zephyrine is the quarto scheduler we run the nightly jobs on"}},
+		})
+	}
+	sessions = append(sessions, model.Session{
+		ID: "answer", Harness: "claude", Project: "p", Updated: time.Now(),
+		Messages: []model.Message{{Role: "user",
+			Text: "quarto was moved to the first of the month"}},
+	})
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, sessions, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	res, err := SearchDetailed(dir, query.Options{
+		Query: "when did we last change the zephyrine schedule", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ids []string
+	for _, s := range res.Sessions {
+		ids = append(ids, s.ID)
+	}
+	if !strings.Contains(strings.Join(ids, " "), "answer") {
+		t.Errorf("the ladder never reached the rescue: tier=%q %v", res.Tier, ids)
+	}
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -195,7 +195,15 @@ func searchDetailedOnce(dir string, o query.Options) (SearchResult, error) {
 			} else if len(result.Sessions) > 0 {
 				return result, nil
 			}
-			return relevanceSearch(dir, m, o)
+			ranked, rerr := relevanceSearch(dir, m, o)
+			if rerr != nil || len(ranked.Sessions) > 0 {
+				return ranked, rerr
+			}
+			// Nothing anywhere. The neighbour map holds the one link left to
+			// try — the project's own word for what the reader asked about —
+			// and asking it over the question's identifying words is what
+			// makes it readable by a sentence (#2331).
+			return cooccurNarrowedSearch(dir, m, o)
 		}
 		ss, err := scanRecords(dir, m, o, nil)
 		return SearchResult{Sessions: ss, Tier: fallbackTier, Variants: fallbackVariants}, err


### PR DESCRIPTION
#2331's opening line: the co-occurrence map holds exactly the link a reworded question needs, and the tier that reads it required the whole AND to match after one substitution — so it could only ever fire on a query short enough not to need it.

Three things were in the way, and each is one line of the fix:

1. **The AND was over the whole question.** It is now retried over the words that identify something — the ordinary words are what it was failing on and they are not what the answer is found by. Widths tried: the three rarest, then the bridgeable word paired with each of the others, then that word alone.
2. **The record matcher still demanded the whole sentence.** The scan re-checks each record against the query, so even when the postings intersected, a session that says "the pgbouncer pool ran out of connections" was rejected for not also saying "why", "would" and "exhaust".
3. **The first neighbour that matched won.** That is the sentence explaining the word — it holds both vocabularies by definition — and the session that used it comes after. The narrowed rung collects across attempts instead.

**Where it sits matters as much as what it does.** Putting the narrowed rung where the whole-AND rung sits cost LongMemEval hit@1 79.5% → 73.5% and MRR .857 → .795: it answered questions the ranked tier answers better. Below the ranked tier — reached only when everything, including relevance, came back empty — all benchmarks are unchanged (79.5 / 94.0 / 96.0 / 97.0, MRR .857; decisionbench 8/8, 8/8, 4/4, 4/4) and a sentence whose subject the project calls something else now reaches the session that settled it.

Four of five mutations caught. The fifth — dropping the pair attempts — survives because the single-word attempt covers the same fixtures; said here rather than papered over with a test written to the mutation.

Closes #2331.