### PR TITLE
feat(dsh): a root manifest so the catalogs see the plugin in the monorepo

### DIFF
--- a/cmd/deja/root_dsh_manifest_test.go
+++ b/cmd/deja/root_dsh_manifest_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The repository root carries a package.json that re-exports extensions/dsh.
+// It exists for one reader: the DeepSeek Harness catalogs, whose admission
+// bots take "repository = plugin" and look for `dsh.bundle` in the root
+// manifest — a monorepo with the plugin in a subdirectory was filed with no
+// npm name by one bot, marked "unavailable" by another and refused by a third
+// for that alone. The root manifest has to stay a faithful pointer at the real
+// one, or the catalogs install something the npm package is not.
+func TestRootManifestMirrorsTheDshPlugin(t *testing.T) {
+	root := filepath.Join("..", "..")
+	read := func(p string) map[string]any {
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(p)))
+		if err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("%s: %v", p, err)
+		}
+		return m
+	}
+	top := read("package.json")
+	sub := read("extensions/dsh/package.json")
+
+	for _, key := range []string{"name", "version", "license", "engines", "dependencies"} {
+		a, _ := json.Marshal(top[key])
+		b, _ := json.Marshal(sub[key])
+		if string(a) != string(b) {
+			t.Errorf("root package.json %s = %s, extensions/dsh has %s", key, a, b)
+		}
+	}
+	if top["private"] != true {
+		t.Error("the root manifest must be private: the package on npm is extensions/dsh, not the repository")
+	}
+
+	// What the admission bots resolve: dsh.bundle is a non-empty object, and
+	// every ./path it names is a file in the tree.
+	bundle, _ := top["dsh"].(map[string]any)["bundle"].(map[string]any)
+	if len(bundle) == 0 {
+		t.Fatal("root package.json declares no dsh.bundle")
+	}
+	for key, v := range bundle {
+		p, _ := v.(string)
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(p))); err != nil {
+			t.Errorf("dsh.bundle.%s names %q, which is not in the repository: %v", key, p, err)
+		}
+	}
+	for _, key := range []string{"main"} {
+		p, _ := top[key].(string)
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(p))); err != nil {
+			t.Errorf("root package.json %s names %q, which is not in the repository: %v", key, p, err)
+		}
+	}
+}

--- a/extensions/dsh/README.md
+++ b/extensions/dsh/README.md
@@ -18,6 +18,13 @@ week, everything you did before last week is still reachable from inside it.
 dsh plugin --profile web add dsh-deja
 ```
 
+From the repository instead of npm — the root manifest re-exports this
+directory, so either form works:
+
+```sh
+dsh plugin --profile web add github:vshulcz/deja-vu#path:extensions/dsh
+```
+
 The plugin runs the `deja` binary. It is pulled in as a dependency, so npm
 installs it with the plugin; a `deja` already on `PATH` is used as-is, and
 `DEJA_BIN` overrides both.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "dsh-deja",
+  "version": "0.20.4",
+  "private": true,
+  "description": "Repository-root manifest for the DeepSeek Harness plugin that lives in extensions/dsh — the same package published to npm as dsh-deja. It re-exports the subdirectory so the plugin installs from a bare git URL or from github:vshulcz/deja-vu#path:extensions/dsh; the npm package is the shorter path. The repository itself is the Go project behind the deja binary.",
+  "type": "module",
+  "main": "./extensions/dsh/index.js",
+  "exports": {
+    ".": "./extensions/dsh/index.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "extensions/dsh",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vshulcz/deja-vu.git",
+    "directory": "extensions/dsh"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh",
+  "bugs": {
+    "url": "https://github.com/vshulcz/deja-vu/issues"
+  },
+  "keywords": [
+    "dsh",
+    "dsh-plugin",
+    "deepseek-harness",
+    "memory",
+    "recall",
+    "session-history"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./extensions/dsh/cordis.patch.yml"
+    }
+  },
+  "dependencies": {
+    "@vshulcz/deja-vu": "^0.18.0"
+  }
+}


### PR DESCRIPTION
Three DeepSeek Harness catalogs read the plugin the same way: repository = plugin, `dsh.bundle` in the root `package.json`. With ours in `extensions/dsh`, the dsh-pluginmarket scanner filed us with an empty npm field, dsh-suite marked us "unavailable — npm package not found", and deepseek-plugin-store's admission bot refused the submission (Ericwong5021/deepseek-plugin-store#197: "Root package.json is missing", "does not declare a valid dsh.bundle").

This adds a root manifest that re-exports the subdirectory — `main`, `exports` and `dsh.bundle.patch` all point into `extensions/dsh` — the shape `@omdp/dsh-connector` uses for the same situation. It is `private`, so nothing publishes the repository as a package; the npm package is still `dsh-deja` from `extensions/dsh`, and the plugin now also installs as `github:vshulcz/deja-vu#path:extensions/dsh` (README updated). I read the bot's check (`plugin-intake-agent.mjs`): non-empty `dsh.bundle`, every `./path` in it present in the tree, README with install guidance, no failing default-branch checks — the last one is #2979.

`TestRootManifestMirrorsTheDshPlugin` keeps name, version, license, engines and dependencies identical to the real manifest and resolves every path the bundle names. `extensions.yml` reads `package.json` inside `extensions/dsh`, so it is unaffected.