### PR TITLE
fix(opencode): a query that names one of deja's flags reaches the store

### DIFF
--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -14,6 +14,7 @@ import { join } from "node:path"
 import { accessSync, constants, existsSync, readFileSync } from "node:fs"
 
 import {
+  argv,
   clampLimit,
   cliPluginPath,
   configPaths,
@@ -166,7 +167,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
         },
         async execute(args) {
           const limit = String(clampLimit(args.limit))
-          return answer(await ask(["search", "--json", "--limit", limit, String(args.query)]))
+          return answer(await ask(argv("search", ["--json", "--limit", limit], args.query)))
         },
       }),
       deja_session: tool({
@@ -176,7 +177,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
           query: schema.string().describe("A query, or a session id prefix returned by deja_recall."),
         },
         async execute(args) {
-          return answer(await ask(["ctx", String(args.query)]))
+          return answer(await ask(argv("ctx", [], args.query)))
         },
       }),
       deja_blame: tool({
@@ -186,7 +187,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
           path: schema.string().describe("Path to the file, absolute or relative to the project."),
         },
         async execute(args) {
-          return answer(await ask(["blame", String(args.path), "--json"]))
+          return answer(await ask(argv("blame", ["--json"], args.path)))
         },
       }),
       deja_fix: tool({
@@ -196,7 +197,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
           error: schema.string().describe("The failing output, copied as it was printed."),
         },
         async execute(args) {
-          return answer(await ask(["fix", String(args.error)]))
+          return answer(await ask(argv("fix", [], args.error)))
         },
       }),
       deja_how: tool({
@@ -206,7 +207,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
           what: schema.string().describe("The thing to run: a tool, a task, a script name."),
         },
         async execute(args) {
-          return answer(await ask(["how", String(args.what)]))
+          return answer(await ask(argv("how", [], args.what)))
         },
       }),
       deja_remember: tool({
@@ -216,7 +217,7 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
           text: schema.string().describe("The decision, in one or two sentences, with the reason it was taken."),
         },
         async execute(args) {
-          const written = await ask(["remember", String(args.text)])
+          const written = await ask(argv("remember", [], args.text))
           if (!installed) return MISSING
           return written || "deja did not record that."
         },

--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -118,6 +118,22 @@ export function contributions(wiring, config = {}) {
   }
 }
 
+// argv builds the call for a query somebody typed, rather than handing the text
+// to deja as it stands.
+//
+// A query that starts with a dash is read as a flag: `deja search --no-verify`
+// exits on an unknown flag, run() turns a failed call into "", and the model is
+// told the history holds nothing about --no-verify while the sessions that
+// discuss it sit right there. A wrong answer, where an error would at least be
+// visible. `--` ends the flags.
+//
+// Sent only when the query needs it, so a deja too old to know the terminator
+// on this subcommand still answers every ordinary query.
+export function argv(cmd, flags, text) {
+  const arg = String(text)
+  return arg.startsWith("-") ? [cmd, ...flags, "--", arg] : [cmd, ...flags, arg]
+}
+
 // clampLimit keeps a model that asks for a hundred sessions from spending the
 // window on a tail nobody reads.
 export function clampLimit(value, fallback = 5) {

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -1,11 +1,12 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import {
+  argv,
   clampLimit,
   cliPluginPath,
   contextText,
@@ -149,4 +150,47 @@ test("contributions fills the gaps and never repeats the installer", () => {
   assert.deepEqual(contributions({}, { tools: false }), { tools: false, recall: true })
   assert.deepEqual(contributions({}, { autoRecall: false }), { tools: true, recall: false })
   assert.deepEqual(contributions(undefined, {}), { tools: true, recall: true })
+})
+
+// deja's flag parser reads a query that starts with a dash as a flag, exits,
+// and the plugin turns the failed call into "" — which the model receives as
+// "nothing in this machine's history", while the sessions that discuss the flag
+// sit right there.
+test("a query that starts with a dash is not read as a flag", () => {
+  assert.deepEqual(argv("search", [], "--no-verify"), ["search", "--", "--no-verify"])
+  assert.deepEqual(argv("fix", [], "-race detected"), ["fix", "--", "-race detected"])
+  // The plugin's own flags stay ahead of the terminator, or deja reads them as
+  // part of the query.
+  assert.deepEqual(argv("search", ["--json", "--limit", "5"], "--all-matches"), [
+    "search",
+    "--json",
+    "--limit",
+    "5",
+    "--",
+    "--all-matches",
+  ])
+})
+
+test("the terminator is sent only when the query needs it", () => {
+  // A deja too old to know `--` on this subcommand would otherwise fail on
+  // every ordinary query, not just the ones that start with a dash.
+  assert.deepEqual(argv("search", ["--json"], "the checkout worker"), [
+    "search",
+    "--json",
+    "the checkout worker",
+  ])
+  assert.deepEqual(argv("blame", ["--json"], "internal/index/sync.go"), [
+    "blame",
+    "--json",
+    "internal/index/sync.go",
+  ])
+})
+
+test("every query the plugin sends goes through argv", () => {
+  // The rule is worth nothing if one call site passes its text straight
+  // through, which is how this got in.
+  const source = readFileSync(new URL("../index.js", import.meta.url), "utf8")
+  for (const call of source.match(/ask\(\[[^\]]*\]/g) || []) {
+    assert.doesNotMatch(call, /String\(args\./, `${call} passes a query to deja without argv()`)
+  }
 })


### PR DESCRIPTION
The same defect #2988 fixed for dsh, in the package that ships to opencode: the six tools hand the model's text to deja as it stands, so a query that collides with a flag deja knows dies in flag parsing. `run()` turns the failed call into `""`, which the model receives as "nothing in this machine's history" — a confident wrong answer where an error would at least have been visible.

Measured against this machine's real store, `deja search --json --limit 3 <query>`:

    --json         plain: FAILS   with --: answers
    --limit        plain: FAILS   with --: answers
    --re           plain: FAILS   with --: answers
    --since        plain: FAILS   with --: answers
    --all-matches  plain: FAILS   with --: answers   (13 sessions)
    --dry-run      plain: FAILS   with --: answers
    --no-verify    plain: answers with --: answers
    -race          plain: answers with --: answers

So it is narrower than "any query starting with a dash" — an unknown double-dash word and a single dash both pass through. It is the flag names themselves, which in a repository about a CLI are ordinary things to search for.

The terminator goes out only when the query needs it, so a deja too old to accept `--` on a given subcommand still answers every ordinary query. Same shape as the dsh fix, including the source check that keeps a new call site from bypassing it.

Not ported: the duplicate-registration guard from #2990. opencode's plugin returns a hooks object rather than calling a register function, so that failure mode does not exist here — I did not test for it and am not claiming it.