### PR TITLE
plugin(claude): a plugin.json at the plugin root, the layout directories read

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -11,12 +11,13 @@
   "license": "MIT",
   "keywords": [
     "memory",
-    "session history",
+    "session-history",
     "recall",
     "context",
-    "claude code",
+    "claude-code",
     "codex",
-    "cursor"
+    "cursor",
+    "copilot-cli"
   ],
   "skills": "./skills/",
   "hooks": {

--- a/claude-plugin/plugin.json
+++ b/claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "deja-vu",
+  "version": "0.19.2",
+  "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
+  "author": {
+    "name": "vshulcz",
+    "url": "https://github.com/vshulcz"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu",
+  "repository": "https://github.com/vshulcz/deja-vu",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "session-history",
+    "recall",
+    "context",
+    "claude-code",
+    "codex",
+    "cursor",
+    "copilot-cli"
+  ]
+}

--- a/cmd/deja/agent_plugin_test.go
+++ b/cmd/deja/agent_plugin_test.go
@@ -15,9 +15,43 @@ import (
 //
 // https://open-plugins.com/plugin-authors/manifest
 func TestAgentPluginManifestIsPortable(t *testing.T) {
+	for _, path := range []string{"plugin.json", "claude-plugin/plugin.json"} {
+		t.Run(path, func(t *testing.T) { checkAgentPluginManifest(t, path) })
+	}
+}
+
+// The Claude Code plugin carries its manifest twice: .claude-plugin/plugin.json
+// for Claude Code and plugin.json at the plugin root for directories that read
+// the Agent Plugins layout (awesome-copilot's intake rejected the plugin for
+// its absence, and then for the version being behind the tag). One version.
+func TestClaudePluginManifestsAgree(t *testing.T) {
+	var a, b map[string]any
+	if err := json.Unmarshal(repoFile(t, "claude-plugin/.claude-plugin/plugin.json"), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(repoFile(t, "claude-plugin/plugin.json"), &b); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"name", "version", "description", "license"} {
+		if a[k] != b[k] {
+			t.Errorf("%s: .claude-plugin has %v, plugin.json has %v", k, a[k], b[k])
+		}
+	}
+	for _, m := range []map[string]any{a, b} {
+		kws, _ := m["keywords"].([]any)
+		for _, kw := range kws {
+			if s, _ := kw.(string); !regexp.MustCompile(`^[a-z0-9-]+$`).MatchString(s) {
+				t.Errorf("keyword %q: directories accept lowercase letters, digits and hyphens only", s)
+			}
+		}
+	}
+}
+
+func checkAgentPluginManifest(t *testing.T, path string) {
+	t.Helper()
 	var manifest map[string]any
-	if err := json.Unmarshal(repoFile(t, "plugin.json"), &manifest); err != nil {
-		t.Fatalf("plugin.json: %v", err)
+	if err := json.Unmarshal(repoFile(t, path), &manifest); err != nil {
+		t.Fatalf("%s: %v", path, err)
 	}
 
 	allowed := map[string]bool{

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -43,6 +43,9 @@ const (
 	// the default branch. It had no version field at all until the directory's
 	// own scanner asked for one.
 	claudePlugin = "claude-plugin/.claude-plugin/plugin.json"
+	// The same plugin in the Agent Plugins v1 layout, which directories such as
+	// awesome-copilot read: plugin.json at the plugin root.
+	claudeAgentPlugin = "claude-plugin/plugin.json"
 	// The Gemini gallery crawls the manifest at the repository root and shows
 	// its version, and `gemini extensions install` reads the same file.
 	geminiExtension = "gemini-extension.json"
@@ -136,17 +139,18 @@ func parse(version, checksums string) (pins, error) {
 
 func write(root string, p pins) error {
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:       renderScoop,
-		versionPath:     renderVersion,
-		localePath:      renderLocale,
-		installer:       renderInstaller,
-		codexPlugin:     renderPluginVersion(codexPlugin),
-		claudePlugin:    renderPluginVersion(claudePlugin),
-		geminiExtension: renderPluginVersion(geminiExtension),
-		kimiPlugin:      renderPluginVersion(kimiPlugin),
-		kimiPacked:      renderPluginVersion(kimiPacked),
-		kimiConst:       renderGoVersionConst(kimiConst, "kimiPluginVersion"),
-		agentPlugin:     renderPluginVersion(agentPlugin),
+		scoopPath:         renderScoop,
+		versionPath:       renderVersion,
+		localePath:        renderLocale,
+		installer:         renderInstaller,
+		codexPlugin:       renderPluginVersion(codexPlugin),
+		claudePlugin:      renderPluginVersion(claudePlugin),
+		claudeAgentPlugin: renderPluginVersion(claudeAgentPlugin),
+		geminiExtension:   renderPluginVersion(geminiExtension),
+		kimiPlugin:        renderPluginVersion(kimiPlugin),
+		kimiPacked:        renderPluginVersion(kimiPacked),
+		kimiConst:         renderGoVersionConst(kimiConst, "kimiPluginVersion"),
+		agentPlugin:       renderPluginVersion(agentPlugin),
 	} {
 		body, err := render(p)
 		if err != nil {
@@ -328,17 +332,18 @@ func runCheck(root string) error {
 		return err
 	}
 	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:       renderScoop,
-		versionPath:     renderVersion,
-		localePath:      renderLocale,
-		installer:       renderInstaller,
-		codexPlugin:     renderPluginVersion(codexPlugin),
-		claudePlugin:    renderPluginVersion(claudePlugin),
-		geminiExtension: renderPluginVersion(geminiExtension),
-		kimiPlugin:      renderPluginVersion(kimiPlugin),
-		kimiPacked:      renderPluginVersion(kimiPacked),
-		kimiConst:       renderGoVersionConst(kimiConst, "kimiPluginVersion"),
-		agentPlugin:     renderPluginVersion(agentPlugin),
+		scoopPath:         renderScoop,
+		versionPath:       renderVersion,
+		localePath:        renderLocale,
+		installer:         renderInstaller,
+		codexPlugin:       renderPluginVersion(codexPlugin),
+		claudePlugin:      renderPluginVersion(claudePlugin),
+		claudeAgentPlugin: renderPluginVersion(claudeAgentPlugin),
+		geminiExtension:   renderPluginVersion(geminiExtension),
+		kimiPlugin:        renderPluginVersion(kimiPlugin),
+		kimiPacked:        renderPluginVersion(kimiPacked),
+		kimiConst:         renderGoVersionConst(kimiConst, "kimiPluginVersion"),
+		agentPlugin:       renderPluginVersion(agentPlugin),
 	} {
 		want, err := render(p)
 		if err != nil {


### PR DESCRIPTION
Closes #3010. `claude-plugin/plugin.json` in the Agent Plugins v1 schema, mirroring `.claude-plugin/plugin.json` (name, version, description, author, license) — Claude Code keeps reading the latter, the Copilot directory's intake reads the former. `pinmanifests` bumps both on release; `TestClaudePluginManifestsAgree` holds them to one version and to hyphenated keywords. `claude plugin validate --strict` passes.