### PR TITLE
fix(codex): the digest comes back after a compaction

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -35,6 +35,11 @@ var codexHookWiring = []struct{ Event, Sub, Matcher string }{
 	// And the fix pair when a command fails, which is the moment an agent never
 	// thinks to ask for it.
 	{"PostToolUse", "hook-tool-after", "Bash"},
+	// Compaction throws away the blocks this session was shown while the list
+	// that stops them repeating outlives them, so without this the memory codex
+	// just lost is the memory recall refuses to send again. Codex fires it with
+	// trigger "auto", the same shape Claude sends.
+	{"PreCompact", "hook-precompact", "manual|auto"},
 }
 
 func installCodexHooks(exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -22,8 +22,12 @@ import (
 // on the strength of the trust entry, and the events added since reached
 // nobody.
 var codexHookWiring = []struct{ Event, Sub, Matcher string }{
-	// SessionStart carries the project digest.
-	{"SessionStart", "hook-context", "startup|resume"},
+	// SessionStart carries the project digest. No matcher, as in Claude: codex
+	// fires this again with source "compact" after each compaction, and that is
+	// the moment the digest is worth most — measured on codex 0.149.0, one
+	// `codex exec` run compacted six times and "startup|resume" caught none of
+	// them, so the agent came out of every compaction with nothing.
+	{"SessionStart", "hook-context", ""},
 	// UserPromptSubmit answers the prompt itself. Codex sends the same payload
 	// Claude does — prompt, session_id, cwd — so hook-prompt reads it unchanged;
 	// measured on codex 0.149.0, the event fires on every `codex exec` turn.
@@ -99,6 +103,16 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 			}
 			found = true
 			adoptCodexHookEntry(entry, cmd, event)
+			// The matcher is part of the wiring, not a user setting, so an
+			// upgrade has to rewrite it: the SessionStart entry written when
+			// this meant "startup|resume" went on missing every compaction
+			// through any number of installs, because adopting it left the
+			// pattern alone.
+			if matcher == "" {
+				delete(entry, "matcher")
+			} else {
+				entry["matcher"] = matcher
+			}
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -18,12 +18,16 @@ import (
 // everything else in the file alone.
 // codexHookWiring is every event deja installs into Codex, in one place because
 // install writes from it and doctor reads it. A hooks.json written by an older
-// deja — SessionStart alone, where there are now three — was reported as wired
-// on the strength of the trust entry, and the two events added since reached
+// deja — SessionStart alone, where there are now four — was reported as wired
+// on the strength of the trust entry, and the events added since reached
 // nobody.
 var codexHookWiring = []struct{ Event, Sub, Matcher string }{
 	// SessionStart carries the project digest.
 	{"SessionStart", "hook-context", "startup|resume"},
+	// UserPromptSubmit answers the prompt itself. Codex sends the same payload
+	// Claude does — prompt, session_id, cwd — so hook-prompt reads it unchanged;
+	// measured on codex 0.149.0, the event fires on every `codex exec` turn.
+	{"UserPromptSubmit", "hook-prompt", ""},
 	// PreToolUse carries the prior decision for the file or command about to
 	// change, scoped to the tools that run a command or change a file (codex
 	// edits via apply_patch) so the hook does not spawn on every read.
@@ -99,7 +103,13 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 		if msg := hookStatusMessage(event); msg != "" {
 			h["statusMessage"] = msg
 		}
-		kept = append(kept, map[string]any{"matcher": matcher, "hooks": []any{h}})
+		entry := map[string]any{"hooks": []any{h}}
+		// An event that applies to every turn has no matcher, and codex's own
+		// examples leave the key out rather than carrying an empty pattern.
+		if matcher != "" {
+			entry["matcher"] = matcher
+		}
+		kept = append(kept, entry)
 	}
 	if len(kept) == 0 {
 		delete(hooks, event)

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -96,6 +96,44 @@ func TestInstallCodexWiresThePromptItself(t *testing.T) {
 	}
 }
 
+// Codex compacts on its own and fires PreCompact with trigger "auto" first.
+// Unwired, the session keeps its record of what it was shown while losing the
+// blocks themselves, so recall stays quiet about exactly what was just dropped.
+func TestInstallCodexWiresCompaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["PreCompact"]
+	if len(entries) != 1 {
+		t.Fatalf("PreCompact entries = %d, want 1: %s", len(entries), b)
+	}
+	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "deja hook-precompact") {
+		t.Fatalf("command = %q, want deja hook-precompact", got)
+	}
+	// Codex sends "auto" when it compacts by itself, which is how it compacts.
+	if m := entries[0].Matcher; !strings.Contains(m, "auto") {
+		t.Fatalf("matcher = %q, want it to cover codex's own compaction", m)
+	}
+}
+
 func TestInstallCodexHooksErrorsAndMissingUninstall(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		home := t.TempDir()

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -56,6 +56,46 @@ func TestInstallCodexHooksMergeAndUninstall(t *testing.T) {
 	}
 }
 
+// Codex sends the same UserPromptSubmit payload Claude does, and it is the only
+// event that carries the user's own words. Without it a codex session recalls
+// nothing between the session digest and a command it is about to run: measured
+// on codex 0.149.0, the event fires on every `codex exec` turn.
+func TestInstallCodexWiresThePromptItself(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher *string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["UserPromptSubmit"]
+	if len(entries) != 1 {
+		t.Fatalf("UserPromptSubmit entries = %d, want 1: %s", len(entries), b)
+	}
+	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "deja hook-prompt") {
+		t.Fatalf("command = %q, want deja hook-prompt", got)
+	}
+	// Codex's own examples carry no matcher on an every-turn event, and an
+	// empty pattern is not the same thing as an absent one.
+	if entries[0].Matcher != nil {
+		t.Fatalf("matcher = %q, want the key left out", *entries[0].Matcher)
+	}
+}
+
 func TestInstallCodexHooksErrorsAndMissingUninstall(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		home := t.TempDir()

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -99,6 +99,45 @@ func TestInstallCodexWiresThePromptItself(t *testing.T) {
 // Codex compacts on its own and fires PreCompact with trigger "auto" first.
 // Unwired, the session keeps its record of what it was shown while losing the
 // blocks themselves, so recall stays quiet about exactly what was just dropped.
+// Codex fires SessionStart again with source "compact" after it compacts, which
+// is when the digest is worth most — and an install that predates this carries
+// the old pattern, so the upgrade has to rewrite it rather than adopt it.
+func TestInstallCodexSessionStartSurvivesCompaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/usr/local/bin/deja hook-context"}]}]}}`
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher *string `json:"matcher"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["SessionStart"]
+	if len(entries) != 1 {
+		t.Fatalf("SessionStart entries = %d, want the old one adopted: %s", len(entries), b)
+	}
+	if entries[0].Matcher != nil {
+		t.Fatalf("matcher = %q, want it widened to every source", *entries[0].Matcher)
+	}
+}
+
 func TestInstallCodexWiresCompaction(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Codex fires `SessionStart` again with source `compact` every time it compacts — one `codex exec` run here compacted 12 times. Our matcher was `startup|resume`, so none of them reached the hook and the agent came out of every compaction with nothing. Claude's wiring has had no matcher on this event all along.

Measured on codex 0.149.0 with only SessionStart wired: 2 of 13 requests carried a recall block with the old matcher, 13 of 13 with none.

Install also rewrites the matcher on an entry it already owns. It only rewrote the command, so an entry written by an older deja would have kept the narrow pattern through every upgrade.

Stacked on #3042.