### PR TITLE
test: pin the notes file in withStatsStores, which leaked through %AppData% on Windows

### DIFF
--- a/cmd/deja/main_test.go
+++ b/cmd/deja/main_test.go
@@ -432,6 +432,11 @@ func withStatsStores(t *testing.T) {
 	t.Setenv("DEJA_CODEX_ROOT", codexRoot)
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "opencode.db"))
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	// The notes file falls back to %AppData% on Windows, which moving HOME
+	// does not move — so every test that left it unpinned shared one real
+	// file, and a note another test promoted turned up in this fixture's
+	// install proof and its totals (#2978).
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
 	t.Setenv("NO_COLOR", "1")
 
 	writeClaudeFixture(t, filepath.Join(claudeRoot, "-tmp-alpha", "c1.jsonl"), "c1", []string{


### PR DESCRIPTION
Closes #2978.

`withStatsStores` moved HOME and USERPROFILE but not the notes file, which on Windows falls back to `os.UserConfigDir()` — `%AppData%` — so the package's tests shared one real notes file there and a note another test promoted showed up in this fixture's install proof and its totals. Pinned into the fixture's temp dir, the way `hermeticEnv` already does. The `windows` label is on so the Windows leg runs on this PR; it has been red on main since 2026-09-01 without a PR ever showing it.