### PR TITLE
fix(harness): every /deja runs a search, not deja's first word

### DIFF
--- a/claude-plugin/commands/deja.md
+++ b/claude-plugin/commands/deja.md
@@ -14,7 +14,7 @@ recall_context using a term from it.
 If the deja MCP tools are unavailable, fall back to the CLI:
 
 ```bash
-deja "$ARGUMENTS"
+deja search -- "$ARGUMENTS"
 ```
 
 Answer with what actually happened in those sessions — when it was, which

--- a/cmd/deja/command_files_query_test.go
+++ b/cmd/deja/command_files_query_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The CLI fallback these command files hand the model was the bare-query form,
+// `deja "$ARGUMENTS"`. deja dispatches a first word that happens to be a
+// command, so a one-word question ran that command instead of searching for the
+// word — `deja version` prints a version number — and a query naming one of
+// deja's own flags died in flag parsing.
+func TestWrittenCommandFilesNameTheSubcommand(t *testing.T) {
+	for _, tc := range []struct {
+		name, body, token string
+	}{
+		{"markdown", markdownCommand("/bin/deja"), "$ARGUMENTS"},
+		{"body", commandBody("/bin/deja", "{{args}}"), "{{args}}"},
+	} {
+		call := "/bin/deja search -- \"" + tc.token + "\""
+		if !strings.Contains(tc.body, call) {
+			t.Errorf("%s does not run a search:\n%s", tc.name, tc.body)
+		}
+		if strings.Contains(tc.body, "/bin/deja \""+tc.token+"\"") {
+			t.Errorf("%s still hands the query over as deja's first word", tc.name)
+		}
+	}
+}

--- a/cmd/deja/command_quoting_test.go
+++ b/cmd/deja/command_quoting_test.go
@@ -26,7 +26,9 @@ func TestCommandSnippetLeavesAPlainPathAlone(t *testing.T) {
 	if strings.Contains(body, `'/usr/local/bin/deja'`) {
 		t.Fatalf("an ordinary path was quoted:\n%s", body)
 	}
-	if !strings.Contains(body, "/usr/local/bin/deja \"the user's request\"") {
+	// The snippet names the subcommand now; what this test is about is that the
+	// path itself is left unquoted.
+	if !strings.Contains(body, "/usr/local/bin/deja search -- \"the user's request\"") {
 		t.Fatalf("the snippet lost its shape:\n%s", body)
 	}
 }

--- a/cmd/deja/install_command_files.go
+++ b/cmd/deja/install_command_files.go
@@ -42,7 +42,7 @@ result looks right but is too short to act on, follow up with recall_context.
 
 If the deja MCP tools are unavailable, run the CLI instead:
 
-` + "```bash\n" + shellQuoteIfNeeded(exe) + ` "` + argsToken + `"
+` + "```bash\n" + shellQuoteIfNeeded(exe) + ` search -- "` + argsToken + `"
 ` + "```" + `
 
 Answer with what actually happened in those sessions — when it was, which

--- a/cmd/deja/install_commands.go
+++ b/cmd/deja/install_commands.go
@@ -53,7 +53,7 @@ recall_context using a term from it.
 
 If the deja MCP tools are unavailable, fall back to the CLI:
 
-` + "```bash\n" + exe + ` "$ARGUMENTS"
+` + "```bash\n" + exe + ` search -- "$ARGUMENTS"
 ` + "```" + `
 
 Answer with what actually happened in those sessions — when it was, which

--- a/extensions/grok/commands/recall.md
+++ b/extensions/grok/commands/recall.md
@@ -14,7 +14,7 @@ recall_context using a term from it.
 If the deja MCP tools are unavailable, fall back to the CLI:
 
 ```bash
-deja "$ARGUMENTS"
+deja search -- "$ARGUMENTS"
 ```
 
 Answer with what actually happened in those sessions — when it was, which

--- a/extensions/kimi/commands/recall.md
+++ b/extensions/kimi/commands/recall.md
@@ -14,7 +14,7 @@ recall_context using a term from it.
 If the deja MCP tools are unavailable, fall back to the CLI:
 
 ```bash
-deja "$ARGUMENTS"
+deja search -- "$ARGUMENTS"
 ```
 
 Answer with what actually happened in those sessions — when it was, which

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -270,8 +270,20 @@ impl zed::Extension for DejaExtension {
                     .to_string()
             })?;
 
+        // `search` is named rather than handed over as deja's first word: the
+        // bare-query path dispatches a first word that happens to be a
+        // command, so `/deja version` printed a version number and `/deja
+        // index` rebuilt the index. `--` then keeps a query that names one of
+        // deja's own flags out of its flag parsing, where it would exit and
+        // come back to the reader as an empty history.
+        let mut args = vec!["search".to_string()];
+        if query.starts_with('-') {
+            args.push("--".to_string());
+        }
+        args.push(query.clone());
+
         let output = zed::process::Command::new(binary)
-            .arg(query.clone())
+            .args(args)
             .envs(worktree.map(|worktree| worktree.shell_env()).unwrap_or_default())
             .output()?;
 


### PR DESCRIPTION
The rest of the sweep, and the part I got wrong in #3015 — I had said Grok, Kimi and Zed carried no query-building command. They all do:

    extensions/zed/src/lib.rs            Command::new(binary).arg(query)
    extensions/grok/commands/recall.md   deja "$ARGUMENTS"
    extensions/kimi/commands/recall.md   deja "$ARGUMENTS"
    cmd/deja/install_commands.go         the CLI fallback written into every markdown and TOML harness
    cmd/deja/install_command_files.go    the same body, shared

That is the bare-query path, which dispatches a first word that happens to be a command: `/deja version` prints a version number, `/deja index` rebuilds the index. The last two reach every harness whose command is a file rather than code, so this is wider than the three packages.

All of them now run `deja search`, with `--` for a query that names one of deja's own flags.

The shipped `claude-plugin/commands/deja.md` moved with the generator — there is a test that keeps them identical, which caught it. `TestCommandSnippetLeavesAPlainPathAlone` also moved: it pinned the whole call while what it is about is that an ordinary path is not quoted, and the comment now says so. The Zed change compiles under `cargo check`.