### PR TITLE
docs(zh): Chinese guides for the questions people search

### DIFF
--- a/README.zh.md
+++ b/README.zh.md
@@ -69,7 +69,7 @@ dsh plugin --profile web add dsh-deja
 
 ## 能得到什么
 
-**在 Codex 里解决，Claude 记得。** 二十个编程智能体把每一次对话都写进本地文件，
+**在 Codex 里解决，Claude 记得。** 二十一个编程智能体把每一次对话都写进本地文件，
 deja 把这些文件变成一层它们都能读的记忆。
 
 | | |
@@ -245,6 +245,9 @@ rm -rf ~/.cache/deja
 
 按场景写的，不是按功能：
 
+- [快速开始（中文）](https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html)——安装、接上智能体、第一次查询
+- [编程智能体记得之前的对话吗（中文）](https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html)——各个工具跨会话留下了什么
+- [为什么智能体会忘事（中文）](https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html)——会话结束时消失的是什么
 - [编码智能体记得之前的对话吗？](https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html)——每个智能体在会话之间留下了什么，又丢掉了什么
 - [磁盘上的会话文件](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html)——`~/.claude/projects` 会长到多大，删掉要付出什么代价
 - [智能体把你刚才的上下文弄丢了](https://vshulcz.github.io/deja-vu/guide/lost-context.html)——崩溃之后、清空之后，或者会话回来时空空如也

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -7,6 +7,9 @@
 <title>Does Claude Code remember previous conversations? — deja-vu</title>
 <meta name="description" content="Claude Code, Codex, Cursor and Gemini CLI all forget between sessions. What each one keeps on disk, what compaction really preserves, and three ways to get history back.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Does your coding agent remember previous conversations?">
 <meta property="og:description" content="Why every coding agent starts empty, what each keeps on disk, and three ways to give it the history back.">

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -7,6 +7,9 @@
 <title>Your coding agent forgets everything between sessions — deja-vu</title>
 <meta name="description" content="Why coding agents start from scratch every session, what compaction actually keeps, and how to read the history Claude Code, Codex and Cursor already wrote to disk.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/forgetting.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/forgetting.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/forgetting.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Your coding agent forgets everything between sessions">
 <meta property="og:description" content="Why coding agents start from scratch every session, what compaction actually keeps, and how to read the history they already wrote to disk.">

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -7,6 +7,9 @@
 <title>Search your Claude Code and Codex session history in one command — deja-vu</title>
 <meta name="description" content="Install deja and index your coding-agent history in one command, then search it and wire it into your agents over MCP.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Search your Claude Code and Codex session history in one command — deja-vu">
 <meta property="og:description" content="Install deja and index your coding-agent history in one command, then search it and wire it into your agents over MCP.">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,6 +30,12 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 - [Across machines](https://vshulcz.github.io/deja-vu/guide/sync-across-machines.html): sync between machines with no server
 - [What memory costs](https://vshulcz.github.io/deja-vu/guide/token-cost.html): the measured token cost of recall
 
+## 中文
+
+- [快速开始](https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html)：安装、接上智能体、第一次查询
+- [智能体记得之前的对话吗](https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html)：各个工具跨会话留下了什么
+- [为什么会忘事](https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html)：会话结束时消失的是什么，磁盘上留下的是什么
+
 ## Per-harness setup
 
 - [Claude Code, Codex and the rest](https://vshulcz.github.io/deja-vu/guide/harnesses.html): the full support matrix

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -59,4 +59,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/registry/deepseek.html</loc><lastmod>2026-08-21</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/omp.html</loc><lastmod>2026-08-21</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/prime.html</loc><lastmod>2026-08-30</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
 </urlset>

--- a/docs/zh/guide/does-my-agent-remember.html
+++ b/docs/zh/guide/does-my-agent-remember.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="zh-Hans" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Claude Code 记得之前的对话吗？ — deja-vu</title>
+<meta name="description" content="Claude Code、Codex、Cursor、Gemini CLI 都不会跨会话记忆。这篇讲清楚每个工具在磁盘上留下了什么、压缩到底保住了多少，以及把历史找回来的三种办法。">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html">
+<meta property="og:type" content="article">
+<meta property="og:locale" content="zh_CN">
+<meta property="og:title" content="Claude Code 记得之前的对话吗？">
+<meta property="og:description" content="Claude Code、Codex、Cursor、Gemini CLI 都不会跨会话记忆。这篇讲清楚每个工具在磁盘上留下了什么、压缩到底保住了多少，以及把历史找回来的三种办法。">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — 给编程智能体的可搜索本地记忆">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<meta name="twitter:title" content="Claude Code 记得之前的对话吗？">
+<meta name="twitter:description" content="Claude Code、Codex、Cursor、Gemini CLI 都不会跨会话记忆。这篇讲清楚每个工具在磁盘上留下了什么、压缩到底保住了多少，以及把历史找回来的三种办法。">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../../assets/icon.svg">
+<link rel="stylesheet" href="../../assets/site.css">
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<link rel="apple-touch-icon" href="../../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Claude Code 记得之前的对话吗？", "description": "Claude Code、Codex、Cursor、Gemini CLI 都不会跨会话记忆。这篇讲清楚每个工具在磁盘上留下了什么、压缩到底保住了多少，以及把历史找回来的三种办法。", "url": "https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html", "inLanguage": "zh-Hans", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "智能体记得之前的对话吗", "item": "https://vshulcz.github.io/deja-vu/zh/guide/does-my-agent-remember.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Claude Code 记得之前的对话吗？", "acceptedAnswer": {"@type": "Answer", "text": "不记得。智能体的记忆就是上下文窗口，会话结束窗口就被丢弃。会话记录仍然写在 ~/.claude/projects 下，但没有任何东西会去读它，所以新会话从空白开始。"}}, {"@type": "Question", "name": "Codex、Cursor、Gemini CLI 会记得过去的会话吗？", "acceptedAnswer": {"@type": "Answer", "text": "不会。它们都会把会话写到磁盘上，其中几个可以重新打开过去的某一个会话并接着做，但没有一个会主动检索你更早的会话。"}}, {"@type": "Question", "name": "压缩算不算记忆？", "acceptedAnswer": {"@type": "Answer", "text": "只在同一个会话里算，而且只是散文。对 43 次真实压缩的测量：摘要保留了 77% 的决策，以及 0.2% 实际执行过的命令。"}}, {"@type": "Question", "name": "怎么让编程智能体记住之前的会话？", "acceptedAnswer": {"@type": "Answer", "text": "三种办法：手写进 CLAUDE.md 这类规则文件；装一个从安装时开始往后记录的记忆服务；或者给磁盘上已有的会话记录建索引，这样连你安装之前的历史也能搜到。"}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../../"><img src="../../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../../">首页</a><a class="lnk" href="getting-started.html">文档</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../../">← deja-vu</a><div class="grp">中文指南</div>
+<a href="getting-started.html">快速开始</a>
+<a href="does-my-agent-remember.html" aria-current="page">智能体记得之前的对话吗</a>
+<a href="forgetting.html">为什么会忘事</a>
+<div class="grp">English</div>
+<a href="../../guide/getting-started.html">Getting started</a>
+<a href="../../guide/does-my-agent-remember.html">Does my agent remember?</a>
+<a href="../../guide/session-files-on-disk.html">Session files on disk</a>
+<a href="../../guide/harnesses.html">Harnesses</a>
+<a href="../../guide/benchmarks.html">Benchmarks</a>
+<a href="../../guide/compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a>
+<a href="../../registry/README.html">Format registry</a><a class="sidecat" href="../../"><img src="../../assets/icon-live.svg" width="46" height="46" alt=""><span>它记得，你就不必记</span></a></aside>
+<article>
+
+<h1>编程智能体记得之前的对话吗？</h1>
+<p class="pagelede">简短的回答：不记得。但那些对话都还在你的磁盘上<span class="mins" data-mins></span></p>
+
+<p>Claude Code、Codex CLI、Cursor、Gemini CLI 在这件事上是一样的：同一个会话里它记得你说过的每一句话；开一个新会话，它对上一个一无所知——昨天一起修好的 bug、试过又放弃的方案、最后真正跑通的那条命令，全都不在。</p>
+<p>这不是 bug，也不是你漏开了什么开关。智能体在会话中的记忆<b>就是</b>上下文窗口，会话结束，窗口就被丢掉了。</p>
+
+<h2>三样东西都叫「记忆」</h2>
+<table>
+<tr><th>机制</th><th>跨会话保留</th><th>里面有什么</th></tr>
+<tr><td>上下文窗口</td><td>否</td><td>当前会话的全部内容，直到装不下为止</td></tr>
+<tr><td>规则文件（<code>CLAUDE.md</code>、<code>AGENTS.md</code>）</td><td>是</td><td>只有你亲手写进去的那些</td></tr>
+<tr><td>磁盘上的会话记录</td><td>是，但没有人去读</td><td>每一轮对话、每条命令、每个报错，原样保存</td></tr>
+</table>
+<p>所以老实的回答是：你的智能体把发生过的一切都写下来了，然后再也没打开过那个文件。</p>
+
+<h2>各家的情况</h2>
+<p>下面每一个都会把会话写到磁盘上。「能恢复会话」指这个工具可以重新打开过去的某一个会话并接着做，但没有一个会主动去检索你更早的会话。</p>
+<table>
+<tr><th>工具</th><th>跨会话记忆</th><th>能恢复单个会话</th><th>记录位置</th></tr>
+<tr><td>Claude Code</td><td>否</td><td>是（<code>--resume</code>）</td><td><code>~/.claude/projects/**/*.jsonl</code></td></tr>
+<tr><td>Codex CLI</td><td>否</td><td>是</td><td><code>~/.codex/sessions/**/rollout-*.jsonl</code></td></tr>
+<tr><td>Cursor</td><td>否</td><td>是</td><td><code>state.vscdb</code>（SQLite）与 <code>~/.cursor</code></td></tr>
+<tr><td>Gemini CLI</td><td>否</td><td>是</td><td><code>~/.gemini/tmp/*/chats/</code></td></tr>
+<tr><td>Copilot CLI</td><td>否</td><td>是</td><td><code>~/.copilot/session-state/*/events.jsonl</code></td></tr>
+<tr><td>DeepSeek Harness（dsh）</td><td>否</td><td>否</td><td><code>~/.dsh/sessions/*/session-*/session.jsonl.zstd</code></td></tr>
+<tr><td>Kimi Code</td><td>否</td><td>是</td><td><code>~/.kimi-code/sessions/*/*/agents/main/wire.jsonl</code></td></tr>
+<tr><td>Qwen Code</td><td>否</td><td>是</td><td><code>~/.qwen/projects/*/chats/*.jsonl</code></td></tr>
+</table>
+<p><a href="../../registry/README.html">格式登记表</a>里有全部二十一个工具：各自的路径通配符，以及一条记录长什么样。</p>
+
+<h2>「它不是给会话做了总结吗？」</h2>
+<p>压缩（compaction）是会话变长、窗口装不下时发生的事：早先的轮次被一段摘要替换掉，剩下的才放得进去。这段摘要只活在那个会话里，而且它是散文。</p>
+<p>在一台机器上对 43 次真实压缩做的测量（方法和语料见<a href="../../guide/benchmarks.html">评测</a>）：</p>
+<ul>
+<li>决策保留了 <b>77%</b>。</li>
+<li>实际跑过的命令保留了 <b>0.2%</b>。</li>
+</ul>
+<p>这和使用时的感受是一致的：它还记得你们选了 Postgres，但完全不知道当时的迁移命令是什么。</p>
+
+<h2>怎么让它记住</h2>
+<h3>1. 自己写下来</h3>
+<p>规则文件每次会话开始都会被读一遍，写进去的东西就永远记得。它适合放约定、构建命令、不要碰的地方；不适合放历史——你得提前预判什么以后会用到，而没有人会去记录一个还没踩到第二次的坑。</p>
+<h3>2. 记忆服务</h3>
+<p>这类平台从你装上它的那一刻开始往后记录，通常还要靠一个抽取模型。它们从空的开始——你之前几个月的工作不在里面——并且给本来不需要联网的流程加进了一次网络调用。</p>
+<h3>3. 直接读已经存在的会话记录</h3>
+<p>不需要提前记录，因为记录早就发生了。在这些文件上建一个索引，就能回答「这个我是不是遇到过」——包括你装任何工具之前的每一个会话。<a href="https://github.com/vshulcz/deja-vu">deja</a> 做的就是这件事：</p>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto</pre>
+<pre>$ deja "connection pool exhausted"
+[claude] api   · Jul 8 · 8f31c0a9 — 2 matches
+  login started failing after refresh token rotation; jwt kid mismatch in tests
+  fixed by reloading jwks cache after rotateKey and adding a clock-skew test
+[codex]  web   · Jul 1 · b77d91e2 — 1 match
+  refresh token cookie needed SameSite=Lax in local callback flow</pre>
+<p>接上自动召回之后，这次查询是智能体自己发起的：会话开始时、提问命中过去的工作时、动手改文件或执行命令之前、命令失败之后。全部在本地：不需要账号，不上传，也不调用模型。</p>
+
+<p>就算你不装任何东西，这些历史也是你自己的，而且是纯文本。<a href="getting-started.html">快速开始</a> · <a href="forgetting.html">为什么会忘事</a> · <a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a></p>
+
+</article>
+</div>
+<footer>deja-vu 采用 MIT 许可，全部在本地运行。<a href="https://github.com/vshulcz/deja-vu">GitHub 源码</a> · <a href="../../">首页</a></footer>
+</div>
+<script src="../../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/zh/guide/forgetting.html
+++ b/docs/zh/guide/forgetting.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="zh-Hans" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>为什么智能体在会话之间会忘事 — deja-vu</title>
+<meta name="description" content="会话结束时上下文窗口被丢弃，但会话记录还在磁盘上。这篇讲压缩到底保住了什么、丢掉了什么，以及为什么直接 grep 日志代价高得多。">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/forgetting.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/forgetting.html">
+<meta property="og:type" content="article">
+<meta property="og:locale" content="zh_CN">
+<meta property="og:title" content="为什么智能体在会话之间会忘事">
+<meta property="og:description" content="会话结束时上下文窗口被丢弃，但会话记录还在磁盘上。这篇讲压缩到底保住了什么、丢掉了什么，以及为什么直接 grep 日志代价高得多。">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — 给编程智能体的可搜索本地记忆">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<meta name="twitter:title" content="为什么智能体在会话之间会忘事">
+<meta name="twitter:description" content="会话结束时上下文窗口被丢弃，但会话记录还在磁盘上。这篇讲压缩到底保住了什么、丢掉了什么，以及为什么直接 grep 日志代价高得多。">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../../assets/icon.svg">
+<link rel="stylesheet" href="../../assets/site.css">
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<link rel="apple-touch-icon" href="../../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "为什么智能体在会话之间会忘事", "description": "会话结束时上下文窗口被丢弃，但会话记录还在磁盘上。这篇讲压缩到底保住了什么、丢掉了什么，以及为什么直接 grep 日志代价高得多。", "url": "https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html", "inLanguage": "zh-Hans", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "为什么会忘事", "item": "https://vshulcz.github.io/deja-vu/zh/guide/forgetting.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "为什么智能体在会话之间会忘事？", "acceptedAnswer": {"@type": "Answer", "text": "会话的上下文窗口在会话结束时被丢弃。会话记录仍然写在磁盘上——Claude Code、Codex、Cursor 各写各的——但没有东西会把它读回来，所以下一个会话从空白开始。"}}, {"@type": "Question", "name": "压缩会保住会话早先的内容吗？", "acceptedAnswer": {"@type": "Answer", "text": "只保住一部分。对 43 次真实压缩的测量：摘要保留了 77% 的决策，以及 0.2% 实际执行过的命令。散文活下来了，具体的工作没有。"}}, {"@type": "Question", "name": "智能体能读到我装工具之前的会话吗？", "acceptedAnswer": {"@type": "Answer", "text": "可以，前提是这个工具索引的是磁盘上已有的会话记录，而不是从安装那一刻开始往后记录。那些文件里有几个月的历史，早于任何记忆工具的存在。"}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../../"><img src="../../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../../">首页</a><a class="lnk" href="getting-started.html">文档</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../../">← deja-vu</a><div class="grp">中文指南</div>
+<a href="getting-started.html">快速开始</a>
+<a href="does-my-agent-remember.html">智能体记得之前的对话吗</a>
+<a href="forgetting.html" aria-current="page">为什么会忘事</a>
+<div class="grp">English</div>
+<a href="../../guide/getting-started.html">Getting started</a>
+<a href="../../guide/does-my-agent-remember.html">Does my agent remember?</a>
+<a href="../../guide/session-files-on-disk.html">Session files on disk</a>
+<a href="../../guide/harnesses.html">Harnesses</a>
+<a href="../../guide/benchmarks.html">Benchmarks</a>
+<a href="../../guide/compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a>
+<a href="../../registry/README.html">Format registry</a><a class="sidecat" href="../../"><img src="../../assets/icon-live.svg" width="46" height="46" alt=""><span>它记得，你就不必记</span></a></aside>
+<article>
+
+<h1>为什么你的智能体每次都从零开始</h1>
+<p class="pagelede">上下文窗口没了；会话记录还在<span class="mins" data-mins></span></p>
+
+<p>三月份你解决过一个问题。八月份，同一个智能体、同一个仓库，它提出的正是你当时试过又退掉的方案。没有什么坏掉了——装着答案的那个会话结束了，它的上下文窗口也跟着没了。</p>
+
+<h2>会话结束时到底发生了什么</h2>
+<p>会话期间，智能体的记忆就是上下文窗口；会话结束，窗口被丢弃。留下来的是一份会话记录，由工具自己写：Claude Code 写在 <code>~/.claude/projects</code> 下的 JSONL，Codex 在 <code>~/.codex</code>，opencode 用本地数据库，Cursor、Gemini CLI、Zed 等等各有各的格式。<a href="../../registry/README.html">格式登记表</a>写清了每一个写在哪里、记录长什么样。</p>
+<p>所以工作并没有丢，只是没人去读。默认配置里，没有任何东西会在你今天提问时打开昨天的记录。</p>
+
+<h2>压缩不是记忆</h2>
+<p>长会话会压缩：工具用一段摘要替换掉早先的轮次，好让窗口继续装得下。摘要是散文，而散文不是你需要拿回来的东西。</p>
+<p>对一台机器上 43 次真实压缩的测量：</p>
+<ul>
+<li>决策保留 <b>77%</b>。</li>
+<li>实际执行过的命令保留 <b>0.2%</b>。</li>
+</ul>
+<p>这个落差就是问题本身。推理进了摘要；那条带四个参数才跑通的命令、你贴进去的报错原文、某次编辑替换掉的那一段——恰恰是摘要最先丢掉的，也恰恰是你再次撞墙时最需要的。</p>
+
+<h2>人们试过的三条路</h2>
+<h3>规则文件</h3>
+<p><code>CLAUDE.md</code>、<code>AGENTS.md</code> 每个会话都会被读，所以它们是放长期约定的好地方——代码风格、构建命令、别动哪里。放历史就不合适：每条事实都得手写，而还没踩到第二次的坑，没有人会去写。</p>
+<h3>记忆服务</h3>
+<p>记忆平台从安装那一刻开始往后记录，通常在写入时用模型抽取一遍事实。它们能用，但一开始是空的：安装之前的几个月不在里面，抽取步骤认为「不算事实」的东西也不在。</p>
+<h3>读你已经有的会话记录</h3>
+<p>第三条路把日志本身当成记忆。不需要提前记录，因为记录已经发生了——包括工具装上之前的一切。<a href="https://github.com/vshulcz/deja-vu">deja</a> 就是这么做的：在本地给这些文件建索引，谁来问就交给谁。</p>
+
+<h2>为什么不直接 grep 日志</h2>
+<p>因为代价。在三十条任务链的评测语料上，靠 grep 原始记录拿到同样的工作上下文，中位数花了 <b>57,489</b> tokens；重放完整历史花 <b>16,919</b>；召回在同样的事实覆盖率下花 <b>286</b>，而在历史里本来就没有答案的链上一个 token 都不花。这些数字、语料生成器和相关性标注都在仓库里——在相信任何一个数字之前，包括我们的，先去看「相关」是怎么定义的。</p>
+
+<h2>它不做什么</h2>
+<p>它不写记忆，所以编不出记忆。它不往外发东西：索引和检索都在本地，凭据在建索引时就被脱敏。它不会让智能体更聪明；它只是让它不再从空白开始。</p>
+
+<p><a href="getting-started.html">快速开始</a> · <a href="does-my-agent-remember.html">智能体记得之前的对话吗</a> · <a href="https://github.com/vshulcz/deja-vu">源码</a></p>
+
+</article>
+</div>
+<footer>deja-vu 采用 MIT 许可，全部在本地运行。<a href="https://github.com/vshulcz/deja-vu">GitHub 源码</a> · <a href="../../">首页</a></footer>
+</div>
+<script src="../../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/zh/guide/getting-started.html
+++ b/docs/zh/guide/getting-started.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="zh-Hans" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>deja 快速开始：让编程智能体能搜自己的会话历史 — deja-vu</title>
+<meta name="description" content="安装 deja、确认它认出了哪些工具、在 Claude Code 与 Codex 的历史里搜索，并把自动召回接到智能体上。全部在本地，不需要账号。">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html">
+<link rel="alternate" hreflang="zh-Hans" href="https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html">
+<link rel="alternate" hreflang="en" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
+<link rel="alternate" hreflang="x-default" href="https://vshulcz.github.io/deja-vu/guide/getting-started.html">
+<meta property="og:type" content="article">
+<meta property="og:locale" content="zh_CN">
+<meta property="og:title" content="deja 快速开始：让编程智能体能搜自己的会话历史">
+<meta property="og:description" content="安装 deja、确认它认出了哪些工具、在 Claude Code 与 Codex 的历史里搜索，并把自动召回接到智能体上。全部在本地，不需要账号。">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — 给编程智能体的可搜索本地记忆">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<meta name="twitter:title" content="deja 快速开始：让编程智能体能搜自己的会话历史">
+<meta name="twitter:description" content="安装 deja、确认它认出了哪些工具、在 Claude Code 与 Codex 的历史里搜索，并把自动召回接到智能体上。全部在本地，不需要账号。">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../../assets/icon.svg">
+<link rel="stylesheet" href="../../assets/site.css">
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<link rel="apple-touch-icon" href="../../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "deja 快速开始：让编程智能体能搜自己的会话历史", "description": "安装 deja、确认它认出了哪些工具、在 Claude Code 与 Codex 的历史里搜索，并把自动召回接到智能体上。全部在本地，不需要账号。", "url": "https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html", "inLanguage": "zh-Hans", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "快速开始", "item": "https://vshulcz.github.io/deja-vu/zh/guide/getting-started.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "怎么安装 deja？", "acceptedAnswer": {"@type": "Answer", "text": "一条 curl 安装脚本，然后 deja install --auto。也可以用 Homebrew 安装，或从 GitHub releases 下载二进制。安装约十秒，首次建索引约十秒。"}}, {"@type": "Question", "name": "deja 需要联网或者 API key 吗？", "acceptedAnswer": {"@type": "Answer", "text": "不需要。索引和检索都在本地，默认没有账号、没有网络调用，也不需要模型。"}}, {"@type": "Question", "name": "deja 能搜到安装之前的会话吗？", "acceptedAnswer": {"@type": "Answer", "text": "能。它索引的是各个工具本来就写在磁盘上的会话记录，所以第一次建完索引，安装之前的历史就已经可以搜到了。"}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../../"><img src="../../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../../">首页</a><a class="lnk" href="getting-started.html">文档</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../../">← deja-vu</a><div class="grp">中文指南</div>
+<a href="getting-started.html" aria-current="page">快速开始</a>
+<a href="does-my-agent-remember.html">智能体记得之前的对话吗</a>
+<a href="forgetting.html">为什么会忘事</a>
+<div class="grp">English</div>
+<a href="../../guide/getting-started.html">Getting started</a>
+<a href="../../guide/does-my-agent-remember.html">Does my agent remember?</a>
+<a href="../../guide/session-files-on-disk.html">Session files on disk</a>
+<a href="../../guide/harnesses.html">Harnesses</a>
+<a href="../../guide/benchmarks.html">Benchmarks</a>
+<a href="../../guide/compare.html">Compare</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a>
+<a href="../../registry/README.html">Format registry</a><a class="sidecat" href="../../"><img src="../../assets/icon-live.svg" width="46" height="46" alt=""><span>它记得，你就不必记</span></a></aside>
+<article>
+
+<h1>快速开始</h1>
+<p class="pagelede">装十秒，建索引十秒，然后智能体就能查自己的历史了<span class="mins" data-mins></span></p>
+
+<h2>安装</h2>
+<pre>curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
+deja install --auto</pre>
+<p>第二条命令做三件事：把 MCP 召回接到它在这台机器上找到的每一个智能体，在支持的地方打开会话启动时的自动召回，并建好第一份索引。也可以用 Homebrew（<code>brew install deja-vu</code>）或从 <a href="https://github.com/vshulcz/deja-vu/releases">releases</a> 直接下二进制。</p>
+<p>建索引读的是你磁盘上<b>已经有</b>的会话记录，所以第一次跑完，你几个月前的工作就已经能搜到了——不需要提前记录任何东西。</p>
+
+<h2>先确认它看到了什么</h2>
+<pre>deja sources
+deja stats</pre>
+<p><code>sources</code> 列出它在每个工具下找到的路径和会话数；<code>stats</code> 给出索引里有多少会话、来自哪些项目、活跃度如何。如果某个工具没被认出来，<a href="../../guide/harnesses.html">支持矩阵</a>里有它期望的路径和对应的环境变量。</p>
+
+<h2>自己搜一下</h2>
+<pre>$ deja "connection pool exhausted"
+[claude] api   · Jul 8 · 8f31c0a9 — 2 matches
+  login started failing after refresh token rotation; jwt kid mismatch in tests
+  fixed by reloading jwks cache after rotateKey and adding a clock-skew test
+[codex]  web   · Jul 1 · b77d91e2 — 1 match
+  refresh token cookie needed SameSite=Lax in local callback flow</pre>
+<p>几条常用的：</p>
+<ul>
+<li><code>deja "报错原文"</code> —— 跨所有工具搜历史。</li>
+<li><code>deja fix "报错原文"</code> —— 上次这个报错之后，真正跑通的是哪条命令。</li>
+<li><code>deja how "docker build"</code> —— 你在这台机器上实际用过的调用方式。</li>
+<li><code>deja show &lt;id&gt;</code> —— 打开某一个会话；<code>deja last</code> 列出最近的。</li>
+<li><code>deja blame &lt;文件&gt;</code> —— 哪些会话动过这个文件、当时在做什么。</li>
+</ul>
+
+<h2>让智能体自己去查</h2>
+<p><code>deja install --auto</code> 已经把这条路接好了。之后是智能体自己发起召回，不用你开口：会话开始时、提问命中过去的工作时、改文件或执行命令之前、命令失败之后。哪个工具支持哪一个时机，见<a href="../../guide/agents.html">agents 指南</a>。</p>
+<p>只想手动用也完全可以：不接自动召回，deja 就只是一个命令行搜索工具。</p>
+
+<h2>关于隐私</h2>
+<p>索引和检索都在本地，默认不需要网络、账号或 API key。建索引时凭据会被脱敏。除非你显式配置了远程 embedding 端点，否则没有任何内容离开这台机器——细节见<a href="../../guide/privacy.html">隐私说明</a>。</p>
+
+<h2>不想要了</h2>
+<pre>deja uninstall --all
+rm -rf ~/.cache/deja</pre>
+<p>会话记录本来就是各个工具自己写的，deja 不动它们。</p>
+
+<p><a href="does-my-agent-remember.html">智能体记得之前的对话吗</a> · <a href="forgetting.html">为什么会忘事</a> · <a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a></p>
+
+</article>
+</div>
+<footer>deja-vu 采用 MIT 许可，全部在本地运行。<a href="https://github.com/vshulcz/deja-vu">GitHub 源码</a> · <a href="../../">首页</a></footer>
+</div>
+<script src="../../assets/guide.js" defer></script>
+</body>
+</html>

--- a/extensions/dsh/docs/zh.md
+++ b/extensions/dsh/docs/zh.md
@@ -4,7 +4,7 @@
 
 DeepSeek Harness 自带的 `session-query` 已经可以检索它自己的会话。这个插件回答的是另一个问题：你在这台机器上**其他**智能体里做过什么。
 
-deja 索引 Claude Code、Codex、Cursor、opencode、Antigravity、Grok Build、Kimi、Cline、Zed 等二十个智能体本来就写在磁盘上的会话文件。不需要提前录制：历史已经在那里，包括安装 deja 之前的那些月份。如果你上周才转到 dsh，上周之前做过的事仍然可以在 dsh 里查到。
+deja 索引 Claude Code、Codex、Cursor、opencode、Antigravity、Grok Build、Kimi、Cline、Zed 等二十一个智能体本来就写在磁盘上的会话文件。不需要提前录制：历史已经在那里，包括安装 deja 之前的那些月份。如果你上周才转到 dsh，上周之前做过的事仍然可以在 dsh 里查到。
 
 ## 安装
 


### PR DESCRIPTION
The dsh extension ships a Chinese doc and the README has a Chinese twin, but none of the guide pages do, so a Chinese-speaking reader gets the reference and not the answers. Three pages, mirroring the English ones people arrive on: does my agent remember previous conversations, why it forgets, and getting started.

hreflang is reciprocal with the English twins, and the pages are in the sitemap and llms.txt. Also fixes the harness count in README.zh.md and the dsh Chinese doc — both still said twenty.
