### PR TITLE
ci: keep the embed redaction test out of the plugin scanner

### DIFF
--- a/.plugin-scanner.toml
+++ b/.plugin-scanner.toml
@@ -11,6 +11,7 @@
 ignore_paths = [
   "internal/redact/*_test.go",
   "internal/index/*_test.go",
+  "internal/embed/*_test.go",
   "cmd/deja/*_test.go",
   # Drives a real agent against a throwaway config and prints the placeholder
   # key it wired, so the run is reproducible.


### PR DESCRIPTION
internal/embed/auth_test.go landed after #1717 scoped the scanner, and its fake token is the 2 high findings that fail the awesome-codex-plugins gate. Same treatment as the other redaction corpora: path-scoped, plugin bundles stay in scope. Local rescan: high 0, score 93.

Closes #3031