### PR TITLE
docs(extensions): the npm pages were still describing nineteen agents

### DIFF
--- a/cmd/deja/readme_harness_count_test.go
+++ b/cmd/deja/readme_harness_count_test.go
@@ -191,3 +191,53 @@ func TestNpmReadmeLeadsWithWhatTheMainOneLeadsWith(t *testing.T) {
 		}
 	}
 }
+
+// The two npm pages count what a plugin brings its host: every harness except
+// the host itself. Between them they are installed a couple of thousand times a
+// week — more people than the site sees — and both were describing nineteen
+// agents months after there were twenty, because the count was written relative
+// to whatever the sentence had just listed ("and ten more") and nothing could
+// check that against anything.
+func TestPluginPagesCountTheOtherHarnesses(t *testing.T) {
+	root := filepath.Join("..", "..")
+	want, words := harnessCountWords(t, root, -1)
+
+	for _, name := range []string{
+		"extensions/dsh/package.json",
+		"extensions/dsh/README.md",
+		"extensions/opencode/package.json",
+		"extensions/opencode/README.md",
+	} {
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(name)))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		text := strings.ToLower(string(b))
+		rest := strings.ReplaceAll(text, want, "")
+		for _, stale := range words {
+			if stale != want && strings.Contains(rest, stale) {
+				t.Errorf("%s still counts %q other agents; there are %s", name, stale, want)
+			}
+		}
+		if !strings.Contains(text, want) {
+			t.Errorf("%s never says %q, which is how many other agents deja reads", name, want)
+		}
+	}
+}
+
+// harnessCountWords is the registry count plus an offset, as a word, together
+// with the words this test knows — a page that counts the harnesses says the
+// first, and a page that counts the other ones says it with offset -1.
+func harnessCountWords(t *testing.T, root string, offset int) (string, map[int]string) {
+	t.Helper()
+	n := registryHarnessCount(t, root) + offset
+	words := map[int]string{
+		15: "fifteen", 16: "sixteen", 17: "seventeen", 18: "eighteen",
+		19: "nineteen", 20: "twenty", 21: "twenty-one",
+	}
+	want, ok := words[n]
+	if !ok {
+		t.Fatalf("the count is %d and this test has no word for it; add one", n)
+	}
+	return want, words
+}

--- a/extensions/dsh/README.md
+++ b/extensions/dsh/README.md
@@ -1,14 +1,14 @@
 # dsh-deja
 
-English | [中文](docs/zh.md)
+English | [中文](https://github.com/vshulcz/deja-vu/blob/main/extensions/dsh/docs/zh.md)
 
 DeepSeek Harness can already search its own sessions — that is what the built-in
 `session-query` subsystem does. This plugin answers the other question: what you
 did in the *other* agents on this machine.
 
-deja indexes the session files that Claude Code, Codex, Cursor, opencode,
-Antigravity, Grok Build, Kimi, Cline, Zed and ten more agents already write to
-disk. Nothing has to have been recorded ahead of time: the history is already
+deja indexes the session files that twenty other coding agents — Claude Code,
+Codex, Cursor, opencode, Antigravity, Grok Build, Kimi, Cline and Zed among
+them — already write to disk. Nothing has to have been recorded ahead of time: the history is already
 there, including the months before deja was installed. If you moved to dsh last
 week, everything you did before last week is still reachable from inside it.
 

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-deja",
   "version": "0.20.4",
-  "description": "Brings the session history of nineteen other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
+  "description": "Brings the session history of twenty other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/extensions/opencode/README.md
+++ b/extensions/opencode/README.md
@@ -1,8 +1,9 @@
 # opencode-deja
 
 opencode remembers its own sessions. This plugin answers the other question:
-what you did in Claude Code, Codex, Cursor, Gemini, Zed and fifteen more agents
-on this machine — including the months before you installed anything.
+what you did in the twenty other coding agents on this machine — Claude Code,
+Codex, Cursor, Gemini and Zed among them — including the months before you
+installed anything.
 
 It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that
 indexes the transcripts those agents already wrote to disk. No LLM, no

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-deja",
   "version": "0.1.2",
-  "description": "Brings the session history of nineteen other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
+  "description": "Brings the session history of twenty other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
   "type": "module",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
dsh-deja is installed ~1,800 times a week and opencode-deja ~770 — between them more people than the docs site sees in a fortnight. Both npm pages described nineteen agents, because the count in them was written relative to whatever the sentence had just listed ("and ten more"), which nothing could check. Absolute now, and pinned to the registry by a test that counts the *other* harnesses, since that is what a plugin page counts.

The Chinese link in the dsh README was relative, so it did not resolve on npm.