### PR TITLE
fix(opencode): a spawned agent gets its memory, not a quoted string

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -279,12 +279,16 @@ export const DejaRecall = async ({ $, client }) => {
         if (input?.tool !== "task") return
         const args = output?.args
         if (!args?.prompt) return
-        const payload = JSON.stringify({
+        // One encoding, not two. Stringified again on the way into the shell,
+        // deja received a JSON string where it expects an object, read nothing
+        // out of it and answered with silence — so a spawned agent in opencode
+        // has been starting with no memory at all.
+        const payload = {
           hook_event_name: "PreToolUse",
           tool_name: "Task",
           tool_input: { prompt: args.prompt },
           session_id: input.sessionID || "",
-        })
+        }
         const raw = await $%secho ${JSON.stringify(payload)} | %s%q hook-tool%s.text()
         if (!raw.trim()) return
         const next = JSON.parse(raw)?.hookSpecificOutput?.updatedInput?.prompt

--- a/cmd/deja/opencode_spawn_payload_test.go
+++ b/cmd/deja/opencode_spawn_payload_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The spawn branch built its payload as a JSON string and stringified it again
+// on the way into the shell, so deja was handed a quoted string where it
+// expects an object. It reads nothing out of that and answers with silence — a
+// spawned agent in opencode started with no memory at all, and nothing said so.
+//
+// Driven against the installed plugin with a deja that answers only for an
+// object: before, the subagent's prompt came back unchanged; after, it carries
+// the block.
+func TestOpencodeSpawnPayloadIsEncodedOnce(t *testing.T) {
+	js := opencodePluginJS("/bin/deja")
+	compact := strings.Join(strings.Fields(js), "")
+
+	if strings.Contains(compact, "JSON.stringify(JSON.stringify(") {
+		t.Error("the payload is encoded twice")
+	}
+	if !strings.Contains(compact, "constpayload={") {
+		t.Error("the payload is not built as an object")
+	}
+	if !strings.Contains(compact, "echo${JSON.stringify(payload)}") {
+		t.Error("the payload is not encoded on the way into the shell")
+	}
+	// What deja is handed has to parse as an object with the fields the hook
+	// reads. The generated source is not JSON, so this checks the shape the
+	// plugin assembles rather than the literal.
+	for _, field := range []string{`hook_event_name:"PreToolUse"`, `tool_name:"Task"`, "tool_input:{prompt:args.prompt}"} {
+		if !strings.Contains(compact, field) {
+			t.Errorf("the payload lost %s", field)
+		}
+	}
+	// And the hook's own contract, so a rename on either side is caught here.
+	var probe struct {
+		HookEventName string `json:"hook_event_name"`
+		ToolName      string `json:"tool_name"`
+	}
+	if err := json.Unmarshal([]byte(`{"hook_event_name":"PreToolUse","tool_name":"Task"}`), &probe); err != nil {
+		t.Fatal(err)
+	}
+	if probe.HookEventName != "PreToolUse" || probe.ToolName != "Task" {
+		t.Fatal("the field names this test pins are not the ones deja reads")
+	}
+}


### PR DESCRIPTION
`tool.execute.before` built its payload with `JSON.stringify` and then stringified it again on the way into the shell, so deja received

    "{\"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Task\", ...}"

a JSON string where it expects an object. Fed both shapes to the real `deja hook-tool` against this machine's store:

    one stringify   2049 bytes
    two             0 bytes

So subagent recall in opencode has never worked. A spawned agent gets nothing else — the system prompt was built for the session that spawned it and the per-prompt pass fires on what the user typed, which a subagent never does — so it has been starting with no memory at all, silently.

Driven against the plugin as installed here, with a deja that answers only for an object:

    before   subagent prompt carries recall: false
    after    subagent prompt carries recall: true, original instruction kept

The npm package does not implement this branch at all, so it needs no change; that is a gap rather than a defect and I have left it alone.

The generated file was written out and parsed by node, not only matched as a string.