### PR TITLE
feat(opencode): bring the npm package up to the installed plugin's channels

### DIFF
--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -288,11 +288,15 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
   // Per-prompt recall, the relevance pass Claude Code gets on
   // UserPromptSubmit: the digest above is ranked by the project, this is ranked
   // by what the user just asked. Silent when nothing matches.
-  hooks["experimental.chat.messages.transform"] = async (_input, output) => {
+  hooks["experimental.chat.messages.transform"] = async (input, output) => {
     try {
-      const { parts, prompt } = lastUserText(output?.messages)
+      const { parts, prompt, sessionID } = lastUserText(output?.messages)
       if (!prompt) return
-      const raw = await ask(["hook-prompt"], JSON.stringify({ prompt, cwd }))
+      // The session id lets recall skip what it already showed this session.
+      // Without it every message re-injects the same block — measured on a real
+      // store, half of all injections were a word-for-word repeat.
+      const key = input?.sessionID || sessionID || ""
+      const raw = await ask(["hook-prompt"], JSON.stringify({ prompt, session_id: key, cwd }))
       if (!raw) return
       const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
       if (!extra) return
@@ -309,6 +313,57 @@ export const DejaPlugin = async ({ client, directory }, options = {}) => {
       await ask(["hook-precompact"], undefined, 60000)
     } catch {
       // memory is optional: never break a compaction over it
+    }
+  }
+
+  // A spawned agent gets none of the above: the system prompt was built for the
+  // session that spawned it, and the per-prompt pass fires on what the user
+  // typed, which a subagent never does. Its instructions are the one thing that
+  // reaches it, so recall goes in there.
+  hooks["tool.execute.before"] = async (input, output) => {
+    try {
+      if (input?.tool !== "task") return
+      const args = output?.args
+      if (!args?.prompt) return
+      const payload = {
+        hook_event_name: "PreToolUse",
+        tool_name: "Task",
+        tool_input: { prompt: args.prompt },
+        session_id: input.sessionID || "",
+        cwd,
+      }
+      const raw = await ask(["hook-tool"], JSON.stringify(payload))
+      if (!raw) return
+      const next = JSON.parse(raw)?.hookSpecificOutput?.updatedInput?.prompt
+      if (next) args.prompt = next
+    } catch {
+      // memory is optional: never break a spawn over it
+    }
+  }
+
+  // The moment a command fails is the one an agent never thinks to ask about,
+  // and tool.execute.after is the only seam opencode gives for it. The hook
+  // returns nothing to inject, so the line is folded into the tool output,
+  // which the next request carries as the tool result.
+  hooks["tool.execute.after"] = async (input, output) => {
+    try {
+      if (input?.tool !== "bash") return
+      const text = output?.output
+      if (!text) return
+      const payload = {
+        hook_event_name: "PostToolUse",
+        tool_name: "bash",
+        tool_input: { command: input?.args?.command || "" },
+        tool_response: { output: text },
+        session_id: input.sessionID || "",
+        cwd,
+      }
+      const raw = await ask(["hook-tool-after"], JSON.stringify(payload))
+      if (!raw) return
+      const extra = JSON.parse(raw)?.hookSpecificOutput?.additionalContext
+      if (extra) output.output = text + "\n\n" + extra
+    } catch {
+      // memory is optional: never break a tool call over it
     }
   }
 

--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -29,11 +29,12 @@ export function lastUserText(messages) {
   const list = Array.isArray(messages) ? messages : []
   for (let i = list.length - 1; i >= 0; i--) {
     if (list[i]?.info?.role !== "user") continue
+    const sessionID = list[i].info?.sessionID || ""
     const parts = (list[i].parts || []).filter((p) => p?.type === "text" && p.text)
-    if (!parts.length) return { parts: [], prompt: "" }
-    return { parts, prompt: parts.map((p) => p.text).join("\n").trim() }
+    if (!parts.length) return { parts: [], prompt: "", sessionID }
+    return { parts, prompt: parts.map((p) => p.text).join("\n").trim(), sessionID }
   }
-  return { parts: [], prompt: "" }
+  return { parts: [], prompt: "", sessionID: "" }
 }
 
 // cliPluginPath is where `deja install opencode-auto` writes its own plugin.

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -105,6 +105,51 @@ test("without it the recall hooks are installed", async () => {
   })
 })
 
+// The package lagged the plugin `deja install` writes by two whole channels: a
+// spawned agent got no memory, and a failed command never surfaced the repair.
+test("every channel the generated plugin has, the package has", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "deja-oc-"))
+  await withConfigHome(dir, async () => {
+    const hooks = await DejaPlugin({ client: quietClient(), directory: dir })
+    for (const name of [
+      "experimental.chat.system.transform",
+      "experimental.chat.messages.transform",
+      "experimental.session.compacting",
+      "tool.execute.before",
+      "tool.execute.after",
+    ]) {
+      assert.equal(typeof hooks[name], "function", `${name} is not wired`)
+    }
+  })
+})
+
+test("the spawn hook rewrites a subagent's prompt, and only a subagent's", () => {
+  const source = readFileSync(new URL("../index.js", import.meta.url), "utf8")
+  const at = source.indexOf('"tool.execute.before"')
+  const body = source.slice(at, source.indexOf('"tool.execute.after"'))
+  assert.ok(body.includes('input?.tool !== "task"'), "not scoped to the spawn tool")
+  assert.ok(body.includes("hook-tool"), "does not call the pre-tool hook")
+  assert.ok(body.includes("updatedInput?.prompt"), "does not read the rewritten prompt")
+  assert.ok(body.includes("args.prompt = next"), "does not put the recall in the child's prompt")
+})
+
+test("the after-tool hook folds the fix line into a failed command's output", () => {
+  const source = readFileSync(new URL("../index.js", import.meta.url), "utf8")
+  const at = source.indexOf('"tool.execute.after"')
+  const body = source.slice(at)
+  assert.ok(body.includes('input?.tool !== "bash"'), "not scoped to bash")
+  assert.ok(body.includes("hook-tool-after"), "does not call the failure hook")
+  assert.ok(body.includes("tool_response: { output: text }"), "does not pass the command output")
+  assert.ok(body.includes("output.output = text +"), "does not fold the line into the output")
+})
+
+test("the per-prompt hook carries the session id, so it does not repeat itself", () => {
+  const source = readFileSync(new URL("../index.js", import.meta.url), "utf8")
+  const at = source.indexOf('"experimental.chat.messages.transform"')
+  const body = source.slice(at, source.indexOf('"experimental.session.compacting"'))
+  assert.ok(body.includes("session_id: key"), "the per-prompt payload carries no session id")
+})
+
 test("mcpWired reads the entry the installer writes, comments and all", () => {
   const config = `{
   // deja was wired by \`deja install opencode\`


### PR DESCRIPTION
The plugin `deja install opencode-auto` writes has two channels the npm package never got: subagent memory (`tool.execute.before`) and the error→fix recall (`tool.execute.after`). Anyone installing via the opencode marketplace got a plugin missing both. The package's per-prompt hook also passed no session id, so it re-injected the same block every turn.

All three fixed to match the generated plugin. Verified by driving the package's own `DejaPlugin` against an isolated seeded store: the spawn hook rewrites the child's prompt with recall, the after-tool hook folds the fix line into a failed command's output, and the per-prompt hook injects on turn 1 and is deduped on turn 2 of the same session.