### PR TITLE
feat(codex): recall the prompt itself, not just the session digest

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -18,12 +18,16 @@ import (
 // everything else in the file alone.
 // codexHookWiring is every event deja installs into Codex, in one place because
 // install writes from it and doctor reads it. A hooks.json written by an older
-// deja — SessionStart alone, where there are now three — was reported as wired
-// on the strength of the trust entry, and the two events added since reached
+// deja — SessionStart alone, where there are now four — was reported as wired
+// on the strength of the trust entry, and the events added since reached
 // nobody.
 var codexHookWiring = []struct{ Event, Sub, Matcher string }{
 	// SessionStart carries the project digest.
 	{"SessionStart", "hook-context", "startup|resume"},
+	// UserPromptSubmit answers the prompt itself. Codex sends the same payload
+	// Claude does — prompt, session_id, cwd — so hook-prompt reads it unchanged;
+	// measured on codex 0.149.0, the event fires on every `codex exec` turn.
+	{"UserPromptSubmit", "hook-prompt", ""},
 	// PreToolUse carries the prior decision for the file or command about to
 	// change, scoped to the tools that run a command or change a file (codex
 	// edits via apply_patch) so the hook does not spawn on every read.
@@ -99,7 +103,13 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 		if msg := hookStatusMessage(event); msg != "" {
 			h["statusMessage"] = msg
 		}
-		kept = append(kept, map[string]any{"matcher": matcher, "hooks": []any{h}})
+		entry := map[string]any{"hooks": []any{h}}
+		// An event that applies to every turn has no matcher, and codex's own
+		// examples leave the key out rather than carrying an empty pattern.
+		if matcher != "" {
+			entry["matcher"] = matcher
+		}
+		kept = append(kept, entry)
 	}
 	if len(kept) == 0 {
 		delete(hooks, event)

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -56,6 +56,46 @@ func TestInstallCodexHooksMergeAndUninstall(t *testing.T) {
 	}
 }
 
+// Codex sends the same UserPromptSubmit payload Claude does, and it is the only
+// event that carries the user's own words. Without it a codex session recalls
+// nothing between the session digest and a command it is about to run: measured
+// on codex 0.149.0, the event fires on every `codex exec` turn.
+func TestInstallCodexWiresThePromptItself(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher *string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["UserPromptSubmit"]
+	if len(entries) != 1 {
+		t.Fatalf("UserPromptSubmit entries = %d, want 1: %s", len(entries), b)
+	}
+	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "deja hook-prompt") {
+		t.Fatalf("command = %q, want deja hook-prompt", got)
+	}
+	// Codex's own examples carry no matcher on an every-turn event, and an
+	// empty pattern is not the same thing as an absent one.
+	if entries[0].Matcher != nil {
+		t.Fatalf("matcher = %q, want the key left out", *entries[0].Matcher)
+	}
+}
+
 func TestInstallCodexHooksErrorsAndMissingUninstall(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		home := t.TempDir()


### PR DESCRIPTION
Codex fires `UserPromptSubmit` with the same payload Claude does — prompt, session_id, cwd — so `deja hook-prompt` reads it unchanged. We wired SessionStart, PreToolUse and PostToolUse and left the one event that carries the user's own words unwired, so between the session digest and a command about to run, a codex session recalled nothing.

Measured on codex 0.149.0 with a seeded store (13 sessions; the answer eight days back, the recent ones about other work) and the real installer: the invented token appeared in all 6 request bodies codex sent to the model with the event wired, and in 0 of 6 without it. Cost on that store: 21 ms and 716 bytes per prompt.

Codex hooks stay silent until trusted (`/hooks`), which install already tells you.