### PR TITLE
fix(index): say a format change is one, and say what it costs read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The index format moved: this release rebuilds the index once on first run.
+  Arabic, Hebrew, Thai and the Indic scripts are tokenized as words rather than
+  as single letters, Thai gets the bigrams the other unspaced scripts have,
+  grammar-only CJK bigrams are no longer stored, and a posting's session id is
+  written as a delta — measured at 5.9% to 16.1% smaller `buckets/` across four
+  stores.
+
+  **A read-only index directory needs its index replaced by hand.** deja serves
+  a directory it cannot lock without a version check, by design, so it cannot
+  rebuild one in place: a pre-0.20 index inside a read-only image will make
+  `deja search` exit with `index written by another version of deja` until the
+  directory is rebuilt somewhere writable and copied in. The alternative was
+  reading old posting bytes under the new rule, which returns session ids that
+  are wrong without saying so.
+
 
 ## [0.19.1] - 2026-08-28
 

--- a/internal/index/bucket_format_message_test.go
+++ b/internal/index/bucket_format_message_test.go
@@ -1,0 +1,52 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A bucket file written by another version of deja is not a damaged one, and
+// the line a reader gets is the only thing that tells them which it is: the
+// first wording sent someone looking for a disk fault they did not have
+// (#492).
+func TestAnIndexFromAnotherVersionIsNotCalledDamaged(t *testing.T) {
+	tmp := t.TempDir()
+	buckets := filepath.Join(tmp, "buckets", "x00.bin")
+	if err := os.MkdirAll(filepath.Dir(buckets), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A bucket in the shape the previous format wrote: right size, old magic.
+	if err := os.WriteFile(buckets, append([]byte("DJB1"), 0x00), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := openBucketDir(buckets)
+	if err == nil {
+		t.Fatal("a bucket in the old format was accepted")
+	}
+	if !IsCorrupt(err) {
+		t.Errorf("the old format is not reported as unreadable: %v", err)
+	}
+	if !strings.Contains(err.Error(), "older deja") || !strings.Contains(err.Error(), "DJB1") {
+		t.Errorf("the error does not say which version wrote it: %v", err)
+	}
+	if got := damagedOrOutdated(err); got != "index written by another version of deja" {
+		t.Errorf("the line a reader sees is %q", got)
+	}
+
+	// And a bucket that really is corrupt still reads as damage.
+	if err := os.WriteFile(buckets, []byte{0x01, 0x02, 0x03, 0x04, 0x00}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = openBucketDir(buckets)
+	if err == nil {
+		t.Fatal("a bucket with no magic at all was accepted")
+	}
+	if got := damagedOrOutdated(err); got != "index damaged" {
+		t.Errorf("a corrupt bucket reads as %q", got)
+	}
+	if strings.ContainsAny(err.Error(), "\x00\x01\x02") {
+		t.Errorf("raw bytes reached the message: %q", err.Error())
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -110,8 +110,11 @@ import (
 // posting in its block rather than in full. A block is sorted by offset and
 // records.bin is written in session order, so on a real store 99.66% of
 // postings already hold a session id no smaller than the one before them.
-// Measured by two contributors on two real stores, buckets fall 16.11% and
-// 11.95%; the bucket magic moves with it so a reader that skips the version
+// Measured here at 5.91% of buckets on a mixed store, and by two contributors
+// at 16.11% and 11.95% on theirs — none of those three is reproducible from
+// this repository, which is why the first number is the one taken on the
+// machine that merged it. The bucket magic moves with it so a reader that
+// skips the version
 // check — an index directory that cannot be locked is served without one —
 // gets errCorruptIndex rather than session ids that are wrong without saying
 // so (#492).
@@ -130,7 +133,15 @@ const maxRecordSize = 8 << 20
 // repo deliberately supports. Reading old posting bytes under a new rule
 // there would hand back session ids that are wrong rather than absent, and
 // nothing would say so; failing the magic check instead makes it a corrupt
-// index, which callers already treat as a cache miss (#492).
+// index (#492).
+//
+// What that costs, stated because the first version of this comment said the
+// opposite: on a writable index it is a cache miss — the recovery path
+// rebuilds and the reader sees an answer. On a read-only directory it is not.
+// The rebuild cannot run, so `deja search` exits non-zero with no results
+// until the index is replaced by hand. That is the right trade against wrong
+// session ids served silently, and it is a break for anyone shipping a
+// pre-34 index inside a read-only image.
 var bucketMagic = []byte("DJB2")
 
 // errCorruptIndex marks unreadable index structures (e.g. a bucket file cut

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2667,7 +2667,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		filesTouched, messages, unreadable, err := appendIncremental(dir, harness, scope, old, files, changed)
 		if IsCorrupt(err) {
 			if progress != nil {
-				fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
+				fmt.Fprintf(progress, "deja: %s (%v), rebuilding ...\n", damagedOrOutdated(err), err)
 			}
 			return rebuild(dir, harness, scope, files, progress)
 		}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -1405,7 +1405,7 @@ func SearchWithRecoveryDetailed(dir string, o query.Options, progress io.Writer)
 		return r, err
 	}
 	if progress != nil {
-		fmt.Fprintf(progress, "deja: index damaged (%v), rebuilding ...\n", err)
+		fmt.Fprintf(progress, "deja: %s (%v), rebuilding ...\n", damagedOrOutdated(err), err)
 	}
 	if rerr := EnsureForSearch(dir, o, true, progress); rerr != nil {
 		return SearchResult{}, rerr

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -804,7 +804,11 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 	}
 	if string(magic) != string(bucketMagic) {
 		f.Close()
-		return nil, nil, fmt.Errorf("%w: bad bucket magic", errCorruptIndex)
+		// Named for what it is. The magic moves when the posting format
+		// changes, and every reader of an index written by another version
+		// lands here — telling them the index is damaged sends them looking
+		// for a disk fault they do not have (#492).
+		return nil, nil, fmt.Errorf("%w: %s", errCorruptIndex, wrongBucketFormat(magic))
 	}
 	count, err := binary.ReadUvarint(r)
 	if err != nil {
@@ -869,7 +873,52 @@ func openBucketDir(p string) ([]bucketEntry, *os.File, error) {
 	return entries, f, nil
 }
 
-// encodePostings encodes a posting block with per-block offset and session deltas.
+// damagedOrOutdated names the two reasons an index cannot be read. A format
+// this build does not write is not damage, and saying so sent a reader looking
+// for a disk fault (#492).
+func damagedOrOutdated(err error) string {
+	if err != nil && strings.Contains(err.Error(), "bucket format") {
+		return "index written by another version of deja"
+	}
+	return "index damaged"
+}
+
+// wrongBucketFormat says which of the two shapes a bucket file is in, so the
+// message a reader gets names the version rather than a fault.
+func wrongBucketFormat(magic []byte) string {
+	// Only a magic deja itself has written means another version. Anything
+	// else is a header that is not one, which is damage — and calling that a
+	// version difference would send a reader to the release notes for a disk
+	// fault.
+	for _, known := range formerBucketMagics {
+		if string(magic) == known {
+			return fmt.Sprintf("postings written by an older deja (bucket format %s, this build reads %s)",
+				known, string(bucketMagic))
+		}
+	}
+	return fmt.Sprintf("bad bucket magic %q", printableMagic(magic))
+}
+
+// formerBucketMagics are the bucket headers earlier releases wrote. A reader
+// that meets one is behind or ahead of a format change rather than looking at
+// a damaged file.
+var formerBucketMagics = []string{"DJB1"}
+
+// printableMagic keeps a corrupt header out of the terminal as raw bytes.
+func printableMagic(magic []byte) string {
+	out := make([]rune, 0, len(magic))
+	for _, b := range magic {
+		if b < 0x20 || b > 0x7e {
+			out = append(out, '?')
+			continue
+		}
+		out = append(out, rune(b))
+	}
+	return string(out)
+}
+
+// encodePostings encodes a posting block with per-block offset and session
+// deltas.
 func encodePostings(posts []posting) []byte {
 	if len(posts) == 0 {
 		return nil
@@ -906,8 +955,13 @@ func encodePostings(posts []posting) []byte {
 }
 
 // decodePostings mirrors encodePostings. A truncated varint ends the walk and
-// yields what was whole: a bucket cut short by a crash is a cache miss, not a
-// panic, and two callers already depend on the prefix coming back.
+// yields what was whole rather than panicking.
+//
+// Defensive only: every caller sizes its buffer from the directory entry and
+// gets io.EOF from ReadAt before a short block reaches here, and openBucketDir
+// bounds each block against the file size. Nothing in the product depends on
+// the prefix coming back — an earlier version of this comment claimed two
+// callers did, and none does.
 func decodePostings(b []byte) []posting {
 	out := make([]posting, 0)
 	var prev int64


### PR DESCRIPTION
Follow-up to #2942, from a review of it. Three claims in that change were wrong, and one of them is the kind a user meets.

**1. A bucket from another version was reported as damage.** Every reader of an index written by a different deja lands on the magic check, and the line it produced was `index damaged (postings: corrupt index: bad bucket magic)` — which sends someone looking for a disk fault they do not have. A magic deja itself has written now says so: `index written by another version of deja (postings written by an older deja (bucket format DJB1, this build reads DJB2))`. Anything that is not a header deja ever wrote is still damage, and its bytes are escaped rather than printed raw.

**2. The magic comment claimed a cache miss on the path where it is not one.** It justified moving the magic by saying callers treat corruption as a cache miss — true on a writable index, false on the read-only directory the comment itself cites as the reason: the rebuild cannot run there, so `deja search` exits non-zero with no results until the index is replaced by hand. That is still the right trade against wrong session ids served silently, but the comment now says what it costs, and so does the changelog.

**3. The truncation comment claimed two callers depend on the decoder returning a prefix.** None does — every caller sizes its buffer from the directory entry and gets `io.EOF` from `ReadAt` first, and `openBucketDir` bounds each block against the file size. The tolerance is defensive and now says so.

Also: the two contributor measurements quoted in the version note (16.11%, 11.95%) are not reproducible from this repository, so the note leads with the 5.91% taken on the machine that merged it and names the others as theirs.

Test covers both directions of the new message and that raw bytes cannot reach it; two mutations — treating every wrong magic as a version difference, and putting the old wording back — each fail it.

Credit: the read-only regression, the false comment and the false dependency were all found by review, not by me.