### PR TITLE
docs(site): reach every guide from the home page

### DIFF
--- a/cmd/deja/page_titles_count_test.go
+++ b/cmd/deja/page_titles_count_test.go
@@ -36,6 +36,18 @@ func TestPageTitlesCountTheRestOfTheHarnesses(t *testing.T) {
 		}
 	}
 
+	// The home page says it in a figure of its own — "Works with 18" — sitting
+	// above a grid that listed twenty. The digit test looks for "N harnesses"
+	// or "N agents" and a bare number in a span is neither, so it stayed at
+	// eighteen through three harnesses landing.
+	home, err := os.ReadFile(filepath.Join(root, "docs", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := fmt.Sprintf(`Works with <span class="fig">%d</span>`, n); !strings.Contains(string(home), want) {
+		t.Errorf("docs/index.html does not say %q — the registry has %d harnesses", want, n)
+	}
+
 	// The registry pages close with "deja reads this format and N others". The
 	// word was typed into the generator's template, so all twenty pages kept
 	// saying seventeen for three harnesses running.

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,7 +402,7 @@ footer a:hover{color:var(--ph-hi)}
 </section>
 
 <section class="reveal">
-  <h2>Works with <span class="fig">18</span></h2>
+  <h2>Works with <span class="fig">21</span></h2>
   <div class="split">
     <div><p class="big" style="margin:0">Solve it in Codex. <em>Claude remembers.</em></p></div>
     <div class="right"><div class="agents" style="margin:0">
@@ -438,6 +438,49 @@ footer a:hover{color:var(--ph-hi)}
   </div>
 </section>
 
+<section class="reveal" id="guides">
+  <h2>When this is what happened</h2>
+  <div class="steps">
+    <div class="step"><span class="n">01</span><h3>Something is gone</h3>
+      <p><a href="guide/does-my-agent-remember.html">Does my agent remember previous conversations?</a> ·
+        <a href="guide/forgetting.html">Why it forgets</a> ·
+        <a href="guide/lost-context.html">It lost the context you had</a> ·
+        <a href="guide/context-window-full.html">The context window is full</a> ·
+        <a href="guide/after-compaction.html">What compaction dropped</a> ·
+        <a href="guide/repeated-mistakes.html">It repeats a mistake you fixed</a></p></div>
+    <div class="step"><span class="n">02</span><h3>Finding it again</h3>
+      <p><a href="guide/find-a-session.html">Finding a session</a> ·
+        <a href="guide/resume-a-session.html">Resuming yesterday's session</a> ·
+        <a href="guide/where-sessions-are-stored.html">Where each agent keeps its history</a> ·
+        <a href="guide/session-files-on-disk.html">Session files on disk</a> ·
+        <a href="guide/export-conversations.html">Exporting a conversation</a> ·
+        <a href="guide/switching-agents.html">Switching agents</a> ·
+        <a href="guide/parallel-sessions.html">Parallel sessions</a> ·
+        <a href="guide/sync-across-machines.html">Across machines</a></p></div>
+    <div class="step"><span class="n">03</span><h3>Keeping it honest</h3>
+      <p><a href="guide/token-cost.html">What memory costs in tokens</a> ·
+        <a href="guide/rules-files.html">When CLAUDE.md grows</a> ·
+        <a href="guide/auditing-agents.html">Auditing what an agent did</a> ·
+        <a href="guide/privacy.html">Privacy</a> ·
+        <a href="guide/benchmarks.html">Benchmarks</a> ·
+        <a href="guide/compare.html">How it compares</a></p></div>
+  </div>
+  <p class="agents" style="margin-top:18px">
+    <span><a href="guide/memory-for-claude-code.html">Claude Code</a></span>
+    <span><a href="guide/memory-for-codex.html">Codex</a></span>
+    <span><a href="guide/memory-for-cursor.html">Cursor</a></span>
+    <span><a href="guide/memory-for-copilot.html">Copilot CLI</a></span>
+    <span><a href="guide/memory-for-opencode.html">opencode</a></span>
+    <span><a href="guide/memory-for-gemini.html">Gemini CLI</a></span>
+    <span><a href="guide/memory-for-qwen.html">Qwen Code</a></span>
+    <span><a href="guide/memory-for-kimi.html">Kimi Code</a></span>
+    <span><a href="guide/memory-for-dsh.html">DeepSeek Harness</a></span>
+    <span><a href="guide/memory-for-grok.html">Grok Build</a></span>
+    <span><a href="guide/memory-for-zed.html">Zed</a></span>
+    <span class="more">memory for each, set up in a minute</span>
+  </p>
+</section>
+
 <section class="closer reveal">
   <img src="assets/icon-live.svg" width="110" height="110" alt="">
   <h2>Your history is already on this machine.</h2>
@@ -465,6 +508,12 @@ footer a:hover{color:var(--ph-hi)}
     <a href="guide/benchmarks.html">Benchmarks</a>
     <a href="guide/compare.html">How it compares</a>
     <a href="guide/privacy.html">Privacy</a>
+  </div>
+  <div class="col"><b>中文</b>
+    <a href="zh/guide/getting-started.html">快速开始</a>
+    <a href="zh/guide/does-my-agent-remember.html">智能体记得之前的对话吗</a>
+    <a href="zh/guide/forgetting.html">为什么会忘事</a>
+    <a href="https://github.com/vshulcz/deja-vu/blob/main/README.zh.md">中文 README</a>
   </div>
   <div class="col"><b>Project</b>
     <a href="https://github.com/vshulcz/deja-vu">GitHub</a>


### PR DESCRIPTION
Google has never indexed the site: `site:vshulcz.github.io/deja-vu` returns nothing, and the exact title of a page from 24 July brings up ten other people's articles and not ours. Two things on our side made that easy for a crawler. Every external link points at the home page, and the home page linked eight reference pages and none of the twenty-eight guides written for a situation — so the pages we want found were three clicks deep with no link from anywhere a crawler starts. This adds a section that reaches all of them, plus a footer column for the Chinese pages.

Also "Works with 18" on the home page while the registry has 21: the digit test looks for "N harnesses" and a bare number in a span is not that. Pinned now.

IndexNow for the full sitemap (63 URLs) was submitted separately; Google does not take IndexNow.
