### PR TITLE
docs: Chinese README parity, and titles written for the query

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,14 @@ deja 把这些文件变成一层它们都能读的记忆。
 `deja handoff --to codex` 把当前上下文打包，好在另一个智能体里接着做；
 密钥、令牌、JWT 和私钥块在建索引时就被剥掉。
 
+### 把你自己的工作画出来
+
+`deja stats --card` 直接画在终端里；给它一个文件名，它会写出一张 SVG，可以放进个人主页的 README。
+
+<p align="center"><img src="docs/assets/stats-card-demo.svg" width="760" alt="deja 统计卡片：一年的会话热力图、它们来自哪些智能体、以及最长的一次"></p>
+
+完整的功能参考在[文档站](https://vshulcz.github.io/deja-vu/)。
+
 ## 隐私
 
 建索引和搜索都在本地。只有 `deja update`、`deja sync ssh` 和 `deja doctor` 里的版本检查会用到网络。
@@ -138,6 +146,26 @@ Copilot CLI · Roo Code · DeepSeek Harness · Zed。
 每个工具分别支持 MCP 召回、自动召回、技能、命令、resume 和 handoff 中的哪些，见
 [英文 README 的能力矩阵](README.md#supported-harnesses)。自定义存储位置通过 `DEJA_*_ROOT`
 变量指定，各家自己的迁移变量也会被尊重。
+
+### 自带插件包的智能体
+
+`deja install --auto` 会像接其他工具一样把下面这几个接好，那始终是最短的一条路。
+它们同时在各自的生态里有一个包，方便习惯从那边装扩展的人：
+
+| 智能体 | 包 | 安装 |
+| --- | --- | --- |
+| opencode | npm `opencode-deja` | `opencode plugin opencode-deja` |
+| DeepSeek Harness | npm `dsh-deja` | `dsh plugin --profile web add dsh-deja` |
+| Zed | `deja-context-server` | Zed → Extensions → deja |
+| Kimi Code | 插件 `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
+| Codex CLI | 插件 `deja-vu` | `codex plugin marketplace add https://github.com/vshulcz/deja-vu`，然后 `codex plugin add deja-vu@deja-vu` |
+| Grok Build | 插件 `deja` | `grok plugin marketplace add xai-org/plugin-marketplace`，然后 `grok plugin install deja` |
+
+两条路各自都够用，两条都走也不会出问题：opencode、dsh、Kimi、Grok 和 Codex 的包会读
+`deja install` 写下的配置，只补上缺的那部分；在 Zed 里两边用的是同一个 server id，
+所以无论先装哪个都不会重复。
+
+它们用的都是你已经装好的 deja，包里自带的那份只是兜底。
 
 ## 可选的语义召回
 
@@ -212,6 +240,30 @@ MCP 服务端、统计、分享和同步都读这一份索引。细节见
 deja uninstall --all
 rm -rf ~/.cache/deja
 ```
+
+## 指南
+
+按场景写的，不是按功能：
+
+- [智能体把你刚才的上下文弄丢了](https://vshulcz.github.io/deja-vu/guide/lost-context.html)——崩溃之后、清空之后，或者会话回来时空空如也
+- [上下文窗口满了](https://vshulcz.github.io/deja-vu/guide/context-window-full.html)——压缩到底保住了什么，实测数据，以及可以换成什么做法
+- [接着昨天的会话做](https://vshulcz.github.io/deja-vu/guide/resume-a-session.html)——跨所有智能体找到它，再回到它原来所属的那一个里打开
+- [智能体又犯了你已经修过的错](https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html)
+- [找到当初解决它的那次会话](https://vshulcz.github.io/deja-vu/guide/find-a-session.html)
+- [为什么智能体在会话之间会忘事](https://vshulcz.github.io/deja-vu/guide/forgetting.html) · [每个智能体把历史存在哪里](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html)
+- [压缩会丢掉什么](https://vshulcz.github.io/deja-vu/guide/after-compaction.html) · [换一个智能体](https://vshulcz.github.io/deja-vu/guide/switching-agents.html) · [审计智能体做过什么](https://vshulcz.github.io/deja-vu/guide/auditing-agents.html) · [导出一次对话](https://vshulcz.github.io/deja-vu/guide/export-conversations.html) · [跨机器](https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html) · [记忆要花多少 token](https://vshulcz.github.io/deja-vu/guide/token-cost.html)
+
+按工具：[opencode](https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html) · [DeepSeek Harness](https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html) · [Kimi Code](https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html) · [Zed](https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html) · [Grok Build](https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html) · [Gemini CLI](https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html) · [Qwen Code](https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html)
+
+## 在你自己的历史上试一次
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto
+```
+
+装好十秒，建索引十来秒。下一次智能体打开会话，它就已经知道你在这个项目里解决过什么——
+包括你装 deja 之前的那些。
 
 ## 参与开发
 

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Benchmarks — deja-vu docs</title>
+<title>Coding-agent memory benchmarks: search quality and token cost — deja-vu</title>
 <meta name="description" content="Reproducible, honest measurements of deja's search quality and the token cost of reaching working context — run them yourself.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Benchmarks — deja-vu docs">
+<meta property="og:title" content="Coding-agent memory benchmarks: search quality and token cost — deja-vu">
 <meta property="og:description" content="Reproducible, honest measurements of deja's search quality and the token cost of reaching working context — run them yourself.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/benchmarks.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Benchmarks — deja-vu docs">
+<meta name="twitter:title" content="Coding-agent memory benchmarks: search quality and token cost — deja-vu">
 <meta name="twitter:description" content="Reproducible, honest measurements of deja&#x27;s search quality and the token cost of reaching working context — run them yourself.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>CLI reference — deja-vu docs</title>
+<title>deja CLI reference: search, recall, blame, stats — deja-vu</title>
 <meta name="description" content="Every deja subcommand: search, recall, ctx, blame, remember, forget, stats, last, sources, install, embed, sync, doctor, bench and update.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/commands.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="CLI reference — deja-vu docs">
+<meta property="og:title" content="deja CLI reference: search, recall, blame, stats — deja-vu">
 <meta property="og:description" content="Every deja subcommand: search, recall, ctx, blame, remember, forget, stats, last, sources, install, embed, sync, doctor, bench and update.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/commands.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="CLI reference — deja-vu docs">
+<meta name="twitter:title" content="deja CLI reference: search, recall, blame, stats — deja-vu">
 <meta name="twitter:description" content="Every deja subcommand: search, recall, ctx, blame, remember, forget, stats, last, sources, install, embed, sync, doctor, bench and update.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>The context window is full — deja-vu</title>
+<title>Claude Code context window full: what compaction drops — deja-vu</title>
 <meta name="description" content="Compaction keeps 77% of decisions and 0.2% of commands — measured. What to do instead of paying for a window that grows until it breaks.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/context-window-full.html">
 <meta property="og:type" content="article">

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Getting started — deja-vu docs</title>
+<title>Search your Claude Code and Codex session history in one command — deja-vu</title>
 <meta name="description" content="Install deja and index your coding-agent history in one command, then search it and wire it into your agents over MCP.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Getting started — deja-vu docs">
+<meta property="og:title" content="Search your Claude Code and Codex session history in one command — deja-vu">
 <meta property="og:description" content="Install deja and index your coding-agent history in one command, then search it and wire it into your agents over MCP.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Getting started — deja-vu docs">
+<meta name="twitter:title" content="Search your Claude Code and Codex session history in one command — deja-vu">
 <meta name="twitter:description" content="Install deja and index your coding-agent history in one command, then search it and wire it into your agents over MCP.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>The agent lost the context you had — deja-vu</title>
+<title>Claude Code lost your context: how to get it back — deja-vu</title>
 <meta name="description" content="A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/lost-context.html">
 <meta property="og:type" content="article">

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>The agent keeps making a mistake you already fixed — deja-vu</title>
+<title>Stop Claude Code repeating a bug you already fixed — deja-vu</title>
 <meta name="description" content="Why a coding agent hits the same wall it solved last month, how to see which walls a machine keeps hitting, and how to hand it the fix at the moment it fails.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html">
 <meta property="og:type" content="article">

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Resuming the session you had yesterday — deja-vu</title>
+<title>Resume a Claude Code or Codex session from yesterday — deja-vu</title>
 <meta name="description" content="Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/resume-a-session.html">
 <meta property="og:type" content="article">

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Where each coding agent stores its conversation history — deja-vu</title>
+<title>Where Claude Code, Codex and Cursor store session history — deja-vu</title>
 <meta name="description" content="Where each coding agent keeps its conversation history file, in twenty formats, and how to read them without the tool that wrote them.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html">
 <meta property="og:type" content="article">


### PR DESCRIPTION
Two documentation fixes.

**The Chinese README was four sections behind** while zh pages are read: `README.zh.md` took 63 views (42 unique) in the last fortnight and `extensions/dsh/docs/zh.md` another 55 (44 unique) — and CN/JP communities are where people have written about deja without being asked. Added, in the same register as the rest of that file: the stats card, the harnesses that ship a package of their own, the guides list, and the invitation to try it on your own history. Closes #1934 and #1831.

**Eight guide titles named the situation where a search result has to name the thing.** "The context window is full" carries no word anyone types; "Claude Code context window full: what compaction drops" does. The H1s are untouched — the situation is the right frame once a reader is on the page.

```
Benchmarks                          -> Coding-agent memory benchmarks: search quality and token cost
CLI reference                       -> deja CLI reference: search, recall, blame, stats
Getting started                     -> Search your Claude Code and Codex session history in one command
The agent lost the context you had  -> Claude Code lost your context: how to get it back
The context window is full          -> Claude Code context window full: what compaction drops
The agent keeps making a mistake…   -> Stop Claude Code repeating a bug you already fixed
Resuming the session you had…       -> Resume a Claude Code or Codex session from yesterday
Where each coding agent stores…     -> Where Claude Code, Codex and Cursor store session history
```

Repo topics were retargeted the same way, outside this PR: `transcript-search`, `session-management`, `ai-coding-agents`, `developer-tools`, `local-first`, `cli`, `anthropic` in; the narrowest per-integration tags out, since those integrations are already listed in their own registries.
