### PR TITLE
fix(codex): the digest comes back after a compaction

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -22,8 +22,12 @@ import (
 // on the strength of the trust entry, and the events added since reached
 // nobody.
 var codexHookWiring = []struct{ Event, Sub, Matcher string }{
-	// SessionStart carries the project digest.
-	{"SessionStart", "hook-context", "startup|resume"},
+	// SessionStart carries the project digest. No matcher, as in Claude: codex
+	// fires this again with source "compact" after each compaction, and that is
+	// the moment the digest is worth most — measured on codex 0.149.0, one
+	// `codex exec` run compacted six times and "startup|resume" caught none of
+	// them, so the agent came out of every compaction with nothing.
+	{"SessionStart", "hook-context", ""},
 	// UserPromptSubmit answers the prompt itself. Codex sends the same payload
 	// Claude does — prompt, session_id, cwd — so hook-prompt reads it unchanged;
 	// measured on codex 0.149.0, the event fires on every `codex exec` turn.
@@ -99,6 +103,16 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 			}
 			found = true
 			adoptCodexHookEntry(entry, cmd, event)
+			// The matcher is part of the wiring, not a user setting, so an
+			// upgrade has to rewrite it: the SessionStart entry written when
+			// this meant "startup|resume" went on missing every compaction
+			// through any number of installs, because adopting it left the
+			// pattern alone.
+			if matcher == "" {
+				delete(entry, "matcher")
+			} else {
+				entry["matcher"] = matcher
+			}
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -99,6 +99,45 @@ func TestInstallCodexWiresThePromptItself(t *testing.T) {
 // Codex compacts on its own and fires PreCompact with trigger "auto" first.
 // Unwired, the session keeps its record of what it was shown while losing the
 // blocks themselves, so recall stays quiet about exactly what was just dropped.
+// Codex fires SessionStart again with source "compact" after it compacts, which
+// is when the digest is worth most — and an install that predates this carries
+// the old pattern, so the upgrade has to rewrite it rather than adopt it.
+func TestInstallCodexSessionStartSurvivesCompaction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := filepath.Join(home, ".codex", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/usr/local/bin/deja hook-context"}]}]}}`
+	if err := os.WriteFile(path, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installCodexHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher *string `json:"matcher"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["SessionStart"]
+	if len(entries) != 1 {
+		t.Fatalf("SessionStart entries = %d, want the old one adopted: %s", len(entries), b)
+	}
+	if entries[0].Matcher != nil {
+		t.Fatalf("matcher = %q, want it widened to every source", *entries[0].Matcher)
+	}
+}
+
 func TestInstallCodexWiresCompaction(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
Codex fires `SessionStart` again with source `compact` every time it compacts — one `codex exec` run here compacted 12 times. Our matcher was `startup|resume`, so none of them reached the hook and the agent came out of every compaction with nothing. Claude's wiring has had no matcher on this event all along.

Measured on codex 0.149.0 with only SessionStart wired: 2 of 13 requests carried a recall block with the old matcher, 13 of 13 with none.

Install also rewrites the matcher on an entry it already owns. It only rewrote the command, so an entry written by an older deja kept the narrow pattern through every upgrade.

Replaces #3045.