### PR TITLE
chore(dsh): 0.20.5, to republish with today's two fixes

### DIFF
--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-deja",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "Brings the session history of twenty-one other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
   "type": "module",
   "main": "index.js",
@@ -44,7 +44,7 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.18.0"
+    "@vshulcz/deja-vu": "^0.19.2"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "dsh-deja",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "private": true,
-  "description": "Repository-root manifest for the DeepSeek Harness plugin that lives in extensions/dsh — the same package published to npm as dsh-deja. It re-exports the subdirectory so the plugin installs from a bare git URL or from github:vshulcz/deja-vu#path:extensions/dsh; the npm package is the shorter path. The repository itself is the Go project behind the deja binary.",
+  "description": "Repository-root manifest for the DeepSeek Harness plugin that lives in extensions/dsh \u2014 the same package published to npm as dsh-deja. It re-exports the subdirectory so the plugin installs from a bare git URL or from github:vshulcz/deja-vu#path:extensions/dsh; the npm package is the shorter path. The repository itself is the Go project behind the deja binary.",
   "type": "module",
   "main": "./extensions/dsh/index.js",
   "exports": {
@@ -41,6 +41,6 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.18.0"
+    "@vshulcz/deja-vu": "^0.19.2"
   }
 }


### PR DESCRIPTION
npm still serves 0.20.4, which predates #2988 and #2990 — `/deja version` printing a version number and a second copy failing the whole profile are both still live for anyone installing the package today.

The dependency moves with it. 0.20.4 was published by hand, so it kept the `^0.18.0` that `scripts/release-npm.mjs` rewrites at publish time; opencode-deja, which went out through the script, correctly carries `^0.19.2`.

Separately, and worth its own decision: because npm has 0.20.4 and deja is at 0.19.2, the release script's "npm is ahead, skip it" rule has been excluding dsh-deja from every release since 25 August, and will keep doing so until deja passes 0.20.4. That is why these fixes would never have shipped on their own.