### PR TITLE
chore(packaging): the winget and scoop line says what people search for

### DIFF
--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,6 +1,6 @@
 {
     "version": "0.19.2",
-    "description": "Persistent memory for coding agents",
+    "description": "Search Claude Code, Codex and Cursor session history locally",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -8,7 +8,7 @@ PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
 LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.2/LICENSE
-ShortDescription: Persistent memory for coding agents
+ShortDescription: Search Claude Code, Codex and Cursor session history locally
 Tags:
 - aider
 - claude-code

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -190,7 +190,7 @@ type scoopAutoupdate struct {
 func renderScoop(p pins) ([]byte, error) {
 	m := scoopManifest{
 		Version:     p.version,
-		Description: "Persistent memory for coding agents",
+		Description: "Search Claude Code, Codex and Cursor session history locally",
 		Homepage:    "https://github.com/vshulcz/deja-vu",
 		License:     "MIT",
 		Architecture: map[string]scoopArch{


### PR DESCRIPTION
The same change #2960 made for brew and npm, on the two Windows manifests: `winget search` and `scoop search` match on the description, and "Persistent memory for coding agents" names neither the agents nor the history. The template in `scripts/pinmanifests` carries it, so the next pin keeps it; `pinmanifests -check` still matches the release.