### PR TITLE
chore(packaging): say what the thing does where people search for it

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,7 +137,11 @@ brews:
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: https://github.com/vshulcz/deja-vu
-    description: Persistent memory for your coding agents
+    # What people type into `brew search`, which matches names and
+    # descriptions: the old line said neither the agents nor the thing it
+    # searches, so `brew search claude` and `brew search session history`
+    # both missed us.
+    description: Search Claude Code, Codex and Cursor session history locally
     license: MIT
 
 # nfpms intentionally omitted for now; add .deb/.rpm packaging when distro packages are needed.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vshulcz/deja-vu",
   "version": "0.0.0",
-  "description": "Persistent memory for your coding agents",
+  "description": "Search the sessions your coding agents already wrote to disk — Claude Code, Codex, Cursor and the rest — locally, from the CLI or over MCP.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`brew search` matches formula names and descriptions. Ours read "Persistent memory for your coding agents" — no "Claude Code", no "Codex", no "session history", so a search for any of those missed us. Same sentence sat on the main npm package, which is installed about 900 times a week and 3,500 times a month.

Both now name the agents and the thing being searched. 60 characters, which is inside what brew audit wants.