### PR TITLE
feat(install): open the proof with the error this machine keeps hitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The proof after `deja install --auto` opens with the error this machine keeps
+  hitting — "this machine has hit `command not found: timeout` in 18 sessions"
+  — above the recent-sessions list. The same rule and threshold as `friction`;
+  nothing is claimed when nothing recurs. (#2966)
+
 ### Changed
 - The index format moved: this release rebuilds the index once on first run.
   Arabic, Hebrew, Thai and the Indic scripts are tokenized as words rather than

--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -73,6 +73,120 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	if err := index.Ensure(dir, "", false, os.Stderr); err != nil {
 		return ensureError(dir, err)
 	}
+	pol := policy.Load()
+	scan, err := scanFriction(dir, pol)
+	if err != nil {
+		return err
+	}
+	rows, sessions := scan.rows, scan.sessions
+	withheldOutput, ignoredOutput := scan.withheldOutput, scan.ignoredOutput
+	if note := policyHiddenNote(policy.ActivationSearch, scan.withheldSessions); note != "" {
+		fmt.Fprintln(os.Stderr, note)
+	}
+	if note := ignoredHiddenNoteFor("answer", scan.ignoredSessions); note != "" {
+		fmt.Fprint(os.Stderr, note)
+	}
+	if asJSON {
+		return writeFrictionJSON(stdout, rows, sessions, limit)
+	}
+	if len(rows) == 0 {
+		// The count is sessions-with-tool-output, and it reads as
+		// sessions-indexed: a store with six conversations reported zero,
+		// which is the sentence #637 was about — a reader told the index holds
+		// nothing concludes the tool is broken (#705).
+		// Two counts, because they answer two questions. What is on disk
+		// decides whether this machine has any history at all, and what the
+		// rules leave decides how much friction had to read: naming the store
+		// for the second put "none of the 4 indexed sessions" over a note
+		// saying two of them are withheld (#2709, the shape #2707 fixed on the
+		// empty search). Reading the store count for the first is what keeps a
+		// machine whose history is entirely behind a rule from being told it
+		// has none.
+		stored, err := index.SessionCount(dir)
+		total := stored
+		if reach, _, _, ok := reachableSessionCount(dir); ok {
+			total = reach
+		}
+		switch {
+		case err != nil || stored == 0:
+			// "no sessions are indexed yet" is a claim about the machine, and
+			// a store deja is not allowed to open produces the same zero —
+			// the failure #1020 closed on last and search. friction is where
+			// someone lands when recall feels thin, so it is the worst place
+			// to say the history is not there (#1044).
+			fmt.Fprintln(stdout, strings.TrimPrefix(emptyIndexHint("nothing recurring"), "deja: "))
+		case sessions == 0 && withheldOutput > 0:
+			// The sessions that recorded tool output are exactly the ones a
+			// rule took away, and saying the machine never had them is a claim
+			// about the store rather than about the rule — the misread #637
+			// and #1044 closed elsewhere. The stderr note above says the same
+			// thing, and stdout is what a redirect keeps (#2319).
+			fmt.Fprintf(stdout, "nothing recurring — the trust policy withheld the %d session%s that recorded tool output, which is what friction reads errors from\n",
+				withheldOutput, pluralS(withheldOutput))
+		case sessions == 0 && ignoredOutput > 0:
+			// The same claim about the store rather than about the rule, for
+			// the other rule: the sessions with the tool output are there and
+			// the ignore rule is what keeps them out (#2630).
+			fmt.Fprintf(stdout, "nothing recurring — the ignore rule keeps the %d session%s that recorded tool output out of recall, which is what friction reads errors from\n",
+				ignoredOutput, pluralS(ignoredOutput))
+		case sessions == 0 && total == 0:
+			// Every session on this machine is behind a rule, and none of them
+			// recorded tool output — so neither arm above fired and the count
+			// is zero. "none of the 0 indexed sessions" is arithmetic; what
+			// the reader needs is which rule leaves friction nothing to read.
+			fmt.Fprintf(stdout, "nothing recurring — %s keeps every one of the %d indexed session%s out of recall, and friction reads errors from what it may open\n",
+				emptiedBy(pol), stored, pluralS(stored))
+		case sessions == 0:
+			fmt.Fprintf(stdout, "nothing recurring — none of the %d indexed session%s recorded tool output, which is what friction reads errors from\n",
+				total, pluralS(total))
+		case sessions == total:
+			// The parenthetical is there to say how much was not read. When
+			// the rules leave exactly the sessions that recorded tool output,
+			// it repeats the number beside it.
+			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output — no error hit %d separate sessions\n",
+				sessions, pluralS(sessions), index.FrictionMinSessions)
+		default:
+			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output (of %d indexed) — no error hit %d separate sessions\n",
+				sessions, pluralS(sessions), total, index.FrictionMinSessions)
+		}
+		return nil
+	}
+	total := len(rows)
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d session%s read\n", sessions, pluralS(sessions))
+	for _, r := range rows {
+		where := strings.Join(r.harnesses, ", ")
+		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, trimFriction(r.line))
+		fmt.Fprintf(stdout, "               %s", where)
+		if !r.when.IsZero() {
+			fmt.Fprintf(stdout, " · last %s", r.when.Local().Format("Jan 2"))
+		}
+		fmt.Fprintln(stdout)
+	}
+	// The header claims to say what this machine keeps tripping over, so a cut
+	// list with nothing after it reads as all of it — the sentence `how` and
+	// `files` print for the same flag (#2311).
+	if total > len(rows) {
+		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", len(rows), total)
+	}
+	return nil
+}
+
+// frictionScan is one pass over the record log: the recurring errors, ranked,
+// and the counts the sentences around them need. The install proof reads it
+// too, so the loop lives here rather than inside runFriction (#2966).
+type frictionScan struct {
+	rows     []frictionRow
+	sessions int // sessions that recorded tool output and were read
+	// Sessions a rule kept out — those with a friction line in them, and those
+	// that recorded tool output at all; two sentences, two counts (#2794).
+	withheldSessions, ignoredSessions int
+	withheldOutput, ignoredOutput     int
+}
+
+func scanFriction(dir string, pol policy.Policy) (*frictionScan, error) {
 	type seen struct {
 		sessions map[string]bool
 		harness  map[string]bool
@@ -90,7 +204,6 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 	// hosts, its infra IPs — surfaced here even when the trust policy withheld
 	// imported content from every other browsing surface. Browsing is the search
 	// activation, as in `last` and `stats` (#937, and its friction gap #1120).
-	pol := policy.Load()
 	// Sessions, not records: the note says "hides N matching sessions", and
 	// counting the callback's firings reported one hidden session with ten
 	// error lines as ten (#1639).
@@ -159,15 +272,8 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 			}
 		}
 	}); err != nil {
-		return fmt.Errorf("friction: %w", err)
+		return nil, fmt.Errorf("friction: %w", err)
 	}
-	if note := policyHiddenNote(policy.ActivationSearch, len(withheldSessions)); note != "" {
-		fmt.Fprintln(os.Stderr, note)
-	}
-	if note := ignoredHiddenNoteFor("answer", len(ignoredSessions)); note != "" {
-		fmt.Fprint(os.Stderr, note)
-	}
-
 	var rows []frictionRow
 	for _, s := range found {
 		line := s.text
@@ -187,92 +293,11 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		}
 		return rows[i].line < rows[j].line
 	})
-	if asJSON {
-		return writeFrictionJSON(stdout, rows, len(sessions), limit)
-	}
-	if len(rows) == 0 {
-		// The count is sessions-with-tool-output, and it reads as
-		// sessions-indexed: a store with six conversations reported zero,
-		// which is the sentence #637 was about — a reader told the index holds
-		// nothing concludes the tool is broken (#705).
-		// Two counts, because they answer two questions. What is on disk
-		// decides whether this machine has any history at all, and what the
-		// rules leave decides how much friction had to read: naming the store
-		// for the second put "none of the 4 indexed sessions" over a note
-		// saying two of them are withheld (#2709, the shape #2707 fixed on the
-		// empty search). Reading the store count for the first is what keeps a
-		// machine whose history is entirely behind a rule from being told it
-		// has none.
-		stored, err := index.SessionCount(dir)
-		total := stored
-		if reach, _, _, ok := reachableSessionCount(dir); ok {
-			total = reach
-		}
-		switch {
-		case err != nil || stored == 0:
-			// "no sessions are indexed yet" is a claim about the machine, and
-			// a store deja is not allowed to open produces the same zero —
-			// the failure #1020 closed on last and search. friction is where
-			// someone lands when recall feels thin, so it is the worst place
-			// to say the history is not there (#1044).
-			fmt.Fprintln(stdout, strings.TrimPrefix(emptyIndexHint("nothing recurring"), "deja: "))
-		case len(sessions) == 0 && len(withheldOutput) > 0:
-			// The sessions that recorded tool output are exactly the ones a
-			// rule took away, and saying the machine never had them is a claim
-			// about the store rather than about the rule — the misread #637
-			// and #1044 closed elsewhere. The stderr note above says the same
-			// thing, and stdout is what a redirect keeps (#2319).
-			fmt.Fprintf(stdout, "nothing recurring — the trust policy withheld the %d session%s that recorded tool output, which is what friction reads errors from\n",
-				len(withheldOutput), pluralS(len(withheldOutput)))
-		case len(sessions) == 0 && len(ignoredOutput) > 0:
-			// The same claim about the store rather than about the rule, for
-			// the other rule: the sessions with the tool output are there and
-			// the ignore rule is what keeps them out (#2630).
-			fmt.Fprintf(stdout, "nothing recurring — the ignore rule keeps the %d session%s that recorded tool output out of recall, which is what friction reads errors from\n",
-				len(ignoredOutput), pluralS(len(ignoredOutput)))
-		case len(sessions) == 0 && total == 0:
-			// Every session on this machine is behind a rule, and none of them
-			// recorded tool output — so neither arm above fired and the count
-			// is zero. "none of the 0 indexed sessions" is arithmetic; what
-			// the reader needs is which rule leaves friction nothing to read.
-			fmt.Fprintf(stdout, "nothing recurring — %s keeps every one of the %d indexed session%s out of recall, and friction reads errors from what it may open\n",
-				emptiedBy(pol), stored, pluralS(stored))
-		case len(sessions) == 0:
-			fmt.Fprintf(stdout, "nothing recurring — none of the %d indexed session%s recorded tool output, which is what friction reads errors from\n",
-				total, pluralS(total))
-		case len(sessions) == total:
-			// The parenthetical is there to say how much was not read. When
-			// the rules leave exactly the sessions that recorded tool output,
-			// it repeats the number beside it.
-			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output — no error hit %d separate sessions\n",
-				len(sessions), pluralS(len(sessions)), index.FrictionMinSessions)
-		default:
-			fmt.Fprintf(stdout, "nothing recurring in the %d session%s that recorded tool output (of %d indexed) — no error hit %d separate sessions\n",
-				len(sessions), pluralS(len(sessions)), total, index.FrictionMinSessions)
-		}
-		return nil
-	}
-	total := len(rows)
-	if len(rows) > limit {
-		rows = rows[:limit]
-	}
-	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d session%s read\n", len(sessions), pluralS(len(sessions)))
-	for _, r := range rows {
-		where := strings.Join(r.harnesses, ", ")
-		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, trimFriction(r.line))
-		fmt.Fprintf(stdout, "               %s", where)
-		if !r.when.IsZero() {
-			fmt.Fprintf(stdout, " · last %s", r.when.Local().Format("Jan 2"))
-		}
-		fmt.Fprintln(stdout)
-	}
-	// The header claims to say what this machine keeps tripping over, so a cut
-	// list with nothing after it reads as all of it — the sentence `how` and
-	// `files` print for the same flag (#2311).
-	if total > len(rows) {
-		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", len(rows), total)
-	}
-	return nil
+	return &frictionScan{
+		rows: rows, sessions: len(sessions),
+		withheldSessions: len(withheldSessions), ignoredSessions: len(ignoredSessions),
+		withheldOutput: len(withheldOutput), ignoredOutput: len(ignoredOutput),
+	}, nil
 }
 
 func trimFriction(l string) string {

--- a/cmd/deja/import_proof_test.go
+++ b/cmd/deja/import_proof_test.go
@@ -188,6 +188,12 @@ func TestImportProofShowsOnlyWhatArrived(t *testing.T) {
 	if strings.Contains(proof, "local work on the ticker window") {
 		t.Errorf("a session that was here before the transfer is offered as proof of it:\n%s", proof)
 	}
+	// And not the error *this* machine keeps hitting, which the install proof
+	// leads with: under a heading about the machine you came from it would be
+	// a claim about the wrong machine (#2966).
+	if strings.Contains(proof, "this machine has hit") {
+		t.Errorf("the import proof names a local recurring error under a heading about another machine:\n%s", proof)
+	}
 
 	// With every arrived row hidden by a rule, the reader gets the rule — not
 	// this machine's own sessions under someone else's heading.

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -399,11 +399,6 @@ func printInstallProof(dir string) {
 	printMemoryProofOf(dir, "deja already knows this machine:", nil, recurringErrorLine(dir))
 }
 
-// printMemoryProof is that same proof under a caller's heading. `sync import`
-// ends the move to a new machine and said only "imported 59000 records" —
-// deja's own unit, and nothing a person can check (#929).
-func printMemoryProof(dir, heading string) { printMemoryProofOf(dir, heading, nil, "") }
-
 // printMemoryProofOf is the proof narrowed to the rows a caller can honestly
 // claim. `sync import` says "from the machine you came from" and was handed
 // the recent list, so on a batch that added nothing visible it offered this

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -395,18 +395,24 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 // printInstallProof shows the "starts full" moment right in the install: a
 // few real sessions deja already indexed from this machine's history, so the
 // value is visible before the first agent session ever runs.
-func printInstallProof(dir string) { printMemoryProof(dir, "deja already knows this machine:") }
+func printInstallProof(dir string) {
+	printMemoryProofOf(dir, "deja already knows this machine:", nil, recurringErrorLine(dir))
+}
 
 // printMemoryProof is that same proof under a caller's heading. `sync import`
 // ends the move to a new machine and said only "imported 59000 records" —
 // deja's own unit, and nothing a person can check (#929).
-func printMemoryProof(dir, heading string) { printMemoryProofOf(dir, heading, nil) }
+func printMemoryProof(dir, heading string) { printMemoryProofOf(dir, heading, nil, "") }
 
 // printMemoryProofOf is the proof narrowed to the rows a caller can honestly
 // claim. `sync import` says "from the machine you came from" and was handed
 // the recent list, so on a batch that added nothing visible it offered this
 // machine's own sessions as the evidence a transfer had landed (#988).
-func printMemoryProofOf(dir, heading string, keep func(model.Session) bool) {
+// lead is one line printed under the heading before the listing, or "". Only
+// the install passes one: `sync import` shows sessions from another machine
+// under a heading that says so, and the error *this* machine keeps hitting
+// would be a lie there (#2966).
+func printMemoryProofOf(dir, heading string, keep func(model.Session) bool, lead string) {
 	if !index.HasManifest(dir) {
 		return
 	}
@@ -482,10 +488,33 @@ func printMemoryProofOf(dir, heading string, keep func(model.Session) bool) {
 		return
 	}
 	fmt.Fprintln(os.Stderr, "\n"+heading)
+	// The one thing here the reader does not already know. The titles below
+	// are their own words from last week; the error their agents hit in a
+	// dozen sessions is what nobody kept score of, and it is the reason to
+	// keep reading (#2966).
+	if lead != "" {
+		fmt.Fprintln(os.Stderr, "  "+lead)
+	}
 	for _, l := range lines {
 		fmt.Fprintln(os.Stderr, l)
 	}
 	fmt.Fprintln(os.Stderr, "ask your agent about any of these — it will remember.")
+}
+
+// recurringErrorLine is the top row of `deja friction`, as one sentence, or ""
+// when nothing clears the threshold — a pattern claimed over a single sighting
+// would be the tool inventing one.
+func recurringErrorLine(dir string) string {
+	scan, err := scanFriction(dir, policy.Load())
+	if err != nil || len(scan.rows) == 0 {
+		return ""
+	}
+	r := scan.rows[0]
+	if r.n < index.FrictionMinSessions {
+		return ""
+	}
+	return fmt.Sprintf("this machine has hit `%s` in %d sessions (%s) — your agent will be told before it runs into it again",
+		trimFriction(r.line), r.n, strings.Join(r.harnesses, ", "))
 }
 
 // shortHome contracts the home directory to ~ for display.

--- a/cmd/deja/install_proof_friction_test.go
+++ b/cmd/deja/install_proof_friction_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The proof after `deja install --auto` listed three recent sessions — titles
+// the reader typed last week and already knows. What they do not know is the
+// error their agents have hit in a dozen separate sessions, which is the one
+// thing the index holds that they never kept score of. That is the line the
+// install shows now, and it is the same rule `friction` prints by (#2966).
+func TestInstallProofNamesTheRecurringError(t *testing.T) {
+	hermeticEnv(t)
+	root := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-w-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// One error across four sessions, one session that is fine.
+	for i := 1; i <= 4; i++ {
+		id := fmt.Sprintf("s%d", i)
+		writeClaudeFixture(t, filepath.Join(root, id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/p","timestamp":"2026-07-2` + fmt.Sprint(i) + `T10:00:00Z","message":{"role":"user","content":"deploy it"}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/p","timestamp":"2026-07-2` + fmt.Sprint(i) + `T10:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"zsh: command not found: timeout"}]}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "ok.jsonl"), "ok", []string{
+		`{"type":"user","sessionId":"ok","cwd":"/w/p","timestamp":"2026-07-28T10:00:00Z","message":{"role":"user","content":"all green today"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStderr(t, func() { printInstallProof(index.DefaultDir()) })
+	if !strings.Contains(out, "command not found: timeout") || !strings.Contains(out, "4 sessions") {
+		t.Errorf("the proof does not name the error this machine keeps hitting:\n%s", out)
+	}
+	// Above the listing, not below it: the listing is what the reader already
+	// knows, and the line is the reason to keep reading.
+	if at, list := strings.Index(out, "command not found"), strings.Index(out, "[claude"); at < 0 || list < 0 || at > list {
+		t.Errorf("the recurring error sits below the session listing:\n%s", out)
+	}
+}
+
+// And nothing when nothing recurs — a line that says "this machine keeps
+// hitting …" over a single sighting would be the tool inventing a pattern.
+func TestInstallProofStaysQuietWithoutARecurringError(t *testing.T) {
+	withStatsStores(t)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStderr(t, func() { printInstallProof(index.DefaultDir()) })
+	if strings.Contains(out, "keeps hitting") || strings.Contains(out, "has hit") {
+		t.Errorf("the proof claims a recurring error on a store that has none:\n%s", out)
+	}
+	if !strings.Contains(out, "deja already knows this machine:") {
+		t.Errorf("the listing itself went missing:\n%s", out)
+	}
+}

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -246,7 +246,7 @@ func runSync(dir string, args []string) error {
 		// and install proves it with real lines rather than a count (#929).
 		printMemoryProofOf(dir, "deja now knows, from the machine you came from:", func(s model.Session) bool {
 			return strings.HasPrefix(s.Project, "imported:")
-		})
+		}, "")
 		return nil
 	default:
 		return fmt.Errorf("unknown sync command %q", args[0])


### PR DESCRIPTION
Closes #2966.

After `deja install --auto` the proof block led with three recent session titles — the reader's own words from last week. It now leads with the top row of `friction`:

```
deja already knows this machine:
  this machine has hit `command not found: timeout` in 18 sessions (claude, opencode) — your agent will be told before it runs into it again
  [claude · goprojects/deja-vu · Sep 2] fix the goose reader
  …
```

The collection loop in `runFriction` moved into `scanFriction`, which both callers use; `friction`'s own output is unchanged (its tests pass as they were). The line is passed in by the install only — `sync import` prints the same block under "from the machine you came from", where a local error would be a claim about the wrong machine; the import test now asserts it stays out.

Cost measured on this store (1,378 sessions, 194,789 messages): 2.3–3.0 s for the pass, after a ~10 s index build. Nothing is printed when nothing clears `FrictionMinSessions`.

Tests: `TestInstallProofNamesTheRecurringError` (fails before), `TestInstallProofStaysQuietWithoutARecurringError`, and the added assertion in `TestImportProofShowsOnlyWhatArrived`.