### PR TITLE
fix(goose): index the command it ran and what the command printed

### DIFF
--- a/internal/sources/goose.go
+++ b/internal/sources/goose.go
@@ -113,11 +113,12 @@ func parseGooseFileFromOffset(path string, offset int64) ([]model.Session, error
 		if t.IsZero() {
 			t = parseTimeAny(m["timestamp"])
 		}
-		s.Touch(t)
-		text := gooseText(m["content"])
-		if text != "" {
-			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
+		speech, toolOut, commands, paths := gooseParts(m["content"])
+		if speech == "" && toolOut == "" && len(commands) == 0 && len(paths) == 0 {
+			return
 		}
+		s.Touch(t)
+		appendGooseParts(&s, role, t, speech, toolOut, commands, paths)
 	})
 	if s.Project == "" {
 		s.Project = "goose"
@@ -176,6 +177,148 @@ func gooseText(v any) string {
 	default:
 		return textFromContent(v)
 	}
+}
+
+// appendGooseParts files one row's content under the roles deja indexes, the
+// way the Claude reader does: speech under the speaker, tool output under the
+// role that marks it as a printout, and the command and the paths as their own
+// records so `how`, `blame` and the fix pairs can find them.
+func appendGooseParts(s *model.Session, role string, t time.Time, speech, toolOut string, commands, paths []string) {
+	if speech != "" {
+		s.Messages = append(s.Messages, model.Message{Role: role, Text: capParsedMessage(speech), Time: t})
+	}
+	if toolOut != "" {
+		s.Messages = append(s.Messages, model.Message{Role: RoleToolOutput, Text: capParsedMessage(toolOut), Time: t})
+	}
+	if IndexToolPaths() && len(paths) > 0 {
+		s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: strings.Join(paths, "\n"), Time: t})
+	}
+	for _, cmd := range commands {
+		s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: t})
+	}
+}
+
+// gooseParts splits a goose content array into the four things deja indexes
+// separately. goose stores far more than speech in the same column — measured
+// against goose 1.48.0 by importing a transcript and reading the row back:
+//
+//	toolRequest  {"type":"toolRequest","id":..,"toolCall":{"status":"success",
+//	              "value":{"name":"Bash","arguments":{"command":"go build ./..."}}}}
+//	toolResponse {"type":"toolResponse","id":..,"toolResult":{"status":"success",
+//	              "value":{"resultType":"complete","content":[{"type":"text","text":".."}],
+//	              "isError":false}}}
+//
+// Only `text` parts were read, so a goose store contributed no commands and no
+// tool output at all: `how` had nothing to answer from, and friction and the
+// fix pairs never saw the error a build printed. Every other harness that
+// records structured tool output has had this since the roles were named.
+//
+// The response arrives on a `user` row — goose files a tool result as the
+// user's turn, the same way Claude Code does — so a row that holds only
+// responses is tool output rather than something a person said.
+func gooseParts(v any) (speech, toolOut string, commands, paths []string) {
+	items, ok := gooseContentArray(v)
+	if !ok {
+		return gooseText(v), "", nil, nil
+	}
+	var say, out []string
+	for _, it := range items {
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch m["type"] {
+		case "text":
+			if t := withoutGooseTurnContext(str(m["text"])); t != "" {
+				say = append(say, t)
+			}
+		case "toolRequest":
+			name, args := gooseToolCall(m)
+			if cmd := strings.TrimSpace(str(args["command"])); cmd != "" && worthIndexing(cmd) {
+				commands = append(commands, "$ "+cmd)
+			}
+			// The editor tools name the file they are about to change, which is
+			// what blame reads. `path` is what goose's own editor takes; a tool
+			// from an extension may spell it either way.
+			for _, key := range []string{"path", "file_path"} {
+				if pth := strings.TrimSpace(str(args[key])); pth != "" {
+					paths = append(paths, pth)
+					break
+				}
+			}
+			_ = name
+		case "toolResponse":
+			if t := gooseToolResult(m); t != "" {
+				out = append(out, t)
+			}
+		}
+	}
+	return strings.Join(say, "\n"), strings.Join(out, "\n"), commands, paths
+}
+
+// withoutGooseTurnContext removes the block goose injects ahead of a turn —
+// the clock, the working directory and the standing task list, wrapped in
+// <turn-context>. goose writes it as a message of the user's own role, so
+// every turn on a real store added one and deja indexed it as something the
+// person said. Stripped rather than dropped whole, because a turn that carries
+// both the envelope and real words must keep the words.
+func withoutGooseTurnContext(text string) string {
+	for {
+		open := strings.Index(text, "<turn-context>")
+		if open < 0 {
+			break
+		}
+		close := strings.Index(text[open:], "</turn-context>")
+		if close < 0 {
+			text = text[:open]
+			break
+		}
+		text = text[:open] + text[open+close+len("</turn-context>"):]
+	}
+	return strings.TrimSpace(text)
+}
+
+// gooseContentArray unwraps the column, which holds the array either as JSON
+// text or already decoded, depending on how it was read.
+func gooseContentArray(v any) ([]any, bool) {
+	switch x := v.(type) {
+	case string:
+		var parsed any
+		if json.Unmarshal([]byte(x), &parsed) != nil {
+			return nil, false
+		}
+		items, ok := parsed.([]any)
+		return items, ok
+	case []any:
+		return x, true
+	}
+	return nil, false
+}
+
+func gooseToolCall(m map[string]any) (string, map[string]any) {
+	call, _ := m["toolCall"].(map[string]any)
+	value, _ := call["value"].(map[string]any)
+	args, _ := value["arguments"].(map[string]any)
+	return str(value["name"]), args
+}
+
+// gooseToolResult reads the text a tool produced, from either side of the
+// status: an error carries what went wrong, which is the half friction and the
+// fix pairs are built on.
+func gooseToolResult(m map[string]any) string {
+	res, _ := m["toolResult"].(map[string]any)
+	if value, ok := res["value"].(map[string]any); ok {
+		if t := textFromContent(value["content"]); t != "" {
+			return t
+		}
+	}
+	if e, ok := res["error"].(map[string]any); ok {
+		return strings.TrimSpace(str(e["message"]))
+	}
+	if t := strings.TrimSpace(str(res["error"])); t != "" {
+		return t
+	}
+	return ""
 }
 
 // gooseTypeFilter keeps out of recall what goose wrote for itself: Goose
@@ -311,17 +454,16 @@ func parseGooseDBWhere(db, where string, limit int) ([]model.Session, error) {
 			by[id] = s
 		}
 		role := str(r["role"])
-		txt := gooseText(r["content_json"])
-		if txt == "" {
-			continue
-		}
-		txt = capParsedMessage(txt)
 		t := parseTimeAny(r["created_timestamp"])
 		if t.IsZero() {
 			t = s.Updated
 		}
+		speech, toolOut, commands, paths := gooseParts(r["content_json"])
+		if speech == "" && toolOut == "" && len(commands) == 0 && len(paths) == 0 {
+			continue
+		}
 		s.Touch(t)
-		s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
+		appendGooseParts(s, role, t, speech, toolOut, commands, paths)
 	}
 	if _, err := dec.Token(); err != nil {
 		_ = cmd.Wait()

--- a/internal/sources/goose_parts_test.go
+++ b/internal/sources/goose_parts_test.go
@@ -1,0 +1,138 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The shapes below are goose 1.48.0's own, read off a real store: a transcript
+// was imported with `goose session import` and the row read back, rather than
+// guessed from its source.
+const (
+	gooseToolRequestJSON = `[{"type":"text","text":"Running the build now."},` +
+		`{"type":"toolRequest","id":"t1","toolCall":{"status":"success","value":` +
+		`{"name":"Bash","arguments":{"command":"go build ./... && echo built"}}}}]`
+	gooseToolResponseJSON = `[{"type":"toolResponse","id":"t1","toolResult":{"status":"success","value":` +
+		`{"resultType":"complete","content":[{"type":"text","text":"undefined: snorblefunc in vendor/blarg/api.go\nexit status 2"}],` +
+		`"isError":false}}}]`
+)
+
+// goose stores the command it ran and what the command printed in the same
+// column as speech, and only `text` parts were read — so a goose store
+// contributed no commands and no tool output at all. `how` had nothing to
+// answer from, and friction and the fix pairs never saw the error a build
+// printed.
+func TestGooseKeepsTheCommandAndWhatItPrinted(t *testing.T) {
+	speech, toolOut, commands, _ := gooseParts(gooseToolRequestJSON)
+	if speech != "Running the build now." {
+		t.Errorf("speech = %q", speech)
+	}
+	if len(commands) != 1 || commands[0] != "$ go build ./... && echo built" {
+		t.Errorf("commands = %q", commands)
+	}
+	if toolOut != "" {
+		t.Errorf("a request is not output: %q", toolOut)
+	}
+
+	speech, toolOut, commands, _ = gooseParts(gooseToolResponseJSON)
+	if !strings.Contains(toolOut, "undefined: snorblefunc") || !strings.Contains(toolOut, "exit status 2") {
+		t.Errorf("tool output = %q", toolOut)
+	}
+	if speech != "" || len(commands) != 0 {
+		t.Errorf("a response is not speech or a command: %q %q", speech, commands)
+	}
+}
+
+// goose files a tool result under the user's own role, the way Claude Code
+// does. Indexed as speech it reads as something the person typed, and friction
+// counts it as a person's words rather than a printout.
+func TestAGooseToolResultIsNotFiledAsSpeech(t *testing.T) {
+	s := gooseSessionFrom(t, "user", gooseToolResponseJSON)
+	if len(s.Messages) != 1 {
+		t.Fatalf("want one message, got %d: %#v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != RoleToolOutput {
+		t.Errorf("role = %q, want %q", s.Messages[0].Role, RoleToolOutput)
+	}
+}
+
+// The command is its own record, so `how` and the fix pairs can find it, and
+// it comes after the speech of the turn that ran it.
+func TestAGooseCommandIsItsOwnRecord(t *testing.T) {
+	s := gooseSessionFrom(t, "assistant", gooseToolRequestJSON)
+	if len(s.Messages) != 2 {
+		t.Fatalf("want speech and a command, got %#v", s.Messages)
+	}
+	if s.Messages[0].Role != "assistant" || s.Messages[1].Role != RoleCommand {
+		t.Errorf("roles = %q, %q", s.Messages[0].Role, s.Messages[1].Role)
+	}
+}
+
+// An editor call names the file it is about to change, which is what blame
+// reads. Both spellings, because an extension's tool may take either.
+func TestAGooseEditorCallNamesItsFile(t *testing.T) {
+	for _, key := range []string{"path", "file_path"} {
+		raw := `[{"type":"toolRequest","id":"t2","toolCall":{"status":"success","value":` +
+			`{"name":"developer__text_editor","arguments":{"` + key + `":"/w/app/queue.go","command":"str_replace"}}}}]`
+		_, _, _, paths := gooseParts(raw)
+		if len(paths) != 1 || paths[0] != "/w/app/queue.go" {
+			t.Errorf("%s: paths = %q", key, paths)
+		}
+	}
+}
+
+// The error side of a result is the half friction and the fix pairs are built
+// on, so it cannot be dropped for not being a success.
+func TestAFailedGooseToolStillCarriesWhatWentWrong(t *testing.T) {
+	raw := `[{"type":"toolResponse","id":"t3","toolResult":{"status":"error",` +
+		`"error":{"code":-32603,"message":"command not found: shellcheck"}}}]`
+	_, toolOut, _, _ := gooseParts(raw)
+	if !strings.Contains(toolOut, "command not found: shellcheck") {
+		t.Errorf("tool output = %q", toolOut)
+	}
+}
+
+// goose writes the turn envelope — clock, working directory, standing tasks —
+// as a message of the user's own role, so every turn on a real store added one
+// and deja indexed it as something the person said.
+func TestTheGooseTurnEnvelopeIsNotIndexedAsSpeech(t *testing.T) {
+	raw := `[{"type":"text","text":"<turn-context>\n<current-time>2026-09-02 01:07:00 +03:00</current-time>\n<working-directory>/private/tmp</working-directory>\n</turn-context>"}]`
+	speech, _, _, _ := gooseParts(raw)
+	if speech != "" {
+		t.Errorf("the envelope was kept as speech: %q", speech)
+	}
+
+	// Stripped, not dropped whole: a turn that carries the envelope and real
+	// words has to keep the words.
+	both := `[{"type":"text","text":"<turn-context>\n<current-time>x</current-time>\n</turn-context>\nraise the pool to 40"}]`
+	speech, _, _, _ = gooseParts(both)
+	if speech != "raise the pool to 40" {
+		t.Errorf("speech = %q, want the words without the envelope", speech)
+	}
+}
+
+// A row deja can make nothing of stays out rather than arriving empty.
+func TestAGooseRowWithNothingToIndexIsSkipped(t *testing.T) {
+	for _, raw := range []string{
+		`[{"type":"thinking","thinking":"..."}]`,
+		`[]`,
+		`[{"type":"text","text":"   "}]`,
+	} {
+		speech, toolOut, commands, paths := gooseParts(raw)
+		if speech != "" || toolOut != "" || len(commands) != 0 || len(paths) != 0 {
+			t.Errorf("%s produced %q %q %q %q", raw, speech, toolOut, commands, paths)
+		}
+	}
+}
+
+// gooseSessionFrom runs one row through the same appender both readers use.
+func gooseSessionFrom(t *testing.T, role, raw string) model.Session {
+	t.Helper()
+	var s model.Session
+	speech, toolOut, commands, paths := gooseParts(raw)
+	appendGooseParts(&s, role, time.Unix(0, 0), speech, toolOut, commands, paths)
+	return s
+}


### PR DESCRIPTION
goose keeps a turn's speech, the tool it called and what the tool printed in one `content_json` column. Only `text` parts were read, so a goose store contributed **no commands and no tool output at all** — `how` had nothing to answer from, `friction` and the fix pairs never saw the error a build printed, and `--role tool` matched nothing. Every other harness that records structured tool output has had this since the roles were named; goose was the one that looked fine because speech still arrived.

Read off a real store rather than guessed from goose's source: a transcript imported with `goose session import` on goose 1.48.0, then the row read back.

```json
{"type":"toolRequest","id":"t1","toolCall":{"status":"success","value":
  {"name":"Bash","arguments":{"command":"go build ./... && echo built"}}}}

{"type":"toolResponse","id":"t1","toolResult":{"status":"success","value":
  {"resultType":"complete","content":[{"type":"text","text":"undefined: snorblefunc …"}],"isError":false}}}
```

The same store, before and after, through the built binary:

```
                     before                     after
deja how go          no command mentions "go"   $ go build ./... && echo built (2 runs)
                                                $ go mod vendor && go build ./...
deja fix "undefined: no session ran a command    ran next: $ go mod vendor && go build ./...
  snorblefunc …"       after that error
--role tool          matched nothing            the build's error, in the session that hit it
```

**A tool result arrives on a `user` row** — goose files it as the user's turn, the way Claude Code does — so a row holding only responses is filed as `tool-output` rather than as something a person said. The error half of a result is read too: `status: error` carries what went wrong, which is the half friction and the fix pairs are built on.

**The turn envelope stops being indexed as speech.** goose writes `<turn-context>` — clock, working directory, standing tasks — as a message of the user's own role, so a real store gained one per turn and deja stored each as something the person typed. Stripped rather than dropped whole, because a turn carrying both the envelope and real words has to keep the words.

Both readers get it: the sqlite store and the legacy `.jsonl` files go through the same two functions.

Eight mutations, all red — dropping either part type, filing tool output as speech, dropping the command record, dropping the error half of a result, keeping the envelope, dropping the envelope whole instead of stripping it, and dropping the file path an editor call names.

**Not in this PR, and worth its own decision:** goose 1.48 also has `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `BeforeShellExecution`, `AfterShellExecution` and `AfterFileEdit`, and deja wires only `SessionStart` and `UserPromptSubmit`. That is where the fix pair would arrive at the failure rather than being waited for — filed separately.
