### PR TITLE
chore(packaging): the winget manifests carry the schema header

### DIFF
--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
 PackageIdentifier: vshulcz.deja-vu
 PackageVersion: 0.19.2
 InstallerType: zip

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
 PackageIdentifier: vshulcz.deja-vu
 PackageVersion: 0.19.2
 PackageLocale: en-US

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
 PackageIdentifier: vshulcz.deja-vu
 PackageVersion: 0.19.2
 DefaultLocale: en-US


### PR DESCRIPTION
microsoft/winget-pkgs#428125 was sent back for the `# yaml-language-server: $schema=…` header their review and validation require on every manifest. Added to the three files here so the next pin carries it; `pinmanifests` edits these in place rather than regenerating, and `-check` still matches the release.