### PR TITLE
feat(index): a first build answers before it finishes

### DIFF
--- a/internal/index/first_build_answers_test.go
+++ b/internal/index/first_build_answers_test.go
@@ -1,0 +1,163 @@
+package index
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A first build has nothing to answer with until it finishes, and on a large
+// corpus that is the wait a user decides in (#505). The newest slice is
+// published first, so the wait is for the tail rather than for everything.
+func TestAFirstBuildAnswersBeforeItFinishes(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "idx")
+	now := time.Now()
+	var ss []model.Session
+	for i := 0; i < 500; i++ {
+		ss = append(ss, model.Session{
+			ID: fmt.Sprintf("s%03d", i), Harness: "claude", Project: "p",
+			Updated: now.Add(-time.Duration(i) * time.Hour),
+			Messages: []model.Message{{Role: "user",
+				Text: fmt.Sprintf("session %d talked about the zephyrine%d rollout", i, i)}},
+		})
+	}
+	publishNewestFirst(dir, ss, io.Discard)
+
+	if !HasManifest(dir) {
+		t.Fatal("nothing was published, so the build still answers nothing until it ends")
+	}
+	// The newest sessions are there and searchable, and it is the newest they
+	// are: a slice of the oldest would answer nothing anyone is about to ask.
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != partialPublishSessions {
+		t.Errorf("the slice holds %d sessions, want %d", len(metas), partialPublishSessions)
+	}
+	held := map[string]bool{}
+	for _, meta := range metas {
+		held[meta.ID] = true
+	}
+	if !held["s000"] || !held["s199"] {
+		t.Errorf("the newest sessions are not the ones published: %v", ids(sessionsOfMetas(metas)))
+	}
+	if held["s499"] {
+		t.Error("the oldest session was published ahead of newer ones")
+	}
+	res, err := SearchDetailed(dir, query.Options{Query: "zephyrine0", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) == 0 {
+		t.Error("the newest session is not searchable in the published slice")
+	}
+	// And it claims no file coverage: the state of the files is what tells the
+	// next incremental run what it may skip, and this index holds a slice.
+	m, err := readManifestCached(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Files) != 0 {
+		t.Errorf("the published slice claimed %d files as parsed", len(m.Files))
+	}
+}
+
+// It publishes only where the wait is real, and never over an index that
+// already answers.
+func TestTheEarlyPublishHoldsBackWhereItWouldNotHelp(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	now := time.Now()
+	small := make([]model.Session, 0, 10)
+	for i := 0; i < 10; i++ {
+		small = append(small, model.Session{
+			ID: fmt.Sprintf("s%d", i), Harness: "claude", Project: "p", Updated: now,
+			Messages: []model.Message{{Role: "user", Text: "a short store"}},
+		})
+	}
+	dir := filepath.Join(tmp, "small")
+	publishNewestFirst(dir, small, io.Discard)
+	if HasManifest(dir) {
+		t.Error("a corpus that builds fast anyway paid for a second pass")
+	}
+
+	// And where an index already exists, replacing it with a slice would be a
+	// regression rather than a head start.
+	dir2 := filepath.Join(tmp, "existing")
+	var many []model.Session
+	for i := 0; i < 500; i++ {
+		many = append(many, model.Session{
+			ID: fmt.Sprintf("s%03d", i), Harness: "claude", Project: "p",
+			Updated:  now.Add(-time.Duration(i) * time.Hour),
+			Messages: []model.Message{{Role: "user", Text: fmt.Sprintf("old session %d", i)}},
+		})
+	}
+	if err := os.MkdirAll(filepath.Join(dir2+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir2+".tmp", dir2, many, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	res, err := SearchDetailed(dir2, query.Options{Query: "old session 499", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := len(res.Sessions)
+	publishNewestFirst(dir2, many, io.Discard)
+	res, err = SearchDetailed(dir2, query.Options{Query: "old session 499", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sessions) != before {
+		t.Errorf("an index that already answered was replaced by a slice: %d sessions, was %d",
+			len(res.Sessions), before)
+	}
+}
+
+// sessionsOfMetas is for the failure message only: what got published.
+func sessionsOfMetas(metas []SessionMeta) []model.Session {
+	out := make([]model.Session, 0, len(metas))
+	for _, meta := range metas {
+		out = append(out, model.Session{ID: meta.ID, Harness: meta.Harness})
+	}
+	return out
+}
+
+// And the build itself says so: the line is what tells a person the wait is
+// for the tail rather than for everything.
+func TestARealFirstBuildSaysItIsSearchableAlready(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	now := time.Now()
+	for i := 0; i < 420; i++ {
+		at := now.Add(-time.Duration(i) * time.Hour).UTC().Format(time.RFC3339)
+		id := fmt.Sprintf("b%03d", i)
+		writeLines(t, filepath.Join(claude, "-proj", id+".jsonl"),
+			claudeLine(id, at, fmt.Sprintf("session %d about the rollout", i)))
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	dir := filepath.Join(tmp, "idx")
+	var out strings.Builder
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "searchable now") {
+		t.Errorf("a first build over 420 sessions published nothing early:\n%s", out.String())
+	}
+	// And the finished index holds everything, not the slice.
+	metas, err := AllMeta(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 420 {
+		t.Errorf("the finished index holds %d sessions, want 420", len(metas))
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -460,6 +460,11 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// what a peer already pushed, not only what arrives next.
 	ss = append(ss, sources.FilterSessions(imported.sessions)...)
 	ss = filterTombstonedSet(ss, dead)
+	// Nothing to search until the whole corpus is written, and on a first
+	// install that is the fourteen seconds a user decides in (#505). Publish
+	// the newest slice first: it is a valid index of a few hundred sessions,
+	// it lands in about a second, and the full one replaces it moments later.
+	publishNewestFirst(dir, ss, progress)
 	// A full build passes every session through the exclusion patterns, so
 	// this is the one place the current set can be claimed as applied. An
 	// incremental build carries the old stamp forward: it keeps records it
@@ -887,6 +892,57 @@ func dropEmptySessions(m *Manifest, wrote map[string]bool) {
 func ReportEmptySessions() int {
 	return int(emptied.Swap(0))
 }
+
+// publishNewestFirst writes an index of the newest sessions and swaps it in,
+// so a first build answers before it finishes. Best effort in every sense: any
+// failure leaves the build to write the whole thing as it always did.
+//
+// Only on a first build, and only a big one — replacing an index that already
+// answers with a smaller one would be a regression, and on a small corpus the
+// full build is already fast enough that the extra pass is the slower path.
+//
+// The file states are deliberately not carried into it. They are the record of
+// what has been parsed, and claiming the whole corpus for an index holding a
+// slice of it would let the next incremental run skip files whose sessions
+// were never written.
+func publishNewestFirst(dir string, ss []model.Session, progress io.Writer) {
+	if HasManifest(dir) || len(ss) < partialPublishFrom {
+		return
+	}
+	newest := append([]model.Session(nil), ss...)
+	sort.Slice(newest, func(i, j int) bool { return newest[i].Updated.After(newest[j].Updated) })
+	newest = newest[:partialPublishSessions]
+	tmp := dir + ".part"
+	_ = os.RemoveAll(tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, "buckets"), 0o700); err != nil {
+		return
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	// The counters this pass moves belong to the build that follows it, so
+	// they are put back where it left them: writeSessions zeroes and fills
+	// them, and a line saying "3 empty transcripts" must count the whole
+	// corpus rather than this slice of it.
+	wasEmptied, wasCollisions, wasMerged := emptied.Load(), collisions.Load(), merged.Load()
+	err := writeSessions(tmp, dir, newest, nil, "")
+	emptied.Store(wasEmptied)
+	collisions.Store(wasCollisions)
+	merged.Store(wasMerged)
+	if err != nil {
+		return
+	}
+	if progress != nil {
+		fmt.Fprintf(progress, "deja: searchable now with the %d most recent sessions while the rest is indexed\n", len(newest))
+	}
+}
+
+// partialPublishFrom is the corpus size at which the wait is worth a second
+// pass, and partialPublishSessions how much of it lands first. A few hundred
+// sessions is what a person has touched recently enough to ask about, and it
+// writes in about a second where the whole corpus takes fourteen.
+const (
+	partialPublishFrom     = 400
+	partialPublishSessions = 200
+)
 
 func writeSessions(tmp, dir string, ss []model.Session, files map[string]FileState, scope string) error {
 	return writeSessionsWithSync(tmp, dir, ss, files, scope, importedState{})


### PR DESCRIPTION
#505 is a first-impression problem: a full build takes seconds a new user decides in, and until it ends deja answers nothing at all. Of the three ways out the issue lists, two turned out to be done already (the opencode reader stopped reading what it does not use; there is a progress bar with per-harness weights). This is the third: be useful before finishing.

The newest 200 sessions are written and swapped in as a valid index, then the build continues and replaces it with the whole corpus. Measured on a 98 MB synthetic store, 2,000 sessions, cold index directory:

```
                first answer   whole build
before              7.09s          7.09s
after               2.26s          8.83s
```

So the wait to usefulness is a third of what it was, and the full build costs a quarter more — paid once, on the first build only.

Three guards, each mutation-checked: it does nothing when an index already exists (replacing one that answers with a slice is a regression, not a head start), nothing below 400 sessions (where the whole build is already quick and the extra pass is the slower path), and it deliberately claims no file coverage — the file states are what tell the next incremental run what it may skip, and a slice must not claim the corpus.

The line it prints says what is happening: `searchable now with the 200 most recent sessions while the rest is indexed`.

Closes #505.