### PR TITLE
fix(release): keep plugin tags out of goreleaser's version templates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,9 +72,16 @@ signs:
 
 # The nightly publishes a rolling `nightly` tag. Left visible, it becomes the
 # most recent tag and every version template downstream fails on it.
+#
+# The harness plugins are tagged in this repository too, and their names are not
+# semver: `copilot-plugin-0.19.2` became the newest tag and `goreleaser check`
+# failed on every pull request with "invalid semantic version". The glob covers
+# the ones added since as well, which is the point — a release tag here is
+# `vX.Y.Z` and anything else belongs to something that ships on its own.
 git:
   ignore_tags:
     - nightly
+    - "*-plugin-*"
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
`goreleaser check` fails on every pull request right now:

    current tag is not semver   error=invalid semantic version  tag=copilot-plugin-0.19.2
    release failed: failed to parse snapshot name: template: "{{ incpatch .Version }}-next": invalid semantic version

The harness plugins are tagged in this repository and their names are not semver, so the newest tag stopped being a release. `git.ignore_tags` already carried `nightly` for the same reason; the glob covers the plugin tags added since.

Found because it turned my own PR red; it is not caused by anything in it.