### PR TITLE
chore: drop a state file a test run left in cmd/deja, anchor the aider ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ deja-stats.svg
 # Harness artefacts: running an agent inside this checkout to test an
 # integration leaves its own history and config here. None of it belongs in
 # the repository — three of these were committed by a careless `git add -A`.
-.aider.chat.history.md
+/.aider.chat.history.md
 .aider.input.history
 .aider.tags.cache.v*/
 .grok/
@@ -77,3 +77,5 @@ extensions/zed/Cargo.lock
 extensions/*/node_modules/
 extensions/*/*.tgz
 extensions/*/package-lock.json
+# a test run that starts deja from cmd/deja writes its state dir there
+/cmd/deja/deja/

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -388,8 +388,8 @@ func GeneratePrompt(seed int64) PromptCorpus {
 	// The bucket case. An agent started from a parent directory — a home
 	// directory, a workspace root — gets a project scope that holds everything
 	// ever launched from there, and not the repository actually being worked
-	// on. Measured on a real machine 2026-08-19: from /Users/shulcz the scope
-	// was [shulcz, Users/shulcz], the answer lay in another project entirely,
+	// on. Measured on a real machine 2026-08-19: from the home directory the
+	// scope was [<user>, Users/<user>], the answer lay in another project entirely,
 	// and the hook injected an unrelated session from the bucket instead.
 	//
 	// The right answer is silence. A neighbour from the bucket is worse than


### PR DESCRIPTION
Removes `cmd/deja/deja/tombstones` and ignores `/cmd/deja/deja/` so a test run cannot write it back; anchors `.aider.chat.history.md` so the tracked fixture is no longer matched by the ignore; the bench comment uses a placeholder home path.

Closes #3039