### PR TITLE
fix(goose): put the session-start recall where goose reads it

### DIFF
--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -218,8 +218,56 @@ func gooseConfigDir() string {
 	return filepath.Join(homeDir(), ".config", "goose")
 }
 
+// gooseHintsPath is where the session-start recall goes: AGENTS.md in goose's
+// own config directory.
+//
+// It used to be `.goosehints` beside it, and that never reached the model on
+// goose 1.48 — measured by pointing goose at a stub endpoint and reading the
+// request it sent. Of the places a global file can live, only this one arrives:
+//
+//	<project>/.goosehints          reaches the model
+//	<project>/AGENTS.md            reaches the model
+//	~/.config/goose/AGENTS.md      reaches the model
+//	~/.config/goose/.goosehints    does not
+//	~/.goosehints                  does not
+//	an ancestor directory's .goosehints  does not
+//
+// The file belongs to the reader, so deja edits its own marked block inside it
+// and leaves every other line alone — the same discipline guidance already uses
+// for an AGENTS.md.
 func gooseHintsPath() string {
+	return filepath.Join(gooseConfigDir(), "AGENTS.md")
+}
+
+// retiredGooseHintsPath is the file deja used to write. Install clears its
+// block, because a stale copy of somebody's history sitting in a file nothing
+// reads is the worst of both: invisible and wrong.
+func retiredGooseHintsPath() string {
 	return filepath.Join(gooseConfigDir(), ".goosehints")
+}
+
+const (
+	gooseRecallStart = "<!-- deja recall:start -->"
+	gooseRecallEnd   = "<!-- deja recall:end -->"
+)
+
+// gooseRecallBlock puts the body inside deja's markers, replacing an earlier
+// block and leaving the rest of the file as it was.
+func gooseRecallBlock(doc, body string) string {
+	block := gooseRecallStart + "\n" + strings.TrimRight(body, "\n") + "\n" + gooseRecallEnd + "\n"
+	start := strings.Index(doc, gooseRecallStart)
+	if start < 0 {
+		if strings.TrimSpace(doc) == "" {
+			return block
+		}
+		return strings.TrimRight(doc, "\n") + "\n\n" + block
+	}
+	end := strings.Index(doc[start:], gooseRecallEnd)
+	if end < 0 {
+		return doc[:start] + block
+	}
+	tail := doc[start+end+len(gooseRecallEnd):]
+	return doc[:start] + block + strings.TrimLeft(tail, "\n")
 }
 
 // installGooseAuto adds the session-start half: a plugin hook that refreshes
@@ -235,18 +283,36 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 		// The hook lives in its own plugin directory; leaving it behind means
 		// Goose keeps running a command that no longer exists.
 		_ = os.RemoveAll(filepath.Dir(filepath.Dir(gooseHookPath())))
-		if _, serr := os.Stat(path); serr == nil {
-			if rerr := os.Remove(path); rerr != nil {
-				return installResult{}, rerr
-			}
+		// The recall now lives in the reader's own AGENTS.md, so uninstall
+		// takes deja's block out and leaves the file. Removing it was right
+		// while the target was a `.goosehints` deja owned outright; against
+		// AGENTS.md it would delete whatever the reader had written there.
+		if rerr := dropGooseRecallBlock(path); rerr != nil {
+			return installResult{}, rerr
+		}
+		if rerr := dropRetiredGooseHints(); rerr != nil {
+			return installResult{}, rerr
 		}
 		return res, nil
 	}
 	if err := refreshGooseHints(); err != nil {
 		return installResult{}, err
 	}
-	if err := writeGooseHook(); err != nil {
+	// The hook is the whole of what -auto adds over the plain target, and it
+	// was written without a word: run `deja install goose` and then
+	// `goose-auto` and every line said "unchanged" while the session-start
+	// recall was being switched on. Report the file, the way omp-auto reports
+	// its extension.
+	action, err := writeGooseHook(exe)
+	if err != nil {
 		return installResult{}, err
+	}
+	// Whichever half moved. Reporting the hook alone hid a rewritten config,
+	// and reporting the config alone hid the hook — which is the only thing
+	// -auto adds, so `deja install goose` followed by `goose-auto` said
+	// "unchanged" three times while switching session-start recall on.
+	if action != "unchanged" {
+		return installResult{Path: gooseHookPath(), Action: action}, nil
 	}
 	return res, nil
 }
@@ -258,11 +324,7 @@ func gooseHookPath() string {
 	return filepath.Join(homeDir(), ".agents", "plugins", "deja", "hooks", "hooks.json")
 }
 
-func writeGooseHook() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
+func writeGooseHook(exe string) (string, error) {
 	body, err := json.MarshalIndent(map[string]any{
 		"hooks": map[string]any{
 			"SessionStart": []any{map[string]any{
@@ -288,19 +350,18 @@ func writeGooseHook() error {
 		},
 	}, "", "  ")
 	if err != nil {
-		return err
+		return "", err
 	}
 	body = append(body, '\n')
 	path := gooseHookPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return "", err
 	}
 	old, err := readConfig(path)
 	if err != nil {
-		return err
+		return "", err
 	}
-	_, werr := writeIfChanged(path, old, body)
-	return werr
+	return writeIfChanged(path, old, body)
 }
 
 // cmdGooseHook is what the SessionStart hook runs. Under the wrapper it
@@ -408,8 +469,50 @@ func refreshGooseHintsFor(cwd string) error {
 	if err != nil {
 		return err
 	}
-	_, err = writeIfChanged(path, old, []byte(body))
+	// The MOIM file is deja's own and holds nothing else; AGENTS.md is the
+	// reader's, so only the block between the markers is ours to rewrite.
+	next := []byte(body)
+	if path == gooseHintsPath() {
+		next = []byte(gooseRecallBlock(string(old), body))
+	}
+	if _, err := writeIfChanged(path, old, next); err != nil {
+		return err
+	}
+	return dropRetiredGooseHints()
+}
+
+// dropGooseRecallBlock takes deja's block out of the file and removes the file
+// only when nothing else was in it.
+func dropGooseRecallBlock(path string) error {
+	old, err := readConfig(path)
+	if err != nil || len(old) == 0 {
+		return nil
+	}
+	start := strings.Index(string(old), gooseRecallStart)
+	if start < 0 {
+		return nil
+	}
+	rest := string(old)[start:]
+	end := strings.Index(rest, gooseRecallEnd)
+	next := string(old)[:start]
+	if end >= 0 {
+		next += rest[end+len(gooseRecallEnd):]
+	}
+	if strings.TrimSpace(next) == "" {
+		return os.Remove(path)
+	}
+	_, err = writeIfChanged(path, old, []byte(strings.TrimLeft(next, "\n")))
 	return err
+}
+
+// dropRetiredGooseHints removes the file deja used to write, once it holds
+// nothing but what deja put there.
+func dropRetiredGooseHints() error {
+	path := retiredGooseHintsPath()
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+	return os.Remove(path)
 }
 
 const gooseLead = "The sessions below are from this project's recent history. " +

--- a/cmd/deja/install_goose_agents_test.go
+++ b/cmd/deja/install_goose_agents_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// deja wrote the session-start recall to `.goosehints` in goose's config
+// directory, and goose 1.48 does not read that file. Measured by pointing goose
+// at a stub endpoint and reading the request it sent: a project-local
+// `.goosehints`, a project `AGENTS.md` and `~/.config/goose/AGENTS.md` all
+// arrive; the config-directory `.goosehints`, a `~/.goosehints` and an
+// ancestor's do not. So the block existed, was refreshed every session, and
+// never reached the model.
+func TestGooseRecallGoesWhereGooseReadsIt(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	if _, err := installGooseAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg, "goose", "AGENTS.md")); err != nil {
+		t.Errorf("nothing at the path goose reads: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg, "goose", ".goosehints")); err == nil {
+		t.Error("the file goose does not read was written anyway")
+	}
+}
+
+// An install that upgrades over an older one has to clear the file deja used to
+// write. A stale copy of somebody's history, in a file nothing reads, is the
+// worst of both — invisible and wrong.
+func TestGooseRecallClearsTheFileItUsedToWrite(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	retired := filepath.Join(cfg, "goose", ".goosehints")
+	if err := os.MkdirAll(filepath.Dir(retired), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(retired, []byte("recall from an older deja\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGooseAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(retired); !os.IsNotExist(err) {
+		t.Errorf("the retired file survived the install: %v", err)
+	}
+}
+
+// The file is the reader's. deja edits its own block and leaves the rest, and
+// uninstall takes the block out rather than the file — removing it would delete
+// whatever they had written there.
+func TestGooseRecallLeavesTheRestOfAgentsAlone(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	path := filepath.Join(cfg, "goose", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const mine = "# my own notes\n\nalways use pgx, never database/sql\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGooseAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "always use pgx") {
+		t.Errorf("deja overwrote the reader's file:\n%s", b)
+	}
+	if !strings.Contains(string(b), gooseRecallStart) {
+		t.Errorf("no recall block was added:\n%s", b)
+	}
+
+	if _, err := installGooseAuto("/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("uninstall deleted the reader's file: %v", err)
+	}
+	if !strings.Contains(string(after), "always use pgx") {
+		t.Errorf("uninstall took the reader's lines with it:\n%s", after)
+	}
+	if strings.Contains(string(after), gooseRecallStart) {
+		t.Errorf("deja's block survived uninstall:\n%s", after)
+	}
+}
+
+// A second refresh replaces the block rather than stacking another one, or a
+// long-running install would grow the file a session at a time.
+func TestGooseRecallReplacesItsOwnBlock(t *testing.T) {
+	gooseHomeForTest(t)
+	doc := gooseRecallBlock("", "first")
+	doc = gooseRecallBlock(doc, "second")
+	if n := strings.Count(doc, gooseRecallStart); n != 1 {
+		t.Errorf("%d blocks after a refresh:\n%s", n, doc)
+	}
+	if strings.Contains(doc, "first") || !strings.Contains(doc, "second") {
+		t.Errorf("the block was not replaced:\n%s", doc)
+	}
+}
+
+func gooseHomeForTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	cfg := filepath.Join(home, "cfg")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", "")
+	return cfg
+}

--- a/cmd/deja/install_goose_auto_test.go
+++ b/cmd/deja/install_goose_auto_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The hook is the whole of what -auto adds over the plain target, and it was
+// written without a word: `deja install goose` followed by `deja install
+// goose-auto` printed "unchanged" three times while switching session-start
+// recall on, because the result described the config the first target had
+// already written.
+func TestGooseAutoSaysItWroteTheHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	exe := filepath.Join(home, "bin", "deja")
+	if _, err := installTarget("goose", exe, false); err != nil {
+		t.Fatal(err)
+	}
+	res, err := installTarget("goose-auto", exe, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Path != gooseHookPath() {
+		t.Errorf("reported %q, want the hook it just wrote", res.Path)
+	}
+	if res.Action == "" || res.Action == "unchanged" {
+		t.Errorf("action = %q over a file that did not exist", res.Action)
+	}
+	// And a second run is honestly unchanged, or every session start would
+	// report maintenance that did not happen.
+	again, err := installTarget("goose-auto", exe, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Action != "unchanged" {
+		t.Errorf("a repeat run reported %q", again.Action)
+	}
+
+	// And the other half: the config edited by hand, the hook already right.
+	// Reporting the hook blind would say "unchanged" over a config deja just
+	// put back.
+	config := filepath.Join(gooseConfigDir(), "config.yaml")
+	if err := os.WriteFile(config, []byte("GOOSE_PROVIDER: openai\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	back, err := installTarget("goose-auto", exe, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.Action == "unchanged" {
+		t.Errorf("the config was rewritten and the run reported %q", back.Action)
+	}
+	if back.Path != config {
+		t.Errorf("reported %q, want the config it put back", back.Path)
+	}
+}
+
+// Every other installer wires the binary its caller names. This one called
+// os.Executable() instead, so the hook pointed at whatever process happened to
+// run the install — the test binary under test, and the repair's own binary
+// when a release moved deja somewhere else.
+func TestTheGooseHookWiresTheBinaryItWasGiven(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	const want = "/opt/somewhere/else/deja"
+	if _, err := installTarget("goose-auto", want, false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(gooseHookPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), want) {
+		t.Errorf("the hook does not run the binary it was given:\n%s", b)
+	}
+	if self, err := os.Executable(); err == nil && strings.Contains(string(b), self) {
+		t.Errorf("the hook wired the running process instead:\n%s", b)
+	}
+}

--- a/cmd/deja/install_goose_prompt_test.go
+++ b/cmd/deja/install_goose_prompt_test.go
@@ -13,8 +13,14 @@ func TestGooseHookCoversTheUserPrompt(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	if err := writeGooseHook(); err != nil {
+	action, err := writeGooseHook("/usr/local/bin/deja")
+	if err != nil {
 		t.Fatalf("write: %v", err)
+	}
+	// -auto adds the hook and nothing else; a caller that cannot tell it what
+	// happened reports "unchanged" over a file it just created (#2953).
+	if action == "" || action == "unchanged" {
+		t.Errorf("writing the hook reported %q", action)
 	}
 	b, err := os.ReadFile(gooseHookPath())
 	if err != nil {

--- a/cmd/deja/install_goose_test.go
+++ b/cmd/deja/install_goose_test.go
@@ -110,9 +110,14 @@ func TestInstallGooseAutoWritesHints(t *testing.T) {
 	if _, err := installGooseAuto("/bin/deja", false); err != nil {
 		t.Fatalf("install: %v", err)
 	}
-	hints := filepath.Join(cfg, "goose", ".goosehints")
-	if _, err := os.Stat(hints); err != nil {
+	hints := filepath.Join(cfg, "goose", "AGENTS.md")
+	b, err := os.ReadFile(hints)
+	if err != nil {
 		t.Fatalf("hints not written: %v", err)
+	}
+	// Inside deja's markers, because the file is the reader's.
+	if !strings.Contains(string(b), gooseRecallStart) || !strings.Contains(string(b), gooseRecallEnd) {
+		t.Errorf("the recall is not in a marked block:\n%s", b)
 	}
 	if _, err := installGooseAuto("/bin/deja", true); err != nil {
 		t.Fatalf("uninstall: %v", err)
@@ -178,7 +183,9 @@ func TestGooseRecallPathFollowsMOIM(t *testing.T) {
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
 	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", "")
-	if got := gooseRecallPath(); !strings.HasSuffix(got, ".goosehints") {
+	// AGENTS.md in goose's config directory: the `.goosehints` beside it never
+	// reached the model on goose 1.48.
+	if got := gooseRecallPath(); !strings.HasSuffix(got, filepath.Join("goose", "AGENTS.md")) {
 		t.Fatalf("without MOIM the target is %q", got)
 	}
 	moim := filepath.Join(home, "recall.md")


### PR DESCRIPTION
`deja install goose-auto` wrote the session-start recall to `.goosehints` in goose's config directory. goose 1.48 does not read that file. The hook ran, the file was refreshed every session, and none of it ever reached the model.

Measured rather than read: goose pointed at a stub endpoint that records the request body, one marker per candidate location, one run each.

```
<project>/.goosehints                reaches the model
<project>/AGENTS.md                  reaches the model
~/.config/goose/AGENTS.md            reaches the model
~/.config/goose/.goosehints          does not      <- where deja wrote
~/.goosehints                        does not
an ancestor directory's .goosehints  does not
```

So the recall moves to `AGENTS.md` in the same directory. End to end on goose 1.48 afterwards, from a project with history: the SessionStart hook refreshes the block, and both the block and the recalled session's own text arrive in the request.

**The file is the reader's, so deja edits a marked block inside it** — `<!-- deja recall:start -->` — and leaves every other line. A refresh replaces its own block rather than stacking another. Uninstall takes the block out and removes the file only when nothing else was in it: the old code did `os.Remove`, which was right for a `.goosehints` deja owned outright and would have deleted whatever someone had written in their AGENTS.md. An install also clears the retired `.goosehints`, because a stale copy of somebody's history in a file nothing reads is the worst of both.

**Two more found while validating the wiring.**

`deja install goose-auto` reported nothing about the hook, which is the only thing it adds over the plain target — run `goose` then `goose-auto` and all three lines said "unchanged" while session-start recall was being switched on. It now reports whichever half moved.

`writeGooseHook` called `os.Executable()` instead of wiring the binary its caller named, unlike every other installer. The repair path hid it by happening to run the right binary; an install asked to wire a specific path did not.

**Also measured, not fixed here:** `GOOSE_MOIM_MESSAGE_FILE` does not reach the model on 1.48 either, so the per-turn channel the `deja goose` wrapper relies on is dead as well. That is a separate change and wants its own measurement — filed.

Eight mutations, all red: sending the recall back to the unread file, dropping the markers so the file is overwritten, deleting the reader's file on uninstall, leaving the retired file behind, stacking a second block, and the three on the install reporting and the wired binary.
