### PR TITLE
fix(embed): let the localhost probe be switched off

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,10 @@ export DEJA_EMBED_MODEL='text-embedding-3-small'
 deja embed
 ```
 
+With no `DEJA_EMBED_URL` set, deja probes `localhost:11434` and `localhost:1234`,
+so a machine already running Ollama or LM Studio is picked up without being asked.
+`DEJA_EMBED_OFF=1` turns that probe off — a configured `DEJA_EMBED_URL` still wins.
+
 For another authenticated OpenAI-compatible endpoint, set `DEJA_EMBED_KEY` explicitly:
 
 ```sh

--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -46,6 +46,10 @@ func hermeticEnv(t *testing.T) string {
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	t.Setenv("DEJA_WARMUP_SENTINEL", filepath.Join(tmp, "warmup-guard"))
+	// The embedding client probes localhost when no endpoint is configured, so
+	// a developer running a local model got a different answer from CI — two
+	// doctor tests red on a clean tree, and bench recall quietly switching arms.
+	t.Setenv("DEJA_EMBED_OFF", "1")
 	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "aider"))
 	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "gemini"))
 	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "cursor"))

--- a/cmd/deja/friction_test.go
+++ b/cmd/deja/friction_test.go
@@ -76,6 +76,7 @@ func frictionEnv(t *testing.T) string {
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	t.Setenv("DEJA_EMBED_OFF", "1")
 	return root
 }
 

--- a/internal/embed/client.go
+++ b/internal/embed/client.go
@@ -21,13 +21,25 @@ type Client struct {
 
 var probeURLs = []string{"http://localhost:11434/api/embed", "http://localhost:1234/v1/embeddings"}
 
+// Off reports whether embedding is switched off for this process. The probe
+// below reaches localhost, so without a way to say no, a machine running a
+// local model answers differently from one that is not — a test suite that
+// asserts "no endpoint" goes red on a developer's machine and stays green on
+// CI, which is the worst way round for a contributor to meet it.
+func Off() bool { return os.Getenv("DEJA_EMBED_OFF") == "1" }
+
 func New() (*Client, error) {
 	model := os.Getenv("DEJA_EMBED_MODEL")
 	if model == "" {
 		model = "nomic-embed-text"
 	}
+	// A configured endpoint wins over the switch: saying where to embed is
+	// asking for it, and the switch is about the probe below.
 	if endpoint := os.Getenv("DEJA_EMBED_URL"); endpoint != "" {
 		return &Client{URL: endpoint, Model: model, apiKey: embedAPIKey(endpoint), HTTP: &http.Client{Timeout: 30 * time.Second}}, nil
+	}
+	if Off() {
+		return nil, fmt.Errorf("embedding is off (DEJA_EMBED_OFF=1)")
 	}
 	for _, endpoint := range probeURLs {
 		c := &Client{URL: endpoint, Model: model, HTTP: &http.Client{Timeout: 30 * time.Second}}

--- a/internal/embed/off_test.go
+++ b/internal/embed/off_test.go
@@ -1,0 +1,45 @@
+package embed
+
+import "testing"
+
+// Without a switch, New probes localhost — so a developer running a local model
+// gets a different answer from CI. That is how two doctor tests were red on a
+// clean tree here while green everywhere else, and how `bench recall` quietly
+// grew a hybrid arm mid-run.
+func TestEmbeddingCanBeSwitchedOff(t *testing.T) {
+	t.Setenv("DEJA_EMBED_URL", "")
+	t.Setenv("DEJA_EMBED_OFF", "1")
+	if c, err := New(); err == nil {
+		t.Errorf("the probe ran with the switch on: %#v", c)
+	}
+}
+
+// Saying where to embed is asking for it. The switch is about the probe, not
+// about an endpoint someone configured — otherwise the tests that exercise the
+// embedding path against a stub server would have no way to run.
+func TestAConfiguredEndpointBeatsTheSwitch(t *testing.T) {
+	t.Setenv("DEJA_EMBED_OFF", "1")
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:9/embed")
+	c, err := New()
+	if err != nil {
+		t.Fatalf("a configured endpoint was refused: %v", err)
+	}
+	if c.URL != "http://127.0.0.1:9/embed" {
+		t.Errorf("endpoint = %q", c.URL)
+	}
+}
+
+// One value, the same as DEJA_NO_REDACT: "0" is somebody saying no, and
+// reading it as yes turns the switch on for a person trying to turn it off.
+func TestOnlyOneSwitchesItOff(t *testing.T) {
+	for _, v := range []string{"", "0", "false", "no"} {
+		t.Setenv("DEJA_EMBED_OFF", v)
+		if Off() {
+			t.Errorf("DEJA_EMBED_OFF=%q switched embedding off", v)
+		}
+	}
+	t.Setenv("DEJA_EMBED_OFF", "1")
+	if !Off() {
+		t.Error(`DEJA_EMBED_OFF="1" did not switch embedding off`)
+	}
+}


### PR DESCRIPTION
Found by running the suite on a clean tree here and getting two failures:

```
--- FAIL: TestDoctorSaysNothingWhenThereIsNoSidecarAtAll
    a deja that was never asked to embed anything reported:
    &doctorEmbedReport{State:"reachable", Model:"nomic-embed-text", ...}
--- FAIL: TestDoctorJSONGolden
```

Nothing was wrong with main. `embed.New` probes `localhost:11434` and `localhost:1234` when `DEJA_EMBED_URL` is unset, and this machine has a local model running — so doctor honestly reported an endpoint the tests are written to assert is absent. The same thing showed up sideways earlier today: `deja bench recall` printed `hybrid: endpoint unavailable, skipped` in one run and a live `hybrid 1.00 13.31 ms` arm in the next, on the same commit.

That is the worst way round for a contributor to meet a test suite: green on CI, red on the machine of anyone running Ollama or LM Studio, with the failure pointing at doctor rather than at their laptop.

`DEJA_EMBED_OFF=1` turns the probe off, and `hermeticEnv`/`frictionEnv` set it — the test env already isolates every store path and every root, and localhost is the one thing it did not. A configured `DEJA_EMBED_URL` still wins over the switch: saying where to embed is asking for it, which is what the three tests that exercise the embedding path against a stub server rely on.

The value is `"1"`, matching `DEJA_NO_REDACT`. Four mutations, all red: dropping the switch, letting it beat a configured endpoint, accepting any non-empty value (so `DEJA_EMBED_OFF=0` would switch it on), and removing it from the test env. The third was blind until the test stopped early-returning on the empty case — it asserted nothing at all as written.

README gained two lines saying the probe exists, since a machine being picked up without being asked is worth documenting either way.
