### PR TITLE
fix(goose): refresh the recall on every prompt, not only under the wrapper

### DIFF
--- a/cmd/deja/goose_per_turn_test.go
+++ b/cmd/deja/goose_per_turn_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The prompt hook returned immediately unless MOIM was set, because the file it
+// wrote was read once when the session started. That is not true of where the
+// recall lives now: measured against goose 1.48 with a stub endpoint, a change
+// to AGENTS.md between two turns of one session arrives on the second — the
+// file is re-read every turn. So the guard was the only thing keeping per-turn
+// recall to the wrapper.
+func TestTheGoosePromptHookRefreshesWithoutTheWrapper(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	path := filepath.Join(cfg, "goose", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const mine = "# my own notes\n\nalways use pgx\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No MOIM in the environment: this is plain `goose`.
+	if err := refreshGooseForPrompt(t.TempDir(), []byte(`{"prompt":"pgbouncer pool"}`)); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Whatever the store answered — including nothing — the reader's own lines
+	// have to survive. The prompt path wrote the file raw and erased them.
+	if !strings.Contains(string(b), "always use pgx") {
+		t.Errorf("the prompt refresh overwrote the reader's file:\n%s", b)
+	}
+}
+
+// And the writer both halves share keeps the markers on the file that is the
+// reader's, while the MOIM file — deja's own — is written whole.
+func TestGooseRecallWritesAMarkedBlockOnlyInTheReadersFile(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	agents := filepath.Join(cfg, "goose", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(agents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agents, []byte("mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGooseRecall("recalled text"); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(agents)
+	if !strings.Contains(string(b), gooseRecallStart) || !strings.Contains(string(b), "mine") {
+		t.Errorf("AGENTS.md was not edited in place:\n%s", b)
+	}
+
+	moim := filepath.Join(t.TempDir(), "recall.md")
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", moim)
+	if err := writeGooseRecall("recalled text"); err != nil {
+		t.Fatal(err)
+	}
+	m, err := os.ReadFile(moim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(m), gooseRecallStart) {
+		t.Errorf("the MOIM file is deja's own and needs no markers:\n%s", m)
+	}
+	if strings.TrimSpace(string(m)) != "recalled text" {
+		t.Errorf("MOIM = %q", m)
+	}
+}
+
+// And it has to actually write: a test that only checks the reader's lines
+// survive passes just as well when the hook returns without doing anything,
+// which is what it did before the guard came off.
+func TestTheGoosePromptHookWritesWhatItFound(t *testing.T) {
+	hermeticEnv(t)
+	claude := os.Getenv("DEJA_CLAUDE_ROOT")
+	proj := filepath.Join(claude, "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(role, text string) string {
+		return `{"type":"` + role + `","sessionId":"gp1","cwd":"/app",` +
+			`"timestamp":"2026-07-30T03:04:05Z","message":{"role":"` + role + `","content":"` + text + `"}}`
+	}
+	body := line("user", "why does pgbouncer keep timing out") + "\n" +
+		line("assistant", "The fix was raising default_pool_size to 40.") + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "gp1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", "")
+
+	if err := refreshGooseForPrompt(dir, []byte(`{"prompt":"pgbouncer timing out","cwd":"/app"}`)); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(gooseHintsPath())
+	if err != nil {
+		t.Fatalf("the prompt hook wrote nothing: %v", err)
+	}
+	if !strings.Contains(string(b), gooseRecallStart) {
+		t.Errorf("no recall block was written:\n%s", b)
+	}
+	if !strings.Contains(string(b), "pgbouncer") {
+		t.Errorf("the block does not carry what was asked about:\n%s", b)
+	}
+}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -389,10 +389,17 @@ func cmdGooseHook(_ string, _ []string) error {
 // session opens. Overwriting the hints file mid-session would therefore
 // replace the recall that is already in front of the model with nothing the
 // model will ever see, so without MOIM this leaves the session as it is.
+// refreshGooseForPrompt rewrites the recall for what was just typed, so the
+// block follows the conversation instead of staying on whatever the session
+// opened with.
+//
+// It used to return here unless MOIM was set, because the file it wrote was
+// read once when the session started and refreshing it mid-session reached
+// nobody. That is no longer true of where the recall lives: measured against
+// goose 1.48 with a stub endpoint, a change to `AGENTS.md` between two turns of
+// one session arrives on the second — the file is re-read every turn. So the
+// guard was the only thing keeping per-turn recall to the wrapper.
 func refreshGooseForPrompt(dir string, payload []byte) error {
-	if os.Getenv("GOOSE_MOIM_MESSAGE_FILE") == "" {
-		return nil
-	}
 	var input struct {
 		// Goose calls it message; matcher_context carries the same text.
 		Message string `json:"message"`
@@ -424,6 +431,14 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 	if strings.TrimSpace(out.String()) == "" {
 		return nil
 	}
+	return writeGooseRecall(out.String())
+}
+
+// writeGooseRecall puts the recall where goose will read it. The MOIM file is
+// deja's own and holds nothing else; AGENTS.md is the reader's, so only the
+// block between deja's markers is ours to rewrite — the prompt path wrote it
+// raw and erased everything else in the file.
+func writeGooseRecall(body string) error {
 	path := gooseRecallPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -432,8 +447,14 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 	if err != nil {
 		return err
 	}
-	_, err = writeIfChanged(path, old, []byte(out.String()))
-	return err
+	next := []byte(body)
+	if path == gooseHintsPath() {
+		next = []byte(gooseRecallBlock(string(old), body))
+	}
+	if _, err := writeIfChanged(path, old, next); err != nil {
+		return err
+	}
+	return dropRetiredGooseHints()
 }
 
 // gooseRecallPath is the hints file, or the MOIM file when the wrapper set
@@ -465,20 +486,7 @@ func refreshGooseHintsFor(cwd string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	old, err := readConfig(path)
-	if err != nil {
-		return err
-	}
-	// The MOIM file is deja's own and holds nothing else; AGENTS.md is the
-	// reader's, so only the block between the markers is ours to rewrite.
-	next := []byte(body)
-	if path == gooseHintsPath() {
-		next = []byte(gooseRecallBlock(string(old), body))
-	}
-	if _, err := writeIfChanged(path, old, next); err != nil {
-		return err
-	}
-	return dropRetiredGooseHints()
+	return writeGooseRecall(body)
 }
 
 // dropGooseRecallBlock takes deja's block out of the file and removes the file


### PR DESCRIPTION
`refreshGooseForPrompt` returned immediately unless `GOOSE_MOIM_MESSAGE_FILE` was set. That was right when the recall lived in a file goose read once at session start: refreshing it mid-session reached nobody, so only the wrapper's MOIM file was worth writing.

It is not right about where the recall lives after #2954. Measured against goose 1.48 with a stub endpoint that records the request, two turns of one session with the file changed in between:

```
turn one   MARK-ONE=true   MARK-TWO=false
turn two   MARK-ONE=false  MARK-TWO=true
```

goose re-reads `AGENTS.md` every turn. So the guard was the only thing keeping per-turn recall to the wrapper, and plain `goose` had a block fixed at whatever the session opened with.

With it gone, on a real store: two prompts, two different blocks, and the second one opens with *"This was asked here before — kafka consumer rebalance"*. End to end through goose, the block and the text about that turn both reach the model.

**Taking the guard off exposed a second bug in the same path.** The prompt half wrote the recall file raw, which was fine for a `.goosehints` deja owned and destroys an `AGENTS.md` that belongs to the reader — it erased everything else in the file the first time I ran it. Both halves now go through one writer: the MOIM file is written whole, the reader's file only between deja's markers.

Three mutations, all red: putting the MOIM-only guard back, dropping the markers in the shared writer, and marking the MOIM file that needs none.

The first of those was blind at first. A test that only checks the reader's lines survived passes just as well when the hook does nothing at all, which is exactly what it used to do — so there is now a case with a store that has something to answer, asserting the block was written and carries what was asked about.

**This also corrects #2956.** I filed it saying the wrapper's per-turn channel was dead. MOIM is still dead, but the channel is not: `AGENTS.md` is re-read every turn and now carries it, for plain `goose` as well as under the wrapper.
