### PR TITLE
feat(codex): let recall serve again what compaction threw away

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -35,6 +35,11 @@ var codexHookWiring = []struct{ Event, Sub, Matcher string }{
 	// And the fix pair when a command fails, which is the moment an agent never
 	// thinks to ask for it.
 	{"PostToolUse", "hook-tool-after", "Bash"},
+	// Compaction throws away the blocks this session was shown while the list
+	// that stops them repeating outlives them, so without this the memory codex
+	// just lost is the memory recall refuses to send again. Codex fires it with
+	// trigger "auto", the same shape Claude sends.
+	{"PreCompact", "hook-precompact", "manual|auto"},
 }
 
 func installCodexHooks(exe string, uninstall bool) (installResult, error) {

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -96,6 +96,44 @@ func TestInstallCodexWiresThePromptItself(t *testing.T) {
 	}
 }
 
+// Codex compacts on its own and fires PreCompact with trigger "auto" first.
+// Unwired, the session keeps its record of what it was shown while losing the
+// blocks themselves, so recall stays quiet about exactly what was just dropped.
+func TestInstallCodexWiresCompaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["PreCompact"]
+	if len(entries) != 1 {
+		t.Fatalf("PreCompact entries = %d, want 1: %s", len(entries), b)
+	}
+	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "deja hook-precompact") {
+		t.Fatalf("command = %q, want deja hook-precompact", got)
+	}
+	// Codex sends "auto" when it compacts by itself, which is how it compacts.
+	if m := entries[0].Matcher; !strings.Contains(m, "auto") {
+		t.Fatalf("matcher = %q, want it to cover codex's own compaction", m)
+	}
+}
+
 func TestInstallCodexHooksErrorsAndMissingUninstall(t *testing.T) {
 	t.Run("malformed json", func(t *testing.T) {
 		home := t.TempDir()


### PR DESCRIPTION
Codex compacts on its own and fires `PreCompact` with trigger `auto` first. deja was not listening, so the session kept its record of what it had been shown while losing the blocks themselves — recall then stays quiet about exactly what compaction discarded.

Measured on codex 0.149.0 with a seeded store: after a compaction the seen-ledger still held the session that answered the question, and its block fingerprint, without the hook; it held neither with it.

Replaces #3042, which stopped merging cleanly once #3041 landed.