### PR TITLE
chore: pin the manifests to 0.19.2

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -12,7 +12,7 @@ import (
 // only offers an update for a plugin it installed from its own marketplace, so
 // for a repository or zip install nothing tells the user their copy is behind.
 // deja knows both numbers, and doctor is where someone looks.
-const kimiPluginVersion = "0.1.0"
+const kimiPluginVersion = "0.19.2"
 
 // kimiPluginInstalledVersion returns the version of the installed copy, or ""
 // when the plugin is not there.

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.1.0",
+  "version": "0.19.2",
   "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
   "keywords": ["memory", "recall", "sessions", "search", "history"],
   "author": "vshulcz",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Search the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and seventeen more — including work from before deja was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.1.0",
+  "version": "0.19.2",
   "description": "Recall the sessions your other coding agents already wrote \u2014 Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
   "keywords": [
     "memory",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.1",
+    "version": "0.19.2",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_amd64.zip",
-            "hash": "978766f735e6f8fc3e210fa2feaa715d547bb951d5630bba4d2eccc2230f8f80"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip",
+            "hash": "d5897addafc95c45451a7e1ee7a8222101375a3fa9faaa0b6521c80f9e39a1f1"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_arm64.zip",
-            "hash": "2ae3c8898b712766a5389fdc80d4bac4856c655ff774fe4bd0a0d26ec8a384fd"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip",
+            "hash": "c4b3e8550396e8af74e737b3ed63aa4f749c4327301fd0395d9b40b946a517ab"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_amd64.zip
-  InstallerSha256: 978766F735E6F8FC3E210FA2FEAA715D547BB951D5630BBA4D2ECCC2230F8F80
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip
+  InstallerSha256: D5897ADDAFC95C45451A7E1EE7A8222101375A3FA9FAAA0B6521C80F9E39A1F1
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_arm64.zip
-  InstallerSha256: 2AE3C8898B712766A5389FDC80D4BAC4856C655FF774FE4BD0A0D26EC8A384FD
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip
+  InstallerSha256: C4B3E8550396E8AF74E737B3ED63AA4F749C4327301FD0395D9B40B946A517AB
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.2/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.1
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.2
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Search the coding sessions already on your disk — Claude Code, Codex, Cursor, opencode and seventeen more — including work from before deja was installed.",
   "author": {
     "name": "vshulcz",

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -50,8 +50,19 @@ const (
 	// straight from the default branch, so its version is the one a
 	// listing shows.
 	agentPlugin = "plugin.json"
-	releaseAPI  = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
-	assetBase   = "https://github.com/vshulcz/deja-vu/releases/download"
+	// The Kimi Code plugin is packed into the release archive, so the version
+	// in its manifest is the one a Kimi user reads. It sat at 0.1.0 from the
+	// day it was added — the same way the Codex plugin did, and for the same
+	// reason: the workflow that validates its shape never compares its version
+	// to anything.
+	kimiPlugin = "kimi.plugin.json"
+	// Packed under extensions/, and a test pins the two to agree.
+	kimiPacked = "extensions/kimi/kimi.plugin.json"
+	// doctor compares the installed copy against this constant to tell a
+	// user their zip install is behind, so it has to move with the manifest.
+	kimiConst  = "cmd/deja/kimi_plugin.go"
+	releaseAPI = "https://api.github.com/repos/vshulcz/deja-vu/releases/latest"
+	assetBase  = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
 type pins struct {
@@ -131,6 +142,9 @@ func write(root string, p pins) error {
 		codexPlugin:     renderPluginVersion(codexPlugin),
 		claudePlugin:    renderPluginVersion(claudePlugin),
 		geminiExtension: renderPluginVersion(geminiExtension),
+		kimiPlugin:      renderPluginVersion(kimiPlugin),
+		kimiPacked:      renderPluginVersion(kimiPacked),
+		kimiConst:       renderGoVersionConst(kimiConst, "kimiPluginVersion"),
 		agentPlugin:     renderPluginVersion(agentPlugin),
 	} {
 		body, err := render(p)
@@ -223,6 +237,23 @@ func renderInstaller(p pins) ([]byte, error) { return edit(installer, p) }
 // descriptions, prompts and pointers that no release derives, so regenerating
 // them from a template here would drop whatever someone adds later — the same
 // reason the winget files are edited rather than rendered.
+// renderGoVersionConst pins a Go constant that mirrors a manifest's version.
+// Without it the constant and the manifest drift, and the drift is exactly
+// what the constant exists to report.
+func renderGoVersionConst(path, name string) func(pins) ([]byte, error) {
+	re := regexp.MustCompile(`(const ` + name + ` = )"[^"]*"`)
+	return func(p pins) ([]byte, error) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if !re.MatchString(string(b)) {
+			return nil, fmt.Errorf("%s has no %s to pin", path, name)
+		}
+		return []byte(re.ReplaceAllString(string(b), `${1}"`+p.version+`"`)), nil
+	}
+}
+
 func renderPluginVersion(path string) func(pins) ([]byte, error) {
 	return func(p pins) ([]byte, error) {
 		b, err := os.ReadFile(path)
@@ -303,6 +334,9 @@ func runCheck(root string) error {
 		codexPlugin:     renderPluginVersion(codexPlugin),
 		claudePlugin:    renderPluginVersion(claudePlugin),
 		geminiExtension: renderPluginVersion(geminiExtension),
+		kimiPlugin:      renderPluginVersion(kimiPlugin),
+		kimiPacked:      renderPluginVersion(kimiPacked),
+		kimiConst:       renderGoVersionConst(kimiConst, "kimiPluginVersion"),
 		agentPlugin:     renderPluginVersion(agentPlugin),
 	} {
 		want, err := render(p)


### PR DESCRIPTION
The release job regenerates these in the runner and attaches them to the release, but does not commit them — so main carries the previous version and `pinmanifests -check` is red until this lands. Checksums are from the signed `checksums.txt` of the v0.19.2 run, not from a local rebuild.

**The Kimi plugin joins the pinned set.** `kimi.plugin.json` has said `0.1.0` in every release since it was added: the workflow that validates its shape never compares its version to anything, which is the same hole `pinmanifests` was written for after the Codex plugin sat at 0.1.0 from July through 0.17.1. Both copies are pinned — the root one and the packed one under `extensions/` that `TestKimiManifestsAgree` holds together.

And `kimiPluginVersion` in `cmd/deja/kimi_plugin.go` with them. `doctor` compares an installed copy against that constant to tell someone their zip install is behind, so a constant that drifts from the manifest reports the drift it is itself part of. The test caught this halfway through: pinning the manifests alone left it disagreeing with both.