### PR TITLE
docs: every listing leads with deja-vu and the word memory

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja-vu",
   "version": "0.19.2",
-  "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
+  "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"

--- a/claude-plugin/plugin.json
+++ b/claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
   "version": "0.19.2",
-  "description": "Memory for AI coding agents: your own past sessions, recalled before you ask.",
+  "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"

--- a/cmd/deja/skill_cli.go
+++ b/cmd/deja/skill_cli.go
@@ -13,7 +13,7 @@ import (
 // other; the same index answers both.
 const (
 	cliSkillName = "deja-search"
-	cliSkillDesc = "Search the user's past AI coding sessions with the deja CLI. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved."
+	cliSkillDesc = "deja-vu memory — search the user's past AI coding sessions with the deja CLI. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved."
 )
 
 const cliSkillBody = `Search deja before re-deriving past work: when the user refers to earlier sessions or decisions, before debugging an error, and before implementing something that may already exist. It searches this machine's own history across every AI coding tool used on it, going back further than deja itself was installed.

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja-vu",
   "version": "0.19.2",
-  "description": "Recall your own past coding sessions, across every AI tool you use.",
+  "description": "deja-vu memory for Codex: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "deja-vu",
     "shortDescription": "Search and recall your own past AI coding sessions.",
-    "longDescription": "deja indexes the sessions you already have on this machine \u2014 Claude Code, Codex, Cursor, opencode and a dozen others \u2014 and gives Codex tools to search them. Ask what you fixed before instead of debugging it twice.",
+    "longDescription": "deja indexes the sessions you already have on this machine — Claude Code, Codex, Cursor, opencode and a dozen others — and gives Codex tools to search them. Ask what you fixed before instead of debugging it twice.",
     "developerName": "vshulcz",
     "category": "Productivity",
     "capabilities": [],

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dsh-deja",
   "version": "0.20.5",
-  "description": "Brings the session history of twenty-one other coding agents into DeepSeek Harness: recall, session digest and per-file history tools over a local index, plus optional automatic recall before each step.",
+  "description": "deja-vu memory for DeepSeek Harness: the session history of twenty-one other coding agents, searchable and recalled before each step — a local index, no LLM.",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,8 +1,14 @@
 {
   "name": "deja",
   "version": "0.19.2",
-  "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
-  "keywords": ["memory", "recall", "sessions", "search", "history"],
+  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
+  "keywords": [
+    "memory",
+    "recall",
+    "sessions",
+    "search",
+    "history"
+  ],
   "author": "vshulcz",
   "homepage": "https://github.com/vshulcz/deja-vu",
   "license": "MIT",
@@ -21,7 +27,9 @@
   "mcpServers": {
     "deja": {
       "command": "node",
-      "args": ["./bin/deja-mcp.mjs"]
+      "args": [
+        "./bin/deja-mcp.mjs"
+      ]
     }
   },
   "hooks": [

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-deja",
   "version": "0.1.2",
-  "description": "Brings the session history of twenty-one other coding agents into opencode: recall, session digest and per-file history tools over a local index, plus automatic recall on every request.",
+  "description": "deja-vu memory for opencode: the session history of twenty-one other coding agents, searchable and recalled on every request — a local index, no LLM.",
   "type": "module",
   "main": "index.js",
   "exports": {

--- a/extensions/zed/extension.toml
+++ b/extensions/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "deja-context-server"
 name = "deja"
-description = "Search the sessions your other coding agents already wrote to disk, from inside Zed"
+description = "deja-vu memory for Zed: search and recall the sessions your other coding agents already wrote, from inside Zed"
 version = "0.1.0"
 schema_version = 1
 authors = ["vshulcz <vshulcz@gmail.com>"]
@@ -10,5 +10,5 @@ repository = "https://github.com/vshulcz/deja-vu"
 name = "deja"
 
 [slash_commands.deja]
-description = "Search the sessions your other coding agents already wrote"
+description = "deja-vu memory for Zed: search and recall the sessions your other coding agents already wrote, from inside Zed"
 requires_argument = true

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.19.2",
-  "description": "Search the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and eighteen more — including work from before deja was installed.",
+  "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and eighteen more — searchable and recalled, including work from before it was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "deja": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.19.2",
-  "description": "Recall the sessions your other coding agents already wrote \u2014 Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
+  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
   "keywords": [
     "memory",
     "recall",
@@ -15,7 +15,7 @@
   "interface": {
     "displayName": "deja",
     "shortDescription": "Search your own past AI coding sessions, from every tool on this machine.",
-    "longDescription": "deja indexes the session files coding agents already write to disk \u2014 Claude Code, Codex, Cursor, opencode, Gemini, Zed and more \u2014 and answers from them. Ask what you fixed before instead of debugging it twice. The index is local: no LLM, no embeddings, nothing leaves the machine. Needs the deja binary: https://github.com/vshulcz/deja-vu",
+    "longDescription": "deja indexes the session files coding agents already write to disk — Claude Code, Codex, Cursor, opencode, Gemini, Zed and more — and answers from them. Ask what you fixed before instead of debugging it twice. The index is local: no LLM, no embeddings, nothing leaves the machine. Needs the deja binary: https://github.com/vshulcz/deja-vu",
     "developerName": "vshulcz",
     "websiteURL": "https://github.com/vshulcz/deja-vu"
   },

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vshulcz/deja-vu",
   "version": "0.0.0",
-  "description": "Search the sessions your coding agents already wrote to disk — Claude Code, Codex, Cursor and the rest — locally, from the CLI or over MCP.",
+  "description": "deja-vu: memory for coding agents from the sessions they already wrote to disk — Claude Code, Codex, Cursor and the rest — local, from the CLI or over MCP.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "deja-vu",
   "display_name": "deja-vu",
   "version": "0.0.0",
-  "description": "Local searchable memory over the session histories of twenty-two coding agents.",
+  "description": "deja-vu: local memory over the session histories of twenty-two coding agents.",
   "long_description": "deja indexes the session transcripts your coding agents already write to disk — Claude Code, Codex, Cursor, opencode, aider, cline, roo, goose and others — and serves them back over MCP. It starts full rather than empty: history from before you installed it is searchable immediately. Retrieval is lexical, with no LLM, no embedding model and no API key. Secrets are redacted before anything is indexed. Nothing leaves the machine.",
   "author": {
     "name": "vshulcz",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
   "version": "0.19.2",
-  "description": "Search the coding sessions already on your disk — Claude Code, Codex, Cursor, opencode and eighteen more — including work from before deja was installed.",
+  "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and eighteen more — including work from before it was installed.",
   "author": {
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.vshulcz/deja-vu",
-  "description": "Local searchable memory over the session histories of twenty-two coding agents.",
+  "description": "deja-vu: local memory over the session histories of twenty-two coding agents.",
   "repository": {
     "url": "https://github.com/vshulcz/deja-vu",
     "source": "github"

--- a/skills/deja-search/SKILL.md
+++ b/skills/deja-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deja-search
-description: Search the user's past AI coding sessions with the deja CLI. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved.
+description: deja-vu memory — search the user's past AI coding sessions with the deja CLI. Use when they say things like 'didn't we fix this before', 'what did we decide about X', or before re-debugging an error that may already be solved.
 metadata:
   openclaw:
     homepage: https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html


### PR DESCRIPTION
Closes #3025. Thirteen descriptions rewritten to open with `deja-vu memory for <host>` (or `deja-vu: memory for coding agents`), harness counts kept in the words the count tests pin, the registry pair at 77 characters. Kimi's root and packaged manifests stay in step; the bundled CLI skill text moves with `skills/deja-search/SKILL.md`. The npm and plugin registries pick the new text up at the next publish.