### PR TITLE
test(goose): the parent of AGENTS.md is filepath.Dir, not a trimmed slash

### DIFF
--- a/cmd/deja/goose_recall_off_test.go
+++ b/cmd/deja/goose_recall_off_test.go
@@ -38,7 +38,7 @@ func TestTheGooseRecallHonoursTheKillSwitch(t *testing.T) {
 func TestTheKillSwitchLeavesTheReadersLines(t *testing.T) {
 	gooseHomeForTest(t)
 	path := gooseHintsPath()
-	if err := os.MkdirAll(strings.TrimSuffix(path, "/AGENTS.md"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, []byte("# mine\n\nalways use pgx\n"), 0o644); err != nil {


### PR DESCRIPTION
Closes #2982. `strings.TrimSuffix(path, "/AGENTS.md")` trims nothing on Windows, so `MkdirAll` built a directory where the file goes. `filepath.Dir`. The `windows` label runs the leg here; it is the last red job on main.