### PR TITLE
feat(hook): say what this command broke here last time

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -208,6 +208,26 @@ func applyPatchFiles(patch string) []string {
 //     the command.
 //
 // So the count stands alone on purpose (#2587).
+// commandFailureLine is what this command shape ended in before, or "" when
+// nothing confirmed is on file.
+//
+// It states what happened and recommends nothing — which is why it is keyed on
+// the command's shape rather than on the whole line the way CommandHistory is.
+// That rule exists so deja cannot endorse a command it half recognises; a
+// warning cannot endorse anything, and its cost when wrong is a line the
+// reader ignores.
+func commandFailureLine(dir, cmd string) string {
+	pol := policy.Load()
+	fail, ok := index.CommandFailedBefore(dir, cmd, func(project string) bool {
+		return pol.Allows(policy.ActivationAuto, project)
+	})
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("Last time this machine ran %s it ended with: %s (in %s)",
+		search.SafeCommand(fail.Head), search.SafeLine(fail.Line), toolSessionCount(fail.Sessions))
+}
+
 func commandHookLine(dir, cwd, cmd string) string {
 	// "You have run this before" is worthless for an inspection command the
 	// agent runs constantly — git status, git diff, ls, cat. On a real store
@@ -216,6 +236,16 @@ func commandHookLine(dir, cwd, cmd string) string {
 	// a test, a deploy — a command that does something.
 	if index.InspectionCommand(cmd) {
 		return ""
+	}
+	// What this command did to this machine last time, before what it is.
+	// Measured on a real store, the "you have run this" line answers 2 of 120
+	// commands an agent actually runs — everything else is a compound unique
+	// in its arguments — while a failure is keyed on the shape of the command
+	// and reaches the ones that matter (#2924). It is also the more useful of
+	// the two: knowing a command has been run says nothing about whether to
+	// run it now.
+	if line := commandFailureLine(dir, cmd); line != "" {
+		return line
 	}
 	use, ok := index.CommandHistory(dir, cmd)
 	if !ok {

--- a/cmd/deja/hook_tool_command_failure_test.go
+++ b/cmd/deja/hook_tool_command_failure_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The command branch of the per-action hook answered 2 of 120 commands an
+// agent actually runs: "you have run this before" needs the whole line, and
+// everything an agent runs is a compound unique in its arguments. What a
+// command did to this machine last time is keyed on its shape, and says
+// something worth acting on (#2924).
+func TestTheHookSaysWhatTheCommandBrokeLastTime(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i, id := range []string{"f1", "f2"} {
+		at := time.Now().Add(-time.Duration(i+1) * time.Hour).UTC().Format(time.RFC3339)
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"check the helm chart"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t` + id +
+				`","input":{"command":"make check --jobs 4 2>&1 | tail -20"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` + id +
+				`","content":"make: *** [analysis-coverage] Error 1"}]}}`,
+		})
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different invocation of the same command: different flags, different
+	// pipeline, same thing being run.
+	line := toolHookText(t, "make check --verbose | grep -i error")
+	if !strings.Contains(line, "Error 1") {
+		t.Errorf("the hook said nothing about what this command broke:\n%s", line)
+	}
+	if !strings.Contains(line, "make check") {
+		t.Errorf("the line does not name what it is about:\n%s", line)
+	}
+	// A command with no such history stays silent.
+	if line := toolHookText(t, "cargo build --release"); line != "" {
+		t.Errorf("a command with no history got a line:\n%s", line)
+	}
+}
+
+// One session hitting something is an anecdote. The bar is the same as the
+// command table's own.
+func TestOneFailureIsNotAWarning(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(root, "-tmp-app", "only.jsonl"), "only", []string{
+		`{"type":"user","sessionId":"only","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"try the deploy"}}`,
+		`{"type":"assistant","sessionId":"only","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t1","input":{"command":"terraform apply -auto-approve"}}]}}`,
+		`{"type":"user","sessionId":"only","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"Error: Backend initialization required"}]}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if line := toolHookText(t, "terraform apply"); strings.Contains(line, "Backend initialization") {
+		t.Errorf("one sighting was served as a warning:\n%s", line)
+	}
+}
+
+func toolHookText(t *testing.T, command string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"cwd":        "/tmp/app",
+		"session_id": fmt.Sprintf("hook-%d", time.Now().UnixNano()),
+		"tool_input": map[string]any{"command": command},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	if err := runHookTool(index.DefaultDir(), strings.NewReader(string(payload)), &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.String()
+}

--- a/internal/index/commandfails.go
+++ b/internal/index/commandfails.go
@@ -1,0 +1,251 @@
+package index
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+const (
+	commandFailsFile = "commandfails.gob"
+	// commandFailMinSessions is the bar a warning has to clear. The same as
+	// the command table's own: one session hitting something is an anecdote,
+	// two is a property of this machine.
+	commandFailMinSessions = 2
+	// commandFailsMax bounds the table. It is read whole on the per-action
+	// hook, which fires before every tool call an agent makes.
+	commandFailsMax = 500
+	// commandFailHeadWords is how much of a command a warning is about: the
+	// program, its subcommand, and the first argument that is not a flag.
+	//
+	// Looser than CommandHistory's whole-line match on purpose. That rule is
+	// what keeps deja from *endorsing* a command it only half recognises —
+	// "git status\nrm -rf /" must never be answered as "you have run this".
+	// A warning is the other direction: it recommends nothing, and the cost of
+	// being wrong is a line the reader ignores rather than a command they run.
+	// Measured on a real store, the whole-line key confirms 25 command-failure
+	// pairs and the head confirms 45 (#2924).
+	commandFailHeadWords = 3
+)
+
+func commandFailsPath(dir string) string { return filepath.Join(dir, commandFailsFile) }
+
+// CommandFailure is what a command did to this machine last time, for the hook
+// that fires before it runs again.
+type CommandFailure struct {
+	// Head is the command shape this is about, normalised.
+	Head string
+	// Line is the friction the run ended with, and Sessions how many separate
+	// sessions saw this command end that way.
+	Line     string
+	Sessions int
+	// Project is one of the projects it happened in, for the trust policy.
+	Project string
+}
+
+// CommandHead is the part of a command a warning is about: the program, its
+// subcommand and the first argument that is not a flag. Empty when there is no
+// such shape — a bare `cd`, an assignment, an empty line.
+func CommandHead(cmd string) string {
+	cmd = strings.TrimSpace(withoutExitStatus(strings.TrimSpace(firstTextLine(cmd))))
+	// A stored command carries the prompt marker the transcript wrote it with;
+	// the one the hook is asked about does not.
+	cmd = strings.TrimSpace(strings.TrimPrefix(cmd, "$ "))
+	// Only the first command of a compound: what follows ran in a state this
+	// one made, and a warning about it would be about a different situation.
+	if i := strings.IndexAny(cmd, "|;&"); i > 0 {
+		cmd = cmd[:i]
+	}
+	fields := strings.Fields(strings.ToLower(cmd))
+	if len(fields) == 0 {
+		return ""
+	}
+	// An assignment is not a program, and `cd` on its own says nothing about
+	// what failed.
+	if strings.Contains(fields[0], "=") || fields[0] == "cd" {
+		return ""
+	}
+	head := []string{fields[0]}
+	skipNext := false
+	for _, f := range fields[1:] {
+		// A redirect is not an argument. `make check --jobs 4 2>&1 | tail`
+		// cut at the pipe leaves "2>" behind, and a shape with that in it
+		// matches nothing a reader would type.
+		if strings.ContainsAny(f, "<>") {
+			continue
+		}
+		if strings.HasPrefix(f, "-") {
+			// A flag's value is part of the flag, not part of the shape:
+			// `make check --jobs 4` is a `make check`, and keeping the 4 made
+			// it a shape of its own. A flag written with "=" carries its value
+			// already.
+			skipNext = !strings.Contains(f, "=")
+			continue
+		}
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		head = append(head, f)
+		if len(head) == commandFailHeadWords {
+			break
+		}
+	}
+	return strings.Join(head, " ")
+}
+
+// commandFailAcc gathers the failures a command shape has ended in.
+type commandFailAcc struct {
+	by map[string]*struct {
+		fail     CommandFailure
+		sessions map[string]bool
+	}
+	// The command each session last ran, so the output that follows it can be
+	// attributed. Records and messages both arrive in the order they were
+	// written.
+	pending map[string]string
+}
+
+func newCommandFailAcc() *commandFailAcc {
+	return &commandFailAcc{
+		by: map[string]*struct {
+			fail     CommandFailure
+			sessions map[string]bool
+		}{},
+		pending: map[string]string{},
+	}
+}
+
+func (a *commandFailAcc) command(key, text string) { a.pending[key] = CommandHead(text) }
+
+func (a *commandFailAcc) output(key, project, text string) {
+	head := a.pending[key]
+	if head == "" {
+		return
+	}
+	line, _, ok := firstFrictionLine(text)
+	if !ok {
+		return
+	}
+	// One failure per run: the first friction line is what the run ended on,
+	// and the rest is that failure repeating itself.
+	delete(a.pending, key)
+	k := head + "\x00" + line
+	entry := a.by[k]
+	if entry == nil {
+		entry = &struct {
+			fail     CommandFailure
+			sessions map[string]bool
+		}{fail: CommandFailure{Head: head, Line: line, Project: project}, sessions: map[string]bool{}}
+		a.by[k] = entry
+	}
+	entry.sessions[key] = true
+}
+
+func (a *commandFailAcc) table() []CommandFailure {
+	out := make([]CommandFailure, 0, len(a.by))
+	for _, entry := range a.by {
+		if len(entry.sessions) < commandFailMinSessions {
+			continue
+		}
+		entry.fail.Sessions = len(entry.sessions)
+		out = append(out, entry.fail)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Sessions != out[j].Sessions {
+			return out[i].Sessions > out[j].Sessions
+		}
+		if out[i].Head != out[j].Head {
+			return out[i].Head < out[j].Head
+		}
+		return out[i].Line < out[j].Line
+	})
+	if len(out) > commandFailsMax {
+		out = out[:commandFailsMax]
+	}
+	return out
+}
+
+// buildCommandFails mines the failures out of the sessions a full build holds.
+func buildCommandFails(tmp string, ss []model.Session) {
+	acc := newCommandFailAcc()
+	for _, s := range ss {
+		key := s.Harness + ":" + s.ID
+		for _, m := range s.Messages {
+			switch m.Role {
+			case roleCommand:
+				acc.command(key, m.Text)
+			case roleToolOutput:
+				acc.output(key, s.Project, m.Text)
+			default:
+				// Anything else ends the run this output would belong to.
+				delete(acc.pending, key)
+			}
+		}
+	}
+	writeCommandFails(tmp, acc.table())
+}
+
+// buildCommandFailsFromIndex is the same from the records an index already
+// holds, for the incremental path — which has only the sessions it touched,
+// while these counts are over the whole corpus (the reason
+// buildCommandsFromIndex exists).
+func buildCommandFailsFromIndex(tmp string) {
+	acc := newCommandFailAcc()
+	err := eachCommandAndOutput(tmp, func(meta SessionMeta, r Record) {
+		if r.Role == roleCommand {
+			acc.command(r.Key, r.Text)
+			return
+		}
+		acc.output(r.Key, meta.Project, r.Text)
+	})
+	if err != nil {
+		// An extra, never a reason to fail an update.
+		return
+	}
+	writeCommandFails(tmp, acc.table())
+}
+
+func writeCommandFails(tmp string, out []CommandFailure) {
+	if len(out) == 0 {
+		return
+	}
+	_ = writeGobAtomic(commandFailsPath(tmp), out)
+}
+
+// ReadCommandFails loads the mined failures. An index built before they existed
+// simply has none.
+func ReadCommandFails(dir string) []CommandFailure {
+	var out []CommandFailure
+	if err := readGob(commandFailsPath(dir), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// CommandFailedBefore is what this command shape ended in on this machine, or
+// false when nothing confirmed is on file.
+func CommandFailedBefore(dir, cmd string, allow func(project string) bool) (CommandFailure, bool) {
+	head := CommandHead(cmd)
+	if head == "" {
+		return CommandFailure{}, false
+	}
+	for _, f := range ReadCommandFails(dir) {
+		if f.Head != head {
+			continue
+		}
+		if allow != nil && !allow(f.Project) {
+			continue
+		}
+		return f, true
+	}
+	return CommandFailure{}, false
+}
+
+// eachCommandAndOutput streams the command records and the tool output records
+// in the order they were written, which is what ties a run to what it printed.
+func eachCommandAndOutput(dir string, fn func(SessionMeta, Record)) error {
+	return eachRecordOfRoles(dir, map[string]bool{roleCommand: true, roleToolOutput: true}, fn)
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -565,6 +565,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	buildCooccur(tmp, ss)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
 	buildCommands(tmp, ss)
+	buildCommandFails(tmp, ss)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err
@@ -1072,6 +1073,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	buildCooccur(tmp, ss)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
 	buildCommands(tmp, ss)
+	buildCommandFails(tmp, ss)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err
@@ -2934,6 +2936,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// have something to say, and the carried file is what a quiet update leaves.
 	mergeFixes(dir, tmp, replacements, replaceKeys)
 	buildCommandsFromIndex(tmp)
+	buildCommandFailsFromIndex(tmp)
 	return swapIndexDir(dir, tmp)
 }
 

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -1206,6 +1206,26 @@ func walkRecordsStable(dir string, walk func(m Manifest) error) error {
 	return errors.New("the index was rebuilt while this read was in flight — run it again")
 }
 
+// eachRecordOfRoles is EachRecordOfRole for more than one role at a time, in
+// the order the records were written. A caller that ties a command to what it
+// printed needs both roles in one pass: two passes would lose the order
+// between them.
+func eachRecordOfRoles(dir string, roles map[string]bool, fn func(SessionMeta, Record)) error {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	return walkRecordsStable(dir, func(m Manifest) error {
+		return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
+			if !roles[r.Role] {
+				return
+			}
+			if meta, ok := m.Sessions[r.Key]; ok {
+				fn(meta, r)
+			}
+		})
+	})
+}
+
 // EachRecordOfRole streams every record of one role with the session it came
 // from. Ranked retrieval is the wrong instrument when the caller has an exact
 // key and needs every match rather than the best ones — restore is that case


### PR DESCRIPTION
Option 3 from #2924, chosen after measuring option 2 and finding it costs a safety property for very little.

**What it does.** Before a Bash call, the per-action hook says what this command shape ended in on this machine, instead of that it has been run:

```
Last time this machine ran make check it ended with: make: *** [analysis-coverage] Error 1 (in 2 sessions)
```

Mined into a sidecar next to the command table — a command record, the friction line the run ended on, counted over distinct sessions — with the same two-session bar the command table uses. One sighting is an anecdote.

**Keyed on the command's shape, not the whole line.** `CommandHistory` matches whole lines because it *endorses*: "git status\nrm -rf /" must never be answered with "you have run this". A warning endorses nothing, and its failure mode when wrong is a line the reader ignores. So the key is the program, its subcommand and the first non-flag argument — flag values and redirects dropped, compounds cut at the first operator.

**Reach, on this machine's store, sampling the commands the store itself holds** (the population #2924 sampled):

```
before   2 of 120 answered
after   17 of 120 answered with a failure, 3 more with the old history line
```

**Why not option 2.** Stripping a leading `cd <path> &&` before keying takes commands with ≥2 sessions from 677 to 688 on this store — and `cd /tmp/x && rm -rf .` becomes `rm -rf .`, endorsed without the directory that made it safe. Eleven commands is not worth that trade; the numbers are in the issue.

Closes #2924.