### PR TITLE
feat(bench): score what the block says, not what it chose

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,22 @@ With Ollama or LM Studio, embedding stays local and needs no key.
 ```sh
 deja bench recall     # ranking regression floor, CI fails if recall drops
 deja bench context    # 30 seeded task chains plus five negative controls
+deja bench block      # does the answer survive into what deja hands over
 ```
+
+`bench block` asks the question the other two cannot: with the right session in
+hand, does the block carry what that session settled. Eight sessions discuss each
+subject and one of them settles it, in the middle of its own transcript rather
+than at the end — so the baseline arm, the newest turns of the top hit, scores
+zero and an arm above zero had to choose.
+
+| Arm | Carries the answer | Median tokens |
+|---|---|---|
+| `deja-block` (session-start block) | 1.00 | 665 |
+| `deja-digest` (context digest) | 1.00 | 1656 |
+| `newest-turn` (baseline) | 0.00 | 289 |
+| `cold` | 0.00 | 0 |
+
 
 The context experiment compares deja-recall against full-history, naive grep and cold
 context. With the default seed:

--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -41,8 +41,11 @@ func runBench(args []string) error {
 	if len(args) > 0 && args[0] == "context" {
 		return runBenchContext(args[1:])
 	}
+	if len(args) > 0 && args[0] == "block" {
+		return runBenchBlock(args[1:])
+	}
 	if len(args) < 1 || args[0] != "recall" {
-		return fmt.Errorf("bench: usage: bench recall|context|prompt [--json] [--seed N]")
+		return fmt.Errorf("bench: usage: bench recall|context|prompt|block [--json] [--seed N]")
 	}
 	jsonOutput, seed, err := parseBenchArgs("recall", args[1:])
 	if err != nil {

--- a/cmd/deja/bench_block.go
+++ b/cmd/deja/bench_block.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/digest"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// `deja bench block` scores what the block says, which the other three benches
+// cannot see (#2933): bench prompt prints identical columns with the block
+// emptied, bench recall cannot see the order inside its own page, and bench
+// context's coverage stays at 1.00 with half the arm deleted.
+//
+// The question here is the one #2243 asks: with the right session in hand, does
+// what deja hands over carry what that session settled. The corpus knows the
+// answer by construction — one sentence, in one of eight sessions that all
+// discuss the subject — so a block can be scored rather than judged.
+//
+// Its own corpus rather than a column on bench context: the corpus has to be
+// hard enough that choosing badly loses, and changing the context corpus would
+// move numbers people have already compared against.
+
+type blockArmReport struct {
+	Carries      float64 `json:"carries_the_answer"`
+	ReadsSettled float64 `json:"reads_as_settled"`
+	MedianTokens int     `json:"median_tokens"`
+}
+
+type blockReport struct {
+	CorpusHash string                    `json:"corpus_hash"`
+	Seed       int64                     `json:"seed"`
+	Chains     int                       `json:"chains"`
+	Priors     int                       `json:"priors_per_chain"`
+	Arms       map[string]blockArmReport `json:"arms"`
+}
+
+type blockMeasurement struct {
+	carries  bool
+	settled  bool
+	tokens   int
+	armEmpty bool
+}
+
+func runBenchBlock(args []string) error {
+	jsonOutput, seed, err := parseBenchArgs("block", args)
+	if err != nil {
+		return err
+	}
+	report, err := measureBlock(seed)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(report)
+	}
+	printBlockReport(os.Stdout, report)
+	return nil
+}
+
+func measureBlock(seed int64) (blockReport, error) {
+	corpus := bench.GenerateBlock(seed)
+	root, err := benchmarkTempDir()
+	if err != nil {
+		return blockReport{}, err
+	}
+	defer func() { releaseBenchTempDir(root) }()
+	claudeRoot := filepath.Join(root, "claude")
+	indexDir := filepath.Join(root, "index.db")
+	var sessions []model.Session
+	for _, chain := range corpus.Chains {
+		sessions = append(sessions, chain.Sessions...)
+	}
+	if err := writeBenchCorpus(claudeRoot, sessions); err != nil {
+		return blockReport{}, err
+	}
+	restore := isolateBenchEnv(root, claudeRoot, indexDir)
+	defer restore()
+	if err := index.EnsureForSearch(indexDir, search.Options{Query: "", All: true}, true, io.Discard); err != nil {
+		return blockReport{}, fmt.Errorf("build block benchmark index: %w", err)
+	}
+
+	measurements := map[string][]blockMeasurement{}
+	for _, chain := range corpus.Chains {
+		hits, err := blockHits(indexDir, chain)
+		if err != nil {
+			return blockReport{}, err
+		}
+		for name, text := range map[string]string{
+			"deja-block":  blockArmBlock(hits, chain),
+			"deja-digest": blockArmDigest(hits, chain),
+			"newest-turn": blockArmNewest(hits),
+			"cold":        "",
+		} {
+			measurements[name] = append(measurements[name], scoreBlock(text, chain))
+		}
+	}
+	report := blockReport{
+		CorpusHash: corpus.Hash, Seed: seed,
+		Chains: bench.BlockChainCount, Priors: bench.BlockPriorCount,
+		Arms: map[string]blockArmReport{},
+	}
+	for name, values := range measurements {
+		report.Arms[name] = summarizeBlock(values)
+	}
+	return report, nil
+}
+
+// blockHits is retrieval, shared by every arm. Scoring the block means holding
+// retrieval constant: an arm that answers better because it searched better
+// would be measuring the thing bench recall already measures.
+func blockHits(dir string, chain bench.BlockChain) ([]model.Session, error) {
+	q := strings.Join(chain.Terms, " ")
+	result, err := index.SearchWithRecoveryDetailed(dir, search.Options{Query: q, All: true}, io.Discard)
+	if err != nil {
+		return nil, fmt.Errorf("block query %q: %w", q, err)
+	}
+	hits, err := search.Run(result.Sessions, search.Options{Query: q, All: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.Session, 0, len(hits))
+	for _, hit := range hits {
+		out = append(out, hit.Session)
+	}
+	return out, nil
+}
+
+// blockArmBlock is the session-start block, the thing an agent is handed
+// before it has asked anything.
+func blockArmBlock(hits []model.Session, chain bench.BlockChain) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	return search.BuildAutoRecall(hits, search.AutoRecallOptions{Mode: search.RecallAggressive}).Text
+}
+
+// blockArmDigest is the context digest, scored on its own so a change to
+// either surface is attributable — the split #2931 asks for.
+func blockArmDigest(hits []model.Session, chain bench.BlockChain) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	// The top hit alone, which is what recall_context returns. Printing every
+	// hit would carry the answer whatever the digest chose, the same way the
+	// context bench's coverage column carries it whatever the arm does.
+	var b bytes.Buffer
+	search.PrintContext(&b, hits[0], strings.Join(chain.Terms, " "))
+	return b.String()
+}
+
+// blockArmNewest is the baseline every ranking has to beat: the last two
+// assistant turns of the top hit. The corpus settles its question in the
+// fourth of eight sessions, so recency alone scores near zero — a bench whose
+// baseline scores full marks is measuring nothing.
+func blockArmNewest(hits []model.Session) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	var said []string
+	for _, m := range hits[0].Messages {
+		if m.Role == "assistant" {
+			said = append(said, m.Text)
+		}
+	}
+	if len(said) > 2 {
+		said = said[len(said)-2:]
+	}
+	return strings.Join(said, "\n")
+}
+
+func scoreBlock(text string, chain bench.BlockChain) blockMeasurement {
+	m := blockMeasurement{tokens: len(text) / 4, armEmpty: strings.TrimSpace(text) == ""}
+	if m.armEmpty {
+		return m
+	}
+	m.carries = strings.Contains(text, chain.SettledMarker())
+	m.settled = digest.CarriesDecision(text)
+	return m
+}
+
+func summarizeBlock(values []blockMeasurement) blockArmReport {
+	if len(values) == 0 {
+		return blockArmReport{}
+	}
+	carries, settled := 0, 0
+	tokens := make([]int, 0, len(values))
+	for _, v := range values {
+		if v.carries {
+			carries++
+		}
+		if v.settled {
+			settled++
+		}
+		tokens = append(tokens, v.tokens)
+	}
+	sort.Ints(tokens)
+	return blockArmReport{
+		Carries:      float64(carries) / float64(len(values)),
+		ReadsSettled: float64(settled) / float64(len(values)),
+		MedianTokens: tokens[len(tokens)/2],
+	}
+}
+
+func printBlockReport(w io.Writer, report blockReport) {
+	fmt.Fprintln(w, "deja bench block")
+	fmt.Fprintf(w, "chains: %d, sessions discussing each: %d, settled in session %d\n",
+		report.Chains, report.Priors, bench.BlockSettledAt+1)
+	fmt.Fprintln(w, "arm          carries the answer  reads as settled  median tokens")
+	for _, name := range []string{"deja-block", "deja-digest", "newest-turn", "cold"} {
+		arm, ok := report.Arms[name]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "%-12s %-19.2f %-17.2f %d\n", name, arm.Carries, arm.ReadsSettled, arm.MedianTokens)
+	}
+}

--- a/cmd/deja/bench_block_test.go
+++ b/cmd/deja/bench_block_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -86,5 +88,55 @@ func TestBlockReportPrintsEveryArm(t *testing.T) {
 		if !strings.Contains(b.String(), want) {
 			t.Errorf("the report does not mention %q:\n%s", want, b.String())
 		}
+	}
+}
+
+// End to end, the same shape the context bench is guarded with: the report
+// parses, every arm is present, the baseline is beaten, and nothing is written
+// outside the scratch directory.
+func TestBlockJSONAndIsolation(t *testing.T) {
+	outside := t.TempDir()
+	t.Setenv("HOME", outside)
+	t.Setenv("USERPROFILE", outside)
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1")
+	out, err := captureRun(t, "bench", "block", "--json", "--seed", "7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report blockReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("invalid block JSON %q: %v", out, err)
+	}
+	if report.Chains != bench.BlockChainCount || report.Priors != bench.BlockPriorCount {
+		t.Fatalf("unexpected block report: %#v", report)
+	}
+	for _, arm := range []string{"deja-block", "deja-digest", "newest-turn", "cold"} {
+		if _, ok := report.Arms[arm]; !ok {
+			t.Fatalf("missing arm %q", arm)
+		}
+	}
+	// The whole point: deja's surfaces carry the answer and the baseline does
+	// not. A run where the baseline scores is a corpus that stopped asking.
+	if report.Arms["deja-block"].Carries <= report.Arms["newest-turn"].Carries {
+		t.Errorf("the block did not beat the baseline: %+v", report.Arms)
+	}
+	if report.Arms["cold"].Carries != 0 {
+		t.Errorf("the empty arm carried something: %+v", report.Arms["cold"])
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("benchmark wrote outside scratch: %v", entries)
+	}
+}
+
+func TestBlockArgs(t *testing.T) {
+	if _, err := captureRun(t, "bench", "block", "--bad"); err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatal("invalid block flag did not fail")
+	}
+	if _, err := captureRun(t, "bench", "block", "--seed"); err == nil {
+		t.Fatal("missing seed did not fail")
 	}
 }

--- a/cmd/deja/bench_block_test.go
+++ b/cmd/deja/bench_block_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/bench"
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The corpus has to be able to say no. A bench whose baseline scores full
+// marks measures nothing, which is how bench context's coverage column ended
+// up unable to move (#2931) — so the shape of this corpus is asserted, not
+// assumed.
+func TestTheBlockCorpusSettlesOnceAndNotLast(t *testing.T) {
+	corpus := bench.GenerateBlock(1)
+	if len(corpus.Chains) != bench.BlockChainCount {
+		t.Fatalf("chains = %d, want %d", len(corpus.Chains), bench.BlockChainCount)
+	}
+	chain := corpus.Chains[0]
+	if len(chain.Sessions) != bench.BlockPriorCount {
+		t.Fatalf("sessions = %d, want %d", len(chain.Sessions), bench.BlockPriorCount)
+	}
+	settled := 0
+	for i, s := range chain.Sessions {
+		for _, m := range s.Messages {
+			if strings.Contains(m.Text, chain.SettledMarker()) {
+				settled++
+				if i != bench.BlockSettledAt {
+					t.Errorf("session %d carries the answer; only %d should", i, bench.BlockSettledAt)
+				}
+			}
+		}
+	}
+	if settled != 1 {
+		t.Errorf("the answer appears %d times in the chain, want once", settled)
+	}
+	// Not the last thing said, or "take the newest turn" scores full marks
+	// without choosing anything.
+	last := chain.Sessions[bench.BlockSettledAt].Messages
+	if strings.Contains(last[len(last)-1].Text, chain.SettledMarker()) {
+		t.Error("the answer is the last message of its session; recency alone would win")
+	}
+}
+
+// The baseline is what says the metric is real: the newest turns of the right
+// session do not carry the answer, so an arm that scores above zero had to
+// find it.
+func TestTheNewestTurnBaselineMissesTheAnswer(t *testing.T) {
+	corpus := bench.GenerateBlock(1)
+	chain := corpus.Chains[0]
+	got := scoreBlock(blockArmNewest([]model.Session{chain.Sessions[bench.BlockSettledAt]}), chain)
+	if got.carries {
+		t.Error("the newest two turns carry the answer, so the baseline cannot fail")
+	}
+}
+
+// And scoring itself: the settled sentence counts, the question's words do not.
+func TestScoringCountsTheAnswerAndNotTheSubject(t *testing.T) {
+	chain := bench.GenerateBlock(1).Chains[0]
+	if got := scoreBlock(chain.Settled, chain); !got.carries || !got.settled {
+		t.Errorf("the settled sentence scored %+v", got)
+	}
+	subjectOnly := strings.Repeat(chain.Terms[0]+" ", 40)
+	if got := scoreBlock(subjectOnly, chain); got.carries {
+		t.Error("saying the subject over and over counted as carrying the answer")
+	}
+	if got := scoreBlock("", chain); got.carries || got.settled || !got.armEmpty {
+		t.Errorf("an empty arm scored %+v", got)
+	}
+}
+
+func TestBlockReportPrintsEveryArm(t *testing.T) {
+	var b bytes.Buffer
+	printBlockReport(&b, blockReport{
+		Chains: 30, Priors: 8,
+		Arms: map[string]blockArmReport{
+			"deja-block":  {Carries: 1, ReadsSettled: 1, MedianTokens: 665},
+			"deja-digest": {Carries: 1, ReadsSettled: 1, MedianTokens: 1656},
+			"newest-turn": {},
+			"cold":        {},
+		},
+	})
+	for _, want := range []string{"deja-block", "deja-digest", "newest-turn", "cold", "carries the answer"} {
+		if !strings.Contains(b.String(), want) {
+			t.Errorf("the report does not mention %q:\n%s", want, b.String())
+		}
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -23,7 +23,7 @@ a `schema_version` field so consumers can detect breaking changes.
   would be written into every line of that file. And the surface answers `null`
   when no digest has been recorded: a shape that is sometimes absent cannot be
   relied on to carry a version.
-- **`deja bench recall|context|prompt --json`** are object-shaped and carry no
+- **`deja bench recall|context|prompt|block --json`** are object-shaped and carry no
   `schema_version` either. They report a benchmark run to whoever asked for it,
   not a contract anything downstream parses on a schedule.
 

--- a/internal/bench/block.go
+++ b/internal/bench/block.go
@@ -1,0 +1,187 @@
+package bench
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+const (
+	// BlockChainCount is how many questions the corpus asks.
+	BlockChainCount = 30
+	// BlockPriorCount is how many sessions in the project discuss the subject.
+	// Enough that the block has to choose one: with two or three, choosing
+	// badly and choosing well both land the answer, which is how the context
+	// bench's coverage column ended up unable to move (#2931).
+	BlockPriorCount = 8
+	// BlockSettledAt is which prior session settled the question. Not the last
+	// one: "take the newest" would then score full marks without choosing.
+	BlockSettledAt = 3
+)
+
+// BlockChain is one question, the sessions that discuss it, and the sentence
+// that settled it. The sentence is the ground truth: a block is right when it
+// carries that, not when it carries the question's words.
+type BlockChain struct {
+	ID       string
+	Terms    []string
+	Settled  string
+	Sessions []model.Session
+}
+
+// BlockCorpus is the seeded corpus for the block benchmark.
+type BlockCorpus struct {
+	Chains []BlockChain
+	Hash   string
+}
+
+// GenerateBlock builds chains where exactly one session settles the question
+// and the rest discuss it without settling anything.
+//
+// Three things make the corpus discriminating, each answering a way a bench can
+// fail to see its subject:
+//
+//   - The settled sentence is in an assistant turn, late in its session, after
+//     the diagnosis. A block that quotes the opening of the right session gets
+//     it wrong, which is the failure #2906 fixed.
+//   - The session that settled it is not the newest, so recency alone scores no
+//     better than chance.
+//   - The other sessions say the subject's words at length. A block that ranks
+//     on how often the words appear picks one of them.
+func GenerateBlock(seed int64) BlockCorpus {
+	rng := rand.New(rand.NewSource(seed))
+	base := time.Date(2099, time.March, 2, 9, 0, 0, 0, time.UTC)
+	chains := make([]BlockChain, 0, BlockChainCount)
+	for i := 0; i < BlockChainCount; i++ {
+		id := fmt.Sprintf("block-chain-%02d", i)
+		project := fmt.Sprintf("block-project-%02d", i)
+		subject := fmt.Sprintf("%s-subject", id)
+		settled := fmt.Sprintf(
+			"The fix was pinning the %s pool at %d connections, decided after the replica lag test.",
+			subject, 20+i%9)
+		chain := BlockChain{ID: id, Terms: []string{subject}, Settled: settled}
+		for j := 0; j < BlockPriorCount; j++ {
+			t := base.Add(time.Duration(i*24+j) * time.Hour)
+			msgs := []model.Message{
+				{Role: "user", Text: fmt.Sprintf("the %s keeps timing out, take %d", subject, j+1), Time: t},
+			}
+			// The sessions that settle nothing say the subject far more often
+			// than the one that does. That is the case ranking cannot see on
+			// its own — a session that mentioned the subject sixty times
+			// outranks the one that answered it in a sentence — so a bench
+			// where the settled session is also the top hit measures nothing.
+			says := 9 + rng.Intn(4)
+			if j == BlockSettledAt {
+				says = 1
+			}
+			for k := 0; k < says; k++ {
+				msgs = append(msgs,
+					model.Message{
+						Role: "assistant",
+						Text: fmt.Sprintf("Looking at %s again. The trace shows the same wait on %s, so I am reading the pool metrics before changing anything.\n%s",
+							subject, subject, fillerText(rng, "ran the reproduction and pasted the output")),
+						Time: t.Add(time.Duration(2*k+1) * time.Minute),
+					},
+					model.Message{
+						Role: "user",
+						Text: fmt.Sprintf("and does %s look any different under load", subject),
+						Time: t.Add(time.Duration(2*k+2) * time.Minute),
+					})
+			}
+			if j == BlockSettledAt {
+				// The answer sits in the middle of its session, after the
+				// diagnosis and before more of it. Put last, "take the newest
+				// turn" scores full marks and the bench measures recency; put
+				// first, it never has to be found. Both are how a block can
+				// look right while choosing nothing.
+				// Two sentences of diagnosis before the one that concludes, so
+				// a block that quotes a message's opening gets the diagnosis
+				// and drops the answer — the failure #2906 fixed. A block that
+				// takes the whole message passes either way, which is why the
+				// conclusion cannot be the first sentence.
+				msgs = append(msgs, model.Message{
+					Role: "assistant",
+					Text: fmt.Sprintf(
+						"Read the replica lag over the whole window. Both pools showed the same wait, and the metrics agreed with the trace. %s",
+						settled),
+					Time: t.Add(30 * time.Minute),
+				})
+				// And something newer that settles nothing but is kept for its
+				// code fence, competing for the slot the conclusion needs —
+				// the failure #2913 fixed.
+				// Two of them, because the block asks for two lines: one fence
+				// leaves the second slot free and the conclusion still lands.
+				for k := 0; k < 2; k++ {
+					msgs = append(msgs, model.Message{
+						Role: "assistant",
+						Text: fmt.Sprintf("Here is the pool config as it stands, pass %d:\n```ini\n%s_pool_size = 40\nmax_client_conn = 200\n```\n%s",
+							k+1, subject, fillerText(rng, "printed the effective config")),
+						Time: t.Add(time.Duration(31+k) * time.Minute),
+					})
+				}
+				for k := 0; k < 4; k++ {
+					msgs = append(msgs,
+						model.Message{
+							Role: "user",
+							Text: fmt.Sprintf("makes sense — anything else worth watching on %s", subject),
+							Time: t.Add(time.Duration(31+2*k) * time.Minute),
+						},
+						model.Message{
+							Role: "assistant",
+							Text: fmt.Sprintf("Watching %s for another window, nothing new to report.\n%s",
+								subject, fillerText(rng, "tailed the logs again")),
+							Time: t.Add(time.Duration(32+2*k) * time.Minute),
+						})
+				}
+			}
+			msgs = append(msgs, model.Message{
+				Role: "assistant",
+				Text: fmt.Sprintf("Still reading %s. Nothing settled here — I will pick this up next session.", subject),
+				Time: t.Add(time.Hour),
+			})
+			chain.Sessions = append(chain.Sessions, model.Session{
+				ID: fmt.Sprintf("%s-session-%d", id, j), Harness: "claude", Project: project,
+				Started: t, Updated: t.Add(time.Hour), Messages: msgs,
+			})
+		}
+		chains = append(chains, chain)
+	}
+	return BlockCorpus{Chains: chains, Hash: blockHash(chains)}
+}
+
+func blockHash(chains []BlockChain) string {
+	h := sha256.New()
+	for _, c := range chains {
+		b, err := json.Marshal(struct {
+			ID      string
+			Terms   []string
+			Settled string
+		}{c.ID, c.Terms, c.Settled})
+		if err != nil {
+			continue
+		}
+		h.Write(b)
+		h.Write([]byte("\n"))
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// SettledMarker is the part of the settled sentence a block has to carry for
+// the answer to have arrived. The whole sentence would fail on a legitimate
+// cut; this is the decision itself.
+func (c BlockChain) SettledMarker() string {
+	_, after, ok := strings.Cut(c.Settled, "The fix was ")
+	if !ok {
+		return c.Settled
+	}
+	if i := strings.Index(after, ", decided"); i > 0 {
+		return after[:i]
+	}
+	return after
+}

--- a/internal/bench/block.go
+++ b/internal/bench/block.go
@@ -3,7 +3,6 @@ package bench
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -155,19 +154,18 @@ func GenerateBlock(seed int64) BlockCorpus {
 	return BlockCorpus{Chains: chains, Hash: blockHash(chains)}
 }
 
+// blockHash identifies the corpus a report was produced from, including the
+// filler the seed varies — two runs that disagree on a number have to be able
+// to say whether they disagreed about the corpus first.
 func blockHash(chains []BlockChain) string {
 	h := sha256.New()
 	for _, c := range chains {
-		b, err := json.Marshal(struct {
-			ID      string
-			Terms   []string
-			Settled string
-		}{c.ID, c.Terms, c.Settled})
-		if err != nil {
-			continue
+		fmt.Fprintf(h, "%s\n%s\n%s\n", c.ID, strings.Join(c.Terms, " "), c.Settled)
+		for _, s := range c.Sessions {
+			for _, m := range s.Messages {
+				fmt.Fprintf(h, "%s\x00%s\n", m.Role, m.Text)
+			}
 		}
-		h.Write(b)
-		h.Write([]byte("\n"))
 	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }

--- a/internal/bench/block_test.go
+++ b/internal/bench/block_test.go
@@ -1,0 +1,96 @@
+package bench
+
+import (
+	"strings"
+	"testing"
+)
+
+// The corpus is the benchmark: if it can be generated two different ways from
+// one seed, or if the answer is reachable without choosing, the numbers mean
+// nothing. Both are asserted here rather than assumed.
+func TestGenerateBlockIsSeeded(t *testing.T) {
+	a, b := GenerateBlock(7), GenerateBlock(7)
+	if a.Hash != b.Hash {
+		t.Errorf("same seed, different hash: %s vs %s", a.Hash, b.Hash)
+	}
+	if len(a.Chains) != BlockChainCount {
+		t.Fatalf("chains = %d, want %d", len(a.Chains), BlockChainCount)
+	}
+	if c := GenerateBlock(8); c.Hash == a.Hash {
+		t.Error("a different seed produced the same corpus hash")
+	}
+}
+
+func TestEachChainSettlesOnceInTheMiddleOfOneSession(t *testing.T) {
+	for _, chain := range GenerateBlock(1).Chains {
+		if len(chain.Sessions) != BlockPriorCount {
+			t.Fatalf("%s: %d sessions, want %d", chain.ID, len(chain.Sessions), BlockPriorCount)
+		}
+		found := 0
+		for i, s := range chain.Sessions {
+			for j, m := range s.Messages {
+				if !strings.Contains(m.Text, chain.SettledMarker()) {
+					continue
+				}
+				found++
+				if i != BlockSettledAt {
+					t.Errorf("%s: session %d carries the answer", chain.ID, i)
+				}
+				if j == len(s.Messages)-1 {
+					t.Errorf("%s: the answer is the last message, so recency alone finds it", chain.ID)
+				}
+				if j == 0 {
+					t.Errorf("%s: the answer opens its session, so it never has to be found", chain.ID)
+				}
+			}
+		}
+		if found != 1 {
+			t.Errorf("%s: the answer appears %d times, want once", chain.ID, found)
+		}
+	}
+}
+
+// The sessions that settle nothing have to say the subject more, or the
+// corpus is not the case ranking finds hard.
+func TestTheUnsettledSessionsSayTheSubjectMore(t *testing.T) {
+	chain := GenerateBlock(1).Chains[0]
+	count := func(i int) int {
+		n := 0
+		for _, m := range chain.Sessions[i].Messages {
+			n += strings.Count(m.Text, chain.Terms[0])
+		}
+		return n
+	}
+	settled := count(BlockSettledAt)
+	for i := range chain.Sessions {
+		if i == BlockSettledAt {
+			continue
+		}
+		if count(i) <= settled {
+			t.Errorf("session %d says the subject %d times, the settled one %d", i, count(i), settled)
+		}
+	}
+}
+
+// SettledMarker is the decision without the sentence around it, so a
+// legitimate cut of the tail still counts as carrying the answer.
+func TestSettledMarkerIsTheDecisionAlone(t *testing.T) {
+	chain := GenerateBlock(1).Chains[0]
+	marker := chain.SettledMarker()
+	if !strings.Contains(chain.Settled, marker) {
+		t.Fatalf("marker %q is not part of the settled sentence %q", marker, chain.Settled)
+	}
+	if strings.Contains(marker, "The fix was ") || strings.Contains(marker, ", decided") {
+		t.Errorf("marker still carries the sentence around it: %q", marker)
+	}
+	// Both fallbacks: a sentence with neither half of the frame comes back
+	// whole rather than empty, which is the only safe answer for a scorer.
+	plain := BlockChain{Settled: "we moved to a read replica"}
+	if got := plain.SettledMarker(); got != plain.Settled {
+		t.Errorf("unframed sentence = %q, want it whole", got)
+	}
+	noTail := BlockChain{Settled: "The fix was moving to a read replica"}
+	if got := noTail.SettledMarker(); got != "moving to a read replica" {
+		t.Errorf("sentence with no tail = %q", got)
+	}
+}


### PR DESCRIPTION
Closes the gap #2933 measured: the three existing benches score whether the hook fired, whether retrieval returned the right session, and what it cost. None of them can see what the block says once the right session is in hand — `bench prompt` prints identical columns with the block emptied, and `bench context`'s coverage stays at 1.00 with half its arm deleted.

```
deja bench block
chains: 30, sessions discussing each: 8, settled in session 4
arm          carries the answer  reads as settled  median tokens
deja-block   1.00                1.00              665
deja-digest  1.00                1.00              1656
newest-turn  0.00                0.00              289
cold         0.00                0.00              0
```

**The corpus is built so that choosing badly loses.** Eight sessions discuss each subject; one settles it. The settled sentence sits in the middle of its session, after two sentences of diagnosis and before more of it — put last, "take the newest turn" scores full marks and the bench measures recency; put first, it never has to be found. Retrieval is held constant across arms, so this scores the block rather than the search.

**The baseline is the point.** `newest-turn` — the last two assistant turns of the top hit — scores 0.00. A bench whose baseline scores full marks measures nothing, which is exactly what #2931 found in the column this one replaces.

**Proved it can go red**, by deletion, which is the check I did not make before citing the other benches:

```
                              deja-block   deja-digest
baseline                         1.00         1.00
BuildAutoRecall emptied          0.00         1.00
PrintContext turn loop emptied   1.00         0.00
#2906 reverted (quote openings)  0.00         1.00
```

Each surface is attributable — the split #2931 asked for — and the third row is the one that matters: reverting today's #2906, so the block quotes a message's opening instead of the sentence that concludes it, takes `deja-block` to zero. The bench detects a real bug that shipped this morning.

**What it does not detect, stated rather than tuned away:** reverting #2913 (a code fence keeping the slot the conclusion needs) leaves both arms at 1.00. I put two fenced messages after the conclusion to reproduce that shape and the answer still lands; rather than keep shaping the corpus around one past commit until it goes red, I am leaving the limit written down. It is a second chain shape to add, not a threshold to move.

Its own corpus and its own subcommand rather than a column on `bench context`: the corpus has to be hard enough to lose, and changing the context corpus would move numbers already compared against. No existing bench output changes.

Four tests on the bench itself — the corpus settles exactly once and not last, the baseline misses, scoring counts the answer and not the subject, every arm prints.
