### PR TITLE
fix(dsh): a duplicate registration stands down instead of failing the profile

### DIFF
--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -48,6 +48,10 @@ import { execFileSync } from "node:child_process";
 const DEJA = %q;
 
 function apply(ctx) {
+  // Loaded twice in one profile the host throws "command deja is already
+  // registered" and the whole profile fails to load, which costs the user
+  // their agent over a duplicate search command. One /deja is enough.
+  try {
   ctx.commands.register({
     name: "deja",
     description: "Search this machine's past AI coding sessions",
@@ -77,6 +81,7 @@ function apply(ctx) {
       }
     },
   });
+  } catch {}
 }
 
 apply.inject = ["commands"];
@@ -163,22 +168,29 @@ function apply(ctx) {
   let asked = "";
   let recalled = "";
 
-  ctx.systemPrompt.context({
-    name: "deja:recall",
-    order: 120,
-    text: (assembly) => {
-      const agent = assembly && assembly.agent;
-      if (!agent) return "";
-      const prompt = lastHumanText(agent);
-      if (!prompt) return "";
-      if (prompt !== asked) {
-        asked = prompt;
-        recalled = recall(prompt);
-      }
-      // Silence is the common case: this speaks only when the history answers.
-      return recalled;
-    },
-  });
+  // A second copy of this file in the same profile — the npm package next to
+  // the installer's, a --patch overlay naming it again — makes the host throw
+  // "prompt context deja:recall is already registered", and that takes the
+  // whole profile down: no agent at all, over an optional memory plugin.
+  // One registration is all recall needs, so the loser stands down quietly.
+  try {
+    ctx.systemPrompt.context({
+      name: "deja:recall",
+      order: 120,
+      text: (assembly) => {
+        const agent = assembly && assembly.agent;
+        if (!agent) return "";
+        const prompt = lastHumanText(agent);
+        if (!prompt) return "";
+        if (prompt !== asked) {
+          asked = prompt;
+          recalled = recall(prompt);
+        }
+        // Silence is the common case: this speaks only when the history answers.
+        return recalled;
+      },
+    });
+  } catch {}
 }
 
 apply.inject = ["systemPrompt"];

--- a/cmd/deja/query_terminator_test.go
+++ b/cmd/deja/query_terminator_test.go
@@ -82,6 +82,36 @@ func TestDSHCommandSearchesRatherThanDispatching(t *testing.T) {
 	}
 }
 
+// dsh refuses a name one of its registries already holds, and the failure is
+// not local: "prompt context deja:recall is already registered" fails the whole
+// plugin tree, so the profile boots with no agent at all. Two copies of these
+// files in one profile — the npm package next to the installer's, a --patch
+// overlay naming them twice — must cost at most the duplicate.
+func TestDSHPluginsStandDownOnADuplicateName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		js   string
+		call string
+	}{
+		{"command", dshCommandJS("/bin/deja"), "ctx.commands.register("},
+		{"auto", dshAutoJS("/bin/deja"), "ctx.systemPrompt.context("},
+	} {
+		if !strings.Contains(tc.js, tc.call) {
+			t.Fatalf("%s: %s is gone, so this test guards nothing", tc.name, tc.call)
+		}
+		// Whitespace-free, so the check does not depend on how the generated
+		// file happens to be indented.
+		compact := strings.Join(strings.Fields(tc.js), "")
+		want := "try{" + strings.ReplaceAll(tc.call, " ", "")
+		if !strings.Contains(compact, want) {
+			t.Errorf("%s registers %s without standing down on a refusal", tc.name, tc.call)
+		}
+		if !strings.Contains(compact, "}catch{}") {
+			t.Errorf("%s does not catch the refusal", tc.name)
+		}
+	}
+}
+
 func TestBlameTakesAPathBehindTheTerminator(t *testing.T) {
 	path, o, jsonOut, err := parseBlame([]string{"--json", "--", "-report.md"})
 	if err != nil {

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -11,7 +11,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { argv, contributions } from "./lib.js";
+import { argv, contributions, guarded } from "./lib.js";
 
 const require = createRequire(import.meta.url);
 
@@ -102,7 +102,7 @@ function tools(ctx) {
     render: (_args, value) => [{ type: "text", text: String(value) }],
   };
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_recall",
     description:
       "Search this machine's own past AI coding sessions — every agent used on it, including months before deja was installed. Use before debugging an error or re-implementing anything that may already exist. Match on the most specific token available: an exact error string, function name, file path or flag.",
@@ -125,9 +125,9 @@ function tools(ctx) {
       const limit = String(Math.min(20, Math.max(1, asked)));
       return Promise.resolve(answer(run(argv("search", ["--json", "--limit", limit], args.query))));
     },
-  }));
+  })));
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_session",
     description:
       "A full digest of the single best-matching past session — what was tried, what was decided, what it cost. Use after deja_recall when the reasoning behind an earlier decision matters, not just that it happened.",
@@ -142,9 +142,9 @@ function tools(ctx) {
     execute(args) {
       return Promise.resolve(answer(run(argv("ctx", [], args.query))));
     },
-  }));
+  })));
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_blame",
     description:
       "The past sessions that discussed a file, so you know why it is shaped the way it is before editing, refactoring or deleting it. Session history, not git authorship.",
@@ -159,9 +159,9 @@ function tools(ctx) {
     execute(args) {
       return Promise.resolve(answer(run(argv("blame", ["--json"], args.path))));
     },
-  }));
+  })));
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_fix",
     description:
       "What this machine ran after that same error before, in the sessions where the error did not come back. Paste the failing output verbatim rather than a paraphrase — the match is on the error's own words.",
@@ -176,9 +176,9 @@ function tools(ctx) {
     execute(args) {
       return Promise.resolve(answer(run(argv("fix", [], args.error))));
     },
-  }));
+  })));
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_how",
     description:
       "The real invocation this machine uses for a build, test, deploy or script, with the flags it actually ran, ordered by how many sessions ran it. A guessed command is plausible and fails on this setup.",
@@ -193,9 +193,9 @@ function tools(ctx) {
     execute(args) {
       return Promise.resolve(answer(run(argv("how", [], args.what))));
     },
-  }));
+  })));
 
-  ctx.tools.register(defineTool({
+  guarded(() => ctx.tools.register(defineTool({
     name: "deja_remember",
     description:
       "Store one durable decision once it is settled, as a single self-contained fact that will make sense months later. Not transcripts, not a summary of the conversation, and not anything already obvious from the code.",
@@ -212,11 +212,11 @@ function tools(ctx) {
       if (!INSTALLED) return Promise.resolve(MISSING);
       return Promise.resolve(written || "deja did not record that.");
     },
-  }));
+  })));
 }
 
 function command(ctx) {
-  ctx.commands.register({
+  guarded(() => ctx.commands.register({
     name: "deja",
     description: "Search this machine's past AI coding sessions",
     input: { hint: "what to look for" },
@@ -232,7 +232,7 @@ function command(ctx) {
       const out = run(argv("search", [], query));
       return { kind: INSTALLED ? "success" : "error", text: answer(out) };
     },
-  });
+  }));
 }
 
 function userText(message) {
@@ -250,26 +250,36 @@ function userText(message) {
 // alternative — splicing a message into the "agent/pre-step" waterfall — looks
 // like it works and does not: a later listener rebuilds its answer from the
 // payload, and the added message is dropped with nothing reported.
+//
+// The registration is guarded because the host throws "prompt context
+// deja:recall is already registered" on a second copy in the same profile, and
+// that failure is not local: the whole profile fails to load, so a duplicate
+// memory plugin costs the user their agent. One registration is all recall
+// needs. installedByCLI() below is the first line of defence; this is the one
+// that holds when the installer wrote to a different DSH_HOME than the profile
+// boots from.
 function autoRecall(ctx) {
   let asked = "";
   let recalled = "";
 
-  ctx.systemPrompt.context({
-    name: "deja:recall",
-    order: 120,
-    text: (assembly) => {
-      const agent = assembly && assembly.agent;
-      if (!agent) return "";
-      const prompt = lastHumanText(agent);
-      if (!prompt) return "";
-      if (prompt !== asked) {
-        asked = prompt;
-        recalled = run(["hook-prompt", "--plain"], JSON.stringify({ prompt, cwd: process.cwd() }));
-      }
-      // Silence is the common case: this speaks only when the history answers.
-      return recalled;
-    },
-  });
+  guarded(() =>
+    ctx.systemPrompt.context({
+      name: "deja:recall",
+      order: 120,
+      text: (assembly) => {
+        const agent = assembly && assembly.agent;
+        if (!agent) return "";
+        const prompt = lastHumanText(agent);
+        if (!prompt) return "";
+        if (prompt !== asked) {
+          asked = prompt;
+          recalled = run(["hook-prompt", "--plain"], JSON.stringify({ prompt, cwd: process.cwd() }));
+        }
+        // Silence is the common case: this speaks only when the history answers.
+        return recalled;
+      },
+    }),
+  );
 }
 
 // lastHumanText is the newest thing the person actually typed. At assembly

--- a/extensions/dsh/lib.js
+++ b/extensions/dsh/lib.js
@@ -21,6 +21,24 @@ export function argv(cmd, flags, text) {
   return arg.startsWith("-") ? [cmd, ...flags, "--", arg] : [cmd, ...flags, arg];
 }
 
+// guarded runs one registration, and swallows the host's refusal of a name it
+// already holds.
+//
+// dsh answers a duplicate with "prompt context deja:recall is already
+// registered" or "command deja is already registered", and that failure is not
+// local: the whole plugin tree fails to load, so a second copy of this plugin —
+// the npm package next to the installer's files, a --patch overlay naming it
+// twice — costs the user their agent over an optional memory plugin. One
+// registration is all any of these need, so the loser stands down.
+export function guarded(register) {
+  try {
+    register();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // contributions says what this package adds, given what `deja install` already
 // wrote into DSH_HOME and what the profile turned off. The rule is the same
 // everywhere: fill the gaps, never repeat the installer.

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import apply from "../index.js";
-import { argv, contributions } from "../lib.js";
+import { argv, contributions, guarded } from "../lib.js";
 
 const source = readFileSync(new URL("../index.js", import.meta.url), "utf8");
 
@@ -82,6 +82,61 @@ test("automatic recall does not use the pre-step waterfall", () => {
   // registration rather than on the words.
   assert.doesNotMatch(source, /ctx\.on\("agent\/pre-step"/);
   assert.match(source, /ctx\.systemPrompt\.context\(/);
+});
+
+// dsh refuses a name one of its registries already holds — "prompt context
+// deja:recall is already registered", "command deja is already registered" —
+// and the failure is not local: the whole profile fails to load, so a second
+// copy of this plugin costs the user their agent.
+test("a refused registration is reported, not thrown", () => {
+  assert.equal(guarded(() => {}), true);
+  assert.equal(
+    guarded(() => {
+      throw new Error('command "deja" is already registered');
+    }),
+    false,
+  );
+});
+
+test("every registration the plugin makes goes through the guard", () => {
+  // The tools cannot be reached from the case below — registering them needs
+  // the dsh-tools peer the host provides — so the rule is pinned here.
+  // Whitespace-free, so a call broken across lines reads the same as one that
+  // is not.
+  const compact = source.replace(/\s+/g, "");
+  const calls = /ctx\.(?:tools\.register|commands\.register|systemPrompt\.context)\(/g;
+  let total = 0;
+  for (const m of compact.matchAll(calls)) {
+    total++;
+    assert.ok(
+      compact.slice(0, m.index).endsWith("guarded(()=>"),
+      `${m[0]} is not wrapped in guarded()`,
+    );
+  }
+  assert.equal(total, 8, "six tools, the command and the recall");
+});
+
+test("a name the host already holds does not take the profile down", () => {
+  const taken = new Set();
+  const refusing = {
+    tools: { register: () => { throw new Error("tool is already registered"); } },
+    commands: {
+      register: (c) => {
+        if (taken.has(c.name)) throw new Error(`command "${c.name}" is already registered`);
+        taken.add(c.name);
+      },
+    },
+    systemPrompt: {
+      context: (c) => {
+        if (taken.has(c.name)) throw new Error(`prompt context "${c.name}" is already registered`);
+        taken.add(c.name);
+      },
+    },
+  };
+  withDSHHome([], () => {
+    assert.doesNotThrow(() => apply(refusing, {}), "first load");
+    assert.doesNotThrow(() => apply(refusing, {}), "second load, every name taken");
+  });
 });
 
 test("the patch names the package the host has to load", () => {


### PR DESCRIPTION
Loading the plugin twice — the npm package next to what `deja install deepseek` wrote, or a `--patch` overlay naming the file again — threw `prompt context "deja:recall" is already registered` and dsh failed the entire plugin tree. The profile then boots with no agent at all, over an optional memory plugin.

Every registration now goes through one helper that reports a refusal rather than throwing. The DSH_HOME check stays as the first line of defence; this is what holds when the installer wrote to a different DSH_HOME than the profile boots from.

Reproduced and verified on dsh 0.1.1-rc.2: before, the double load died on the plugin tree; after, the profile boots and recall still reaches the model in 3 of 3 runs.

Closes #2989