### PR TITLE
fix(goose): honour the recall kill switch

### DIFF
--- a/cmd/deja/goose_recall_off_test.go
+++ b/cmd/deja/goose_recall_off_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// DEJA_RECALL=off is the documented kill switch, and every hook reads it —
+// except this one. So on goose, off left deja writing a block into the
+// reader's AGENTS.md, and that file is re-read every turn, so it kept reaching
+// the model. Found while building the control arm of an A/B: both arms shipped
+// a block, which is what an off arm is supposed to prove cannot happen.
+func TestTheGooseRecallHonoursTheKillSwitch(t *testing.T) {
+	gooseHomeForTest(t)
+
+	// Something to write, then the switch.
+	if err := writeGooseRecall("recalled text"); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(gooseHintsPath())
+	if err != nil || !strings.Contains(string(before), gooseRecallStart) {
+		t.Fatalf("nothing was written to switch off: %v\n%s", err, before)
+	}
+
+	t.Setenv("DEJA_RECALL", "off")
+	if err := refreshGooseHintsFor(""); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(gooseHintsPath()); err == nil && strings.Contains(string(b), gooseRecallStart) {
+		t.Errorf("the block survived the kill switch:\n%s", b)
+	}
+}
+
+// Off must not take the reader's own lines with it: the switch is about deja's
+// block, not about the file.
+func TestTheKillSwitchLeavesTheReadersLines(t *testing.T) {
+	gooseHomeForTest(t)
+	path := gooseHintsPath()
+	if err := os.MkdirAll(strings.TrimSuffix(path, "/AGENTS.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("# mine\n\nalways use pgx\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGooseRecall("recalled text"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DEJA_RECALL", "off")
+	if err := refreshGooseHintsFor(""); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the kill switch deleted the reader's file: %v", err)
+	}
+	if !strings.Contains(string(b), "always use pgx") {
+		t.Errorf("the reader's lines went with the block:\n%s", b)
+	}
+	if strings.Contains(string(b), gooseRecallStart) {
+		t.Errorf("the block survived:\n%s", b)
+	}
+}
+
+// And with the switch off, deja writes nothing where there was nothing —
+// "No matching history yet." is a claim about the store, and off is not that.
+func TestTheKillSwitchWritesNothingAtAll(t *testing.T) {
+	gooseHomeForTest(t)
+	t.Setenv("DEJA_RECALL", "off")
+	if err := refreshGooseHintsFor(""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(gooseHintsPath()); err == nil {
+		b, _ := os.ReadFile(gooseHintsPath())
+		t.Errorf("the switch created a file anyway:\n%s", b)
+	}
+}
+
+// Under the wrapper the recall lives in the MOIM file, which is deja's own —
+// off has to empty it too, or the last thing deja wrote keeps being read every
+// turn with the switch thrown.
+func TestTheKillSwitchEmptiesTheMoimFile(t *testing.T) {
+	gooseHomeForTest(t)
+	moim := filepath.Join(t.TempDir(), "recall.md")
+	t.Setenv("GOOSE_MOIM_MESSAGE_FILE", moim)
+	if err := writeGooseRecall("recalled text"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(moim); err != nil {
+		t.Fatalf("nothing was written to switch off: %v", err)
+	}
+
+	t.Setenv("DEJA_RECALL", "off")
+	if err := refreshGooseHintsFor(""); err != nil {
+		t.Fatal(err)
+	}
+	if b, err := os.ReadFile(moim); err == nil && strings.TrimSpace(string(b)) != "" {
+		t.Errorf("the MOIM file still holds a recall with the switch off:\n%s", b)
+	}
+}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -434,6 +434,20 @@ func refreshGooseForPrompt(dir string, payload []byte) error {
 	return writeGooseRecall(out.String())
 }
 
+// clearGooseRecall takes deja's block out of wherever the recall lives, so a
+// switch thrown mid-session stops the injection instead of freezing it.
+func clearGooseRecall() error {
+	path := gooseRecallPath()
+	if path != gooseHintsPath() {
+		// The MOIM file is deja's own; emptying it is the whole of it.
+		if _, err := os.Stat(path); err != nil {
+			return nil
+		}
+		return os.Remove(path)
+	}
+	return dropGooseRecallBlock(path)
+}
+
 // writeGooseRecall puts the recall where goose will read it. The MOIM file is
 // deja's own and holds nothing else; AGENTS.md is the reader's, so only the
 // block between deja's markers is ours to rewrite — the prompt path wrote it
@@ -474,6 +488,14 @@ func refreshGooseHints() error {
 // project the call is about; "" leaves the chain to answer, which is what the
 // wrapper and the installer want (#2187).
 func refreshGooseHintsFor(cwd string) error {
+	// The documented kill switch. Every other hook reads it; this one did not,
+	// so `DEJA_RECALL=off` left deja writing a block into the reader's
+	// AGENTS.md — and that file is re-read every turn, so it kept reaching the
+	// model. Off has to mean nothing of deja's arrives, which means taking out
+	// what an earlier run put there rather than only declining to write.
+	if recallIsOff() {
+		return clearGooseRecall()
+	}
 	digest, sessions, _, _, _, _, _ := cachedHookDigestFor(index.DefaultDir(), cwd)
 	body := digest
 	if sessions > 0 {


### PR DESCRIPTION
`recallIsOff()` is read by the per-prompt hook, the tool hooks, the plan hook, the session-start hook and the environment block. Not by goose's. So with `DEJA_RECALL=off` deja still wrote its block into the reader's `AGENTS.md` — and #2963 measured that goose re-reads that file every turn, so the switch stopped nothing at all. It also wrote *"No matching history yet."*, which is a claim about the store, and off is not that.

Found while building the control arm of an A/B on a real model: both arms shipped a block, which is precisely what an off arm exists to rule out. The measurement was wrong because the product was.

Off now means nothing of deja's reaches the model, which takes more than declining to write — an earlier run's block is still in the file and still being read, so it comes out. The reader's own lines stay: the switch is about deja's block, not about their file. Under the wrapper the recall lives in the MOIM file, which is deja's own, so that is emptied instead.

Four mutations, all red: not reading the switch, declining to write while leaving the block, deleting the reader's file, and leaving the MOIM file holding the last recall. The fourth was blind until the MOIM case got its own test.