### PR TITLE
perf(index): write a posting's session id as a delta, not in full

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -104,6 +104,17 @@ import (
 // since it was written, and the index was storing the most frequent pairs in
 // the language for nothing. Measured on a 42 MB Chinese corpus, buckets 75.5
 // MB to 70.7 MB (#492).
+//
+// And one more subtraction on the same rebuild, because it is the same
+// rebuild: a posting's session id is written as a delta against the previous
+// posting in its block rather than in full. A block is sorted by offset and
+// records.bin is written in session order, so on a real store 99.66% of
+// postings already hold a session id no smaller than the one before them.
+// Measured by two contributors on two real stores, buckets fall 16.11% and
+// 11.95%; the bucket magic moves with it so a reader that skips the version
+// check — an index directory that cannot be locked is served without one —
+// gets errCorruptIndex rather than session ids that are wrong without saying
+// so (#492).
 const version = 34
 const maxIndexedText = 64 * 1024
 
@@ -112,7 +123,15 @@ const maxIndexedText = 64 * 1024
 // a corrupt length prefix — reject it rather than allocate up to 4 GiB.
 const maxRecordSize = 8 << 20
 
-var bucketMagic = []byte("DJB1")
+// bucketMagic moves whenever the meaning of the bytes behind it moves. The
+// version bump above rebuilds the index on the next Ensure, but a directory
+// that cannot be locked is served as it stands, with no version check at all
+// (EnsureForSearch, EnsureForSearchNoWait) — the read-only container this
+// repo deliberately supports. Reading old posting bytes under a new rule
+// there would hand back session ids that are wrong rather than absent, and
+// nothing would say so; failing the magic check instead makes it a corrupt
+// index, which callers already treat as a cache miss (#492).
+var bucketMagic = []byte("DJB2")
 
 // errCorruptIndex marks unreadable index structures (e.g. a bucket file cut
 // short by a crash). Callers treat it as a cache miss and rebuild.

--- a/internal/index/posting_sid_delta_test.go
+++ b/internal/index/posting_sid_delta_test.go
@@ -1,0 +1,198 @@
+package index
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// Session deltas use modulo-2^32 arithmetic; losing a decrease or boundary ID would make #492 return the wrong session.
+func TestPostingSessionDeltaRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		blocks [][]posting
+	}{
+		{
+			name: "single posting",
+			blocks: [][]posting{
+				{
+					{Off: 11, Sid: 7},
+				},
+			},
+		},
+		{
+			name: "ascending session IDs",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 1},
+					{Off: 5, Sid: 2},
+					{Off: 20, Sid: 100},
+				},
+			},
+		},
+		{
+			name: "decreasing session ID",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 100},
+					{Off: 2, Sid: 7},
+				},
+			},
+		},
+		{
+			name: "zero session ID",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 0},
+				},
+			},
+		},
+		{
+			name: "session ID high bit",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 1 << 31},
+				},
+			},
+		},
+		{
+			name: "maximum session ID",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: math.MaxUint32},
+				},
+			},
+		},
+		{
+			name: "session ID wrap",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: math.MaxUint32},
+					{Off: 2, Sid: 0},
+				},
+			},
+		},
+		{
+			name: "both tool values",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 42, Tool: false},
+					{Off: 2, Sid: 42, Tool: true},
+				},
+			},
+		},
+		{
+			name: "previous session resets between blocks",
+			blocks: [][]posting{
+				{
+					{Off: 1, Sid: 77},
+					{Off: 2, Sid: 80},
+				},
+				{
+					{Off: 3, Sid: 77},
+					{Off: 5, Sid: 80},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for i, want := range tt.blocks {
+				got := decodePostings(encodePostings(want))
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("block %d: got %#v, want %#v", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// Repeated session IDs must beat absolute encoding; otherwise #492 pays a rebuild without the measured storage gain.
+func TestPostingSessionDeltaWireShrinks(t *testing.T) {
+	const sid uint32 = 1 << 28
+
+	posts := make([]posting, 64)
+	for i := range posts {
+		posts[i] = posting{Off: int64(i + 1), Sid: sid}
+	}
+
+	var scratch [binary.MaxVarintLen64]byte
+	var prevOff int64
+	absoluteLen := 0
+	for _, p := range posts {
+		absoluteLen += binary.PutUvarint(scratch[:], uint64(p.Off-prevOff))
+		absoluteLen += binary.PutUvarint(scratch[:], uint64(p.Sid)<<1)
+		prevOff = p.Off
+	}
+
+	if got := len(encodePostings(posts)); got >= absoluteLen {
+		t.Fatalf("encoded length: got %#v, want less than %#v", got, absoluteLen)
+	}
+}
+
+// A cut varint is an incomplete posting, not a zero-valued posting; #492 must preserve that partial-read boundary.
+func TestPostingSessionDeltaTruncatedVarint(t *testing.T) {
+	tests := []struct {
+		name string
+		wire []byte
+	}{
+		{
+			name: "truncated offset",
+			wire: []byte{0x80},
+		},
+		{
+			name: "truncated session",
+			wire: []byte{1, 0x80},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decodePostings(tt.wire)
+			want := []posting{}
+			if len(got) != 0 {
+				t.Fatalf("decodePostings: got %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+// TestPostingSessionDeltaIsZigzagOnTheWire pins the encoding itself, not only
+// that it round-trips. A plain modular delta round-trips too, so the table
+// above cannot tell the two apart; a step backwards is where they diverge.
+// Session 100 then 7 writes the deltas 100 and -93 as zigzag 200 and 185, two
+// varint bytes each. Without zigzag the second would be 0xffffffa3, five
+// bytes, on every posting whose session id steps back (#492).
+func TestPostingSessionDeltaIsZigzagOnTheWire(t *testing.T) {
+	got := encodePostings([]posting{{Off: 1, Sid: 100}, {Off: 2, Sid: 7}})
+	want := []byte{0x01, 0x90, 0x03, 0x01, 0xf2, 0x02}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("encodePostings wire = % x, want % x", got, want)
+	}
+	back := decodePostings(got)
+	if len(back) != 2 || back[0].Sid != 100 || back[1].Sid != 7 {
+		t.Fatalf("decodePostings round trip = %#v", back)
+	}
+}
+
+// TestOpenBucketDirRefusesTheOlderMagic is the other half of the format break.
+// The version bump rebuilds a writable index, but a directory that cannot be
+// locked is served with no version check at all, so a v31 bucket has to fail
+// here rather than decode its session ids under the new rule (#492).
+func TestOpenBucketDirRefusesTheOlderMagic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x00.bin")
+	old := append([]byte("DJB1"), 0x00)
+	if err := os.WriteFile(path, old, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openBucketDir(path); !errors.Is(err, errCorruptIndex) {
+		t.Fatalf("openBucketDir on a DJB1 bucket = %v, want errCorruptIndex", err)
+	}
+}

--- a/internal/index/posting_sid_property_test.go
+++ b/internal/index/posting_sid_property_test.go
@@ -1,0 +1,63 @@
+package index
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// The session id is written as a delta now, so the property that matters is
+// that any block of postings survives the round trip — not a list of cases
+// someone thought of. The extremes are seeded deliberately because a zigzag
+// over a uint32 subtraction is where an off-by-one lives: 0, 1<<31, MaxUint32,
+// and the steps between them (#492).
+func TestAnyBlockOfPostingsSurvivesTheRoundTrip(t *testing.T) {
+	extremes := []uint32{0, 1, 2, math.MaxUint32, math.MaxUint32 - 1, 1 << 31, (1 << 31) - 1, 1<<31 + 1}
+	rng := rand.New(rand.NewSource(11))
+	for round := 0; round < 300; round++ {
+		n := 1 + rng.Intn(12)
+		posts := make([]posting, 0, n)
+		off := int64(rng.Intn(1000))
+		for i := 0; i < n; i++ {
+			// Offsets must ascend: a block is what writeBucket produced, and
+			// it sorts by offset. The session ids are deliberately not sorted.
+			off += int64(1 + rng.Intn(5000))
+			var sid uint32
+			switch rng.Intn(3) {
+			case 0:
+				sid = extremes[rng.Intn(len(extremes))]
+			case 1:
+				sid = uint32(rng.Intn(50))
+			default:
+				sid = rng.Uint32()
+			}
+			posts = append(posts, posting{Off: off, Sid: sid, Tool: rng.Intn(2) == 1})
+		}
+		got := decodePostings(encodePostings(posts))
+		want := sortedUniquePostings(posts)
+		if len(got) != len(want) {
+			t.Fatalf("round %d: %d postings came back from %d", round, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("round %d posting %d: got %+v, want %+v (block %+v)", round, i, got[i], want[i], want)
+			}
+		}
+	}
+}
+
+// And the delta is scoped to its own block: two blocks encoded one after the
+// other must not read each other's last session id.
+func TestOneBlocksSessionIdsDoNotLeakIntoTheNext(t *testing.T) {
+	first := []posting{{Off: 1, Sid: math.MaxUint32}, {Off: 2, Sid: 5}}
+	second := []posting{{Off: 1, Sid: 7}}
+	if got := decodePostings(encodePostings(second)); len(got) != 1 || got[0].Sid != 7 {
+		t.Fatalf("a block read on its own gave %+v", got)
+	}
+	// Encoding the first block before the second must not change what the
+	// second one decodes to.
+	_ = encodePostings(first)
+	if got := decodePostings(encodePostings(second)); len(got) != 1 || got[0].Sid != 7 {
+		t.Fatalf("the previous block's session id leaked: %+v", got)
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -869,6 +869,7 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 	return entries, f, nil
 }
 
+// encodePostings encodes a posting block with per-block offset and session deltas.
 func encodePostings(posts []posting) []byte {
 	if len(posts) == 0 {
 		return nil
@@ -876,24 +877,41 @@ func encodePostings(posts []posting) []byte {
 	s := sortedUniquePostings(posts)
 	b := make([]byte, 0, len(s)*6)
 	var prev int64
+	var prevSid uint32
 	for _, p := range s {
 		b = binary.AppendUvarint(b, uint64(p.Off-prev))
-		// The tool bit rides in the low bit of the session field: a separate
-		// varint would cost a byte on every posting in the store, and the shift
-		// costs nothing until a corpus passes two billion sessions.
-		v := uint64(p.Sid) << 1
+		// A block is sorted by offset and records.bin is written in session
+		// order, so the session ids in one block are nearly sorted: 99.66% of
+		// postings on a real store carry an id no smaller than the one before
+		// them, and writing the difference instead of the id took 16% off the
+		// buckets (#492). Zigzag because "nearly" is not "always" — the ids
+		// that step backwards must survive too.
+		//
+		// The subtraction is deliberately modulo 2^32, which is what int32 of
+		// a uint32 difference gives: it round-trips the whole id space rather
+		// than the half an int32 could hold.
+		d := int32(p.Sid - prevSid)
+		z := uint32((d << 1) ^ (d >> 31))
+		// The tool bit rides in the low bit, where it has always ridden: a
+		// separate varint would cost a byte on every posting in the store.
+		v := uint64(z) << 1
 		if p.Tool {
 			v |= 1
 		}
 		b = binary.AppendUvarint(b, v)
 		prev = p.Off
+		prevSid = p.Sid
 	}
 	return b
 }
 
+// decodePostings mirrors encodePostings. A truncated varint ends the walk and
+// yields what was whole: a bucket cut short by a crash is a cache miss, not a
+// panic, and two callers already depend on the prefix coming back.
 func decodePostings(b []byte) []posting {
 	out := make([]posting, 0)
 	var prev int64
+	var prevSid uint32
 	for len(b) > 0 {
 		d, n := binary.Uvarint(b)
 		if n <= 0 {
@@ -901,11 +919,15 @@ func decodePostings(b []byte) []posting {
 		}
 		prev += int64(d)
 		b = b[n:]
-		sid, n := binary.Uvarint(b)
+		v, n := binary.Uvarint(b)
 		if n <= 0 {
 			return out
 		}
-		out = append(out, posting{Off: prev, Sid: uint32(sid >> 1), Tool: sid&1 == 1})
+		z := uint32(v >> 1)
+		sidDelta := int32(z>>1) ^ -int32(z&1)
+		sid := prevSid + uint32(sidDelta)
+		out = append(out, posting{Off: prev, Sid: sid, Tool: v&1 == 1})
+		prevSid = sid
 		b = b[n:]
 	}
 	return out


### PR DESCRIPTION
Cherry-picked from @Sora-bluesky's `perf/posting-session-delta`, measured independently here, and folded onto the bump that is already in flight.

**Their measurements, and a third store.** Sora measured −16.11% of `buckets/` on a mixed Japanese/English store; @AliceLJY re-measured on a real Chinese store and got −11.95%, with no build-time effect resolvable against a ~0.3s same-source floor. On this machine's mixed Russian/English store:

```
                buckets       records.bin    build
base         51,766,487      145,068,387     54.9s
delta        48,706,467      145,083,693     46.5s
base again   51,771,093      145,092,191     47.4s
```

−5.91% of buckets, with a base-to-base spread of +0.01% — so the byte figure is solid and the build-time figure is not: delta is 8.4s under base while base is 7.5s under itself. Two synthetic corpora: −5.41% (42 MB Chinese) and −7.71% (98 MB Han). Four stores now, −5.4% to −16.1%, and the spread tracks how much of each store is one long session rather than many short ones.

**Parity.** 15 queries across Russian, English and code on this store: identical tier, total, capped, members *and order* on all 15 when the two indexes are built adjacently. The one difference in my first pass was the store growing between builds — rebuilding both back to back reproduces the same total on each arm.

**The magic does what it claims.** An old binary pointed at a new index:

```
deja: index damaged (corrupt index: bad bucket magic), rebuilding ...
```

which is the failure Sora designed for: a cache miss, not session ids that are wrong without saying so.

**On the forced rebuild, which is what the thread was waiting on.** It costs nothing extra: version 34 is unreleased and already forces a rebuild for the Arabic/Thai tokenizer change and the grammar-bigram subtraction. So this rides that rebuild rather than adding one, and the note is folded into 34 rather than opening 35.

Closes #492.