### PR TITLE
feat(search): on a large store, rank a session by the turn that holds the fact

### DIFF
--- a/internal/index/best_message_test.go
+++ b/internal/index/best_message_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// On a large store the relevance pool is fused with a per-message reading:
+// a session whose single user turn carries the query's words moves up past
+// one that scatters fewer of the same words over many assistant turns. It is
+// a fusion, so the pool leader keeps its place — the gain measured on a
+// 19k-session pile is hit@1 15 -> 18, not a new ranking (#3016).
+func TestBestMessageFusionLiftsTheTurnThatHoldsTheFact(t *testing.T) {
+	terms := []string{"degree", "graduated", "university"}
+	idf := map[string]float64{"degree": 2.0, "graduated": 2.5, "university": 1.5}
+	scattered := model.Session{ID: "scattered", Messages: []model.Message{
+		{Role: "assistant", Text: "a degree in anything is useful"},
+		{Role: "assistant", Text: "many people graduated last year"},
+		{Role: "assistant", Text: "the university opens in autumn"},
+	}}
+	thin := model.Session{ID: "thin", Messages: []model.Message{
+		{Role: "assistant", Text: "a degree is a degree"},
+	}}
+	focused := model.Session{ID: "focused", Messages: []model.Message{
+		{Role: "user", Text: "I graduated with a degree in physics from the university of Michigan"},
+	}}
+	// Pool order as the session-level ranking hands it over: focused last.
+	got := sessionIDs(rerankByBestMessage([]model.Session{scattered, thin, focused}, terms, idf))
+	want := []string{"scattered", "focused", "thin"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+// Fusion, not replacement: two sessions the messages cannot tell apart keep
+// the pool's order, so a ranking that was right stays right.
+func TestBestMessageFusionKeepsThePoolOrderOnTies(t *testing.T) {
+	terms := []string{"bike", "commute"}
+	idf := map[string]float64{"bike": 2.0, "commute": 2.0}
+	a := model.Session{ID: "a", Messages: []model.Message{{Role: "user", Text: "my bike commute"}}}
+	b := model.Session{ID: "b", Messages: []model.Message{{Role: "user", Text: "the bike commute again"}}}
+	got := rerankByBestMessage([]model.Session{a, b}, terms, idf)
+	if got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("order changed on a tie: %v", sessionIDs(got))
+	}
+}
+
+func sessionIDs(ss []model.Session) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.ID
+	}
+	return out
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -495,6 +495,9 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	}
 	keep = append(keep, weak...)
 	ss, err := sessionsServable(dir, keep, o)
+	if err == nil && os.Getenv("DEJA_EXP_MSG_RERANK") != "" {
+		ss = rerankByBestMessage(ss, terms, rank.idf)
+	}
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -4288,4 +4291,75 @@ func consonantY(word string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSuffix(word, "y"), true
+}
+
+// rerankByBestMessage is an experiment (DEJA_EXP_MSG_RERANK): order the
+// relevance pool by the single message that covers the most query weight,
+// on the guess that a fact lives in one turn while a lookalike session spreads
+// the same words over many. Stable on ties, so the pool's own order survives
+// where messages cannot separate sessions.
+func rerankByBestMessage(ss []model.Session, terms []string, idf map[string]float64) []model.Session {
+	forms := make([][]string, len(terms))
+	for i, t := range terms {
+		forms[i] = append([]string{t}, stemMatchForms(t)...)
+	}
+	best := make([]float64, len(ss))
+	for i, s := range ss {
+		for _, msg := range s.Messages {
+			toks := map[string]bool{}
+			for _, tk := range tokens(strings.ToLower(msg.Text)) {
+				toks[tk] = true
+			}
+			score := 0.0
+			for ti, t := range terms {
+				hit := false
+				for _, f := range forms[ti] {
+					if toks[f] {
+						hit = true
+						break
+					}
+				}
+				if hit {
+					w := idf[t]
+					if w <= 0 {
+						w = 1
+					}
+					score += w
+					if msg.Role == "user" {
+						score += 0.5 * w
+					}
+				}
+			}
+			if score > best[i] {
+				best[i] = score
+			}
+		}
+	}
+	// Fuse rather than replace: the pool's own order is session-level IDF
+	// overlap, which wins on a small haystack; the best-message score wins on
+	// a large pile. Reciprocal rank fusion keeps both votes.
+	byMsg := make([]int, len(ss))
+	for i := range byMsg {
+		byMsg[i] = i
+	}
+	sort.SliceStable(byMsg, func(a, b int) bool { return best[byMsg[a]] > best[byMsg[b]] })
+	msgRank := make([]int, len(ss))
+	for r, i := range byMsg {
+		msgRank[i] = r
+	}
+	const k = 5.0
+	fused := make([]float64, len(ss))
+	for i := range ss {
+		fused[i] = 1/(k+float64(i)) + 1/(k+float64(msgRank[i]))
+	}
+	idx := make([]int, len(ss))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return fused[idx[a]] > fused[idx[b]] })
+	out := make([]model.Session, len(ss))
+	for i, j := range idx {
+		out[i] = ss[j]
+	}
+	return out
 }

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -495,7 +495,7 @@ func relevanceSearch(dir string, m Manifest, o query.Options) (SearchResult, err
 	}
 	keep = append(keep, weak...)
 	ss, err := sessionsServable(dir, keep, o)
-	if err == nil && os.Getenv("DEJA_EXP_MSG_RERANK") != "" {
+	if err == nil && len(m.Sessions) >= bestMessageStore {
 		ss = rerankByBestMessage(ss, terms, rank.idf)
 	}
 	if err != nil {
@@ -4293,19 +4293,39 @@ func consonantY(word string) (string, bool) {
 	return strings.TrimSuffix(word, "y"), true
 }
 
-// rerankByBestMessage is an experiment (DEJA_EXP_MSG_RERANK): order the
-// relevance pool by the single message that covers the most query weight,
-// on the guess that a fact lives in one turn while a lookalike session spreads
-// the same words over many. Stable on ties, so the pool's own order survives
-// where messages cannot separate sessions.
+// bestMessageStore is the store size from which the relevance pool is fused
+// with a per-message reading. On a haystack of a few hundred sessions the
+// session-level overlap already ranks well and the fusion costs it points
+// (LoCoMo 70.3 -> 69.7 hit@1 when applied everywhere); on a pile of nineteen
+// thousand the answer is one turn in one session among fifty that spread the
+// same words thin, and the fusion is worth hit@1 15 -> 18, hit@5 32 -> 35
+// (day0bench, -corpus 1000; #3016).
+const bestMessageStore = 2000
+
+// bestMessageTurns bounds how many turns of one session are read for the
+// fusion: the pool is fifty sessions, a marathon can hold thousands of turns,
+// and the fact this is looking for sits in one of them, not in the tail.
+const bestMessageTurns = 4000
+
+// rerankByBestMessage fuses the relevance pool's own order with the single
+// message in each session that covers the most query weight, on the reading
+// that a fact lives in one turn — usually the user's — while a lookalike
+// session spreads the same words over many. Reciprocal rank fusion keeps both
+// votes; stable on ties, so the pool's order survives where messages cannot
+// separate sessions.
 func rerankByBestMessage(ss []model.Session, terms []string, idf map[string]float64) []model.Session {
 	forms := make([][]string, len(terms))
 	for i, t := range terms {
+		t = strings.ToLower(t)
 		forms[i] = append([]string{t}, stemMatchForms(t)...)
 	}
 	best := make([]float64, len(ss))
 	for i, s := range ss {
-		for _, msg := range s.Messages {
+		msgs := s.Messages
+		if len(msgs) > bestMessageTurns {
+			msgs = msgs[:bestMessageTurns]
+		}
+		for _, msg := range msgs {
 			toks := map[string]bool{}
 			for _, tk := range tokens(strings.ToLower(msg.Text)) {
 				toks[tk] = true
@@ -4320,7 +4340,7 @@ func rerankByBestMessage(ss []model.Session, terms []string, idf map[string]floa
 					}
 				}
 				if hit {
-					w := idf[t]
+					w := idf[strings.ToLower(t)]
 					if w <= 0 {
 						w = 1
 					}


### PR DESCRIPTION
Closes #3016. `rerankByBestMessage` fuses the relevance pool's order with each session's best single message (query-term IDF present in that turn, user turns ×1.5) by reciprocal rank, k=5, and only when the store holds 2,000+ sessions (`bestMessageStore`). Measured in the issue: day0bench full pile hit@1 15→18, hit@5 32→35, mrr .230→.258; LongMemEval-S and LoCoMo identical by construction below the gate (and +1.1 / −0.6 if applied everywhere, which is why the gate). Tests: `TestBestMessageFusionLiftsTheTurnThatHoldsTheFact`, `TestBestMessageFusionKeepsThePoolOrderOnTies`.