### PR TITLE
fix(hook): the environment block stops blaming a missing tool for every wall

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -189,7 +189,11 @@ func environmentBlockFrom(dir, activation string) (string, []string) {
 			"it is what this machine ran after that error before; check the rest or use an alternative " +
 			"before running into them again.")
 	} else {
-		b.WriteString("These are environment facts, not history: the tool or module is still missing. " +
+		// Not "the tool or module is still missing": friction is any error
+		// three projects keep hitting, and the block that reached this machine
+		// listed a compile error and an ssh timeout under that sentence. What
+		// is true of all of them is that nothing in the history cleared them.
+		b.WriteString("These are environment facts, not history: nothing here has cleared them yet. " +
 			"Check or use an alternative before running into them again.")
 	}
 	return b.String(), projects

--- a/cmd/deja/environment_claim_test.go
+++ b/cmd/deja/environment_claim_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// The block used to close with "the tool or module is still missing" whenever
+// it knew no remedy. Friction is any error three projects keep hitting, so that
+// sentence was asserted over compile errors and connection timeouts too — the
+// block this machine served listed `undefined: snorblefunc in vendor/blarg/api.go`
+// under it, where nothing is missing and nothing can be installed.
+func TestEnvironmentBlockDoesNotBlameAMissingTool(t *testing.T) {
+	tmp := hermeticEnv(t)
+	var roots []string
+	for i := 0; i < environmentMinProjects; i++ {
+		root := filepath.Join(tmp, "claude", fmt.Sprintf("proj-c%d", i))
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		roots = append(roots, root)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+
+	// Two recurring errors that no install fixes: a compile failure and a
+	// network timeout.
+	for i := 0; i < index.FrictionMinSessions; i++ {
+		sid := fmt.Sprintf("c%02d", i)
+		cwd := fmt.Sprintf("/w/proj%d", i%environmentMinProjects)
+		body := `{"type":"user","sessionId":"` + sid + `","cwd":"` + cwd +
+			`","timestamp":"2026-07-2` + fmt.Sprint(i%10) + `T10:00:00Z","message":{"role":"user","content":"run the checks"}}` + "\n" +
+			`{"type":"user","sessionId":"` + sid + `","cwd":"` + cwd +
+			`","timestamp":"2026-07-2` + fmt.Sprint(i%10) + `T10:05:00Z","message":{"role":"user","content":[{"type":"tool_result",` +
+			`"content":"undefined: widgetFunc in vendor/acme/api.go\nConnection timed out during banner exchange"}]}}` + "\n"
+		if err := os.WriteFile(filepath.Join(roots[i%len(roots)], sid+".jsonl"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := environmentBlock(dir, policy.ActivationAuto)
+	// A test that passes by producing no block would pin nothing.
+	if got == "" {
+		t.Fatal("no block, so this test asserts nothing")
+	}
+	if !strings.Contains(got, "undefined: widgetFunc") {
+		t.Fatalf("the compile error is not in the block:\n%s", got)
+	}
+	if strings.Contains(got, "the tool or module is still missing") {
+		t.Errorf("the block blames a missing tool for errors no install fixes:\n%s", got)
+	}
+	if !strings.Contains(got, "nothing here has cleared them yet") {
+		t.Errorf("the block does not say what is true of all of them:\n%s", got)
+	}
+	// The instruction has to survive the rewording: without it the block is
+	// trivia the model skims past.
+	if !strings.Contains(got, "alternative") {
+		t.Errorf("block says nothing to do about it:\n%s", got)
+	}
+}

--- a/cmd/deja/statusline_injected_test.go
+++ b/cmd/deja/statusline_injected_test.go
@@ -1,12 +1,37 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/usage"
 )
+
+// injectedBytes is the size of what the hook actually put in front of the
+// model. In plain mode that is the framed block on stdout; in the JSON shape it
+// is the additionalContext the reply carries.
+func injectedBytes(t *testing.T, hookOutput string) int {
+	t.Helper()
+	text := strings.TrimSpace(hookOutput)
+	if strings.HasPrefix(text, "{") {
+		var reply struct {
+			HookSpecificOutput struct {
+				AdditionalContext string `json:"additionalContext"`
+			} `json:"hookSpecificOutput"`
+		}
+		if err := json.Unmarshal([]byte(text), &reply); err != nil {
+			t.Fatalf("hook reply is not the shape the statusline counts: %v\n%s", err, hookOutput)
+		}
+		text = reply.HookSpecificOutput.AdditionalContext
+	}
+	if text == "" {
+		t.Fatal("the hook produced nothing, so there is nothing to count")
+	}
+	return len(text)
+}
 
 // A machine whose project has no history of its own still gets the environment
 // block at every session start, and on such a day that block is the whole of
@@ -32,8 +57,12 @@ func TestTheStatuslineCountsTheBlockItInjected(t *testing.T) {
 	// Asserted positively: runStatusline returns early on a warmup, a policy
 	// rule or a quiet week, and every one of those lines would satisfy "does
 	// not say 0 B injected" while saying nothing about the block at all.
+	// The size is measured from what went out, not written down here: a byte
+	// count in the source pins the block's wording, so changing a sentence in
+	// it failed this test for a reason that has nothing to do with counting.
 	got := strings.TrimSpace(line.String())
-	if want := "deja · no agent recalls today · 501 B injected"; got != want {
+	want := fmt.Sprintf("deja · no agent recalls today · %d B injected", injectedBytes(t, out))
+	if got != want {
 		t.Errorf("statusline = %q,\n                 want %q", got, want)
 	}
 }


### PR DESCRIPTION
When it knows no remedy the session-start block closes with "the tool or module is still missing". Friction is any error three projects keep hitting, so that cause is asserted over things no install fixes. The block this machine served today, verbatim:

    - 18 separate sessions hit `command not found: timeout`
    - 15 separate sessions hit `undefined: snorblefunc in vendor/blarg/api.go`
    - 10 separate sessions hit `Connection timed out during banner exchange`
    These are environment facts, not history: the tool or module is still missing.

One of the three is a missing tool. The second is a compile error against a path that does not exist — it is a string from this repository's own test fixtures — and the third is an ssh timeout. It now says what is true of all of them: nothing here has cleared them yet.

The statusline test came along because it held the block's byte count as a literal, so changing a sentence failed a test about counting. It measures the block the hook emitted instead.

Left alone deliberately: that a test fixture reaches the block at all. `environmentMinProjects` exists for exactly that and the comment says so; on this machine the string now spans three projects and clears it honestly.