### PR TITLE
chore: pin the manifests to 0.19.2

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Recall your own past coding sessions, across every AI tool you use.",
   "author": {
     "name": "vshulcz",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Search the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and seventeen more — including work from before deja was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.1",
+    "version": "0.19.2",
     "description": "Persistent memory for coding agents",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_amd64.zip",
-            "hash": "978766f735e6f8fc3e210fa2feaa715d547bb951d5630bba4d2eccc2230f8f80"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip",
+            "hash": "d5897addafc95c45451a7e1ee7a8222101375a3fa9faaa0b6521c80f9e39a1f1"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_arm64.zip",
-            "hash": "2ae3c8898b712766a5389fdc80d4bac4856c655ff774fe4bd0a0d26ec8a384fd"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip",
+            "hash": "c4b3e8550396e8af74e737b3ed63aa4f749c4327301fd0395d9b40b946a517ab"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -8,10 +8,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_amd64.zip
-  InstallerSha256: 978766F735E6F8FC3E210FA2FEAA715D547BB951D5630BBA4D2ECCC2230F8F80
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip
+  InstallerSha256: D5897ADDAFC95C45451A7E1EE7A8222101375A3FA9FAAA0B6521C80F9E39A1F1
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.1/deja-vu_0.19.1_windows_arm64.zip
-  InstallerSha256: 2AE3C8898B712766A5389FDC80D4BAC4856C655FF774FE4BD0A0D26EC8A384FD
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip
+  InstallerSha256: C4B3E8550396E8AF74E737B3ED63AA4F749C4327301FD0395D9B40B946A517AB
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -7,7 +7,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.1/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.2/LICENSE
 ShortDescription: Persistent memory for coding agents
 Tags:
 - aider
@@ -17,6 +17,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.1
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.2
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.1
+PackageVersion: 0.19.2
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Search the coding sessions already on your disk — Claude Code, Codex, Cursor, opencode and seventeen more — including work from before deja was installed.",
   "author": {
     "name": "vshulcz",


### PR DESCRIPTION
The manual step after a release: scoop, winget and the four plugin manifests carry the version and the hashes, and the release workflow cannot commit them for itself. Until it is done, `windows manifests` fails on every open PR — it did on #2947, which has nothing to do with packaging.

`go run ./scripts/pinmanifests -check` is green after this.