### PR TITLE
docs: two guides for the questions people actually search

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ rm -rf ~/.cache/deja
 
 Written for the situation rather than the feature:
 
+- [Does your agent remember previous conversations?](https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html) — what each agent keeps between sessions, and what it drops
+- [Session files on disk](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html) — how big `~/.claude/projects` gets, and what deleting it costs
 - [The agent lost the context you had](https://vshulcz.github.io/deja-vu/guide/lost-context.html) — after a crash, a clear, or a session that came back empty
 - [The context window is full](https://vshulcz.github.io/deja-vu/guide/context-window-full.html) — what compaction keeps, measured, and what to do instead
 - [Resuming yesterday's session](https://vshulcz.github.io/deja-vu/guide/resume-a-session.html) — find it across every agent, reopen it in the one that owns it

--- a/README.zh.md
+++ b/README.zh.md
@@ -245,6 +245,8 @@ rm -rf ~/.cache/deja
 
 按场景写的，不是按功能：
 
+- [编码智能体记得之前的对话吗？](https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html)——每个智能体在会话之间留下了什么，又丢掉了什么
+- [磁盘上的会话文件](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html)——`~/.claude/projects` 会长到多大，删掉要付出什么代价
 - [智能体把你刚才的上下文弄丢了](https://vshulcz.github.io/deja-vu/guide/lost-context.html)——崩溃之后、清空之后，或者会话回来时空空如也
 - [上下文窗口满了](https://vshulcz.github.io/deja-vu/guide/context-window-full.html)——压缩到底保住了什么，实测数据，以及可以换成什么做法
 - [接着昨天的会话做](https://vshulcz.github.io/deja-vu/guide/resume-a-session.html)——跨所有智能体找到它，再回到它原来所属的那一个里打开

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html" aria-current="page">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -71,7 +71,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Does Claude Code remember previous conversations? — deja-vu</title>
+<meta name="description" content="Claude Code, Codex, Cursor and Gemini CLI all forget between sessions. What each one keeps on disk, what compaction really preserves, and three ways to get history back.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Does your coding agent remember previous conversations?">
+<meta property="og:description" content="Why every coding agent starts empty, what each keeps on disk, and three ways to give it the history back.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Does your coding agent remember previous conversations?">
+<meta name="twitter:description" content="Why every coding agent starts empty, what each keeps on disk, and three ways to give it the history back.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Does your coding agent remember previous conversations?", "description": "Claude Code, Codex, Cursor and Gemini CLI all forget between sessions. What each one keeps on disk, what compaction really preserves, and three ways to get history back.", "url": "https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Does my agent remember?", "item": "https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does Claude Code remember previous conversations?", "acceptedAnswer": {"@type": "Answer", "text": "No. An agent's memory is its context window, and the window is discarded when the session ends. The transcript is still written to disk under ~/.claude/projects, but nothing reads it back, so a new session starts empty."}}, {"@type": "Question", "name": "Do Codex, Cursor and Gemini CLI remember past sessions?", "acceptedAnswer": {"@type": "Answer", "text": "No. All of them write a transcript you can read afterwards, and several can resume one specific past session, but none of them search across your earlier sessions on their own."}}, {"@type": "Question", "name": "Does compaction count as memory?", "acceptedAnswer": {"@type": "Answer", "text": "Only within the same session, and only as prose. Measured over 43 real compactions, the summary kept 77% of the decisions and 0.2% of the commands that had been run."}}, {"@type": "Question", "name": "How do I make my coding agent remember previous sessions?", "acceptedAnswer": {"@type": "Answer", "text": "Three options: write facts into a rules file such as CLAUDE.md by hand, install a memory service that records forward from installation, or index the transcripts already on disk so history from before you installed anything is searchable."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html" aria-current="page">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Does your coding agent remember previous conversations?</h1>
+<p class="pagelede">short answer: no — but the conversations are still on your disk<span class="mins" data-mins></span></p>
+
+<p>Claude Code, Codex CLI, Cursor, Gemini CLI and the rest all behave the same way here. Inside one session the agent remembers everything you said. Start a new session and it knows nothing about the last one — not the bug you fixed together yesterday, not the approach you already tried and rejected, not the command that finally worked.</p>
+<p>That is not a bug or a setting you forgot to turn on. An agent's memory <i>is</i> its context window, and the window is thrown away when the session ends.</p>
+
+<h2>What each agent actually keeps</h2>
+<p>Three different things get called "memory", and none of them is what you want on its own:</p>
+<table>
+<tr><th>Mechanism</th><th>Carries across sessions</th><th>What it holds</th></tr>
+<tr><td>Context window</td><td>No</td><td>Everything in the current session, until it fills up</td></tr>
+<tr><td>Rules file (<code>CLAUDE.md</code>, <code>AGENTS.md</code>)</td><td>Yes</td><td>Only what you typed into it by hand</td></tr>
+<tr><td>Session transcript on disk</td><td>Yes, but nothing reads it</td><td>Every turn, command and error, verbatim</td></tr>
+</table>
+<p>So the honest answer to "does it remember?" is: your agent wrote down everything that happened, and then never opened the file again.</p>
+
+<h2>Per agent</h2>
+<p>Every agent below writes a transcript you can read. "Resume" means the harness can re-open one specific past session and continue it; none of them search across sessions on their own.</p>
+<table>
+<tr><th>Agent</th><th>Remembers across sessions</th><th>Can resume one session</th><th>Transcript</th></tr>
+<tr><td>Claude Code</td><td>No</td><td>Yes (<code>--resume</code>)</td><td><code>~/.claude/projects/**/*.jsonl</code></td></tr>
+<tr><td>Codex CLI</td><td>No</td><td>Yes</td><td><code>~/.codex/sessions/**/rollout-*.jsonl</code></td></tr>
+<tr><td>Cursor</td><td>No</td><td>Yes</td><td><code>state.vscdb</code> (SQLite) and <code>~/.cursor</code></td></tr>
+<tr><td>Gemini CLI</td><td>No</td><td>Yes</td><td><code>~/.gemini/tmp/*/chats/</code></td></tr>
+<tr><td>Copilot CLI</td><td>No</td><td>Yes</td><td><code>~/.copilot/session-state/*/events.jsonl</code></td></tr>
+<tr><td>opencode</td><td>No</td><td>Yes</td><td>local database</td></tr>
+<tr><td>aider</td><td>No</td><td>No</td><td><code>~/.aider.chat.history.md</code></td></tr>
+<tr><td>Zed</td><td>No</td><td>No</td><td>application-support database</td></tr>
+</table>
+<p>The <a href="../registry/README.html">format registry</a> has all twenty-one, with the exact glob for each and what a record looks like.</p>
+
+<h2>"But it summarised the session — isn't that memory?"</h2>
+<p>Compaction is what happens when a long session runs out of window: earlier turns are replaced by a summary so the rest keeps fitting. The summary stays inside that session, and it is prose.</p>
+<p>Measured over 43 real compactions from one machine's history (method and corpus in the <a href="benchmarks.html">benchmarks</a>):</p>
+<ul>
+<li><b>77%</b> of the decisions survived the summary.</li>
+<li><b>0.2%</b> of the commands that had actually been run survived it.</li>
+</ul>
+<p>Which matches what it feels like: the agent still knows you chose Postgres, and has no idea what the migration command was.</p>
+
+<h2>How to make it remember</h2>
+<p>Three options, in the order people usually try them.</p>
+<h3>1. Write it down yourself</h3>
+<p>A rules file is read at the start of every session, so anything in it is remembered forever. It is the right home for conventions, the build command, and things not to touch. It is a bad home for history: you have to predict in advance what will matter, and nobody writes down a problem they have not hit twice yet. See <a href="rules-files.html">when CLAUDE.md grows</a>.</p>
+<h3>2. A memory service</h3>
+<p>Memory platforms record facts from the moment you install them, usually through an extraction model. They start empty — the months you already worked are not in them — and they put a network call in a loop that did not have one. <a href="compare.html">Compared here</a>.</p>
+<h3>3. Read the transcripts that already exist</h3>
+<p>Nothing needs recording, because the recording already happened. An index over those files answers "have I seen this before?" including for every session from before you installed anything. That is what <a href="https://github.com/vshulcz/deja-vu">deja</a> is:</p>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto</pre>
+<pre>$ deja "connection pool exhausted"
+[claude] api   · Jul 8 · 8f31c0a9 — 2 matches
+  login started failing after refresh token rotation; jwt kid mismatch in tests
+  fixed by reloading jwks cache after rotateKey and adding a clock-skew test
+[codex]  web   · Jul 1 · b77d91e2 — 1 match
+  refresh token cookie needed SameSite=Lax in local callback flow</pre>
+<p>With auto-recall wired in, the agent runs that lookup itself — at session start, on a prompt that matches earlier work, before it edits a file or runs a command, and after a command fails. It is local: no account, no upload, no model call. <a href="agents.html">Which agent supports which moment</a>.</p>
+
+<p>You do not need any of this to read your own history — the files are yours and they are plain text. <a href="session-files-on-disk.html">What is in them</a> · <a href="find-a-session.html">Finding one session</a> · <a href="getting-started.html">Getting started</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html" aria-current="page">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html" aria-current="page">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html" aria-current="page">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -42,7 +42,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Can you delete Claude Code session files in ~/.claude/projects? — deja-vu</title>
+<meta name="description" content="What Claude Code writes to ~/.claude/projects, how large those JSONL files get in practice, what you lose by deleting them, and how to reclaim space without losing your history.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Claude Code session files: how big they get and whether to delete them">
+<meta property="og:description" content="What is inside ~/.claude/projects, how much space it really uses, and what deleting it costs you.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Claude Code session files: how big they get and whether to delete them">
+<meta name="twitter:description" content="What is inside ~/.claude/projects, how much space it really uses, and what deleting it costs you.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Claude Code session files: how big they get and whether to delete them", "description": "What Claude Code writes to ~/.claude/projects, how large those JSONL files get in practice, what you lose by deleting them, and how to reclaim space without losing your history.", "url": "https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Session files on disk", "item": "https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Can I delete Claude Code session files?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, nothing in the agent breaks. You lose the ability to resume those sessions, any future search over that history, and your record of what the agent ran. Deleting the largest few files usually frees the space without losing much history."}}, {"@type": "Question", "name": "Where does Claude Code store session files?", "acceptedAnswer": {"@type": "Answer", "text": "Under ~/.claude/projects, one directory per project and one JSONL file per session, unless CLAUDE_CONFIG_DIR points elsewhere. Codex uses ~/.codex/sessions and Cursor uses a SQLite state.vscdb."}}, {"@type": "Question", "name": "How much disk space do Claude Code sessions use?", "acceptedAnswer": {"@type": "Answer", "text": "On one machine with thirteen projects and two months of heavy daily use: 875 files totalling 1.6 GB, median 304 KB per session, with a single runaway session accounting for 586 MB."}}, {"@type": "Question", "name": "What is inside a Claude Code .jsonl session file?", "acceptedAnswer": {"@type": "Answer", "text": "JSON Lines: one object per line, appended as the session runs, each carrying a role, timestamp, session id and payload — your prompt, the assistant reply, or a tool call and its output, verbatim."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html" aria-current="page">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Claude Code session files: what they hold, how big they get, whether to delete them</h1>
+<p class="pagelede">875 files and 1.6 GB on one laptop — and one of them was 586 MB<span class="mins" data-mins></span></p>
+
+<p>Every session your agent runs is written to disk as it happens. Claude Code puts JSONL under <code>~/.claude/projects</code>, one directory per project and one file per session; Codex writes <code>~/.codex/sessions/**/rollout-*.jsonl</code>; Cursor uses a SQLite database. <a href="where-sessions-are-stored.html">Where each agent writes</a> has the rest.</p>
+<p>Nobody tells you these files exist until they are large.</p>
+
+<h2>How big they actually get</h2>
+<p>One developer's <code>~/.claude/projects</code>: thirteen projects, two months of heavy daily use.</p>
+<table>
+<tr><th>Measure</th><th>Value</th></tr>
+<tr><td>Session files</td><td>875</td></tr>
+<tr><td>Total size</td><td>1.6 GB</td></tr>
+<tr><td>Median file</td><td>304 KB</td></tr>
+<tr><td>90th percentile</td><td>644 KB</td></tr>
+<tr><td>Largest single file</td><td>586 MB</td></tr>
+</table>
+<p>The distribution is the interesting part: a typical session costs a third of a megabyte, and a handful of runaway sessions carry most of the gigabytes. Growth is driven by tool output, not by how much you typed — a session that catted large files or ran a chatty build is orders of magnitude bigger than one where you talked through a design.</p>
+<p>To find yours:</p>
+<pre>du -sh ~/.claude/projects
+find ~/.claude/projects -name '*.jsonl' -size +50M</pre>
+
+<h2>What is inside one</h2>
+<p>A Claude Code session file is JSON Lines: one JSON object per line, appended as the session runs. Each record carries a role, a timestamp, a session id and the payload — your prompt, the assistant's reply, or a tool call with its result. Codex, Copilot CLI and Antigravity use the same line-per-record shape with different field names; Cursor, Zed, Goose and Hermes use SQLite instead. The <a href="../registry/README.html">format registry</a> documents each one field by field.</p>
+<p>Two consequences worth knowing. It is plain text, so <code>grep</code> works and so does any tool you write. And it is verbatim: whatever scrolled past in your terminal is in there, including anything a command printed. Treat the directory as you would your shell history.</p>
+
+<h2>Can you delete them?</h2>
+<p>Yes — nothing in the agent breaks. What you lose:</p>
+<ul>
+<li><b>Resume.</b> <code>claude --resume</code> lists sessions by reading these files. Delete one and it disappears from the list.</li>
+<li><b>Any history search, forever.</b> Anything that answers "have I hit this before?" reads these files. Deleted transcripts are not recoverable and cannot be re-derived — the agent will not reconstruct them.</li>
+<li><b>Your own audit trail.</b> It is the only record of what an agent actually ran in your repository. See <a href="auditing-agents.html">auditing an agent</a>.</li>
+</ul>
+<p>If you need the space back, delete narrowly rather than emptying the directory:</p>
+<pre># the few outliers, which is usually all the space you need
+find ~/.claude/projects -name '*.jsonl' -size +100M -ls
+
+# a project you will never open again
+rm -rf ~/.claude/projects/-Users-you-old-project</pre>
+<p>Deleting by age is the tempting one and the one to avoid: old sessions are exactly the ones you no longer remember, so they are worth the most per byte.</p>
+
+<h2>Backing them up</h2>
+<p>They are ordinary files, so any backup tool works. If you want them readable somewhere else — a different machine, a different agent, or as Markdown — see <a href="export-conversations.html">exporting sessions</a> and <a href="sync-across-machines.html">across machines</a>.</p>
+
+<h2>Making them useful instead of just large</h2>
+<p>The files are already a complete record of every problem you have solved. What they lack is a way in: opening the right 300 KB file out of 875 is not a thing anyone does by hand.</p>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto</pre>
+<p><a href="https://github.com/vshulcz/deja-vu">deja</a> builds a local index over those transcripts — every agent on the machine, including the sessions from before it was installed — and answers from them in milliseconds. Indexing a few gigabytes takes about ten seconds. Nothing is uploaded and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). On the machine measured above the index is 204 MB against 1.6 GB of transcripts; <a href="token-cost.html">what memory costs</a> has the token side of it.</p>
+
+<p><a href="does-my-agent-remember.html">Does your agent remember previous conversations?</a> · <a href="find-a-session.html">Finding a session</a> · <a href="getting-started.html">Getting started</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -43,7 +43,9 @@
 <aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
 <a href="getting-started.html">Getting started</a>
 <a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
 <a href="where-sessions-are-stored.html" aria-current="page">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
 <a href="find-a-session.html">Finding a session</a>
 <a href="after-compaction.html">After compaction</a>
 <a href="repeated-mistakes.html">Repeated mistakes</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,9 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 
 - [Getting started](https://vshulcz.github.io/deja-vu/guide/getting-started.html): install, wire an agent, and the first query
 - [Why agents forget](https://vshulcz.github.io/deja-vu/guide/forgetting.html): what ends with a session and what survives on disk
+- [Does my agent remember previous conversations](https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html): what Claude Code, Codex and Cursor keep between sessions, and what they do not
 - [Where history lives](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html): the conversation history file each of the twenty agents writes, and its format
+- [Session files on disk](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html): how large ~/.claude/projects gets, what is inside a session file, and what deleting one costs
 - [CLI reference](https://vshulcz.github.io/deja-vu/guide/commands.html): every command and flag
 - [Agents & MCP](https://vshulcz.github.io/deja-vu/guide/agents.html): the six MCP tools, and what each harness supports
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,6 +3,8 @@
   <url><loc>https://vshulcz.github.io/deja-vu/</loc><lastmod>2026-08-11</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/getting-started.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/forgetting.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/after-compaction.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/repeated-mistakes.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
"Does Claude Code remember previous conversations" and "can I delete ~/.claude/projects" are two of the things people type; we had a page for neither. Both answer the question on their own terms, with numbers measured on one machine (875 session files, 1.6 GB, one runaway at 586 MB) rather than a pitch.

Wired into every guide sidebar, the sitemap, llms.txt and both READMEs.