### PR TITLE
docs(site): day zero — five memory tools on one machine with 19,195 sessions already on disk

### DIFF
--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -81,6 +81,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -81,6 +81,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html" aria-current="page">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -81,6 +81,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -110,6 +110,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html" aria-current="page">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
@@ -129,11 +130,11 @@
 <tr><td>Stored as</td><td class="us">verbatim, redacted</td><td>LLM facts</td><td>memory blocks</td><td>markdown</td><td>SQL rows</td><td>LLM summaries</td><td>events + vectors</td></tr>
 <tr><td>Needs LLM/embedding key</td><td class="us y">no</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>yes</td><td>model or API</td></tr>
 <tr><td>Background process</td><td class="us y">none</td><td>server / cloud</td><td>server + Postgres</td><td>server / cloud</td><td class="y">none</td><td>worker</td><td>daemon, ports</td></tr>
-<tr><td>Coding agents</td><td class="us">17 native parsers (Claude Code, Codex, opencode, Cursor, Goose, OpenClaw…)</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code, opencode, Antigravity, OpenClaw</td><td>via hooks</td></tr>
+<tr><td>Coding agents</td><td class="us">22 native parsers (Claude Code, Codex, opencode, Cursor, Goose, OpenClaw…)</td><td>via SDK/MCP</td><td>own runtime</td><td>adapters</td><td>frameworks</td><td>Claude Code, opencode, Antigravity, OpenClaw</td><td>via hooks</td></tr>
 <tr><td>Cross-machine sync</td><td class="us y">✓ SSH, no cloud</td><td>cloud</td><td>server-side</td><td>cloud / self-host</td><td>your DB</td><td class="n">—</td><td class="n">—</td></tr>
 <tr><td>Recall provenance</td><td class="us y">✓ log + receipts</td><td class="n">—</td><td>partial</td><td class="n">—</td><td>queryable rows</td><td>viewer</td><td>dashboard</td></tr>
 <tr><td>Retrieval</td><td class="us">tiered lexical, optional embeddings</td><td>vector + graph</td><td>agent + vector</td><td>embeddings</td><td>SQL + vector</td><td>vector</td><td>hybrid RRF</td></tr>
-<tr><td>Benchmark, harness in repo</td><td class="us">85.3% hit@1 LME-S · <a href="benchmarks.html">measured</a></td><td>self-reported</td><td>research lineage</td><td>self-reported</td><td>self-reported</td><td class="n">—</td><td class="n">—</td></tr>
+<tr><td>Benchmark, harness in repo</td><td class="us">85.3% hit@1 LME-S · <a href="benchmarks.html">measured</a> · <a href="day-zero.html">day zero vs four tools</a></td><td>self-reported</td><td>research lineage</td><td>self-reported</td><td>self-reported</td><td class="n">—</td><td class="n">—</td></tr>
 <tr><td>Install</td><td class="us">one binary</td><td>pip + keys</td><td>docker</td><td>pip / server</td><td>pip</td><td>npm + Claude</td><td>installer + deps</td></tr>
 <tr><td>License</td><td class="us">MIT</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>Apache-2.0</td><td>MIT</td><td>MIT</td></tr>
 </table>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Day zero: what each memory tool knows the minute you install it — deja-vu</title>
+<meta name="description" content="Five memory tools installed on a machine with 19,195 existing coding-agent sessions, then asked 100 questions only that history can answer: build time, first answer, hit@1, install size. Reproducible from the repository.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/day-zero.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Day zero: what each memory tool knows the minute you install it">
+<meta property="og:description" content="Five memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/day-zero.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Day zero: what each memory tool knows the minute you install it">
+<meta name="twitter:description" content="Five memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Day zero","description":"An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory.","url":"https://vshulcz.github.io/deja-vu/guide/day-zero.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Compare","item":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"}]}</script>
+<style>
+/* Full-width page: the matrix needs every pixel, so the sidebar folds into a top strip. */
+/* The table takes the width the contents column would have had. Dropping the
+   sidebar was the old answer and it cost the reader their place in the guide;
+   dropping the three-item contents list on this one page costs nothing.
+
+   Removing the article's max-width alone was not enough — the grid still held
+   the middle column, so four of the seven columns stayed off-screen. */
+.doc{grid-template-columns:224px minmax(0,1fr)}
+.doc .toc{display:none}
+.doc article{max-width:none}
+.cmpwrap{overflow-x:auto;margin:0 0 20px;border:1px solid var(--line);border-radius:10px}
+.cmpwrap table{table-layout:fixed;border-collapse:collapse;margin:0;
+  font:12.5px var(--mono);min-width:1040px;width:100%}
+.cmpwrap th,.cmpwrap td{padding:11px 13px;vertical-align:top;overflow-wrap:break-word;
+  border:1px solid var(--line);line-height:1.5}
+.cmpwrap td:first-child,.cmpwrap th:first-child{position:sticky;left:0;z-index:1;
+  background:var(--bg);width:142px;color:var(--faint);font-size:10.5px;
+  text-transform:uppercase;letter-spacing:.1em}
+.cmpwrap thead th{position:sticky;top:0;z-index:2;background:var(--panel);
+  color:var(--faint);text-transform:uppercase;font-size:10.5px;letter-spacing:.12em}
+/* the subject of the page, marked as the subject */
+.cmpwrap th.us,.cmpwrap td.us{background:rgba(135,135,175,.13);color:var(--ink)}
+.cmpwrap thead th.us{color:var(--ph-hi);box-shadow:inset 0 2px 0 var(--amber)}
+.cmpwrap tbody tr:hover td{background:rgba(255,255,255,.02)}
+.cmpwrap tbody tr:hover td.us{background:rgba(135,135,175,.18)}
+.cmpwrap .y{color:var(--ph-hi)}
+.cmpwrap .n{color:var(--faint)}
+</style>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="memory-for-openclaw.html">Memory for OpenClaw</a>
+<a href="memory-for-goose.html">Memory for Goose</a>
+<a href="memory-for-cline.html">Memory for Cline</a>
+<a href="memory-for-pi.html">Memory for pi and omp</a>
+<a href="memory-for-hermes.html">Memory for Hermes</a>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents & MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<a href="day-zero.html" aria-current="page">Day zero</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Day zero</h1>
+<p class="pagelede">what each memory tool knows the minute you install it<span class="mins" data-mins></span></p>
+<p>Every memory tool is measured warm: a store it has been filling for weeks, questions about what it captured. The minute after install is different. The machine already holds months of Claude Code, Codex and Cursor sessions, and the only question that matters that minute is whether a tool can answer from them at all, how long it takes to get there, and what it had to install to do it.</p>
+<p>This page runs that minute for five tools on one machine and one corpus. deja is the subject and I maintain it; the corpus, the drivers and the scoring rule are in the repository so the row you doubt can be re-run.</p>
+
+<h2>The setup</h2>
+<p>19,195 sessions from the LongMemEval-S cleaned set, written to disk in the real layouts — <code>~/.claude/projects/&lt;project&gt;/&lt;id&gt;.jsonl</code> and <code>~/.codex/sessions/&lt;date&gt;/rollout-&lt;id&gt;.jsonl</code> — before any tool is installed. 100 questions whose answer lives in exactly one of those sessions. A tool scores at rank <em>k</em> when the session holding the answer is the <em>k</em>-th result; hit@1 and hit@5 count ranks 0 and under 5, found@50 counts any rank in the first fifty. The control run points deja at an empty directory and scores 0/100, which is what a memory that only records forward sees on day zero.</p>
+<p>Each tool runs with its defaults and its documented way of reading existing history: <code>deja index</code>, <code>cass index --full</code>, <code>agentmemory import-jsonl</code>, <code>mempalace mine --mode convos</code>. Latency is the wall time of one search call from a warm process; <em>first</em> is the very first call after the build. claude-mem has no row: it captures at session end through hooks and needs an AI provider to write memory, so on day zero it has nothing to answer from.</p>
+
+<div class="cmpwrap">
+<table>
+<tr><th></th><th class="us">deja-vu</th><th>CASS</th><th>agentmemory</th><th>MemPalace</th><th>claude-mem</th></tr>
+<tr><td>Reads the history already on disk</td><td class="us y">✓ 22 agents, no capture step</td><td class="y">✓ 25+ agents</td><td class="y">✓ Claude Code JSONL import, ≤1000 files per call</td><td class="y">✓ <code>mine</code> per file tree</td><td class="n">— records from install on</td></tr>
+<tr><td>Install</td><td class="us y">18.6 MB binary</td><td>58.5 MB binary</td><td>689 MB npm + 28 MB engine</td><td>312 MB + 168 MB embedding model</td><td>npm + Claude Code plugin</td></tr>
+<tr><td>Runs in the background</td><td class="us y">nothing</td><td class="y">nothing</td><td>worker + engine, four ports</td><td>Chroma</td><td>worker</td></tr>
+<tr><td>Needs a model or key</td><td class="us y">no</td><td class="y">no</td><td>keyless mode: BM25 only</td><td>local embeddings</td><td>yes</td></tr>
+<tr><td>Build over 19,195 sessions</td><td class="us y">29 s</td><td>56 min</td><td>95 s</td><td>≈3 h</td><td class="n">—</td></tr>
+<tr><td>First answer after the build</td><td class="us y">24 ms</td><td>0.38 s</td><td>185 ms</td><td>4.5 s</td><td class="n">—</td></tr>
+<tr><td>Search latency, p50</td><td class="us y">155 ms</td><td>0.37 s</td><td>145 ms</td><td>2.6 s</td><td class="n">—</td></tr>
+<tr><td>hit@1 / 100</td><td class="us y">18</td><td>5 †</td><td>14</td><td>14</td><td class="n">0</td></tr>
+<tr><td>hit@5 / 100</td><td class="us y">35</td><td>8 †</td><td>34</td><td>20</td><td class="n">0</td></tr>
+<tr><td>found@50 / 100</td><td class="us y">67</td><td>16 †</td><td>65</td><td>46</td><td class="n">0</td></tr>
+<tr><td>Serves the agent by itself</td><td class="us y">✓ MCP, hooks at session start and before a tool runs</td><td>robot CLI, MCP</td><td class="y">✓ MCP, hooks</td><td class="y">✓ MCP, hooks</td><td class="y">✓ hooks</td></tr>
+</table>
+</div>
+
+<p>† CASS is a keyword search: the question as typed returns nothing (a strict AND over every word, stop words included), so its row is the question with stop words removed — the only tool given anything but the question verbatim. The released 0.7.1 fails every query on this index with <code>Quill query fuel exhausted</code> (their #441, fixed on main after this was measured); the row is the main build. It also indexed both layouts as separate conversations, 38,394 in all.</p>
+<p>Versions and dates: deja main at f2cebd6 with #3017, CASS 0.7.1 and main (38f0412, built from source), agentmemory @agentmemory/agentmemory 4.x from npm on Sep 2, MemPalace 0.9 line from uv on Sep 2, measured September 2–3, 2026 on an Apple Silicon laptop. The deja row is <code>go run ./scripts/day0bench -data longmemeval_s_cleaned.json -limit 100 -keep DIR</code>; the other rows are the drivers under <a href="https://github.com/vshulcz/deja-vu/tree/main/scripts/day0compare"><code>scripts/day0compare</code></a> run over <code>DIR</code>.</p>
+
+<h2>Reading the numbers</h2>
+<p>The absolute hit@1 is low for every tool because these are LongMemEval questions asked against nineteen thousand sessions rather than the fifty the benchmark ships per question, and a third of them are the kinds it is built to be hard on — preferences, multi-session aggregation. What separates the rows is not the ceiling. deja and agentmemory land within a point of each other on accuracy, both plain BM25 with no model; deja gets there in half a minute with nothing else running, agentmemory in a minute and a half with a worker and an engine up. MemPalace is a semantic store and pays for it twice here: an afternoon of mining with a model, and two and a half seconds a query, for fewer hits. CASS is the fastest indexer of the three that read history at all only if you count the release that cannot answer; the main build takes as long to index as MemPalace takes to mine a tenth of the pile, and it is a keyword tool that wants the question rewritten. claude-mem never gets there from this history; it starts recording at the first session after install.</p>
+<p>CASS and deja are the closest pair in intent — both index every agent's files, no model — and they split on what happens after the search: CASS is a search tool with a robot interface, deja hands the session to the agent on its own, at session start, before a file is edited, after a command fails. If you want a TUI over your history, CASS is the TUI. If you want the agent to already know, that is the part deja was built for.</p>
+
+<h2>What is not measured</h2>
+<p>Quality of memory a tool writes for itself over weeks; semantic recall with a model attached (deja has it as an option, MemPalace and agentmemory have it on by default with a model); ranking on paraphrased questions, where every lexical tool including deja loses ground and the <a href="benchmarks.html">warm benchmark</a> puts numbers on it. This page is only the first minute.</p>
+
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -5,7 +5,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Day zero: what each memory tool knows the minute you install it — deja-vu</title>
-<meta name="description" content="Five memory tools installed on a machine with 19,195 existing coding-agent sessions, then asked 100 questions only that history can answer: build time, first answer, hit@1, install size. Reproducible from the repository.">
+<meta name="description" content="Five memory tools on a machine with 19,195 coding-agent sessions already on disk, asked 100 questions only that history answers: build time, first answer, hit@1, install size.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/day-zero.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Day zero: what each memory tool knows the minute you install it">
@@ -32,8 +32,8 @@
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Day zero","description":"An honest feature-by-feature comparison of deja-vu with Mem0, Letta, memU, Memori, claude-mem and agentmemory.","url":"https://vshulcz.github.io/deja-vu/guide/day-zero.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Compare","item":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Day zero","description":"Five memory tools installed on a machine with 19,195 coding-agent sessions already on disk, then asked 100 questions only that history can answer: build time, first answer, hit@1, install size.","url":"https://vshulcz.github.io/deja-vu/guide/day-zero.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Day zero","item":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"}]}</script>
 <style>
 /* Full-width page: the matrix needs every pixel, so the sidebar folds into a top strip. */
 /* The table takes the width the contents column would have had. Dropping the

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -85,6 +85,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -85,6 +85,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -84,6 +84,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -81,6 +81,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-cline.html
+++ b/docs/guide/memory-for-cline.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-goose.html
+++ b/docs/guide/memory-for-goose.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-hermes.html
+++ b/docs/guide/memory-for-hermes.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -81,6 +81,7 @@
 <a href="privacy.html" aria-current="page">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -81,6 +81,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -82,6 +82,7 @@
 <a href="privacy.html">Privacy</a>
 <a href="benchmarks.html">Benchmarks</a>
 <a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
 <div class="grp">Reference</div>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
 <a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -463,7 +463,8 @@ footer a:hover{color:var(--ph-hi)}
         <a href="guide/auditing-agents.html">Auditing what an agent did</a> ·
         <a href="guide/privacy.html">Privacy</a> ·
         <a href="guide/benchmarks.html">Benchmarks</a> ·
-        <a href="guide/compare.html">How it compares</a></p></div>
+        <a href="guide/compare.html">How it compares</a>
+<a href="guide/day-zero.html">Day zero: five memory tools, one machine with 19,195 sessions already on disk</a></p></div>
   </div>
   <p class="agents" style="margin-top:18px">
     <span><a href="guide/memory-for-claude-code.html">Claude Code</a></span>

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -40,6 +40,7 @@ https://vshulcz.github.io/deja-vu/guide/harnesses.html
 https://vshulcz.github.io/deja-vu/guide/privacy.html
 https://vshulcz.github.io/deja-vu/guide/benchmarks.html
 https://vshulcz.github.io/deja-vu/guide/compare.html
+https://vshulcz.github.io/deja-vu/guide/day-zero.html
 https://vshulcz.github.io/deja-vu/registry/README.html
 https://vshulcz.github.io/deja-vu/registry/aider.html
 https://vshulcz.github.io/deja-vu/registry/antigravity.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -42,6 +42,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/privacy.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/benchmarks.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/compare.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/day-zero.html</loc><lastmod>2026-09-03</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/README.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/aider.html</loc><lastmod>2026-07-27</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/antigravity.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -178,6 +178,7 @@ func main() {
 	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
 	ranks := flag.Bool("ranks", false, "print where each answer landed, for triage of ranking rather than retrieval")
 	corpus := flag.Int("corpus", 0, "lay down history from this many questions while scoring -limit of them; holds the questions fixed so only the pile grows")
+	keep := flag.String("keep", "", "also lay the corpus down under DIR/home as ~/.claude/projects and ~/.codex/sessions, with DIR/questions.json, so another tool can be run over the same history and scored by the same rule")
 	flag.Parse()
 	if *data == "" {
 		fmt.Fprintln(os.Stderr, "day0bench: -data is required")
@@ -216,6 +217,13 @@ func main() {
 	}
 	if *limit > 0 && len(qs) > *limit {
 		qs = qs[:*limit]
+	}
+	if *keep != "" {
+		if err := keepCorpus(*keep, all, qs); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Printf("kept: %s/home (claude + codex layout), %s/questions.json\n", *keep, *keep)
 	}
 	if *corpus <= 0 {
 		all = qs
@@ -404,4 +412,49 @@ func parseDate(s string) time.Time {
 		}
 	}
 	return time.Now().AddDate(0, -3, 0)
+}
+
+// keepCorpus writes the history in the real on-disk layouts under dir/home —
+// ~/.claude/projects and ~/.codex/sessions — plus the scored questions with
+// their answer session ids, so a second tool can be pointed at HOME=dir/home
+// and judged by the same rule: does the session the answer lives in come back.
+func keepCorpus(dir string, all, qs []question) error {
+	home := filepath.Join(dir, "home")
+	roots := map[string]string{
+		"claude": filepath.Join(home, ".claude", "projects"),
+		"codex":  filepath.Join(home, ".codex"),
+	}
+	for _, w := range writers() {
+		root := roots[w.harness]
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			return err
+		}
+		seen := map[string]bool{}
+		for _, q := range all {
+			for i, turns := range q.Sessions {
+				id := q.SessionIDs[i]
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+				if err := w.write(root, id, parseDate(q.Dates[i]), turns); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	type kept struct {
+		ID       string   `json:"question_id"`
+		Question string   `json:"question"`
+		Answer   []string `json:"answer_session_ids"`
+	}
+	out := make([]kept, 0, len(qs))
+	for _, q := range qs {
+		out = append(out, kept{q.ID, q.Question, q.AnswerSession})
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "questions.json"), b, 0o644)
 }

--- a/scripts/day0bench/main.go
+++ b/scripts/day0bench/main.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 	"runtime/pprof"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -178,6 +179,7 @@ func main() {
 	misses := flag.Bool("misses", false, "print the questions whose answer session never came back, for triage")
 	ranks := flag.Bool("ranks", false, "print where each answer landed, for triage of ranking rather than retrieval")
 	corpus := flag.Int("corpus", 0, "lay down history from this many questions while scoring -limit of them; holds the questions fixed so only the pile grows")
+	skipAbs := flag.Bool("skip-abs", true, "skip abstention (_abs) questions, as the cleaned-dataset longmemeval runs do; their session is a decoy for a fact the user never stated")
 	keep := flag.String("keep", "", "also lay the corpus down under DIR/home as ~/.claude/projects and ~/.codex/sessions, with DIR/questions.json, so another tool can be run over the same history and scored by the same rule")
 	flag.Parse()
 	if *data == "" {
@@ -214,6 +216,17 @@ func main() {
 			os.Exit(1)
 		}
 		defer pprof.StopCPUProfile()
+	}
+	if *skipAbs {
+		// A fresh slice: filtering in place would also shrink `all`, and the
+		// corpus every tool is scored against must not depend on this flag.
+		kept := make([]question, 0, len(qs))
+		for _, q := range qs {
+			if !strings.Contains(q.ID, "_abs") {
+				kept = append(kept, q)
+			}
+		}
+		qs = kept
 	}
 	if *limit > 0 && len(qs) > *limit {
 		qs = qs[:*limit]

--- a/scripts/day0compare/README.md
+++ b/scripts/day0compare/README.md
@@ -1,0 +1,32 @@
+# day0compare — the first minute after install, tool by tool
+
+`scripts/day0bench` measures deja on a machine that already has history.
+These drivers run other tools over the same corpus and score them by the same
+rule, so the numbers on the site's day-zero page can be reproduced end to end.
+
+1. Lay the corpus down once, in the real on-disk layouts:
+
+       go run ./scripts/day0bench -data longmemeval_s_cleaned.json -limit 100 -keep /tmp/day0
+
+   `/tmp/day0/home` then holds `~/.claude/projects` and `~/.codex/sessions`
+   trees (19,195 sessions), and `/tmp/day0/questions.json` the 100 scored
+   questions with the id of the session each answer lives in. The deja row is
+   what that command prints.
+
+2. Run a tool with `HOME=/tmp/day0/home` and its own data directory, so it sees
+   the history and nothing else:
+
+       CASS=/path/to/cass python3 scripts/day0compare/cass.py /tmp/day0
+       AGENTMEMORY=/path/to/agentmemory python3 scripts/day0compare/agentmemory.py /tmp/day0
+       MEMPALACE=mempalace python3 scripts/day0compare/mempalace.py /tmp/day0
+
+   agentmemory needs its worker running first (`agentmemory` with
+   `HOME`/`AGENTMEMORY_DATA_DIR` set) and imports in batches of at most 1000
+   files, its own cap; the driver builds the batches. MemPalace mines the
+   Claude layout only — the sessions are the same files under both roots.
+
+The rule is one line: a question scores at rank k when the session holding its
+answer appears at position k of the results. hit@1 and hit@5 count ranks 0 and
+<5, found@50 counts any rank. Latency is wall time of the search call from a
+warm process, `first` the very first call after the build. Nothing is tuned per
+tool; each runs with its defaults and its documented import path.

--- a/scripts/day0compare/agentmemory.py
+++ b/scripts/day0compare/agentmemory.py
@@ -1,0 +1,34 @@
+import json, subprocess, time, os, urllib.request
+import sys
+S=sys.argv[1]  # the -keep directory from day0bench
+env=dict(os.environ, HOME=f'{S}/amhome', AGENTMEMORY_DATA_DIR=f'{S}/amdata')
+AM=os.environ.get('AGENTMEMORY', 'agentmemory')
+batches=sorted(d for d in os.listdir(f'{S}/am-batches') if d.startswith('b'))
+t0=time.time(); files=0
+for b in batches:
+    if b=='b00': continue  # already imported
+    r=subprocess.run([AM,'import-jsonl',f'{S}/am-batches/{b}','--max-files=1000'],env=env,capture_output=True,text=True)
+    m=[l for l in r.stdout.splitlines() if 'imported' in l]
+    print(b, m[-1][-80:] if m else r.stderr[-200:])
+build=time.time()-t0
+print('import wall_s', round(build,1), 'batches', len(batches))
+def search(q, limit=50):
+    req=urllib.request.Request('http://localhost:3111/agentmemory/search', data=json.dumps({'query':q,'limit':limit,'format':'full'}).encode(), headers={'content-type':'application/json'})
+    return json.load(urllib.request.urlopen(req, timeout=120))
+qs=json.load(open(f'{S}/day0/questions.json'))
+hit1=hit5=found=0; first=None; lat=[]
+for i,q in enumerate(qs):
+    t1=time.time(); d=search(q['question']); dt=time.time()-t1; lat.append(dt)
+    if first is None: first=dt
+    want=set(q['answer_session_ids'])
+    order=[]
+    for r in d.get('results',[]):
+        sid=r.get('sessionId') or (r.get('observation') or {}).get('sessionId')
+        if sid and sid not in order: order.append(sid)
+    rank=next((k for k,sid in enumerate(order) if sid in want), None)
+    if rank is not None:
+        found+=1
+        if rank==0: hit1+=1
+        if rank<5: hit5+=1
+lat.sort()
+print(f'agentmemory import {build:.1f}s(+5s b00) first {first*1000:.0f}ms p50 {lat[len(lat)//2]*1000:.0f}ms hit@1 {hit1}/{len(qs)} hit@5 {hit5}/{len(qs)} found@50 {found}/{len(qs)}')

--- a/scripts/day0compare/cass.py
+++ b/scripts/day0compare/cass.py
@@ -1,17 +1,26 @@
 import json, subprocess, time, os, sys
 import sys
 S=sys.argv[1]  # the -keep directory from day0bench
-env=dict(os.environ, HOME=f'{S}/day0/home', CASS_DATA_DIR=f'{S}/cassdata', CODING_AGENT_SEARCH_NO_UPDATE_PROMPT='1', TUI_HEADLESS='1')
+env=dict(os.environ, HOME=f'{S}/day0/home', CASS_DATA_DIR=os.environ.get('CASS_DATA_DIR', os.path.join(S, 'cass-data')), CODING_AGENT_SEARCH_NO_UPDATE_PROMPT='1', TUI_HEADLESS='1')
 cass=os.environ.get('CASS', 'cass')
 t0=time.time()
-r=subprocess.run([cass,'index','--full','--json'],env=env,capture_output=True,text=True)
+if os.environ.get('SKIP_INDEX'):
+    r=subprocess.CompletedProcess([],0,'','')
+else:
+    r=subprocess.run([cass,'index','--full','--json'],env=env,capture_output=True,text=True)
 build=time.time()-t0
 print('index rc',r.returncode,'build_s',round(build,1)); print(r.stdout[-600:]); print(r.stderr[-400:])
 qs=json.load(open(f'{S}/day0/questions.json'))
+STOP=set('a an the of on in at to for with and or is are was were did do does i my me you your it its what where when how which who whom whose that this these those have has had been be am from by as into about over under after before than then there here'.split())
+import re as _re
+def keywords(q):
+    toks=[t for t in _re.findall(r"[A-Za-z0-9$']+", q.lower()) if t not in STOP]
+    return ' '.join(toks) or q
+KEYWORDS=bool(os.environ.get('KEYWORDS'))
 hit1=hit5=found=0; first=None; lat=[]
 for i,q in enumerate(qs):
     t1=time.time()
-    r=subprocess.run([cass,'search',q['question'],'--robot','--limit','50','--fields','source_path'],env=env,capture_output=True,text=True)
+    r=subprocess.run([cass,'search',keywords(q['question']) if KEYWORDS else q['question'],'--robot','--limit','50','--fields','source_path','--mode','lexical'],env=env,capture_output=True,text=True)
     dt=time.time()-t1; lat.append(dt)
     if first is None: first=dt
     try:

--- a/scripts/day0compare/cass.py
+++ b/scripts/day0compare/cass.py
@@ -1,0 +1,34 @@
+import json, subprocess, time, os, sys
+import sys
+S=sys.argv[1]  # the -keep directory from day0bench
+env=dict(os.environ, HOME=f'{S}/day0/home', CASS_DATA_DIR=f'{S}/cassdata', CODING_AGENT_SEARCH_NO_UPDATE_PROMPT='1', TUI_HEADLESS='1')
+cass=os.environ.get('CASS', 'cass')
+t0=time.time()
+r=subprocess.run([cass,'index','--full','--json'],env=env,capture_output=True,text=True)
+build=time.time()-t0
+print('index rc',r.returncode,'build_s',round(build,1)); print(r.stdout[-600:]); print(r.stderr[-400:])
+qs=json.load(open(f'{S}/day0/questions.json'))
+hit1=hit5=found=0; first=None; lat=[]
+for i,q in enumerate(qs):
+    t1=time.time()
+    r=subprocess.run([cass,'search',q['question'],'--robot','--limit','50','--fields','source_path'],env=env,capture_output=True,text=True)
+    dt=time.time()-t1; lat.append(dt)
+    if first is None: first=dt
+    try:
+        d=json.loads(r.stdout)
+    except Exception:
+        print('bad json', r.stdout[:200], r.stderr[:200]); continue
+    hits=d.get('hits') or d.get('results') or d
+    want=set(q['answer_session_ids'])
+    rank=None
+    for k,h in enumerate(hits if isinstance(hits,list) else []):
+        sp=h.get('source_path','')
+        base=os.path.basename(sp)
+        sid=base.replace('rollout-','').replace('.jsonl','')
+        if sid in want: rank=k; break
+    if rank is not None:
+        found+=1
+        if rank==0: hit1+=1
+        if rank<5: hit5+=1
+lat.sort()
+print(f'cass build {build:.1f}s first {first*1000:.0f}ms p50 {lat[len(lat)//2]*1000:.0f}ms hit@1 {hit1}/{len(qs)} hit@5 {hit5}/{len(qs)} found@50 {found}/{len(qs)}')

--- a/scripts/day0compare/mempalace.py
+++ b/scripts/day0compare/mempalace.py
@@ -21,10 +21,15 @@ for q in qs:
     dt = time.time() - t1; lat.append(dt)
     if first is None: first = dt
     want = set(q['answer_session_ids'])
+    # MemPalace splits a file into drawers named <id>_<n>.jsonl; an id may
+    # itself carry underscores (ultrachat_440010), so match by prefix rather
+    # than by stripping a suffix.
     order = []
     for m in src.finditer(r.stdout):
-        sid = re.sub(r'(_\d+)?\.jsonl$', '', os.path.basename(m.group(1)))
-        if sid not in order: order.append(sid)
+        base = os.path.basename(m.group(1))
+        sid = next((w for w in want if base == w + '.jsonl' or re.match(re.escape(w) + r'_\d+\.jsonl$', base)), None)
+        key = sid or re.sub(r'\.jsonl$', '', base)
+        if key not in order: order.append(key)
     rank = next((k for k, sid in enumerate(order) if sid in want), None)
     if rank is not None:
         found += 1

--- a/scripts/day0compare/mempalace.py
+++ b/scripts/day0compare/mempalace.py
@@ -1,0 +1,34 @@
+# Score MemPalace over the day0bench corpus: mine the Claude layout, then run
+# every question through `mempalace search` and look for the answer session's
+# id in the "Source:" lines, in rank order. Usage:
+#   python3 mempalace.py <keep-dir> [palace-dir]
+import json, os, re, subprocess, sys, time
+S = sys.argv[1]
+palace = sys.argv[2] if len(sys.argv) > 2 else os.path.join(S, 'mempalace-palace')
+MP = os.environ.get('MEMPALACE', 'mempalace')
+corpus = os.path.join(S, 'home', '.claude', 'projects', '-work-day0')
+t0 = time.time()
+if not os.path.exists(palace):
+    r = subprocess.run([MP, '--palace', palace, 'mine', '--mode', 'convos', corpus], capture_output=True, text=True)
+    print('mine rc', r.returncode, r.stdout[-300:])
+build = time.time() - t0
+qs = json.load(open(os.path.join(S, 'questions.json')))
+hit1 = hit5 = found = 0; first = None; lat = []
+src = re.compile(r'^\s*Source:\s+(\S+)', re.M)
+for q in qs:
+    t1 = time.time()
+    r = subprocess.run([MP, '--palace', palace, 'search', q['question'], '--results', '50'], capture_output=True, text=True)
+    dt = time.time() - t1; lat.append(dt)
+    if first is None: first = dt
+    want = set(q['answer_session_ids'])
+    order = []
+    for m in src.finditer(r.stdout):
+        sid = re.sub(r'(_\d+)?\.jsonl$', '', os.path.basename(m.group(1)))
+        if sid not in order: order.append(sid)
+    rank = next((k for k, sid in enumerate(order) if sid in want), None)
+    if rank is not None:
+        found += 1
+        if rank == 0: hit1 += 1
+        if rank < 5: hit5 += 1
+lat.sort()
+print(f'mempalace mine {build:.0f}s first {first*1000:.0f}ms p50 {lat[len(lat)//2]*1000:.0f}ms hit@1 {hit1}/{len(qs)} hit@5 {hit5}/{len(qs)} found@50 {found}/{len(qs)}')


### PR DESCRIPTION
Closes #3018. New guide page `day-zero.html` (linked from every sidebar, the home page, the compare page and the sitemap) with the table, the method and the versions; `day0bench -keep` lays the corpus down in the real layouts and `scripts/day0compare/{cass,agentmemory,mempalace}.py` score the other tools by the same rule, so every row can be re-run. `day0bench` also skips abstention questions by default now and no longer lets `-skip-abs` shrink the corpus. compare.html: 17 → 22 parsers. Numbers are the ones in the issue; the deja row is main with #3017.