### PR TITLE
docs(readme): the three ways to install deja as a skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ keeping those descriptions checked against the parsers.
 
 ### Harnesses with a package of their own
 
-`deja install --auto` wires all five of these like every other harness, and
+`deja install --auto` wires all six of these like every other harness, and
 that stays the shortest path. They also have a package in their own ecosystem,
 for people who install extensions there rather than from a CLI:
 
@@ -302,6 +302,16 @@ contribute only what is missing, and in Zed both halves use one server id, so
 there is nothing to have twice whichever order you install in.
 
 Each uses the deja you already have; the copy it bundles is only the fallback.
+
+The same search is also a skill, for any agent that loads a `SKILL.md`:
+
+```sh
+npx skills add https://github.com/vshulcz/deja-vu --skill deja-search   # skills CLI: Claude Code, Cursor, Goose, Copilot…
+openclaw skills install @vshulcz/deja-search                            # ClawHub
+hermes skills install vshulcz/deja-vu/skills/deja-search                # Hermes
+```
+
+The skill drives the `deja` binary from the install step above; it does not bundle one.
 
 ## Semantic recall (optional)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,6 +57,16 @@ dsh plugin --profile web add dsh-deja
 `deja install` 写了什么，只补上缺的部分，不会重复注册工具、也不会重复召回。详见
 [`extensions/`](extensions)。
 
+同一套搜索也是一个 skill，任何会读 `SKILL.md` 的智能体都能装：
+
+```sh
+npx skills add https://github.com/vshulcz/deja-vu --skill deja-search   # skills CLI：Claude Code、Cursor、Goose、Copilot…
+openclaw skills install @vshulcz/deja-search                            # ClawHub
+hermes skills install vshulcz/deja-vu/skills/deja-search                # Hermes
+```
+
+skill 调用的是上面装好的 `deja` 二进制，自己不带。
+
 其他安装方式：`brew install deja-vu`、
 `go install github.com/vshulcz/deja-vu/cmd/deja@latest`，或者用
 `npx @vshulcz/deja-vu "查询词"` 先试试而不装任何东西。Windows 上安装脚本会退出并提示


### PR DESCRIPTION
Closes #3002. One block after the packages table: `npx skills add` (skills.sh), `openclaw skills install @vshulcz/deja-search` (ClawHub, as the page prints it), `hermes skills install`. Also "all five" → six in the English table, which has six rows; the Chinese list has five and keeps five.