### PR TITLE
fix(install): cline, pi and hermes end the flags before the query too

### DIFF
--- a/cmd/deja/generated_query_terminator_test.go
+++ b/cmd/deja/generated_query_terminator_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every plugin deja writes builds a search out of what the user typed, and a
+// query that names one of deja's own flags — `--json`, `--all-matches` — dies
+// in flag parsing. The caller turns the failed call into "", so the reader is
+// told their history holds nothing, which is worse than an error.
+//
+// Measured against a real store: of eight dash-leading queries, six failed
+// without `--` and all eight answered with it.
+func TestGeneratedPluginsEndTheFlagsBeforeTheQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		js   string
+		// how the plugin spells the guarded call, whitespace-free
+		want string
+	}{
+		{"cline", clinePluginJS("/bin/deja"), `["search","--",query]`},
+		{"pi", piExtensionTS("/bin/deja"), `["search","--",query]`},
+		{"deepseek", dshCommandJS("/bin/deja"), `["search","--",query]`},
+		{"hermes", hermesPluginPy("/bin/deja"), `["search","--",query]`},
+	} {
+		compact := strings.Join(strings.Fields(tc.js), "")
+		if !strings.Contains(compact, tc.want) {
+			t.Errorf("%s never sends the terminator", tc.name)
+		}
+		// And still sends the plain form, or every ordinary query would carry
+		// a terminator a deja that predates it cannot read.
+		if !strings.Contains(compact, `["search",query]`) {
+			t.Errorf("%s always sends the terminator", tc.name)
+		}
+		// The guard has to be on the query's own shape.
+		if !strings.Contains(compact, `query.startsWith("-")`) &&
+			!strings.Contains(compact, `query.startswith("-")`) {
+			t.Errorf("%s decides without looking at the query", tc.name)
+		}
+	}
+}

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -158,7 +158,13 @@ export default {
         if (!query) return "Usage: /deja <what you are looking for>";
         // A command the user just typed can wait: the first search may have
         // to build the index, which a hook never gets to do.
-        const found = run(["search", query], "", 120000);
+        //
+        // "--" when the query names one of deja's own flags: searching for
+        // "--json" or "--all-matches" otherwise dies in flag parsing and comes
+        // back as an empty history. Sent only when it is needed, so a deja too
+        // old to know the terminator still answers every ordinary query.
+        const args = query.startsWith("-") ? ["search", "--", query] : ["search", query];
+        const found = run(args, "", 120000);
         return found || `+"`No past session matches ${query}.`"+`;
       },
     });

--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -112,7 +112,12 @@ def search(raw_args):
         return "Usage: /deja <what you are looking for>"
     # A hook must not stall a turn, but a command the user just typed can
     # wait: a first search may rebuild the index, which took 18s here.
-    found = _deja(["search", query], timeout=120)
+    #
+    # "--" when the query names one of deja's own flags: searching for
+    # "--json" or "--all-matches" otherwise dies in flag parsing and comes back
+    # as an empty history.
+    args = ["search", "--", query] if query.startswith("-") else ["search", query]
+    found = _deja(args, timeout=120)
     return found or f"Nothing in your history matches {query!r}."
 
 

--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -97,7 +97,12 @@ export default function (pi: any) {
       }
       // The user is waiting on this one, so it may outlive the hook budget:
       // a first search can rebuild the index.
-      const found = run(["search", query], "", 120000);
+      //
+      // "--" when the query names one of deja's own flags: searching for
+      // "--json" or "--all-matches" otherwise dies in flag parsing and comes
+      // back as an empty history.
+      const args = query.startsWith("-") ? ["search", "--", query] : ["search", query];
+      const found = run(args, "", 120000);
       ctx.ui.notify(found || "Nothing in your history matches " + query, "info");
     },
   });


### PR DESCRIPTION
Finishing the sweep #2988 started for dsh and #3014 for opencode. The `/deja` command deja writes into Cline, pi and Hermes passed the user's words straight to `deja search`, so a query that names one of deja's own flags died in flag parsing and the reader was told their history holds nothing.

Measured on this machine's store, `deja search --json --limit 3 <query>`: `--json`, `--limit`, `--re`, `--since`, `--all-matches` and `--dry-run` all fail without the terminator and answer with it; `--no-verify` and `-race` pass either way. In a repository about a CLI those flag names are ordinary things to look for.

One test now holds the rule for all four generated plugins at once, so the next one added has to answer it. Each generated file was written out and parsed by its own runtime — node for the two JS, python for Hermes — rather than only matched as a string, because these live inside Go string literals where a syntax error is invisible until install time.

pi is TypeScript and node cannot check it, so that one is asserted on shape only. Grok, Kimi and Zed were checked and need nothing: they carry no query-building command of their own.