### PR TITLE
feat(index): a transcript the client deleted stays searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- A transcript the client deleted stays in the index. Claude Code removes
+  transcripts older than `cleanupPeriodDays` (30 by default), and the next
+  incremental pass used to drop the session with the file. A file that is gone
+  while its store is still there is now kept and stays searchable; `deja
+  forget` remains the way to drop one on purpose. A store that vanishes whole
+  is dropped as before, and a full `deja index --rebuild` still reads only what
+  is on disk. (#2970)
 - The proof after `deja install --auto` opens with the error this machine keeps
   hitting — "this machine has hit `command not found: timeout` in 18 sessions"
   — above the recent-sessions list. The same rule and threshold as `friction`;

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -147,6 +147,7 @@ func doctorDeep(w io.Writer, r index.DeepReport) {
 	if len(r.Stale) > 0 {
 		fmt.Fprintf(w, "  stale    %s changed since last pass — `deja index` will absorb them\n", doctorCount(len(r.Stale), "source"))
 	}
+	doctorKept(w, &r)
 	if r.Clean() {
 		// What this pass compares is message counts per session, plus the
 		// structure around them: sizes, magic numbers, postings that resolve.
@@ -174,6 +175,16 @@ func doctorDeep(w io.Writer, r index.DeepReport) {
 		fmt.Fprintf(w, "  drift    [%s] %s\n", f.Kind, f.Detail)
 	}
 	fmt.Fprintf(w, "  status   %s — run `deja index --rebuild`\n", doctorCount(len(r.Findings), "finding"))
+}
+
+// doctorKept says which indexed transcripts are no longer on disk and are kept
+// on purpose — the client's cleanup, not drift (#2970). Printed before the
+// verdict so a reader sees it is not what any finding is about.
+func doctorKept(w io.Writer, r *index.DeepReport) {
+	if r == nil || len(r.Kept) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "  kept     %d transcript%s no longer on disk, still searchable — `deja forget <id>` drops one for good\n", len(r.Kept), pluralS(len(r.Kept)))
 }
 
 func deepDriftErr(r *index.DeepReport) error {
@@ -574,6 +585,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 	indexed := index.HarnessSessionCounts(dir)
 	fromElsewhere := index.ImportedSessionCounts(dir)
 	sharedRows := index.HarnessSharedCounts(dir)
+	keptRows := index.HarnessKeptCounts(dir)
 
 	// The same inspection the JSON form reports, so one command does not give
 	// two answers about one store: `found` here and `unreadable` there (#999).
@@ -649,6 +661,13 @@ func doctorHarnesses(w io.Writer, dir string) {
 				// sharing an id. The manifest knows which (#1101).
 				if sh := sharedRows[name]; sh > 0 {
 					detail += fmt.Sprintf(", %d of them shared by two transcripts", sh)
+				}
+				// And the other way the numbers disagree: a session whose
+				// transcript the client cleaned up, kept on purpose (#2970).
+				if k := keptRows[name]; k == 1 {
+					detail += ", 1 from a transcript no longer on disk"
+				} else if k > 1 {
+					detail += fmt.Sprintf(", %d from transcripts no longer on disk", k)
 				}
 			case n:
 				detail += doctorCount(n, "indexed session") + " from elsewhere"

--- a/cmd/deja/doctor_json_contract_test.go
+++ b/cmd/deja/doctor_json_contract_test.go
@@ -64,7 +64,7 @@ func TestDoctorJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		"failed_files": true, "last_error": true,
 		// index.DeepReport / index.DeepFinding
 		"files_checked": true, "sessions_indexed": true, "sampled_files": true,
-		"sampled_postings": true, "stale": true, "findings": true,
+		"sampled_postings": true, "stale": true, "findings": true, "kept": true,
 		"kind": true, "detail": true,
 	}
 	emitted := map[string]bool{}

--- a/cmd/deja/doctor_test.go
+++ b/cmd/deja/doctor_test.go
@@ -486,13 +486,28 @@ func TestDoctorDeepCleanAndDrift(t *testing.T) {
 		t.Fatalf("missing clean deep section:\n%s", got)
 	}
 
+	// One transcript gone, its directory still there: the client's cleanup,
+	// which the index keeps on purpose — not drift, and not a reason to
+	// rebuild, since a rebuild is what would lose it (#2970).
 	if err := os.Remove(src); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	if err := runDoctor(&out, []string{"--deep", "--offline"}, nil, dir); err != nil {
+		t.Fatalf("a transcript the client cleaned up must not fail deep doctor: %v\n%s", err, out.String())
+	}
+	if !strings.Contains(out.String(), "kept") || strings.Contains(out.String(), "orphan-file") {
+		t.Fatalf("a kept transcript is reported as drift, or not at all:\n%s", out.String())
+	}
+
+	// The whole store gone is drift.
+	if err := os.RemoveAll(filepath.Dir(src)); err != nil {
 		t.Fatal(err)
 	}
 	out.Reset()
 	err := runDoctor(&out, []string{"--deep", "--offline"}, nil, dir)
 	if err == nil || !strings.Contains(err.Error(), "index drift") {
-		t.Fatalf("deleted source must fail deep doctor, err=%v", err)
+		t.Fatalf("a vanished store must fail deep doctor, err=%v", err)
 	}
 	if !strings.Contains(out.String(), "orphan-file") || !strings.Contains(out.String(), "deja index --rebuild") {
 		t.Fatalf("drift output missing finding or fix hint:\n%s", out.String())

--- a/cmd/deja/pruned_transcript_test.go
+++ b/cmd/deja/pruned_transcript_test.go
@@ -8,16 +8,17 @@ import (
 	"time"
 )
 
-// A harness that prunes an old transcript is the ordinary case, and deja's
-// answer to it is eviction: the index mirrors the stores, and what is kept back
-// is only the file on a volume that is not mounted (#900) or a tree that was
-// renamed. The tests beside this one cover those two; nothing covered the plain
-// one — one file deleted from a store that is otherwise still there — which is
-// the case a person meets when a harness rotates its history or they tidy up.
+// A harness that prunes an old transcript is the ordinary case — Claude Code
+// does it to everything older than cleanupPeriodDays, 30 by default — and
+// deja's answer to it is to keep what it indexed: the file is gone, the
+// session is not, and `deja forget` is the way to drop one on purpose. Only a
+// store that goes away whole leaves the index; a file on a volume that is not
+// mounted (#900) or a tree that was renamed were already kept.
 //
-// Pinned rather than argued: a change of mind here is a decision about what
-// deja is for, and it should be made on purpose rather than drift in.
-func TestAPrunedTranscriptLeavesTheIndexAndItsNeighbourStays(t *testing.T) {
+// Pinned rather than argued: this is a decision about what deja is for, made
+// on purpose on 2026-09-02 (#2970) after the index had followed the file out
+// the door since the first release.
+func TestAPrunedTranscriptStaysInTheIndexAndItsNeighbourToo(t *testing.T) {
 	tmp := hermeticEnv(t)
 	root := filepath.Join(tmp, "claude", "projects", "-tmp-app")
 	if err := os.MkdirAll(root, 0o755); err != nil {
@@ -48,21 +49,21 @@ func TestAPrunedTranscriptLeavesTheIndexAndItsNeighbourStays(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The pass says one file went, and does not claim the store is gone: this
-	// is a prune, not an unplugged disk.
-	if !strings.Contains(said, "removed_files=1") {
-		t.Errorf("the pass does not report the file that went:\n%s", said)
+	// The pass says the file went and the session did not, and does not
+	// claim the store is gone: this is a prune, not an unplugged disk.
+	if !strings.Contains(said, "no longer on disk") || !strings.Contains(said, "still searchable") {
+		t.Errorf("the pass does not say what it kept:\n%s", said)
 	}
 	if strings.Contains(said, "is gone, and") {
 		t.Errorf("a pruned file was reported as a store that went away whole:\n%s", said)
 	}
 
 	out, _ := captureRun(t, "search", "migration")
-	if strings.Contains(out, "s1") {
-		t.Errorf("the pruned session is still answered from the index:\n%s", out)
+	if !strings.Contains(out, "s1") {
+		t.Errorf("the pruned session left the index with its file:\n%s", out)
 	}
 	if !strings.Contains(out, "s2") {
-		t.Errorf("the session whose transcript is still there went with it:\n%s", out)
+		t.Errorf("the session whose transcript is still there went too:\n%s", out)
 	}
 
 	// And nothing keeps naming the file: doctor counts what is there.
@@ -74,7 +75,7 @@ func TestAPrunedTranscriptLeavesTheIndexAndItsNeighbourStays(t *testing.T) {
 	}
 	// The store's own row, whole, so the count cannot be read out of a larger
 	// number somewhere else on the screen.
-	if !strings.Contains(doc, "(1 file, 1 indexed session)") {
-		t.Errorf("doctor does not count the one file and session that are left:\n%s", doc)
+	if !strings.Contains(doc, "(1 file, 2 indexed sessions, 1 from a transcript no longer on disk)") {
+		t.Errorf("doctor does not say that one of the two sessions has no file any more:\n%s", doc)
 	}
 }

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -111,6 +111,7 @@ find ~/.claude/projects -name '*.jsonl' -size +50M</pre>
 <h2>Claude Code deletes them for you</h2>
 <p>By default Claude Code keeps a transcript for <b>30 days</b> and then removes it — the setting is <code>cleanupPeriodDays</code> in <code>~/.claude/settings.json</code>, documented under <a href="https://code.claude.com/docs/en/data-usage#data-retention">data retention</a>. Nothing announces it; people notice when <code>--resume</code> no longer lists a session they had in June. If you want the files to stay, raise the number before the month is up:</p>
 <pre>{ "cleanupPeriodDays": 3650 }</pre>
+<p>deja keeps what it indexed: a transcript the sweep removes stays searchable, because the index does not follow a single file out the door — only <code>deja forget</code> drops a session on purpose. The files themselves, though, are gone, and so is <code>--resume</code> for them.</p>
 <p>The sweep is Claude Code's own, not a cron job, and it pauses whenever the client cannot safely determine the retention period — which is why the machine measured above, on the default setting, still holds 69 files older than 31 days. Do not read that as safety. The documented behaviour is deletion after 30 days, and the day the sweep runs is the day the June session goes.</p>
 
 <h2>Can you delete them yourself?</h2>

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -401,6 +401,10 @@ permission walk was cut short or blocked carries `partial` or `unchecked`.
 stores, and git supplies changed-file notes, worktree names and the task
 signal. Both degrade quietly, which is why the report names them.
 
+Under `deep`, `kept` lists indexed transcripts that are no longer on disk while
+their directory is — the client's own cleanup, kept on purpose. It is not a
+finding: nothing about the index is wrong, and a rebuild would lose them.
+
 Version `state` is `ok`, `update-available`, `ahead`, `dev`, `offline` (under
 `--offline`), or `unknown`. `policy.state` is `default`, `active` or
 `unreadable` (which adds an `error`); `activations` keys are `search`, `mcp` and

--- a/internal/index/counter_family_test.go
+++ b/internal/index/counter_family_test.go
@@ -42,24 +42,34 @@ func buildWithFiles(t *testing.T, ids ...string) (proj, dir string) {
 func TestTheEvictedCounterBelongsToTheLastBuild(t *testing.T) {
 	proj, dir := buildWithFiles(t, "a", "b", "c")
 
-	for _, id := range []string{"a", "b"} {
-		if err := os.Remove(filepath.Join(proj, id+".jsonl")); err != nil {
-			t.Fatal(err)
-		}
+	// Whole stores, not single files: a file that goes while its directory
+	// stays is kept on purpose now (#2970), and an eviction is a store that
+	// went away. First a second store with one file, then the first with
+	// three; the second count must be its own three, not four.
+	other := filepath.Join(filepath.Dir(proj), "other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLines(t, filepath.Join(other, "d.jsonl"), claudeLine("d", "2026-01-04T00:00:00Z", "delta text"))
+	if err := Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(other); err != nil {
+		t.Fatal(err)
 	}
 	if err := Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
 	// Deliberately not read: the leftover is what the next build must not
 	// inherit.
-	if err := os.Remove(filepath.Join(proj, "c.jsonl")); err != nil {
+	if err := os.RemoveAll(proj); err != nil {
 		t.Fatal(err)
 	}
 	if err := Ensure(dir, "", false, nil); err != nil {
 		t.Fatal(err)
 	}
-	if n := ReportEvictedFiles(); n != 1 {
-		t.Errorf("the second eviction reported %d files, want its own 1", n)
+	if n := ReportEvictedFiles(); n != 3 {
+		t.Errorf("the second eviction reported %d files, want its own 3", n)
 	}
 }
 

--- a/internal/index/deepverify.go
+++ b/internal/index/deepverify.go
@@ -33,6 +33,10 @@ type DeepReport struct {
 	// Findings mean the index disagrees with what it already claimed to hold.
 	Stale    []string      `json:"stale,omitempty"`
 	Findings []DeepFinding `json:"findings,omitempty"`
+	// Kept lists files the manifest holds that are no longer on disk while
+	// their store is: transcripts the client cleaned up, kept in the index on
+	// purpose. Not a finding — nothing is wrong with the index (#2970).
+	Kept []string `json:"kept,omitempty"`
 }
 
 func (r DeepReport) Clean() bool { return len(r.Findings) == 0 }
@@ -79,10 +83,21 @@ func DeepVerify(dir string) (DeepReport, error) {
 		}
 	}
 	for p := range m.Files {
-		if _, ok := current[p]; !ok {
-			report.Findings = append(report.Findings, DeepFinding{Kind: "orphan-file", Detail: p + " is in the manifest but no longer on disk"})
+		if _, ok := current[p]; ok {
+			continue
 		}
+		// A file that is gone while its directory is still there is the
+		// client's cleanup or a deletion by hand, and the index keeps those
+		// on purpose (#2970) — so it is not drift, and the fix the finding
+		// prescribes, a rebuild, is exactly what would lose them. A tree that
+		// is gone whole is still reported.
+		if _, err := os.Stat(filepath.Dir(p)); err == nil {
+			report.Kept = append(report.Kept, p)
+			continue
+		}
+		report.Findings = append(report.Findings, DeepFinding{Kind: "orphan-file", Detail: p + " is in the manifest but no longer on disk"})
 	}
+	sort.Strings(report.Kept)
 	sort.Strings(report.Stale)
 
 	// 2. Parse drift: deterministically sample in-sync source files (stale

--- a/internal/index/deepverify_test.go
+++ b/internal/index/deepverify_test.go
@@ -103,6 +103,10 @@ func TestDeepVerifyFlagsShrunkSource(t *testing.T) {
 	}
 }
 
+// A transcript deleted while its directory stays is the client's cleanup, and
+// the index keeps it on purpose (#2970): listed under Kept, not a finding,
+// because the finding's remedy — a rebuild — is what would lose it. A tree
+// that is gone whole is still drift.
 func TestDeepVerifyFlagsDeletedSource(t *testing.T) {
 	dir, src := deepFixture(t)
 	if err := os.Remove(src); err != nil {
@@ -112,8 +116,21 @@ func TestDeepVerifyFlagsDeletedSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if findingKinds(r)["orphan-file"] {
+		t.Fatalf("a transcript the client cleaned up was reported as drift: %#v", r.Findings)
+	}
+	if len(r.Kept) != 1 || r.Kept[0] != src {
+		t.Fatalf("kept = %v, want the deleted transcript", r.Kept)
+	}
+	if err := os.RemoveAll(filepath.Dir(src)); err != nil {
+		t.Fatal(err)
+	}
+	r, err = DeepVerify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !findingKinds(r)["orphan-file"] {
-		t.Fatalf("want orphan-file for deleted source, got %#v", r.Findings)
+		t.Fatalf("want orphan-file once the whole tree is gone, got %#v", r.Findings)
 	}
 }
 

--- a/internal/index/deleted_transcript_test.go
+++ b/internal/index/deleted_transcript_test.go
@@ -1,0 +1,129 @@
+package index
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// Claude Code deletes a transcript once it is older than cleanupPeriodDays
+// (30 by default), and the next incremental pass dropped the session with it:
+// the one client-side housekeeping deja exists to outlast took the index down
+// with the file. A file that is gone while its store is still there is that
+// cleanup, or a deletion by hand — and `deja forget` is the deliberate path,
+// so the index keeps what it indexed (#2970).
+func TestADeletedTranscriptStaysInTheIndex(t *testing.T) {
+	tmp := t.TempDir()
+	claudeRoot := filepath.Join(tmp, "claude")
+	proj := filepath.Join(claudeRoot, "-Users-shulcz-deja-vu")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	s1 := filepath.Join(proj, "s1.jsonl")
+	s2 := filepath.Join(proj, "s2.jsonl")
+	if err := os.WriteFile(s1, []byte(`{"type":"user","sessionId":"s1","timestamp":"2026-06-02T03:04:05Z","message":{"role":"user","content":"the zorblax pool deadlocked"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(s2, []byte(`{"type":"user","sessionId":"s2","timestamp":"2026-08-02T03:04:05Z","message":{"role":"user","content":"beta stable"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	setHome(t, filepath.Join(tmp, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	t.Setenv("DEJA_CLAUDE_ROOT", claudeRoot)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "no-codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "no-opencode.db"))
+	t.Setenv("DEJA_GEMINI_ROOT", filepath.Join(tmp, "no-gemini"))
+	t.Setenv("DEJA_CURSOR_ROOT", filepath.Join(tmp, "no-cursor"))
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", filepath.Join(tmp, "no-cursor-cli"))
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(tmp, "no-antigravity"))
+	t.Setenv("DEJA_AIDER_ROOTS", filepath.Join(tmp, "no-aider"))
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "claude", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// The cleanup: one file gone, the store around it still there.
+	if err := os.Remove(s1); err != nil {
+		t.Fatal(err)
+	}
+	var log bytes.Buffer
+	if err := Ensure(dir, "claude", false, &log); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := Search(dir, search.Options{Query: "zorblax"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 || ss[0].ID != "s1" {
+		t.Fatalf("a transcript the client deleted left the index with it: %#v\nlog: %s", ss, log.String())
+	}
+	if !strings.Contains(log.String(), "still searchable") {
+		t.Errorf("the pass kept the session and said nothing about it:\n%s", log.String())
+	}
+	// And it stays kept on the pass after that, when there is nothing else to do.
+	if err := Ensure(dir, "claude", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, _ := Search(dir, search.Options{Query: "zorblax"}); len(ss) != 1 {
+		t.Fatalf("the kept session went away on the following pass: %#v", ss)
+	}
+	// And on the pass that appends to a neighbour — the cheap path, which
+	// parses nothing but the grown file — the kept session is still there
+	// and the pass still says so.
+	f, err := os.OpenFile(s2, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"type":"assistant","sessionId":"s2","timestamp":"2026-08-02T03:05:05Z","message":{"role":"assistant","content":"gamma appended"}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	log.Reset()
+	if err := Ensure(dir, "claude", false, &log); err != nil {
+		t.Fatal(err)
+	}
+	if ss, _ := Search(dir, search.Options{Query: "zorblax"}); len(ss) != 1 {
+		t.Fatalf("the kept session went away on an append pass: %#v", ss)
+	}
+	if !strings.Contains(log.String(), "still searchable") {
+		t.Errorf("the append pass kept the session and said nothing about it:\n%s", log.String())
+	}
+	// A session with the same id arriving from another project is a collision
+	// (#699), not the kept transcript being renamed: both stay.
+	other := filepath.Join(claudeRoot, "-Users-shulcz-other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "s1.jsonl"), []byte(`{"type":"user","sessionId":"s1","timestamp":"2026-08-03T03:04:05Z","message":{"role":"user","content":"unrelated quux work"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "claude", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, _ := Search(dir, search.Options{Query: "zorblax"}); len(ss) != 1 {
+		t.Fatalf("a same-id session from another project took the kept one with it: %#v", ss)
+	}
+	if ss, _ := Search(dir, search.Options{Query: "quux"}); len(ss) != 1 {
+		t.Fatalf("the colliding session from the other project was not indexed: %#v", ss)
+	}
+
+	// The other case is unchanged: the whole store gone is not a cleanup —
+	// it is an uninstall, a move, or a disk that is not there — and a tree
+	// that is not a mount point is dropped as before.
+	if err := os.RemoveAll(claudeRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(claudeRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "claude", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ss, _ := Search(dir, search.Options{Query: "stable"}); len(ss) != 0 {
+		t.Fatalf("a store that went away whole was kept: %#v", ss)
+	}
+}

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -576,10 +576,12 @@ func TestIndexRecentFindRecordsAndBranches(t *testing.T) {
 	if err := Ensure(idx, "claude", false, &log); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(log.String(), "removed_files=1") {
-		t.Fatalf("want removed file log, got %q", log.String())
+	// The file is gone and its directory is not: that is the client's
+	// cleanup, and the session is kept on purpose (#2970).
+	if !strings.Contains(log.String(), "still searchable") {
+		t.Fatalf("want the kept-transcript line, got %q", log.String())
 	}
-	if got, err := Recent(idx, 10); err != nil || len(got) != 0 {
+	if got, err := Recent(idx, 10); err != nil || len(got) != 1 {
 		t.Fatalf("recent after remove=%#v err=%v", got, err)
 	}
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2637,8 +2637,36 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 			}
 		}
 	}
-	// Counted after the keep-back above: records that came off an unmounted
-	// volume are still in the index, so they did not go away.
+	// A file that is gone while the directory around it is still there is
+	// not a store that went away: it is Claude Code's own cleanup, which
+	// deletes a transcript once it is older than cleanupPeriodDays (30 by
+	// default), or a deletion by hand. Either way the index keeps what it
+	// read — outlasting the client's housekeeping is the one thing a memory
+	// over transcripts can offer against a 30-day default, and `deja forget`
+	// is the deliberate path for a session that must go (#2970). A tree that
+	// is gone whole is an uninstall or a move, and is dropped as before.
+	kept := map[string]bool{}
+	for p := range removed {
+		if _, err := os.Stat(filepath.Dir(p)); err != nil {
+			continue
+		}
+		if of, ok := old.Files[p]; ok {
+			files[p] = of
+			delete(removed, p)
+			kept[p] = true
+		}
+	}
+	// Said once per pass, and only once the rename filter below has had its
+	// say — except when nothing else changed, in which case there is no
+	// rename to filter and the pass returns early.
+	sayKept := func() {
+		if len(kept) > 0 && progress != nil {
+			fmt.Fprintf(progress, "deja: %d transcript%s no longer on disk — still searchable; `deja forget <id>` drops one for good\n", len(kept), pluralS(len(kept)))
+		}
+	}
+	// Counted after the keep-backs above: records that came off an unmounted
+	// volume, or out of a file the client cleaned up, are still in the index,
+	// so they did not go away.
 	evicted.Add(int64(len(removed)))
 	if progress != nil {
 		for _, g := range gone {
@@ -2660,6 +2688,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		}
 	}
 	if len(changed) == 0 && len(removed) == 0 {
+		sayKept()
 		lastIngestFiles = 0
 		return nil
 	}
@@ -2674,6 +2703,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 		if err != nil {
 			return fmt.Errorf("append: %w", err)
 		}
+		sayKept()
 		if progress != nil {
 			line := fmt.Sprintf("deja: updated %d file%s (%d new message%s)", filesTouched, pluralS(filesTouched), messages, pluralS(messages))
 			// After the first build every run a person sees is this one, so a
@@ -2732,6 +2762,25 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	for _, s := range replacements {
 		replaceKeys[s.Harness+":"+s.ID] = true
 	}
+	// A kept file whose session arrived again from another path is a rename,
+	// not a cleanup: the client moved the transcript, and keeping the old copy
+	// would make the session its own second copy (#1086). Those go back to
+	// being removed, so the records under the old path are dropped below.
+	// Only when the arrival sits in the same directory: two projects can
+	// share a filename-derived id (#699), and that is a collision, not the
+	// kept session moving.
+	arrivedIn := map[string]string{}
+	for _, r := range replacements {
+		arrivedIn[r.Harness+":"+r.ID] = filepath.Dir(r.Path)
+	}
+	for key, meta := range old.Sessions {
+		if kept[meta.Path] && replaceKeys[key] && arrivedIn[key] == filepath.Dir(meta.Path) {
+			removed[meta.Path] = true
+			delete(files, meta.Path)
+			delete(kept, meta.Path)
+		}
+	}
+	sayKept()
 	if progress != nil {
 		fmt.Fprintf(progress, "deja: incremental index changed_files=%d removed_files=%d sessions=%d\n", len(changed), len(removed), len(replacements))
 	}

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -177,6 +177,42 @@ func HarnessSharedCounts(dir string) map[string]int {
 	return out
 }
 
+// HarnessKeptCounts is how many indexed sessions per harness came from a
+// transcript that is no longer on disk while its directory still is — the
+// client's own cleanup, kept on purpose (#2970). doctor prints it beside the
+// session count, since "1 file, 2 indexed sessions" reads as a miscount
+// otherwise.
+func HarnessKeptCounts(dir string) map[string]int {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		return nil
+	}
+	gone := map[string]bool{}
+	out := map[string]int{}
+	for _, meta := range m.Sessions {
+		if meta.Path == "" {
+			continue
+		}
+		g, seen := gone[meta.Path]
+		if !seen {
+			_, err := os.Stat(meta.Path)
+			g = os.IsNotExist(err)
+			if g {
+				_, derr := os.Stat(filepath.Dir(meta.Path))
+				g = derr == nil
+			}
+			gone[meta.Path] = g
+		}
+		if g {
+			out[meta.Harness]++
+		}
+	}
+	return out
+}
+
 func Redactions(dir string) (RedactionStats, error) {
 	if dir == "" {
 		dir = DefaultDir()

--- a/internal/index/sync_persist_test.go
+++ b/internal/index/sync_persist_test.go
@@ -122,8 +122,11 @@ func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != 1 {
-		t.Fatalf("export n=%d, want 1 native record only", n)
+	// Two native records: local2, and local1, whose file was removed while
+	// its directory stayed and which the index therefore kept (#2970). What
+	// must not be here is the imported one.
+	if n != 2 {
+		t.Fatalf("export n=%d, want the 2 native records only", n)
 	}
 	matches, err := filepath.Glob(filepath.Join(outDir, "*.jsonl"))
 	if err != nil {
@@ -146,8 +149,8 @@ func TestImportedRecordsSurviveRebuildAndUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if n != 1 {
-		t.Fatalf("full export n=%d, want 1 native record", n)
+	if n != 2 {
+		t.Fatalf("full export n=%d, want the 2 native records", n)
 	}
 	matches, err = filepath.Glob(filepath.Join(fullDir, "*.jsonl"))
 	if err != nil {


### PR DESCRIPTION
Closes #2970.

Claude Code keeps transcripts for `cleanupPeriodDays` (30 by default) and then deletes them; anthropics/claude-code#62476 is open with 24 reactions from people who found out afterwards. deja indexed those files and then, on the next incremental pass, dropped the session because the file was gone — reproduced in `TestADeletedTranscriptStaysInTheIndex`, which fails before this change.

What changes, in `ingest.go`: a removed path whose directory still exists is kept — its records stay, its `FileState` is carried, and the pass says `N transcripts no longer on disk — still searchable`. A tree that vanished whole (uninstall, move, a disk that is not there) is dropped exactly as before. A rename is not a cleanup: when the same session arrives again from another file in the same directory, the old path goes back to removed, so the session is not its own second copy (#1086); a same-id arrival from another directory is the #699 collision and both stay.

`doctor --deep` lists kept files under `kept` instead of calling them `orphan-file` drift — the finding's remedy, a rebuild, is what would lose them — and the store row reads `2 indexed sessions, 1 from a transcript no longer on disk` so the gap between files and sessions is explained. Four tests that pinned the old behaviour were rewritten; `TestAPrunedTranscriptStaysInTheIndexAndItsNeighbourToo` keeps its original comment's point — this is a decision about what deja is for, made on purpose.

Known limit, stated in the changelog: a full `deja index --rebuild` walks the disk and still loses kept sessions; carrying them across a rebuild is the follow-up on #2970.

Reviewer pass caught two things now fixed: the append path returned without the kept line, and the rename filter did not check the directory.