### PR TITLE
release: name the outside contributor on their line of the notes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -80,8 +80,12 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
+  # Read through the GitHub API rather than git so the author's login is
+  # known. Outside contributors get their name on the line, which is also
+  # the notification that their change shipped; my own lines stay bare.
+  use: github
   sort: asc
-  format: "{{ .Message }}"
+  format: '{{ .Message }}{{ if and .AuthorUsername (ne .AuthorUsername "vshulcz") }} (@{{ .AuthorUsername }}){{ end }}'
   groups:
     - title: Features
       regexp: '^feat(\(.+\))?:'


### PR DESCRIPTION
Closes #2991. `use: github` in the goreleaser changelog so `.AuthorUsername` is populated; the format appends `(@login)` only when the author is not me. Squash merges keep the PR author as commit author, so the login is the contributor's. Takes effect on the next tagged release; nothing to test locally beyond the YAML parsing, which CI's goreleaser check covers.