### PR TITLE
fix(opencode): one failed call no longer costs the session its memory

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -174,6 +174,15 @@ func opencodePluginJS(exe string) string {
 export const DejaRecall = async ({ $, client }) => {
   const cache = new Map()
   const told = new Set()
+  // How many times this session was answered with nothing. The empty answer
+  // is cached so the plugin does not shell out every turn, but its reasons
+  // are not alike: no history is permanent, while a locked index, a call that
+  // did not get through, or an upgrade replacing the binary are over by the
+  // next turn. Cached alike, one bad moment cost the session all of its
+  // memory. Counted, so a store that really is empty is still asked only a
+  // few times.
+  const empties = new Map()
+  const emptyRetries = 3
   return {
     "experimental.chat.system.transform": async (input, output) => {
       try {
@@ -207,8 +216,12 @@ export const DejaRecall = async ({ $, client }) => {
           else output.system.push(ctx)
           return
         }
-        // Nothing to recall: either there is no history yet, or the first
-        // index is still being built. Only the second is worth saying.
+        // Nothing to recall: there is no history yet, the first index is still
+        // being built, or the call did not get through. Only the build is worth
+        // saying out loud; the rest is worth asking again.
+        const asks = (empties.get(key) || 0) + 1
+        empties.set(key, asks)
+        if (asks < emptyRetries) cache.delete(key)
         if (told.has(key)) return
         const status = (await $%s%q %s%s.text()).trim()
         if (!status) return

--- a/cmd/deja/opencode_empty_retry_test.go
+++ b/cmd/deja/opencode_empty_retry_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The opencode plugin caches what the session-start hook answered so it does
+// not shell out on every turn. An empty answer was cached the same way, and its
+// reasons are not alike: no history is permanent, while a locked index, a call
+// that did not get through, or an upgrade replacing the binary are over by the
+// next turn.
+//
+// Driven against the installed plugin with a deja whose first call failed and
+// no build running, turns two and three stayed silent as well — the session
+// lost its memory for good over one bad moment.
+func TestOpencodePluginAsksAgainAfterAnEmptyAnswer(t *testing.T) {
+	js := opencodePluginJS("/bin/deja")
+	compact := strings.Join(strings.Fields(js), "")
+
+	if !strings.Contains(compact, "constemptyRetries=") {
+		t.Error("no bound on how often the session asks again")
+	}
+	if !strings.Contains(compact, "if(asks<emptyRetries)cache.delete(key)") {
+		t.Error("the cached emptiness is never dropped, so the session cannot recover")
+	}
+	// Per session: one session's bad moment must not spend another's retries.
+	if !strings.Contains(compact, "empties.set(key,asks)") {
+		t.Error("the count is not kept per session")
+	}
+	// The build notice keeps its own path — it is the one empty answer worth
+	// saying out loud, and it already dropped the cache before this existed.
+	if !strings.Contains(compact, "told.add(key)") || !strings.Contains(compact, "cache.delete(key)") {
+		t.Error("the warmup notice lost its own recovery")
+	}
+}

--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -31,6 +31,11 @@ const WINDOWS = process.platform === "win32"
 const PLATFORM = WINDOWS ? "windows" : process.platform
 const ARCH = process.arch === "x64" ? "amd64" : process.arch
 const EXE = WINDOWS ? "deja.exe" : "deja"
+// How many turns of a session will ask again after being answered with
+// nothing. Three covers the moments that pass — a locked index, a call that
+// timed out, an upgrade replacing the binary — without turning a store that
+// genuinely holds nothing into a shell-out on every turn.
+const emptyRetries = 3
 
 // The tool helper is a peer of the host, not of us: it is identity plus a zod
 // re-export. Without it the hooks still run and only the model-facing tools are
@@ -144,6 +149,15 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
 
   const digests = new Map()
   const told = new Set()
+  // How many times this session has been answered with nothing. An empty
+  // answer is cached so the plugin does not shell out every turn, but the
+  // reasons for it are not alike: no history is permanent, while a locked
+  // index, a timed-out call or a binary being replaced mid-`deja update` are
+  // over by the next turn. Cached alike, one bad moment cost the session all
+  // of its memory — every later turn read the emptiness rather than asking
+  // again. Counted, so a store that really is empty is still only asked a few
+  // times.
+  const empties = new Map()
 
   const hooks = {}
 
@@ -251,9 +265,13 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
         output.system.push(context)
         return
       }
-      // Nothing recalled: either this machine has no history yet, or the first
-      // index is still building. Only the second is worth saying, and saying it
-      // drops the empty answer so the next turn asks again.
+      // Nothing recalled: this machine has no history yet, the first index is
+      // still building, or the call did not get through. The build is the only
+      // one worth saying out loud, and saying it drops the empty answer so the
+      // next turn asks again.
+      const asks = (empties.get(key) || 0) + 1
+      empties.set(key, asks)
+      if (asks < emptyRetries) digests.delete(key)
       if (told.has(key)) return
       const status = await ask(["warmup-status"], undefined, 5000)
       if (!status) return

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -194,3 +194,22 @@ test("every query the plugin sends goes through argv", () => {
     assert.doesNotMatch(call, /String\(args\./, `${call} passes a query to deja without argv()`)
   }
 })
+
+// An empty answer is cached so the plugin does not shell out every turn. Its
+// reasons are not alike: no history is permanent, a locked index or a call that
+// did not get through is over by the next turn. Cached alike, one bad moment
+// cost the session all of its memory — driven against the installed plugin, a
+// single failed first call left turns two and three silent too.
+test("an empty answer is not cached for the life of the session", () => {
+  const source = readFileSync(new URL("../index.js", import.meta.url), "utf8")
+  const compact = source.replace(/\s+/g, "")
+  assert.match(compact, /constemptyRetries=\d/, "no bound on how often it asks again")
+  assert.match(
+    compact,
+    /if\(asks<emptyRetries\)digests\.delete\(key\)/,
+    "the cached emptiness is never dropped, so the session cannot recover",
+  )
+  // And the counter has to be per session, or one session's bad moment spends
+  // another's retries.
+  assert.match(compact, /empties\.set\(key,asks\)/, "the count is not kept per session")
+})


### PR DESCRIPTION
The plugin caches what the session-start hook answered so it does not shell out on every turn. The empty answer was cached the same way, and its reasons are not alike: no history is permanent, while a locked index, a call that did not get through, or an upgrade replacing the binary are over by the next turn. On a machine running several agents at once the locked index is not hypothetical.

Driven against the plugin as installed here, with a deja whose first `hook-context` fails and no build running:

    before          after
    turn 1 absent   turn 1 absent
    turn 2 absent   turn 2 present
    turn 3 absent   turn 3 present

The build notice keeps its own path — it already dropped the cache so the next turn asks again, and it is the one empty answer worth a toast. What was missing is the case where nothing is building.

Bounded at three, so a store that genuinely holds nothing is still asked only a few times rather than on every turn.

Both copies: the npm package and the plugin `deja install opencode-auto` writes. The generated one was written out and parsed by node, not only matched as a string.

While I was in there I also checked the whole opencode path end to end against a recording endpoint — the block reaches the model in the system prompt at character 0, folded into the first block as the code intends. That part was already right.