### PR TITLE
fix(dsh): /deja searches for a word instead of running the command it names

### DIFF
--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -57,8 +57,15 @@ function apply(ctx) {
       if (!query) {
         return { kind: "error", text: "Say what to look for: /deja <error, file, or decision>" };
       }
+      // "search" is named rather than handed over as deja's first word: the
+      // bare-query path dispatches a word that happens to be a command, so
+      // /deja version printed a version number and /deja index rebuilt the
+      // index. "--" then keeps a query that starts with a dash from being read
+      // as a flag, which came back as an error the caller cannot tell from an
+      // empty history.
+      const args = query.startsWith("-") ? ["search", "--", query] : ["search", query];
       try {
-        const out = execFileSync(DEJA, [query], {
+        const out = execFileSync(DEJA, args, {
           encoding: "utf8",
           timeout: 20000,
           maxBuffer: 4 * 1024 * 1024,

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -869,9 +869,17 @@ func cmdCtx(dir string, rest []string) error {
 	// neighbouring commands — so reaching for one here is the obvious mistake.
 	// Folding it into the query answered "no session matches", which is a
 	// false statement about the store (#721).
-	for _, a := range rest {
-		if strings.HasPrefix(a, "--") {
-			return fmt.Errorf("ctx takes no flags, only a query or id-prefix — got %q", a)
+	// Except behind a leading `--`, which is how search, fix and how already
+	// spell "the rest is the query". Without it no caller can ask about a
+	// query that starts with a dash, and the refusal reads to a plugin exactly
+	// like an empty store.
+	if len(rest) > 0 && rest[0] == "--" {
+		rest = rest[1:]
+	} else {
+		for _, a := range rest {
+			if strings.HasPrefix(a, "--") {
+				return fmt.Errorf("ctx takes no flags, only a query or id-prefix — got %q", a)
+			}
 		}
 	}
 	q := strings.Join(rest, " ")
@@ -2540,6 +2548,18 @@ func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch a {
+		case "--":
+			// The rest is the path, dash or not — the spelling search, fix and
+			// how already take. A file really named `-report.md` was otherwise
+			// unreachable, and the refusal reads to a caller like a file
+			// nobody has ever touched.
+			if i+1 < len(args) {
+				if path != "" {
+					return "", o, false, fmt.Errorf("blame accepts one path")
+				}
+				path = args[i+1]
+			}
+			i++
 		case "--json":
 			jsonOutput = true
 		case "--all":

--- a/cmd/deja/query_terminator_test.go
+++ b/cmd/deja/query_terminator_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// search, fix and how take `--` and read the rest as the query; ctx, blame and
+// remember refused it, so nothing a caller could write reached them with a
+// leading dash. `--no-verify` is a thing people ask about, and the refusal that
+// came back is indistinguishable, through a plugin, from an empty store.
+func TestTerminatorMakesADashLeadingQueryReachTheStore(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-p")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"zz1","cwd":"/w/p","timestamp":"2026-07-22T10:00:00Z","message":{"role":"user","content":"we banned --no-verify in this repo, the hooks catch the secrets"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "zz1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "ctx", "--", "--no-verify")
+	if err != nil {
+		t.Fatalf("ctx -- --no-verify: %v", err)
+	}
+	if !strings.Contains(out, "we banned") {
+		t.Errorf("ctx behind the terminator missed the session that discusses it: %q", out)
+	}
+
+	out, err = captureRun(t, "search", "--", "--no-verify")
+	if err != nil {
+		t.Fatalf("search -- --no-verify: %v", err)
+	}
+	if !strings.Contains(out, "we banned") {
+		t.Errorf("search behind the terminator missed the session: %q", out)
+	}
+}
+
+// Only a leading `--`: a flag that comes first is still the mistake #721 is
+// about, and the refusal has to keep naming it.
+func TestCtxStillRefusesFlagsWithoutTheTerminator(t *testing.T) {
+	tmp := hermeticEnv(t)
+	if err := os.MkdirAll(filepath.Join(tmp, "claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := captureRun(t, "ctx", "pool", "--json")
+	if err == nil || !strings.Contains(err.Error(), "ctx takes no flags") {
+		t.Fatalf("a flag with no terminator must still be named: %v", err)
+	}
+	// The terminator on its own says nothing about what to look for.
+	if _, err := captureRun(t, "ctx", "--"); err == nil || !strings.Contains(err.Error(), "needs a query") {
+		t.Errorf("bare terminator: %v", err)
+	}
+}
+
+// The /deja command deja installs into dsh handed the text over as deja's first
+// word, and the bare-query path dispatches a first word that is a command:
+// `/deja version` printed a version number instead of searching for the word.
+func TestDSHCommandSearchesRatherThanDispatching(t *testing.T) {
+	js := dshCommandJS("/bin/deja")
+	if strings.Contains(js, "execFileSync(DEJA, [query]") {
+		t.Error("the command still hands the query to deja as its first word")
+	}
+	if !strings.Contains(js, `["search", query]`) {
+		t.Error("the command does not name search")
+	}
+	if !strings.Contains(js, `["search", "--", query]`) {
+		t.Error("a query that starts with a dash is still read as a flag")
+	}
+}
+
+func TestBlameTakesAPathBehindTheTerminator(t *testing.T) {
+	path, o, jsonOut, err := parseBlame([]string{"--json", "--", "-report.md"})
+	if err != nil {
+		t.Fatalf("parseBlame: %v", err)
+	}
+	if path != "-report.md" {
+		t.Errorf("path = %q, want -report.md", path)
+	}
+	if !jsonOut {
+		t.Error("--json before the terminator was dropped")
+	}
+	if o.All {
+		t.Error("--all was never given")
+	}
+	// Without it the dash is still a flag, and the message still names it.
+	if _, _, _, err := parseBlame([]string{"-report.md"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("no terminator: %v", err)
+	}
+	// A second path is one too many, terminator or not.
+	if _, _, _, err := parseBlame([]string{"a.go", "--", "b.go"}); err == nil ||
+		!strings.Contains(err.Error(), "one path") {
+		t.Errorf("two paths: %v", err)
+	}
+	if _, _, _, err := parseBlame([]string{"--"}); err == nil ||
+		!strings.Contains(err.Error(), "needs a path") {
+		t.Errorf("bare terminator: %v", err)
+	}
+}
+
+func TestRememberTakesANoteBehindTheTerminator(t *testing.T) {
+	notes := filepath.Join(t.TempDir(), "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", notes)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+	if err := runRemember(index.DefaultDir(), []string{"--", "--no-verify is banned here"}); err != nil {
+		t.Fatalf("remember: %v", err)
+	}
+	stored, err := os.ReadFile(notes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stored), "--no-verify is banned here") {
+		t.Errorf("the note behind the terminator was not stored: %s", stored)
+	}
+	// Without it the note is still refused as a flag, which is what tells
+	// somebody typing by hand that they meant the terminator.
+	if err := runRemember(index.DefaultDir(), []string{"--no-verify is banned here"}); err == nil ||
+		!strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("no terminator: %v", err)
+	}
+	if err := runRemember(index.DefaultDir(), []string{"--"}); err == nil ||
+		!strings.Contains(err.Error(), "text required") {
+		t.Errorf("bare terminator: %v", err)
+	}
+	// The flags it does take still work in front of it.
+	if err := runRemember(index.DefaultDir(), []string{"--tag", "policy", "--", "--force is never used on main"}); err != nil {
+		t.Fatalf("flag before the terminator: %v", err)
+	}
+}

--- a/cmd/deja/remember.go
+++ b/cmd/deja/remember.go
@@ -49,6 +49,20 @@ func runRemember(dir string, args []string) error {
 			i++
 			continue
 		}
+		// `--` says the next word is the note however it starts, the spelling
+		// search, fix and how already take. A decision whose own words begin
+		// with a dash was otherwise refused as a flag.
+		if args[i] == "--" {
+			if i+1 >= len(args) {
+				return fmt.Errorf("remember: text required")
+			}
+			if text != "" {
+				return fmt.Errorf("remember: expected one text argument")
+			}
+			text = args[i+1]
+			i++
+			continue
+		}
 		if strings.HasPrefix(args[i], "-") {
 			return fmt.Errorf("remember: unknown flag %q", args[i])
 		}

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -11,7 +11,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { contributions } from "./lib.js";
+import { argv, contributions } from "./lib.js";
 
 const require = createRequire(import.meta.url);
 
@@ -89,6 +89,7 @@ function answer(text) {
   return MISSING;
 }
 
+
 function tools(ctx) {
   if (!defineTool) return;
 
@@ -122,7 +123,7 @@ function tools(ctx) {
       // spend the model's context on a tail nobody reads.
       const asked = Number.isFinite(args.limit) ? Math.trunc(args.limit) : 5;
       const limit = String(Math.min(20, Math.max(1, asked)));
-      return Promise.resolve(answer(run(["search", "--json", "--limit", limit, String(args.query)])));
+      return Promise.resolve(answer(run(argv("search", ["--json", "--limit", limit], args.query))));
     },
   }));
 
@@ -139,7 +140,7 @@ function tools(ctx) {
     },
     output: TEXT_OUTPUT,
     execute(args) {
-      return Promise.resolve(answer(run(["ctx", String(args.query)])));
+      return Promise.resolve(answer(run(argv("ctx", [], args.query))));
     },
   }));
 
@@ -156,7 +157,7 @@ function tools(ctx) {
     },
     output: TEXT_OUTPUT,
     execute(args) {
-      return Promise.resolve(answer(run(["blame", String(args.path), "--json"])));
+      return Promise.resolve(answer(run(argv("blame", ["--json"], args.path))));
     },
   }));
 
@@ -173,7 +174,7 @@ function tools(ctx) {
     },
     output: TEXT_OUTPUT,
     execute(args) {
-      return Promise.resolve(answer(run(["fix", String(args.error)])));
+      return Promise.resolve(answer(run(argv("fix", [], args.error))));
     },
   }));
 
@@ -190,7 +191,7 @@ function tools(ctx) {
     },
     output: TEXT_OUTPUT,
     execute(args) {
-      return Promise.resolve(answer(run(["how", String(args.what)])));
+      return Promise.resolve(answer(run(argv("how", [], args.what))));
     },
   }));
 
@@ -207,7 +208,7 @@ function tools(ctx) {
     },
     output: TEXT_OUTPUT,
     execute(args) {
-      const written = run(["remember", String(args.text)]);
+      const written = run(argv("remember", [], args.text));
       if (!INSTALLED) return Promise.resolve(MISSING);
       return Promise.resolve(written || "deja did not record that.");
     },
@@ -224,7 +225,11 @@ function command(ctx) {
       if (!query) {
         return { kind: "error", text: "Say what to look for: /deja <error, file, or decision>" };
       }
-      const out = run([query]);
+      // Named, not handed over as deja's first word: the bare-query path
+      // dispatches a word that happens to be a command, so `/deja version`
+      // printed a version number and `/deja index` rebuilt the index, and one
+      // of the words people most want history about is `install`.
+      const out = run(argv("search", [], query));
       return { kind: INSTALLED ? "success" : "error", text: answer(out) };
     },
   });

--- a/extensions/dsh/lib.js
+++ b/extensions/dsh/lib.js
@@ -2,6 +2,25 @@
 // anything a plugin module exports as part of the plugin — opencode does
 // exactly that with its own — and this is a helper, not a second plugin.
 
+// argv builds the call for a query somebody typed, rather than handing the text
+// to deja as it stands.
+//
+// The command is always named. deja's bare-query path dispatches a first word
+// that happens to be a command, so a one-word query went to the command of that
+// name: `version` printed a version number, `index` rebuilt the index, and
+// neither searched anything.
+//
+// A query that starts with a dash is read as a flag: `deja search --no-verify`
+// exits on an unknown flag, the caller turns that into "", and the model is
+// told the history holds nothing about --no-verify while eleven sessions
+// discuss it — a confident wrong answer, which is worse than an error. `--`
+// ends the flags. It is sent only when the query needs it, so a deja too old to
+// know the terminator on this subcommand still answers every ordinary query.
+export function argv(cmd, flags, text) {
+  const arg = String(text);
+  return arg.startsWith("-") ? [cmd, ...flags, "--", arg] : [cmd, ...flags, arg];
+}
+
 // contributions says what this package adds, given what `deja install` already
 // wrote into DSH_HOME and what the profile turned off. The rule is the same
 // everywhere: fill the gaps, never repeat the installer.

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import apply from "../index.js";
-import { contributions } from "../lib.js";
+import { argv, contributions } from "../lib.js";
 
 const source = readFileSync(new URL("../index.js", import.meta.url), "utf8");
 
@@ -22,6 +22,50 @@ test("the recall limit is bounded on both sides", () => {
   assert.equal(clamp(-3), 1);
   assert.equal(clamp(7), 7);
   assert.equal(clamp(9999), 20);
+});
+
+test("a query that is a command name is still searched", () => {
+  // deja's bare-query path dispatches the first word, so `/deja version`
+  // printed a version number instead of searching for the word.
+  assert.deepEqual(argv("search", [], "version"), ["search", "version"]);
+  assert.deepEqual(argv("search", ["--json"], "index"), ["search", "--json", "index"]);
+});
+
+test("a query that starts with a dash is not read as a flag", () => {
+  // Without the terminator deja exits on an unknown flag, which the caller
+  // cannot tell from an empty history.
+  assert.deepEqual(argv("search", [], "--no-verify"), ["search", "--", "--no-verify"]);
+  assert.deepEqual(argv("fix", [], "-race detected"), ["fix", "--", "-race detected"]);
+  // Flags the plugin sends itself stay ahead of the terminator, or deja reads
+  // them as part of the query.
+  assert.deepEqual(argv("search", ["--json", "--limit", "5"], "--all-matches"), [
+    "search",
+    "--json",
+    "--limit",
+    "5",
+    "--",
+    "--all-matches",
+  ]);
+});
+
+test("the terminator is sent only when the query needs it", () => {
+  // A deja too old to know `--` on this subcommand would otherwise fail on
+  // every ordinary query, not just the ones that start with a dash.
+  assert.deepEqual(argv("how", [], "run the tests"), ["how", "run the tests"]);
+  assert.deepEqual(argv("ctx", [], "the checkout worker"), ["ctx", "the checkout worker"]);
+});
+
+test("every query the plugin sends goes through argv", () => {
+  // The rules above are worth nothing if a call site passes its text straight
+  // through, which is how both bugs got in.
+  // A literal list is deja's own vocabulary — `run(["version"])` and the hook.
+  // Anything else in that position is somebody's text, and it belongs in
+  // argv(), which names the command and ends the flags.
+  const calls = source.match(/run\(\[[^\]]*\]/g) || [];
+  for (const call of calls) {
+    assert.match(call, /^run\(\["/, `${call} builds a call out of something other than deja's own words`);
+    assert.doesNotMatch(call, /String\(args\./, `${call} passes a query to deja without argv()`);
+  }
 });
 
 test("tool output declares a plain JSON schema", () => {


### PR DESCRIPTION
`/deja version` printed a version number and `/deja index` rebuilt the index — the query went to deja as its first argument and the bare-query path dispatched it. Fixed in both the npm plugin and the `command.js` the installer writes.

While there: a query starting with a dash was read as a flag, and a failed call is indistinguishable from an empty history through a plugin, so the model was told nothing matches `--no-verify` while eleven sessions discuss it. The calls now send `--` only when the query needs it, and ctx, blame and remember accept it the way search, fix and how already did.

Checked against a real dsh 0.1.1-rc.2 with a stub model endpoint: the recall reaches the model in 4 of 4 runs.

Closes #2987