### PR TITLE
docs(readme): answer where session history lives and why it disappeared

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,17 @@ record-forward tools and worth your time if that model fits you; it still starts
 knows only what an agent chose to save. The
 [full comparison](https://vshulcz.github.io/deja-vu/guide/compare.html) covers eleven of them.
 
+**Where is Claude Code session history stored, and can I search it?** Under
+`~/.claude/projects`, one JSONL file per session; Codex keeps `~/.codex/sessions`, Cursor a
+SQLite `state.vscdb`. `deja search` reads them all in place, `deja last` lists the recent
+sessions of every agent, and `deja view` opens the whole history as one local page. Paths
+for each agent: [where sessions are stored](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html).
+
+**My Claude Code session history disappeared. Is it gone?** Claude Code deletes transcripts
+older than 30 days (`cleanupPeriodDays` in `~/.claude/settings.json`), and `/resume` lists
+only what is left. A session deja indexed before the cleanup stays searchable after the
+file is gone. Details: [session files on disk](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html).
+
 **What about Windows?** Builds exist and CI runs the suite there. macOS and Linux are the
 battle-tested paths. Field reports welcome in [#9](https://github.com/vshulcz/deja-vu/issues/9).
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ sessions of every agent, and `deja view` opens the whole history as one local pa
 for each agent: [where sessions are stored](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html).
 
 **My Claude Code session history disappeared. Is it gone?** Claude Code deletes transcripts
-older than 30 days (`cleanupPeriodDays` in `~/.claude/settings.json`), and `/resume` lists
+older than 30 days (`cleanupPeriodDays` in `~/.claude/settings.json`), and `claude --resume` lists
 only what is left. A session deja indexed before the cleanup stays searchable after the
 file is gone. Details: [session files on disk](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -236,7 +236,7 @@ MCP 服务端、统计、分享和同步都读这一份索引。细节见
 
 **Claude Code 的会话历史存在哪里，能搜索吗？** 在 `~/.claude/projects` 下，每个会话一个 JSONL 文件；Codex 存在 `~/.codex/sessions`，Cursor 存在 SQLite 的 `state.vscdb`。`deja search` 就地读取它们，`deja last` 列出每个智能体最近的会话，`deja view` 把全部历史打开成一个本地页面。各智能体的路径见[会话存在哪里](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html)。
 
-**Claude Code 的会话历史不见了，是丢了吗？** Claude Code 会删除 30 天以前的记录（`~/.claude/settings.json` 里的 `cleanupPeriodDays`），`/resume` 只列出还剩下的。deja 在清理前索引过的会话，文件没了之后仍然可以搜索。详见[磁盘上的会话文件](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html)。
+**Claude Code 的会话历史不见了，是丢了吗？** Claude Code 会删除 30 天以前的记录（`~/.claude/settings.json` 里的 `cleanupPeriodDays`），`claude --resume` 只列出还剩下的。deja 在清理前索引过的会话，文件没了之后仍然可以搜索。详见[磁盘上的会话文件](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html)。
 
 **怎么全部清除？**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -234,6 +234,10 @@ MCP 服务端、统计、分享和同步都读这一份索引。细节见
 
 [完整对比](https://vshulcz.github.io/deja-vu/guide/compare.html)覆盖了其中十一个。
 
+**Claude Code 的会话历史存在哪里，能搜索吗？** 在 `~/.claude/projects` 下，每个会话一个 JSONL 文件；Codex 存在 `~/.codex/sessions`，Cursor 存在 SQLite 的 `state.vscdb`。`deja search` 就地读取它们，`deja last` 列出每个智能体最近的会话，`deja view` 把全部历史打开成一个本地页面。各智能体的路径见[会话存在哪里](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html)。
+
+**Claude Code 的会话历史不见了，是丢了吗？** Claude Code 会删除 30 天以前的记录（`~/.claude/settings.json` 里的 `cleanupPeriodDays`），`/resume` 只列出还剩下的。deja 在清理前索引过的会话，文件没了之后仍然可以搜索。详见[磁盘上的会话文件](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html)。
+
 **怎么全部清除？**
 
 ```sh


### PR DESCRIPTION
Closes #2984. Two FAQ entries in both READMEs, worded the way the questions are typed into Google, linking down to the guides that carry the detail. The 30-day cleanup is `cleanupPeriodDays`, as documented in session-files-on-disk.