### PR TITLE
fix(bench): score the two halves of the injection apart

### DIFF
--- a/cmd/deja/bench_context.go
+++ b/cmd/deja/bench_context.go
@@ -104,18 +104,29 @@ func measureContext(seed int64) (contextReport, error) {
 	if err := index.EnsureForSearch(indexDir, search.Options{Query: "", All: true}, true, io.Discard); err != nil {
 		return contextReport{}, fmt.Errorf("build context benchmark index: %w", err)
 	}
-	measurements := map[string][]contextMeasurement{"deja-recall": nil, "full-history": nil, "naive-grep": nil, "cold": nil}
+	measurements := map[string][]contextMeasurement{
+		"deja-recall": nil, "deja-digest": nil, "deja-block": nil,
+		"full-history": nil, "naive-grep": nil, "cold": nil,
+	}
 	for _, chain := range corpus.Chains {
-		deja, err := contextDeja(indexDir, chain)
+		digest, block, err := contextDejaParts(indexDir, chain)
 		if err != nil {
 			return contextReport{}, err
 		}
+		deja := digest + block
 		full := contextFullHistory(chain)
 		naive, err := contextNaiveGrep(claudeRoot, chain)
 		if err != nil {
 			return contextReport{}, err
 		}
-		for name, text := range map[string]string{"deja-recall": deja, "full-history": full, "naive-grep": naive, "cold": ""} {
+		// The two halves are scored on their own as well as together. Scored
+		// only as a union, the column could not move: each surface carries the
+		// chain's facts by itself, so deleting either one left coverage at
+		// 1.00 and only deleting both showed anything (#2931).
+		for name, text := range map[string]string{
+			"deja-recall": deja, "deja-digest": digest, "deja-block": block,
+			"full-history": full, "naive-grep": naive, "cold": "",
+		} {
 			measurements[name] = append(measurements[name], contextMeasurement{tokens: len(text) / 4, coverage: contextCoverage(text, chain.Facts), negative: chain.Negative})
 		}
 	}
@@ -126,14 +137,18 @@ func measureContext(seed int64) (contextReport, error) {
 	return report, nil
 }
 
-func contextDeja(dir string, chain bench.ContextChain) (string, error) {
+// contextDejaParts returns the two surfaces deja puts in front of an agent
+// separately: the per-hit context digest, and the session-start block. Their
+// concatenation is what an agent sees; scoring them apart is what makes a
+// regression in either attributable (#2931).
+func contextDejaParts(dir string, chain bench.ContextChain) (digest, block string, err error) {
 	result, err := index.SearchWithRecoveryDetailed(dir, search.Options{Query: strings.Join(chain.Terms, " "), All: true}, io.Discard)
 	if err != nil {
-		return "", fmt.Errorf("context query %q: %w", chain.Task, err)
+		return "", "", fmt.Errorf("context query %q: %w", chain.Task, err)
 	}
 	hits, err := search.Run(result.Sessions, search.Options{Query: strings.Join(chain.Terms, " "), All: true})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	var b bytes.Buffer
 	ss := make([]model.Session, 0, len(hits))
@@ -144,9 +159,8 @@ func contextDeja(dir string, chain bench.ContextChain) (string, error) {
 		ss = append(ss, hit.Session)
 		search.PrintContext(&b, hit.Session, strings.Join(chain.Terms, " "))
 	}
-	// This is the same digest builder used by the SessionStart hook.
-	b.WriteString(search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: search.RecallAggressive}).Text)
-	return b.String(), nil
+	// The second is the same digest builder the SessionStart hook uses.
+	return b.String(), search.BuildAutoRecall(ss, search.AutoRecallOptions{Mode: search.RecallAggressive}).Text, nil
 }
 
 func contextFullHistory(chain bench.ContextChain) string {
@@ -249,7 +263,7 @@ func percentileFloat(values []float64, p int) float64 {
 func printContextReport(w io.Writer, report contextReport) {
 	fmt.Fprintf(w, "deja bench context\nchains: %d, negative controls: %d\n", report.Chains, report.Negatives)
 	fmt.Fprintln(w, "arm           median tokens  p10-p90       median coverage  negative median")
-	for _, name := range []string{"deja-recall", "full-history", "naive-grep", "cold"} {
+	for _, name := range []string{"deja-recall", "deja-digest", "deja-block", "full-history", "naive-grep", "cold"} {
 		r := report.Arms[name]
 		span := fmt.Sprintf("%.0f-%.0f", r.P10Tokens, r.P90Tokens)
 		fmt.Fprintf(w, "%-13s %-14.0f %-13s %-16.2f %.0f\n", name, r.MedianTokens, span, r.MedianCoverage, r.NegativeMedian)

--- a/cmd/deja/bench_context_test.go
+++ b/cmd/deja/bench_context_test.go
@@ -40,10 +40,22 @@ func TestContextJSONAndIsolation(t *testing.T) {
 	if report.Chains != bench.ContextChainCount || report.Negatives != bench.ContextNegativeCount || len(report.CorpusHash) != 64 {
 		t.Fatalf("unexpected context report: %#v", report)
 	}
-	for _, arm := range []string{"deja-recall", "full-history", "naive-grep", "cold"} {
+	for _, arm := range []string{"deja-recall", "deja-digest", "deja-block", "full-history", "naive-grep", "cold"} {
 		if _, ok := report.Arms[arm]; !ok {
 			t.Fatalf("missing arm %q", arm)
 		}
+	}
+	// The two halves of what deja injects are scored apart, and each has to
+	// carry its own text: scored only as a union the coverage column could not
+	// move — deleting either surface left it at 1.00 because the other one
+	// still held the chain's facts (#2931).
+	digest, block := report.Arms["deja-digest"], report.Arms["deja-block"]
+	if digest.MedianTokens == 0 || block.MedianTokens == 0 {
+		t.Errorf("a half of the injection is scored empty: digest %.0f tokens, block %.0f", digest.MedianTokens, block.MedianTokens)
+	}
+	if union := report.Arms["deja-recall"]; union.MedianTokens < digest.MedianTokens || union.MedianTokens < block.MedianTokens {
+		t.Errorf("the union is smaller than one of its halves: %.0f against %.0f and %.0f",
+			union.MedianTokens, digest.MedianTokens, block.MedianTokens)
 	}
 	entries, err := os.ReadDir(outside)
 	if err != nil {


### PR DESCRIPTION
#2931: `bench context`'s coverage column stayed at 1.00 with either half of the deja-recall arm deleted, and only reached 0 when both were gone — the arm concatenates the context digest and the session-start block, and each carries the chain's facts by itself.

`deja-digest` and `deja-block` are now arms of their own, with the union kept as `deja-recall`. Deleting either half is visible again:

```
today                    digest half deleted      block half deleted
deja-recall 294  1.00    deja-recall 153  1.00    deja-recall 141  1.00
deja-digest 141  1.00    deja-digest   0  0.00    deja-digest 141  1.00
deja-block  153  1.00    deja-block  153  1.00    deja-block    0  0.00
```

The test asserts both halves are scored and non-empty and that the union is at least as large as either; both deletions above fail it.

This is the first of the two directions #2931 offered. The second — making the facts harder to reach so the column moves on ranking rather than on presence — is untouched, and until it is done the column should still be read as a floor.

Closes #2931.