### PR TITLE
fix(recall): a session start stops repeating the last one

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -899,15 +899,16 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 			}
 		}
 	}
-	// The task signal decides how wide the candidate pool is: with changed
-	// files to match against, older sessions are worth considering; without
-	// it, recency alone decides and a small pool is enough.
 	taskFiles := <-taskCh
 	mark("git-taskfiles")
-	perName := 3
-	if len(taskFiles) > 0 {
-		perName = 12
-	}
+	// Four times what a safe-mode digest serves, so the novelty ordering below
+	// has something to choose from. Without changed files this used to be three
+	// — exactly what the digest serves — so every candidate had just been shown,
+	// unseen was always empty, and each session start in a project repeated the
+	// last one word for word. That is what #2038 measured as 87.5% repeats and
+	// read as a ranking problem. Measured on a seeded store of 300 sessions, the
+	// wider pool costs 1 ms of a 22 ms session start.
+	const perName = 12
 	// The cwd as well as the names it can guess: a session started in a
 	// subdirectory keeps that directory's name, and no list of names reaches
 	// down to it (#2040).
@@ -960,14 +961,14 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 	// block listed the correction as a separate item and left the session it
 	// corrects unmarked (#761).
 	ss, rejectedWarning := orderForInjection(ss)
-	ss = leadWithUnseen(dir, names, ss)
+	ss, unseen := leadWithUnseen(dir, names, ss)
 	// A session found by where its work happened carries the name of the
 	// directory it was started in, which is not one the cwd can guess — the
 	// safe-mode filter is a name list, so the evidence that admitted the
 	// session admits its name with it (#2040). The trust policy has already
 	// had its say on each of these, one session at a time, above.
 	result := search.BuildAutoRecall(ss, search.AutoRecallOptions{
-		Mode: mode, ProjectNames: withProjectsOf(names, ss), TaskScores: scores})
+		Mode: mode, ProjectNames: withProjectsOf(names, ss), TaskScores: scores, Unseen: unseen})
 	mark("build-digest")
 	if result.Sessions == 0 {
 		matched = nil

--- a/cmd/deja/hook_context_novelty.go
+++ b/cmd/deja/hook_context_novelty.go
@@ -56,9 +56,12 @@ const sessionStartWindow = 40
 // Nothing is dropped. A start with no memory is worse than a repeat, and a
 // project whose whole recent tail has been served still deserves its best
 // candidate — it simply goes behind anything newer to say.
-func leadWithUnseen(dir string, projects []string, ss []model.Session) []model.Session {
+// It also returns the ids it treated as new, because the digest builder sorts
+// again on the way past and would otherwise put recency back on top — the
+// reordering happened and was thrown away one call later.
+func leadWithUnseen(dir string, projects []string, ss []model.Session) ([]model.Session, map[string]bool) {
 	if len(ss) < 2 {
-		return ss
+		return ss, nil
 	}
 	seen := map[string]bool{}
 	for _, p := range projects {
@@ -67,7 +70,7 @@ func leadWithUnseen(dir string, projects []string, ss []model.Session) []model.S
 		}
 	}
 	if len(seen) == 0 {
-		return ss
+		return ss, nil
 	}
 	worn := usage.WornSessions(dir)
 	unseen := make([]model.Session, 0, len(ss))
@@ -80,12 +83,16 @@ func leadWithUnseen(dir string, projects []string, ss []model.Session) []model.S
 		unseen = append(unseen, s)
 	}
 	if len(unseen) == 0 || len(repeats) == 0 {
-		return ss
+		return ss, nil
+	}
+	fresh := make(map[string]bool, len(unseen))
+	for _, s := range unseen {
+		fresh[s.ID] = true
 	}
 	// Stable by demand so the repeat that does get through is the one agents
 	// keep coming back to, rather than whichever happened to be newest.
 	stableSortByDemand(repeats, worn)
-	return append(unseen, repeats...)
+	return append(unseen, repeats...), fresh
 }
 
 // stableSortByDemand orders sessions by how many agent-initiated recalls asked

--- a/cmd/deja/hook_context_novelty_test.go
+++ b/cmd/deja/hook_context_novelty_test.go
@@ -20,7 +20,7 @@ func TestUnseenSessionsLeadWhenThereAreEnoughOfThem(t *testing.T) {
 	}
 	rememberInjectedIDsFor(dir, "agent-one", sessionStartKeyPrefix+project, []string{"told-1", "told-2", "told-3"})
 
-	got := leadWithUnseen(dir, []string{project}, ss)
+	got, _ := leadWithUnseen(dir, []string{project}, ss)
 	if len(got) != len(ss) {
 		t.Fatalf("the ordering dropped candidates: %d in, %d out", len(ss), len(got))
 	}
@@ -48,7 +48,7 @@ func TestNothingNewLeavesTheOrderAlone(t *testing.T) {
 	ss := []model.Session{{ID: "a"}, {ID: "b"}, {ID: "c"}}
 	rememberInjectedIDsFor(dir, "agent-one", sessionStartKeyPrefix+project, []string{"a", "b", "c"})
 
-	got := leadWithUnseen(dir, []string{project}, ss)
+	got, _ := leadWithUnseen(dir, []string{project}, ss)
 	for i := range ss {
 		if got[i].ID != ss[i].ID {
 			t.Fatalf("the order changed with nothing new to promote: %v", got)

--- a/cmd/deja/hook_context_repeats_test.go
+++ b/cmd/deja/hook_context_repeats_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedClaudeAt is seedClaude with a timestamp of its own, so an ordering test
+// is not deciding between sessions that all claim the same instant.
+func seedClaudeAt(t *testing.T, root, project, id, userText, asstText string, at time.Time) {
+	t.Helper()
+	dir := filepath.Join(root, "-"+project)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(role, text string) string {
+		rec := map[string]any{
+			"type": role, "sessionId": id, "cwd": "/tmp/" + project,
+			"timestamp": at.UTC().Format(time.RFC3339),
+			"message":   map[string]any{"role": role, "content": text},
+		}
+		b, _ := json.Marshal(rec)
+		return string(b)
+	}
+	body := line("user", userText) + "\n" + line("assistant", asstText) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, id+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A project with more history than one digest can carry should not hear the
+// same three sessions at every session start. It did: the candidate pool was
+// three deep and the digest serves three, so everything on offer had just been
+// served and the novelty ordering had nothing to promote. Measured on a seeded
+// store of 300 sessions, five consecutive starts named 3 distinct sessions
+// before this and 12 after.
+func TestSessionStartSaysSomethingNewTheSecondTime(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	now := time.Now()
+	// Distinct subjects: the digest drops near-duplicates by fingerprint, and
+	// nine variations on one sentence would be served as one.
+	topics := []struct{ q, a string }{
+		{"the invoice total rounds down by a cent", "decimal rather than float in the tax line settled it"},
+		{"the nightly job crawls after midnight", "it re-read the whole table each pass; an index on created_at fixed it"},
+		{"avatar upload rejects valid png files", "mime sniffing read only the first bytes; widening the check fixed it"},
+		{"the search box loses focus while typing", "the list re-mounted on every keystroke; keying the rows fixed it"},
+		{"csv export ends with a blank row", "the writer flushed a newline after the last record"},
+		{"login redirects loop on safari only", "the cookie went out without SameSite=None and safari dropped it"},
+		{"the webhook sender gives up too early", "three attempts with backoff drained the queue"},
+		{"currency table is read on every request", "loading it once per process took the endpoint to a millisecond"},
+		{"the settings header still says the old name", "renamed in the template and in the two tests that asserted it"},
+	}
+	for i, tp := range topics {
+		seedClaudeAt(t, claude, "wide", fmt.Sprintf("session-%02d", i), tp.q, tp.a,
+			now.Add(-time.Duration(i+1)*time.Hour))
+	}
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := filepath.Join(os.TempDir(), "wide")
+	first, n, _, _, _, firstIDs, _ := hookDigestResultFor(dir, cwd)
+	if n == 0 || strings.TrimSpace(first) == "" {
+		t.Fatal("the first session start served nothing to compare")
+	}
+	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+"agent-one", hookProjectKey(cwd), firstIDs)
+
+	_, _, _, _, _, secondIDs, _ := hookDigestResultFor(dir, cwd)
+	if len(secondIDs) == 0 {
+		t.Fatal("the second session start went quiet")
+	}
+	told := map[string]bool{}
+	for _, id := range firstIDs {
+		told[id] = true
+	}
+	fresh := 0
+	for _, id := range secondIDs {
+		if !told[id] {
+			fresh++
+		}
+	}
+	if fresh == 0 {
+		t.Errorf("the second start repeated the first exactly: %v then %v", firstIDs, secondIDs)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -27,6 +27,13 @@ type AutoRecallOptions struct {
 	// right now (harness:ID → matched-file count). Sessions the task points
 	// at outrank plain recency; zero or a nil map falls back to recency.
 	TaskScores map[string]int
+	// Unseen are the sessions this project has not been served recently, by
+	// id. They win ties over recency, which is what stops a session start
+	// repeating itself: the caller's novelty ordering used to be undone here,
+	// because the sort below re-ordered by recency whatever came in, and three
+	// separate sessions in one project were handed the same three sessions.
+	// Nil leaves the order to task score and recency alone.
+	Unseen map[string]bool
 }
 
 type AutoRecallResult struct {
@@ -110,6 +117,12 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 		tj := o.TaskScores[candidates[j].Harness+":"+candidates[j].ID]
 		if ti != tj {
 			return ti > tj
+		}
+		if len(o.Unseen) > 0 {
+			iNew, jNew := o.Unseen[candidates[i].ID], o.Unseen[candidates[j].ID]
+			if iNew != jNew {
+				return iNew
+			}
 		}
 		iRecent := !candidates[i].Updated.Before(o.Now.AddDate(0, 0, -90))
 		jRecent := !candidates[j].Updated.Before(o.Now.AddDate(0, 0, -90))

--- a/internal/search/recall_unseen_test.go
+++ b/internal/search/recall_unseen_test.go
@@ -1,0 +1,82 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The caller orders its candidates so a session start says something the
+// project has not been told, and this used to undo it: with no task scores the
+// sort fell through to recency, so the same three newest sessions were served
+// to every session start in the project. Measured on a seeded store of twelve:
+// three consecutive starts, one block, three sessions, every time.
+func TestUnseenSessionsOutrankRecency(t *testing.T) {
+	now := time.Now()
+	var ss []model.Session
+	for i := 0; i < 6; i++ {
+		ss = append(ss, model.Session{
+			ID:      string(rune('a' + i)),
+			Project: "org/app",
+			Updated: now.Add(-time.Duration(i) * time.Hour),
+			Messages: []model.Message{
+				{Role: "user", Text: "question about widget " + string(rune('a'+i))},
+				{Role: "assistant", Text: "settled it by rewriting the widget " + string(rune('a'+i)) + " loader"},
+			},
+		})
+	}
+	opts := AutoRecallOptions{Mode: RecallSafe, ProjectNames: []string{"org/app"}, Now: now}
+
+	first := BuildAutoRecall(ss, opts)
+	if first.Sessions == 0 {
+		t.Fatal("the digest served nothing to compare")
+	}
+	// What the project has already been told, in the caller's words.
+	told := map[string]bool{}
+	for _, id := range first.IDs {
+		told[id] = true
+	}
+	unseen := map[string]bool{}
+	for _, s := range ss {
+		if !told[s.ID] {
+			unseen[s.ID] = true
+		}
+	}
+	opts.Unseen = unseen
+
+	second := BuildAutoRecall(ss, opts)
+	for _, id := range second.IDs {
+		if told[id] {
+			t.Errorf("the second start repeated %q: first %v, second %v", id, first.IDs, second.IDs)
+		}
+	}
+	if strings.TrimSpace(second.Text) == "" {
+		t.Fatal("promoting the unseen emptied the digest")
+	}
+}
+
+// With nothing marked new the order is exactly what it was, so every other
+// caller of this builder is untouched.
+func TestNoUnseenSetLeavesTheOrderAlone(t *testing.T) {
+	now := time.Now()
+	var ss []model.Session
+	for i := 0; i < 5; i++ {
+		ss = append(ss, model.Session{
+			ID:      string(rune('a' + i)),
+			Project: "org/app",
+			Updated: now.Add(-time.Duration(i) * time.Hour),
+			Messages: []model.Message{
+				{Role: "user", Text: "question " + string(rune('a'+i))},
+				{Role: "assistant", Text: "answer " + string(rune('a'+i))},
+			},
+		})
+	}
+	opts := AutoRecallOptions{Mode: RecallSafe, ProjectNames: []string{"org/app"}, Now: now}
+	a := BuildAutoRecall(ss, opts)
+	b := BuildAutoRecall(ss, opts)
+	if strings.Join(a.IDs, ",") != strings.Join(b.IDs, ",") {
+		t.Fatalf("the same input gave two orders: %v then %v", a.IDs, b.IDs)
+	}
+}


### PR DESCRIPTION
Two things kept a project hearing the same three sessions at every session start, which #2038 measured as 87.5% repeats and read as a ranking problem.

Without changed files to match against, the candidate pool was three deep and a safe-mode digest serves three — so every candidate had just been served, `leadWithUnseen` never had anything to promote, and its ordering was a no-op. The pool is now 12, the same number the changed-files path already reads.

And when it did promote something, `BuildAutoRecall` sorted the candidates again on the way past: with no task scores that fell through to recency and put the same three back on top. It now takes the unseen set and lets it win ties, which leaves every other caller untouched.

Measured on a seeded store of 300 sessions across 7 projects, five consecutive session starts in one project: 3 distinct sessions before, 12 after. Cost 1 ms of a 22 ms session start; the digest still serves three, so nothing extra is injected.