### PR TITLE
fix(sources): record just, task and mise so the pre-tool hook can speak about them

### DIFF
--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -486,6 +486,12 @@ func IndexCommands() bool { return os.Getenv("DEJA_INDEX_COMMANDS") != "0" }
 // for the same reason go mod tidy is: "start the thing that is not running" is
 // the answer to a refused connection, and it was the one remedy the list did
 // not carry while `brew install`, two words away, was carried (#2373).
+// The task runners — just, task, mise — are the same kind of entry as make,
+// and they gate more than the command table: the point-of-action hook only
+// speaks about a command the ingest kept, so on a repository driven by a
+// justfile every deploy and every migration was invisible to it while the same
+// work behind a Makefile was not. They are anchored to the start of a segment
+// because each is an ordinary English word: `git grep task` names no runner.
 var meaningfulCommand = regexp.MustCompile(`\b(go (test|build|vet|run|mod|get|install|generate|work|clean)|brew (install|upgrade|uninstall|reinstall|tap|services)|systemctl|launchctl|service [a-z0-9_.-]+ (start|stop|restart|reload|status)|golangci-lint|gofmt|pytest|python3? -m|uv (run|pip)|pip install|ruff|mypy|npm|npx|pnpm|yarn|bun |cargo |make\b|cmake|ctest|ninja|meson|bazel|buck2|gh (pr|run|release|issue|workflow|api)|git [a-z-]+|docker|kubectl|helm|terraform|psql|mysql|latexmk|mvn|gradle|dotnet|swift (build|test)|bundle exec|rails|rake|rspec|phpunit|composer (install|update|require)|tox|nox|jest|vitest|playwright|cypress|deno|tsc|sbt|stack (build|test|run|exec)|cabal|ghc|dune|zig|nix|rustc|clang\+\+|clang|g\+\+|gcc|pdm run|poetry run|deja )`)
 
 var trivialCommand = regexp.MustCompile(`^\s*(ls|cd|pwd|cat|head|tail|echo|grep|rg|find|which|wc|sed|awk|sleep|mkdir|rm|cp|mv|chmod|export|source|touch|open|printf)\b`)
@@ -518,8 +524,27 @@ func worthIndexing(cmd string) bool {
 			return true
 		}
 	}
+	// The task runners are judged on statement boundaries rather than on every
+	// pipe. Their names are ordinary words, and splitting on a bare `|` cuts
+	// inside a quoted alternation too: `grep "worktree names\|task signal" f`
+	// yields a fragment beginning "task signal" and nothing else about that
+	// line says a runner ran. Nobody pipes into one, so `&&`, `||` and `;` are
+	// the only places a run can begin.
+	for _, seg := range statementChain.Split(cmd, -1) {
+		if taskRunner.MatchString(seg) && !trivialCommand.MatchString(seg) {
+			return true
+		}
+	}
 	return false
 }
+
+// statementChain splits on the operators that start a new command, leaving a
+// pipe inside a quoted argument alone.
+var statementChain = regexp.MustCompile(`&&|\|\||;`)
+
+// taskRunner is just, task and mise at the head of a statement — the same kind
+// of entry as make, kept apart because each name is also an ordinary word.
+var taskRunner = regexp.MustCompile(`^\s*(just|task|mise)\s`)
 
 // commandChain splits a shell line on the operators that separate commands, so
 // each side is judged on its own. Quoted operators are rare in real command

--- a/internal/sources/commands_runners_test.go
+++ b/internal/sources/commands_runners_test.go
@@ -1,0 +1,53 @@
+package sources
+
+import "testing"
+
+// The allowlist carried make and gradle and not just, task or mise, so a
+// repository driven by a justfile recorded none of its own commands. That costs
+// more than the command table: the point-of-action hook asks whether a session
+// ran the command before it speaks, so on those repositories it could never
+// speak about a deploy or a migration at all.
+func TestWorthIndexingKeepsTheTaskRunners(t *testing.T) {
+	for _, c := range []string{
+		"just build",
+		"just deploy staging",
+		"task test",
+		"task db:migrate",
+		"mise run lint",
+		"cd repo && just release",
+	} {
+		if !worthIndexing(c) {
+			t.Errorf("dropped a task runner: %q", c)
+		}
+	}
+	// Each of these names is an ordinary English word, so they only count at
+	// the start of a segment — otherwise every sentence about a task became a
+	// command this machine had run.
+	for _, c := range []string{
+		"echo 'just do it'",
+		"ls tasks/",
+		"cat notes.md | grep task",
+	} {
+		if worthIndexing(c) {
+			t.Errorf("kept a word that names no runner: %q", c)
+		}
+	}
+	// A runner named inside another command's argument is that command's
+	// business, not a run of its own — the rule the allowlist already applies
+	// to `grep "go test" log`. These are the cases the anchor decides: the
+	// segment is neither trivial nor otherwise meaningful, so without it the
+	// word alone would carry them in.
+	for _, c := range []string{
+		"ssh mini task deploy",
+		"xargs just build",
+		"time mise run lint",
+		// The one this rule kept when it was judged per pipe: a quoted
+		// alternation is cut on its own `\|` and the fragment reads like a
+		// run. Found on a real store, one line in 119,024.
+		`grep -n "worktree names\|task signal" cmd/deja/doctor.go`,
+	} {
+		if worthIndexing(c) {
+			t.Errorf("kept a runner named as another command's argument: %q", c)
+		}
+	}
+}


### PR DESCRIPTION
`commandDecisionLine` asks `SessionRanCommand` before the point-of-action hook says anything, and that is answered from the command records `worthIndexing` builds. The list carried `make`, `gradle` and `rake` and not `just`, `task` or `mise`, so on a justfile repository the feature could never fire — no invocation was ever recorded.

Verified on a stand of three seeded Claude sessions that run the command and settle a decision about it. Before: silence. After: "This machine has run that command in 3 sessions, last 2026-07-26 — last time: ... never run it without DRAIN=first." Only the first word of the invocation differs between the two runs.

The three names are judged on statement boundaries rather than on every pipe, because each is an ordinary English word and splitting on a bare `|` cuts inside a quoted alternation: `grep -n "worktree names\\|task signal" f` yields a fragment that reads like a run. That case is in the test — it is the one line in this machine's 119,024 Bash commands that the per-pipe version wrongly kept, and with the statement split the change adds nothing here at all.

So no measured benefit on my own corpus, which uses make: the case is structural, for the repositories that do not.

Closes #2998