### PR TITLE
fix(bench): make the context corpus able to fail

### DIFF
--- a/cmd/deja/bench_context_test.go
+++ b/cmd/deja/bench_context_test.go
@@ -49,6 +49,13 @@ func TestContextJSONAndIsolation(t *testing.T) {
 	// carry its own text: scored only as a union the coverage column could not
 	// move — deleting either surface left it at 1.00 because the other one
 	// still held the chain's facts (#2931).
+	// The coverage column has to be able to move. Every prior session names
+	// the chain and only the first three settle anything, so the block's
+	// budget has to choose — at three prior sessions per chain every arm
+	// scored 1.00 whatever the digest did (#2931, #2933).
+	if c := report.Arms["deja-block"].MedianCoverage; c <= 0 || c >= 1 {
+		t.Errorf("the block's coverage is %.2f — saturated again, so a regression in it cannot show", c)
+	}
 	digest, block := report.Arms["deja-digest"], report.Arms["deja-block"]
 	if digest.MedianTokens == 0 || block.MedianTokens == 0 {
 		t.Errorf("a half of the injection is scored empty: digest %.0f tokens, block %.0f", digest.MedianTokens, block.MedianTokens)

--- a/internal/bench/context.go
+++ b/internal/bench/context.go
@@ -15,7 +15,11 @@ import (
 const (
 	ContextChainCount    = 30
 	ContextNegativeCount = 5
-	ContextPriorCount    = 3
+	// Seven, not three: with one fact per session and the rest naming the
+	// chain without settling anything, the block has to choose what to quote.
+	// At three every arm scored 1.00 whatever the digest did, which is what
+	// made the coverage column unable to move (#2931, #2933).
+	ContextPriorCount = 7
 )
 
 type ContextChain struct {
@@ -61,8 +65,20 @@ func GenerateContext(seed int64) ContextCorpus {
 		// comparison is meaningless, so each prior session carries a
 		// realistic filler load around its one durable fact.
 		for j := 0; j < ContextPriorCount; j++ {
-			text := "routine update with no prior fact"
-			if !chain.Negative {
+			// One fact per session, and the sessions past them carry none:
+			// the number of prior sessions is what makes the facts hard to
+			// reach, and indexing Facts by j made the constant unchangeable —
+			// raising it panicked (#2933).
+			// One fact per session, and the sessions past them carry none —
+			// while still naming the chain, so the ranking has to choose which
+			// of them to quote. Indexing Facts by j made the constant
+			// unchangeable (it panicked above three), and filler that did not
+			// name the chain was never retrieved, so raising it changed
+			// nothing either (#2933).
+			text := fmt.Sprintf("%s routine update, nothing settled here", id)
+			if chain.Negative {
+				text = "routine update with no prior fact"
+			} else if j < len(chain.Facts) {
 				text = chain.Facts[j]
 			}
 			t := base.Add(time.Duration(i*10+j) * time.Minute)


### PR DESCRIPTION
#2931's second direction, and the half of #2933 that is about content: make the facts hard enough to reach that the coverage column can move.

Two things were in the way, and the first is a defect in its own right:

- `ContextPriorCount` could not be raised. The generator indexed `chain.Facts[j]` by prior session, so any value above three panicked. One fact per session now, and the sessions past them carry none.
- Raising it changed nothing anyway, because the extra sessions did not name the chain and were therefore never retrieved. They name it now and settle nothing, so the block's budget has to choose what to quote.

At seven prior sessions per chain:

```
arm           median tokens  median coverage
deja-recall   563            1.00
deja-digest   294            1.00
deja-block    269            0.67   <- was 1.00 at any prior count
```

So the session-start block, whose budget is three sessions, now demonstrably spends part of it on sessions that settled nothing — which is a real property of that surface and the thing #2243 is about. The union stays 1.00, which is honest: an agent gets both halves.

The test requires the block's coverage to be strictly between 0 and 1; putting the prior count back to three fails it.

Refs #2931, #2933.