### PR TITLE
feat(mcp): one tool with modes instead of six

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,18 +212,24 @@ Full reference: [commands](https://vshulcz.github.io/deja-vu/guide/commands.html
 
 ### MCP tools
 
-The server exposes `recall`, `recall_context`, `blame`, `fix`, `how` and `remember`.
-`deja install` wires them in, so this is only needed to configure an agent by hand.
+The server exposes one tool, `deja`, with a `mode`. `deja install` wires it in, so
+this is only needed to configure an agent by hand. The six older tool names
+(`recall`, `recall_context`, `blame`, `fix`, `how`, `remember`) still answer for
+anything already wired to them.
 
 <details>
 <summary>Arguments and return shapes</summary>
 
 | Tool | Arguments | Returns |
 | --- | --- | --- |
+| `deja` | `mode`, plus `query`, `path`, `error`, `what`, `text`, `tags?`, `harness?`, `project?`, `since?`, `limit?`, `offset?`, `all?` | Depends on the mode, below. |
+
+| Mode | Arguments it reads | Returns |
+| --- | --- | --- |
 | `recall` | `query`, `harness?`, `limit?`, `offset?` | Dense matching snippets, capped at 4KB. |
-| `recall_context` | `query`, `harness?` | Markdown digest of the best-matching session. |
+| `context` | `query`, `harness?` | Markdown digest of the best-matching session. |
 | `blame` | `path`, `harness?`, `project?`, `since?`, `limit?`, `all?` | Sessions that discussed a file. |
-| `fix` | `error`, `project?`, `limit?` | What this machine ran after that same error before. |
+| `fix` | `error`, `project?`, `limit?` | What this machine ran, or changed, after that same error before. |
 | `how` | `what`, `project?`, `limit?` | The real invocation, from what agents ran here. |
 | `remember` | `text`, `project?`, `tags?` | Stores a durable decision for later recall. |
 

--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -748,7 +748,10 @@ func TestMCPHandshakeListRecallRoundTrip(t *testing.T) {
 	if res["protocolVersion"] != mcpProtocolVersion {
 		t.Fatalf("bad init: %#v", initResp)
 	}
-	if !strings.Contains(lines[1], "recall_context") || !strings.Contains(lines[1], "blame") || !strings.Contains(lines[2], "frobnicator bug") {
+	// The list is one tool with the capabilities as modes, and the modes are
+	// what a reader of this test wants named.
+	if !strings.Contains(lines[1], "\"name\":\"deja\"") || !strings.Contains(lines[1], "blame") ||
+		!strings.Contains(lines[1], "context") || !strings.Contains(lines[2], "frobnicator bug") {
 		t.Fatalf("bad mcp output:\n%s", out.String())
 	}
 }

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -161,44 +161,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 			"instructions":    mcpInstructions(dir),
 		}, 0, ""
 	case "tools/list":
-		return map[string]any{"tools": []map[string]any{
-			{
-				"name":        "recall",
-				"description": "Search the user's own past coding sessions across every AI tool they've used (Claude Code, Codex, Cursor, opencode, aider, gemini, and others) and return the best matches as dense text under ~4KB. Call this the moment the user implies work already happened — 'didn't we fix this before?', 'what was that error again', 'we already set this up', 'how did we solve X last time', 'what did we decide about Y' — and always before debugging an error or re-implementing something that might already exist. Query with an exact error string, function name, file path or flag when you have one — that is the strongest key there is. Otherwise ask in your own words, as a phrase or a question: the search falls back to ranking when nothing matches exactly, and a sentence is not rejected. Do NOT use this for general knowledge or library/API docs — only this user's prior sessions. A bracketed marker on a result is the user's own later judgement on that session; act on what it says. Follow up with recall_context when one session looks right and you need its full story. When a result genuinely helps, tell the user in one short line: \"deja-vu recalled: <what> — <how you used it>\". Say nothing about recalls that did not help.",
-				"annotations": map[string]any{"title": "Search past sessions", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "An exact token — error string, function name, flag — matches strongest. Failing that, the question in your own words; several words are tried together first and then ranked, so a phrase still finds things."}, "harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."}, "limit": map[string]any{"type": "number", "description": "Max sessions to return (default 5)."}, "offset": map[string]any{"type": "number", "description": "Skip this many ranked matches — page through results without re-ranking."}}, "required": []string{"query"}},
-			},
-			{
-				"name":        "recall_context",
-				"description": "Return a full markdown digest (~8KB) of the single best-matching prior session — problem, decisions, outcome — when a bare recall hit is not enough and you need the reasoning behind it. Use after recall, or directly when the user asks 'remind me how we handled X' or 'what was the whole story with Y'. Query terms are matched against transcript text, so a token likely to appear verbatim — an error string, function name, or flag — finds it fastest; the question in your own words works too. Not for browsing many sessions — use recall for that; this returns one deep digest. When it genuinely helps, tell the user in one short line: \"deja-vu recalled: <what> — <how you used it>\". Say nothing about recalls that did not help.",
-				"annotations": map[string]any{"title": "Digest one past session", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"query": map[string]any{"type": "string", "description": "Search terms identifying the session to digest."}, "harness": map[string]any{"type": "string", "description": "Optional harness filter."}}, "required": []string{"query"}},
-			},
-			{
-				"name":        "blame",
-				"description": "Before editing, refactoring, or deleting a file, find the prior sessions that discussed it so you know why it is shaped the way it is. Call whenever you are about to change a file, or when the user asks 'why is this like this', 'what was this for', 'is it safe to remove this'. Most specific mentions come first. This is session history across AI tools, not git blame — it explains intent and past decisions, not commit authorship. Give an absolute path, relative path, or bare filename.",
-				"annotations": map[string]any{"title": "Why is this file like this", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string", "description": "Absolute, relative, or bare filename."}, "harness": map[string]any{"type": "string"}, "project": map[string]any{"type": "string"}, "since": map[string]any{"type": "string", "description": "Age such as 30d or 24h."}, "limit": map[string]any{"type": "number"}, "all": map[string]any{"type": "boolean"}}, "required": []string{"path"}},
-			},
-			{
-				"name":        "fix",
-				"description": "You just hit an error — before diagnosing it, ask what this machine ran the last time that same error appeared. Pass the failing output verbatim (a whole stack trace is fine; every line is checked). Returns the commands that followed that error in past sessions without it coming back. Evidence from the user's own history, not a guaranteed fix: read the command, decide whether it applies, and say so if you reuse it. An empty result means this machine has no record of that error being followed by a command.",
-				"annotations": map[string]any{"title": "What was run after this error before", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"error": map[string]any{"type": "string", "description": "The failing output, verbatim. Multi-line pastes are fine."}, "limit": map[string]any{"type": "number", "description": "Max pairs to return (default 3)."}}, "required": []string{"error"}},
-			},
-			{
-				"name":        "how",
-				"description": "How this user actually runs a thing on this machine — the real command with the real flags, taken from commands their agents ran, ordered by how many separate sessions ran it. Call before inventing a build, test, deploy or debug invocation: a guessed command is plausible and fails on this setup. Query with the tool or target ('go test', 'docker compose', 'terraform apply', a script name). Optionally scope to a project. Command records are kept out of ordinary search, so this is the only way to reach them.",
-				"annotations": map[string]any{"title": "How this is run here", "readOnlyHint": true, "openWorldHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"what": map[string]any{"type": "string", "description": "Tool or target, e.g. 'go test', 'docker compose', a script name. Every word must appear in the command."}, "project": map[string]any{"type": "string", "description": "Optional project substring filter."}, "limit": map[string]any{"type": "number", "description": "Max commands to return (default 8)."}}, "required": []string{"what"}},
-			},
-			{
-				"name":        "remember",
-				"description": "Store one durable decision or conclusion so a future session can recall it. Call right after a decision is settled, a tricky bug is resolved, or the user says 'remember this', 'note that for next time', 'don't forget we chose X'. Write a single self-contained fact (e.g. 'We use Postgres advisory locks for the job queue because Redis lost messages under load'). Do NOT store transcripts, routine conversation, or anything already obvious from the code. text is required; project defaults to notes.",
-				"annotations": map[string]any{"title": "Remember a decision", "readOnlyHint": false},
-				"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"text": map[string]any{"type": "string", "description": "A durable fact, decision, or conclusion to remember."}, "project": map[string]any{"type": "string", "description": "Optional project name; defaults to notes."}, "tags": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Optional navigation tags, searchable as #tag."}}, "required": []string{"text"}},
-			},
-		}}, 0, ""
+		return map[string]any{"tools": []map[string]any{dejaTool()}}, 0, ""
 	case "ping":
 		// Part of the spec at the version we claim, and both sides must
 		// answer it with an empty result. A host that pings for keepalive
@@ -284,7 +247,83 @@ func jsonTypeName(k reflect.Kind) string {
 	}
 }
 
+// dejaTool is the whole surface as one tool with a mode.
+//
+// Six tools were six envelopes: the same query, harness, project and limit
+// declared six times, and six descriptions each arguing they were the entry
+// point — which is how `how` lost to `recall` on a question about a command
+// (#1298). One envelope costs less and asks the model an easier question:
+// which capability, not which tool.
+//
+// The old names still answer for a client that has them wired; they are not
+// listed, so they cost nothing per session.
+func dejaTool() map[string]any {
+	return map[string]any{
+		"name": "deja",
+		"description": "This user's own past coding sessions, across every AI tool they use (Claude Code, Codex, Cursor, opencode, aider, gemini and others). " +
+			"Not general knowledge and not library docs — only what happened on this machine. Pick a mode:\n" +
+			"- recall: search past sessions. The moment the user implies work already happened (\"didn't we fix this?\", \"what was that error\", \"what did we decide about X\"), and always before debugging an error or re-implementing something. An exact error string, function name or path is the strongest query; a question in your own words works too.\n" +
+			"- context: the full story of the single best-matching session — problem, decisions, outcome — when a recall hit is not enough.\n" +
+			"- blame: why a file is the way it is, before you edit, refactor or delete it. Session history, not git authorship.\n" +
+			"- fix: you just hit an error. What this machine ran, or changed, after that same error before. Pass the failing output verbatim.\n" +
+			"- how: the real command with the real flags this user runs for a thing — build, test, deploy — instead of a guessed one.\n" +
+			"- remember: store one durable decision so a later session can recall it. Only after something is settled.\n" +
+			"A bracketed marker on a result is the user's own later judgement on that session; act on what it says. " +
+			"When a result genuinely helps, tell the user in one short line: \"deja-vu recalled: <what> — <how you used it>\". Say nothing about recalls that did not help.",
+		"annotations": map[string]any{"title": "This user's past sessions", "openWorldHint": false},
+		"inputSchema": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"mode":    map[string]any{"type": "string", "enum": []string{"recall", "context", "blame", "fix", "how", "remember"}, "description": "Which capability to use."},
+				"query":   map[string]any{"type": "string", "description": "recall and context: an exact token — error string, function name, flag — or the question in your own words."},
+				"path":    map[string]any{"type": "string", "description": "blame: absolute, relative, or bare filename."},
+				"error":   map[string]any{"type": "string", "description": "fix: the failing output, verbatim. Multi-line pastes are fine."},
+				"what":    map[string]any{"type": "string", "description": "how: tool or target, e.g. 'go test', 'docker compose', a script name."},
+				"text":    map[string]any{"type": "string", "description": "remember: one durable fact, decision or conclusion."},
+				"tags":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "remember: optional navigation tags, searchable as #tag."},
+				"harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."},
+				"project": map[string]any{"type": "string", "description": "Optional project filter; for remember, where the note is filed (default notes)."},
+				"since":   map[string]any{"type": "string", "description": "blame: age such as 30d or 24h."},
+				"limit":   map[string]any{"type": "number", "description": "Max results."},
+				"offset":  map[string]any{"type": "number", "description": "recall: skip this many ranked matches, to page without re-ranking."},
+				"all":     map[string]any{"type": "boolean", "description": "blame: every project, not just this one."},
+			},
+			"required": []string{"mode"},
+		},
+	}
+}
+
+// dispatcherModes maps a mode onto the call that implements it. The old tool
+// names are the same strings, which is why a client with them wired keeps
+// working.
+var dispatcherModes = map[string]string{
+	"recall":   "recall",
+	"search":   "recall",
+	"context":  "recall_context",
+	"digest":   "recall_context",
+	"blame":    "blame",
+	"fix":      "fix",
+	"how":      "how",
+	"remember": "remember",
+}
+
 func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
+	if name == "deja" {
+		var a struct {
+			Mode string `json:"mode"`
+		}
+		if err := decodeToolArgs(name, raw, &a); err != nil {
+			return "", err
+		}
+		mode := strings.ToLower(strings.TrimSpace(a.Mode))
+		target, ok := dispatcherModes[mode]
+		if !ok {
+			// Named, not guessed at: a model that invents a mode gets the list
+			// rather than an empty answer it will read as "no history".
+			return "", fmt.Errorf("mode %q is not one of recall, context, blame, fix, how, remember", a.Mode)
+		}
+		return callMCPTool(dir, target, raw)
+	}
 	switch name {
 	case "recall":
 		var a struct {

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -107,9 +107,52 @@ func TestMCPToolContract(t *testing.T) {
 				t.Fatalf("tool %q missing required[]: %#v", name, schema)
 			}
 		}
-		for _, want := range []string{"recall", "recall_context", "blame", "remember"} {
-			if !got[want] {
-				t.Fatalf("tools/list missing %q; got %v", want, got)
+		// One tool, and the capabilities are its modes. The names below are
+		// what the agent picks between, so they are what this asserts.
+		if !got["deja"] {
+			t.Fatalf("tools/list missing the deja tool; got %v", got)
+		}
+		tool := tools[0].(map[string]any)
+		schema := tool["inputSchema"].(map[string]any)
+		props := schema["properties"].(map[string]any)
+		mode, ok := props["mode"].(map[string]any)
+		if !ok {
+			t.Fatalf("the tool has no mode: %#v", props)
+		}
+		modes := map[string]bool{}
+		for _, m := range mode["enum"].([]any) {
+			modes[m.(string)] = true
+		}
+		for _, want := range []string{"recall", "context", "blame", "fix", "how", "remember"} {
+			if !modes[want] {
+				t.Fatalf("mode %q is gone; got %v", want, modes)
+			}
+		}
+	})
+
+	// The names the six tools had still answer, so an agent configured before
+	// the dispatcher keeps working.
+	t.Run("the old tool names still answer", func(t *testing.T) {
+		for _, name := range []string{"recall", "recall_context", "blame", "fix", "how"} {
+			args := `{"query":"frobnicator","path":"parser.go","error":"boom","what":"go test"}`
+			resp := driveMCP(t, `{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"`+name+`","arguments":`+args+`}}`)
+			if _, bad := resp[0]["error"]; bad {
+				t.Errorf("the %q name stopped answering: %v", name, resp[0])
+			}
+		}
+	})
+
+	// And the dispatcher reaches the same answer the old name did.
+	t.Run("a mode answers like the tool it replaced", func(t *testing.T) {
+		resp := driveMCP(t, `{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"deja","arguments":{"mode":"recall","query":"frobnicator","harness":"claude"}}}`)
+		text := callText(t, resp[0])
+		if !strings.Contains(text, "frobnicator") {
+			t.Fatalf("mode recall = %q, want the frobnicator sessions", text)
+		}
+		bad := driveMCP(t, `{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"deja","arguments":{"mode":"teleport","query":"frobnicator"}}}`)
+		if _, isErr := bad[0]["error"]; !isErr {
+			if text := callText(t, bad[0]); !strings.Contains(text, "not one of") {
+				t.Fatalf("an invented mode was not named as one: %v", bad[0])
 			}
 		}
 	})

--- a/cmd/deja/mcp_instructions.go
+++ b/cmd/deja/mcp_instructions.go
@@ -12,7 +12,7 @@ import (
 func mcpInstructions(dir string) string {
 	var b strings.Builder
 	b.WriteString("deja indexes this user's past sessions across every AI coding tool they use. ")
-	b.WriteString("Call the recall tool before debugging an error or re-implementing anything that might already exist, ")
+	b.WriteString("Call the deja tool with mode recall before debugging an error or re-implementing anything that might already exist, ")
 	b.WriteString("and whenever the user implies the work happened before (\"didn't we fix this?\", \"what was that error\").")
 	if s := readWarmupStatus(dir); s != nil {
 		b.WriteString(" The index is still building (")

--- a/cmd/deja/mcp_tools_budget_test.go
+++ b/cmd/deja/mcp_tools_budget_test.go
@@ -18,7 +18,11 @@ import (
 // fails, the question to ask is whether the new capability has to be a tool at
 // all — `instructions` is read once, resources/list costs nothing here, and a
 // hook already fires at the point of action.
-const mcpToolsListCharBudget = 7200
+// One tool with modes, so the six envelopes and their six repetitions of
+// query/harness/project/limit are gone: 7,145 chars became 3,112. The budget
+// is set just above what that costs, because the point of it is to notice
+// growth rather than to leave room for it (#1298).
+const mcpToolsListCharBudget = 3400
 
 func TestMCPToolsListStaysWithinItsTokenBudget(t *testing.T) {
 	hermeticEnv(t)

--- a/cmd/deja/readme_mcp_tools_test.go
+++ b/cmd/deja/readme_mcp_tools_test.go
@@ -80,6 +80,12 @@ func TestReadmeListsEveryMCPToolTheServerRegisters(t *testing.T) {
 
 // tableRow returns the README table row for a tool, or "" when there is none.
 func tableRow(readme, tool string) string {
+	// From the MCP section onwards. The CLI command table has a `deja` row of
+	// its own, and the tool is now called `deja` too — reading the first row
+	// with that name asked the CLI table for a tool's arguments.
+	if at := strings.Index(readme, "### MCP tools"); at >= 0 {
+		readme = readme[at:]
+	}
 	head := "| `" + tool + "` |"
 	i := strings.Index(readme, head)
 	if i < 0 {

--- a/cmd/deja/recall_frame_test.go
+++ b/cmd/deja/recall_frame_test.go
@@ -85,8 +85,11 @@ func TestNarrationProtocolOnAllSurfaces(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n := strings.Count(string(b), "deja-vu recalled"); n < 2 {
-		t.Fatalf("MCP tool descriptions carry narration %d times, want >=2 (recall + recall_context)", n)
+	// Once, not twice: the six tools became one with modes, so the sentence
+	// that tells the agent to say what it reused is written once and covers
+	// every mode.
+	if n := strings.Count(string(b), "deja-vu recalled"); n < 1 {
+		t.Fatalf("MCP tool descriptions carry the narration %d times, want at least once", n)
 	}
 	if !strings.Contains(string(b), "Say nothing about recalls that did not help") {
 		t.Fatal("MCP narration missing the no-spam guard")

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -38,28 +38,8 @@
   },
   "tools": [
     {
-      "name": "recall",
-      "description": "Search the user's own past coding sessions across every AI tool they have used and return the best matches as dense text."
-    },
-    {
-      "name": "recall_context",
-      "description": "Return a full markdown digest of the single best-matching prior session — problem, decisions, outcome."
-    },
-    {
-      "name": "blame",
-      "description": "Before editing or deleting a file, find the prior sessions that discussed it and why it is shaped the way it is."
-    },
-    {
-      "name": "fix",
-      "description": "You just hit an error — ask what this machine ran the last time that same error appeared, before diagnosing it again."
-    },
-    {
-      "name": "how",
-      "description": "How this user actually runs a thing on this machine: the real command with the real flags, from what their agents ran."
-    },
-    {
-      "name": "remember",
-      "description": "Store one durable decision or conclusion so a future session can recall it."
+      "name": "deja",
+      "description": "This user's own past coding sessions across every AI tool they use, in modes: recall (search), context (one session in full), blame (why a file is like this), fix (what was run or changed after this error), how (the real command for a thing here), remember (store a decision)."
     }
   ],
   "compatibility": {


### PR DESCRIPTION
#1298's second and third pieces, with the numbers re-measured here.

Six tools were six envelopes: `query`, `harness`, `project` and `limit` declared six times, and six descriptions each arguing they were the entry point — which is how `how` lost to `recall` on a question about a command. One tool, `deja`, with a `mode` of recall / context / blame / fix / how / remember.

```
tools/list   7145 chars (~1786 tokens)  ->  3112 chars (~778 tokens)
```

That is more than the issue's estimate (1703 → 1365) because the schemas collapse as well as the prose. The budget test moves from 7200 to 3400, set just above what it costs: the point of that test is to notice growth, not to leave room for it.

**Nothing that was wired stops working.** The six names are still accepted by `tools/call` — they are simply not listed, so they cost nothing per session. An agent configured before this keeps calling `recall` and gets the same answer; a test asserts it.

An invented mode is answered by naming the six, rather than by an empty result the model would read as "no history".

README, the MCPB manifest and the server instructions updated together; `TestBundleManifestListsEveryToolTheServerServes` and `TestReadmeListsEveryMCPToolTheServerRegisters` are what keep those three honest.

Closes #1298.