### PR TITLE
feat(opencode): recall the repair when a command fails

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -305,9 +305,36 @@ export const DejaRecall = async ({ $, client, directory }) => {
         // memory is optional: never break a spawn over it
       }
     },
+    // The moment a command fails is the one an agent never thinks to ask
+    // about, and this is the only seam opencode has for it. The hook returns
+    // void, so the line cannot be handed to the model directly — it is
+    // appended to the tool's own output, which the next request carries as the
+    // tool result. Verified against a real run: a string written here arrives
+    // in the tool message of the following request.
+    "tool.execute.after": async (input, output) => {
+      try {
+        if (input?.tool !== "bash") return
+        const text = output?.output
+        if (!text) return
+        const payload = {
+          hook_event_name: "PostToolUse",
+          tool_name: "bash",
+          tool_input: { command: input?.args?.command || "" },
+          tool_response: { output: text },
+          session_id: input.sessionID || "",
+          cwd,
+        }
+        const raw = await $%secho ${JSON.stringify(payload)} | %s%q hook-tool-after%s.text()
+        if (!raw.trim()) return
+        const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
+        if (extra) output.output = text + "\n\n" + extra
+      } catch {
+        // memory is optional: never break a tool call over it
+      }
+    },
   }
 }
-`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", exe, "`", "`", "", exe, "`", "`", "", exe, "`")
+`, "`", exe, "hook-context", "`", "`", exe, "warmup-status", "`", "`", exe, "`", "`", "", exe, "`", "`", "", exe, "`", "`", "", exe, "`")
 }
 
 // Gemini CLI and Qwen Code both run a command before the agent loop, which is

--- a/cmd/deja/opencode_after_tool_test.go
+++ b/cmd/deja/opencode_after_tool_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The moment a command fails is the one an agent never thinks to ask about, and
+// tool.execute.after is the only seam opencode gives a plugin for it. The hook
+// returns void, so the fix line cannot be handed to the model directly — it is
+// appended to the tool's own output, which the next request carries as the tool
+// result. Verified in a real opencode run: on an invented error whose repair
+// cannot be guessed, the line lands in the tool message of the following
+// request.
+func TestOpencodePluginCarriesTheFixLineAfterAFailedCommand(t *testing.T) {
+	js := opencodePluginJS("/bin/deja")
+	compact := strings.Join(strings.Fields(js), "")
+
+	if !strings.Contains(compact, `"tool.execute.after":async(input,output)=>`) {
+		t.Fatal("the after-tool channel is not wired")
+	}
+	// Only bash: the error signature this reads is a shell one, and an edit or
+	// a read carries no command that failed.
+	if !strings.Contains(compact, `if(input?.tool!=="bash")return`) {
+		t.Error("the channel is not scoped to bash")
+	}
+	// It calls the failure half of the pair, not the pre-tool half.
+	if !strings.Contains(compact, `hook-tool-after`) {
+		t.Error("the channel does not call hook-tool-after")
+	}
+	// The command's output is what carries the error, and it goes to deja under
+	// the field the hook reads.
+	if !strings.Contains(compact, "tool_response:{output:text}") {
+		t.Error("the command output is not passed as the tool response")
+	}
+	// The line is appended to the output, not pushed as a new message: void is
+	// all the hook can return, so the tool result is the only channel.
+	if !strings.Contains(compact, "output.output=text+") {
+		t.Error("the fix line is not folded into the tool output")
+	}
+	// It runs in the project, like every other call that ranks by history.
+	if !strings.Contains(compact, "cwd,") {
+		t.Error("the after-call does not carry the project directory")
+	}
+}


### PR DESCRIPTION
opencode had no after-tool channel, so the error→fix pair — the one moment an agent never thinks to ask for memory — never reached it. The other harnesses get it through PostToolUse; opencode's seam is `tool.execute.after`, which returns void, so the line is folded into the tool output and the next request carries it as the tool result.

Proven in a real opencode run against an isolated store, on an invented error whose repair cannot be guessed. The command `python3 build_plots.py` (a file that does `import zarnakplot`) fails, and the request that follows carries, in its **tool** message:

    deja: this error came up in 3 sessions in oce2eproj before (2026-07-26) — what followed it: uv pip install zarnakplot==2.4

Before: the channel did not exist on main, so nothing. The mechanism was checked separately first — a marker appended in `tool.execute.after` does reach the model's tool message.

Cost, measured on this machine's real store: 24 ms, 469 bytes, and it fires only when a command fails.

The npm package still lacks this branch (and the spawn branch too) — a standing gap in that package's coverage, not a regression here; left alone.