### PR TITLE
fix(embed): let a caller say there is no endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ export DEJA_EMBED_MODEL='text-embedding-3-small'
 deja embed
 ```
 
+Set `DEJA_EMBED_URL=off` to keep deja from looking for a local runtime at all —
+without an endpoint it probes `localhost:11434` and `localhost:1234`, which finds
+whatever else you happen to be running.
+
 For another authenticated OpenAI-compatible endpoint, set `DEJA_EMBED_KEY` explicitly:
 
 ```sh

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -46,6 +46,10 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(tmp, "warmup-guard"))
+	// The embedding client probes localhost when no endpoint is set, so a
+	// developer running Ollama or LM Studio got a different answer out of
+	// doctor than CI did — "reachable" where the test says nothing is wired.
+	t.Setenv("DEJA_EMBED_URL", "off")
 	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -1,10 +1,10 @@
 package embed
 
 import (
-	"errors"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -1,6 +1,7 @@
 package embed
 
 import (
+	"errors"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -26,7 +27,14 @@ func New() (*Client, error) {
 	if model == "" {
 		model = "nomic-embed-text"
 	}
-	if endpoint := os.Getenv("DEJA_EMBED_URL"); endpoint != "" {
+	// "off" is how a caller says there is no endpoint and none is to be looked
+	// for. Without it the probe below reaches whatever is listening on this
+	// machine, so a developer running Ollama got a different answer out of
+	// `deja doctor` — and out of the tests — than a machine with nothing
+	// wired.
+	if endpoint := os.Getenv("DEJA_EMBED_URL"); strings.EqualFold(strings.TrimSpace(endpoint), "off") {
+		return nil, errNoEmbedEndpoint
+	} else if endpoint != "" {
 		return &Client{URL: endpoint, Model: model, apiKey: embedAPIKey(endpoint), HTTP: &http.Client{Timeout: 30 * time.Second}}, nil
 	}
 	for _, endpoint := range probeURLs {
@@ -35,8 +43,12 @@ func New() (*Client, error) {
 			return c, nil
 		}
 	}
-	return nil, fmt.Errorf("embedding endpoint unavailable (set DEJA_EMBED_URL)")
+	return nil, errNoEmbedEndpoint
 }
+
+// errNoEmbedEndpoint is what every "nothing to embed with" path returns, so a
+// caller can tell it from a transport failure.
+var errNoEmbedEndpoint = errors.New("embedding endpoint unavailable (set DEJA_EMBED_URL)")
 
 func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {


### PR DESCRIPTION
Found by installing Ollama on this machine: two doctor tests went red, because with no `DEJA_EMBED_URL` the client probes `localhost:11434` and `localhost:1234` and takes whatever answers. So `deja doctor` said "reachable" where the test — and a machine with nothing wired — says nothing is configured, and the suite's answer depended on what else the developer happened to be running.

`DEJA_EMBED_URL=off` now means there is no endpoint and none is to be looked for. The test environment sets it, so the suite is hermetic again, and the README says the switch exists next to the probing it disables.

Not caused by the semantic feature and not a change to it: the probe is still what an unconfigured deja does.