### PR TITLE
ci(extensions): say when a package is stranded ahead of the release line

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -228,6 +228,20 @@ jobs:
       - name: The release script's version rules
         run: node --test scripts/release_npm_test.mjs
 
+      - name: The drift guard's own rules
+        run: node --test scripts/extension_drift_test.mjs
+
+      # A package npm holds ahead of the release line is skipped by every
+      # release, silently, until the project's version passes it — dsh-deja sat
+      # that way from 25 August. Reporting rather than failing while that is
+      # still true of dsh-deja: drop continue-on-error once the release line has
+      # caught up, and this becomes the guard that stops it happening again.
+      - name: No harness package is stranded ahead of the release line
+        continue-on-error: true
+        run: |
+          git fetch --tags --quiet || true
+          node scripts/extension-drift.mjs
+
       # Published metadata is what a user follows back to the source. When a
       # package moves, npm keeps serving the old repository field until someone
       # notices; this notices.

--- a/scripts/extension-drift.mjs
+++ b/scripts/extension-drift.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Report harness packages npm holds ahead of this project's release line.
+//
+// The release script refuses to publish a package when npm is ahead of the
+// version being released, because moving `latest` backwards cannot be undone.
+// That refusal is right, and it is also permanent: a package published by hand
+// at a version the release line has not reached is skipped by every release
+// after it, silently, until the project's own version catches up. dsh-deja sat
+// at 0.20.4 that way from 25 August against a 0.19.2 release line, and two
+// fixes merged for it would never have shipped.
+//
+// The comparison is against the newest release tag, not against the version in
+// the package's own package.json: those two are equal in exactly the state this
+// exists to catch.
+//
+// Nothing here publishes.
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+
+export const PACKAGES = ["extensions/opencode", "extensions/dsh"];
+
+// npmLatest is the version npm serves as `latest`, or "" when the package has
+// never been published or npm cannot be reached. Unreachable is not drift: a
+// network failure must not fail a pull request.
+export function npmLatest(name) {
+  try {
+    return execSync(`npm view ${name} version`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// releaseLine is the newest release tag, without its leading v. "" when the
+// tags are not in the checkout, which is the default for a shallow clone —
+// again, not drift.
+export function releaseLine() {
+  try {
+    const tag = execSync("git tag --list 'v*' --sort=-v:refname", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).split("\n")[0].trim();
+    return tag.replace(/^v/, "");
+  } catch {
+    return "";
+  }
+}
+
+// parse rejects anything that is not a plain x.y.z, the rule the release script
+// applies — a prerelease is a reason to stop and think.
+export function parse(v) {
+  const parts = String(v).split(".").map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n))) {
+    throw new Error(`not a plain version: ${v}`);
+  }
+  return parts;
+}
+
+export function compareVersions(a, b) {
+  const [x, y] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i++) {
+    if (x[i] !== y[i]) return x[i] < y[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+// stranded reports the packages the next release would skip. Lookups are
+// injected so the rule can be tested without the network or a tag history.
+export function stranded(packages, readPkg, latest, line) {
+  if (!line) return [];
+  const out = [];
+  for (const dir of packages) {
+    const { name } = readPkg(dir);
+    const live = latest(name);
+    if (!live) continue;
+    if (compareVersions(live, line) > 0) {
+      out.push({ dir, name, npm: live, line });
+    }
+  }
+  return out;
+}
+
+function readPkg(dir) {
+  const pkg = JSON.parse(fs.readFileSync(`${dir}/package.json`, "utf8"));
+  return { name: pkg.name, version: pkg.version };
+}
+
+if (process.argv[1] && process.argv[1].endsWith("extension-drift.mjs")) {
+  const bad = stranded(PACKAGES, readPkg, npmLatest, releaseLine());
+  for (const p of bad) {
+    console.error(
+      `${p.name}: npm serves ${p.npm}, the release line is ${p.line} — ` +
+        `every release skips it until this project's version passes ${p.npm}`,
+    );
+  }
+  process.exit(bad.length ? 1 : 0);
+}

--- a/scripts/extension_drift_test.mjs
+++ b/scripts/extension_drift_test.mjs
@@ -1,0 +1,47 @@
+// The rule this guard exists for: a package npm holds ahead of the release line
+// is skipped by every release, silently, until the project catches up.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PACKAGES, compareVersions, stranded } from "./extension-drift.mjs";
+
+const names = {
+  "extensions/opencode": { name: "opencode-deja" },
+  "extensions/dsh": { name: "dsh-deja" },
+};
+const readPkg = (dir) => names[dir];
+
+// The state this was written for: dsh-deja published by hand at 0.20.4 while
+// the release line was 0.19.2. Comparing the package against its own manifest
+// sees nothing wrong there — both say 0.20.4 — which is why the comparison is
+// against the release line.
+test("the August state is caught", () => {
+  const bad = stranded(PACKAGES, readPkg, (n) => (n === "dsh-deja" ? "0.20.4" : "0.19.2"), "0.19.2");
+  assert.deepEqual(bad.map((p) => p.name), ["dsh-deja"]);
+  assert.equal(bad[0].npm, "0.20.4");
+  assert.equal(bad[0].line, "0.19.2");
+});
+
+test("level with the line, or behind it, is not drift", () => {
+  assert.deepEqual(stranded(PACKAGES, readPkg, () => "0.19.2", "0.19.2"), []);
+  assert.deepEqual(stranded(PACKAGES, readPkg, () => "0.18.0", "0.19.2"), []);
+});
+
+test("what cannot be answered is not drift", () => {
+  // npm unreachable, and a checkout without tags: a pull request must not fail
+  // for either.
+  assert.deepEqual(stranded(PACKAGES, readPkg, () => "", "0.19.2"), []);
+  assert.deepEqual(stranded(PACKAGES, readPkg, () => "0.99.0", ""), []);
+});
+
+test("both packages are reported when both are stranded", () => {
+  const bad = stranded(PACKAGES, readPkg, () => "0.21.0", "0.19.2");
+  assert.deepEqual(bad.map((p) => p.name).sort(), ["dsh-deja", "opencode-deja"]);
+});
+
+test("versions order by number", () => {
+  assert.equal(compareVersions("0.20.4", "0.19.2"), 1);
+  assert.equal(compareVersions("0.9.0", "0.10.0"), -1);
+  assert.equal(compareVersions("0.20.5", "0.20.5"), 0);
+  assert.throws(() => compareVersions("0.21.0-rc.1", "0.20.3"), /not a plain version/);
+});


### PR DESCRIPTION
`release-npm.mjs` skips a package when npm is ahead of the version being released — right, because moving `latest` backwards cannot be undone. What nothing said is that the skip is permanent: dsh-deja was published by hand at 0.20.4 on 25 August against a 0.19.2 release line, and every release since has skipped it. Two fixes merged for it today would not have shipped.

The comparison is against the newest release tag, not against the package's own manifest — in exactly this state those two agree, which is why it went unnoticed. That case is the first test.

Deliberately `continue-on-error` for now, because dsh-deja is still ahead (0.20.5 against a 0.19.2 line) and a guard that fails every pull request gets switched off rather than read. Drop that line once the release line has passed it and this becomes a real gate.

Not in this PR, and your call: how a harness package that ran ahead gets back in step — bring the release line up, or let the extensions carry their own version and stop pretending they ride the same one.