### PR TITLE
fix(goose): /deja takes a query

### DIFF
--- a/cmd/deja/install_goose_command.go
+++ b/cmd/deja/install_goose_command.go
@@ -25,8 +25,16 @@ func gooseRecipe(exe string) string {
 	return `version: 1.0.0
 title: deja
 description: Search this machine's past AI coding sessions (deja-vu)
+prompt: |
+  {{ query }}
 instructions: |
-` + indentLines(commandBody(exe, "the user's request"), "  ")
+` + indentLines(commandBody(exe, "the user's request"), "  ") + `parameters:
+  - key: query
+    input_type: string
+    requirement: optional
+    default: ""
+    description: what to look for; omit to search from what was already said
+`
 }
 
 func indentLines(s, pad string) string {

--- a/cmd/deja/install_goose_recipe_param_test.go
+++ b/cmd/deja/install_goose_recipe_param_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `/deja` took no argument. Typing `/deja pgbouncer timeout` answered "Recipe
+// /deja: Unexpected positional argument: pgbouncer" — goose does not map
+// positionals onto a recipe, so the only working form is a named parameter,
+// and a recipe that declares one has to use it or goose refuses the whole
+// recipe with "Unnecessary parameter definitions".
+//
+// Measured against goose 1.48 with a stub endpoint: with the parameter declared
+// and referenced, `/deja --query "pgbouncer timeout"` puts the query in front
+// of the model, and bare `/deja` still carries the instructions.
+func TestTheGooseRecipeTakesAQuery(t *testing.T) {
+	r := gooseRecipe("/usr/local/bin/deja")
+
+	if !strings.Contains(r, "key: query") {
+		t.Errorf("no query parameter is declared:\n%s", r)
+	}
+	// Declared and used, or goose rejects the recipe outright.
+	if !strings.Contains(r, "{{ query }}") {
+		t.Errorf("the parameter is declared and never used:\n%s", r)
+	}
+	// Optional, or the bare `/deja` a reader types first stops working.
+	if !strings.Contains(r, "requirement: optional") {
+		t.Errorf("the parameter is not optional:\n%s", r)
+	}
+	// And the instructions are still there: the query is what to look for, the
+	// instructions are how to look.
+	if !strings.Contains(r, "instructions: |") {
+		t.Errorf("the recipe lost its instructions:\n%s", r)
+	}
+}
+
+// The parameter block sits after the instructions, not inside them: indented
+// under `instructions: |` it would be part of the prose the model reads rather
+// than something goose parses.
+func TestTheGooseRecipeParameterIsNotSwallowedByTheInstructions(t *testing.T) {
+	r := gooseRecipe("/usr/local/bin/deja")
+	params := strings.Index(r, "parameters:")
+	if params < 0 {
+		t.Fatalf("no parameters block:\n%s", r)
+	}
+	line := r[params:]
+	if strings.HasPrefix(line, "  parameters:") {
+		t.Errorf("the parameters block is indented into the instructions:\n%s", r)
+	}
+	for _, l := range strings.Split(r, "\n") {
+		if strings.TrimSpace(l) == "parameters:" && l != "parameters:" {
+			t.Errorf("parameters is written at %q, want the first column", l)
+		}
+	}
+}


### PR DESCRIPTION
`/deja pgbouncer timeout` answered:

```
Recipe /deja: Unexpected positional argument: pgbouncer
```

Which is the form a reader types first. goose does not map positionals onto a recipe — the working shape is a named parameter, and a recipe that declares one without referencing it is refused outright with `Unnecessary parameter definitions: query`. So both halves are needed: `{{ query }}` in the prompt and the parameter block after the instructions.

Measured against goose 1.48 through a stub endpoint that records the request:

```
/deja --query "pgbouncer timeout"   the query and the instructions reach the model
/deja                               the instructions reach the model
```

Optional with an empty default, so the bare call a reader makes first keeps working — that is the case the mutation `requirement: required` covers.

The block goes after the instructions rather than inside them: indented one level it becomes prose the model reads instead of something goose parses, which is the fourth mutation.

Four mutations, all red.

**Not fixed, because goose owns it:** `/deja some text` still errors. deja cannot change how goose parses a recipe's arguments; what it can do is make the named form work and say so in the parameter's description.