### PR TITLE
feat(gemini): the repair arrives where the command failed

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -131,7 +131,7 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 // speaks for them.
 func isCommandTool(name string) bool {
 	switch name {
-	case "Bash", "bash", "shell", "run_command", "execute_command", "terminal":
+	case "Bash", "bash", "shell", "run_command", "execute_command", "terminal", "run_shell_command":
 		return true
 	}
 	return false
@@ -155,15 +155,46 @@ func toolResponseText(raw json.RawMessage) string {
 	var b strings.Builder
 	// stderr first: the signature is far more often there, and the scan is
 	// capped, so a long stdout must not push it out of reach.
-	for _, key := range []string{"stderr", "error", "output", "stdout", "content", "result"} {
-		if v, ok := obj[key].(string); ok && strings.TrimSpace(v) != "" {
-			if b.Len() > 0 {
-				b.WriteByte('\n')
-			}
-			b.WriteString(v)
+	// llmContent is gemini's: the text it puts in front of the model, which for
+	// a shell tool is the command's own output inside a wrapper of its own.
+	for _, key := range []string{"stderr", "error", "output", "stdout", "content", "result", "llmContent"} {
+		v, ok := obj[key].(string)
+		if !ok || strings.TrimSpace(v) == "" {
+			continue
 		}
+		if key == "llmContent" {
+			v = unwrapGeminiShellOutput(v)
+		}
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(v)
 	}
 	return clampOutput(b.String())
+}
+
+// unwrapGeminiShellOutput strips the frame gemini puts around a command's
+// output before handing it to the model: an <untrusted_context> fence, an
+// "Output:" marker on the first line and a trailing process-group note. The
+// marker is the one that matters — with it in front, the first line of a build
+// failure stops looking like an error, and the fix pair went silent on a
+// failure it answers the moment the marker is gone (gemini-cli 0.55.1).
+func unwrapGeminiShellOutput(s string) string {
+	if !strings.Contains(s, "<untrusted_context>") {
+		return s
+	}
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "<untrusted_context>" || t == "</untrusted_context>" || strings.HasPrefix(t, "Process Group PGID:") {
+			continue
+		}
+		kept = append(kept, strings.TrimPrefix(line, "Output: "))
+	}
+	return strings.Join(kept, "\n")
 }
 
 // after returns what follows key where it is used as one, or "" when the key is

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -82,6 +82,22 @@ func installGeminiExtension(exe string, uninstall bool) (installResult, error) {
 					"timeout": 10000,
 				}},
 			}},
+			// The fix pair, arriving where a failing command is read: what this
+			// hook returns is appended to the tool result as <hook_context>.
+			// Checked on gemini-cli 0.55.1, and BeforeTool is not the pair to
+			// it — that one fires, but what it returns decides whether the tool
+			// runs and never reaches the model, so wiring it would cost a
+			// process per command and inject nothing.
+			//
+			// Matched on the tool that runs a command; gemini honours the
+			// matcher, so this never spawns on a read or a glob.
+			"AfterTool": []any{map[string]any{
+				"matcher": "run_shell_command",
+				"hooks": []any{map[string]any{
+					"type": "command", "command": exe + " hook-tool-after",
+					"timeout": 10000,
+				}},
+			}},
 		},
 	}, "", "  ")
 	if err != nil {

--- a/cmd/deja/install_gemini_tools_test.go
+++ b/cmd/deja/install_gemini_tools_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Gemini appends what an AfterTool hook returns to the tool result as
+// <hook_context>, and deja was not listening: a gemini session got the project
+// digest and the prompt answer, and nothing at the moment a command failed.
+// Checked on gemini-cli 0.55.1 — the hook fires, its context reaches the model,
+// and a matcher scopes it to the tool that runs commands.
+func TestInstallGeminiWiresTheFixPair(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installGeminiExtension("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".gemini", "extensions", "deja", "hooks", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+				Timeout int    `json:"timeout"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	for event, sub := range map[string]string{
+		"AfterTool": "hook-tool-after",
+	} {
+		entries := root.Hooks[event]
+		if len(entries) != 1 {
+			t.Fatalf("%s entries = %d, want 1: %s", event, len(entries), b)
+		}
+		if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, sub) {
+			t.Errorf("%s runs %q, want %s", event, got, sub)
+		}
+		// Gemini reads the timeout in milliseconds; a Claude-style 10 kills the
+		// hook before it can answer.
+		if got := entries[0].Hooks[0].Timeout; got < 1000 {
+			t.Errorf("%s timeout = %d, too short to be milliseconds", event, got)
+		}
+	}
+	// Scoped to the tool that runs a command, so the hook does not spawn on
+	// every read_file and glob.
+	if m := root.Hooks["AfterTool"][0].Matcher; m != "run_shell_command" {
+		t.Errorf("AfterTool matcher = %q, want the tool that runs commands", m)
+	}
+	// BeforeTool fires too, and what it returns never reaches the model — a
+	// process per command for nothing.
+	if len(root.Hooks["BeforeTool"]) != 0 {
+		t.Errorf("BeforeTool is wired, and its output is not context: %s", b)
+	}
+}
+
+// The names and the output field are gemini's own, and recognising them is what
+// makes the wiring above say anything at all.
+func TestGeminiToolNamesAndOutputAreRead(t *testing.T) {
+	if !isCommandTool("run_shell_command") {
+		t.Error("run_shell_command is not read as a command tool, so the fix pair never fires on gemini")
+	}
+	got := toolResponseText(json.RawMessage(`{"llmContent":"make: *** [test] Error 1"}`))
+	if !strings.Contains(got, "Error 1") {
+		t.Errorf("gemini's llmContent was not read: %q", got)
+	}
+	// And the frame gemini wraps it in comes off. The "Output:" marker is the
+	// one that matters: with it in front, the first line of a build failure
+	// stops reading as an error and the fix pair says nothing.
+	wrapped := `{"llmContent":"<untrusted_context>\nOutput: ./main.go:12:2: undefined: zorbquuxHelper\nProcess Group PGID: 98883\n</untrusted_context>"}`
+	got = toolResponseText(json.RawMessage(wrapped))
+	if !strings.HasPrefix(strings.TrimSpace(got), "./main.go:12:2:") {
+		t.Errorf("gemini's wrapper was not stripped: %q", got)
+	}
+}


### PR DESCRIPTION
Gemini appends what an `AfterTool` hook returns to the tool result as `<hook_context>`, which is exactly where the fix pair belongs. We wired SessionStart and BeforeAgent and left that one alone, so a gemini session got the project digest and the prompt answer and nothing at the moment a command failed.

Three things were needed, each checked on gemini-cli 0.55.1 against a stub endpoint:

- `AfterTool` wired to `hook-tool-after`, matched on `run_shell_command` — gemini honours the matcher (a hook matched on a name no tool has did not fire), so it never spawns on a read or a glob.
- Its shell tool is called `run_shell_command`, which `isCommandTool` did not know.
- Its output arrives as `llmContent`, wrapped in `<untrusted_context>` with an `Output:` marker on the first line. The marker is what mattered: with it in front, a build failure stops reading as an error and the fix pair says nothing.

Measured end to end with the real installer and a seeded store: the repair reached the model in the request after the failing command, and in none of the requests without the hook.

`BeforeTool` is deliberately not wired. It fires, but what it returns decides whether the tool runs and never reaches the model — a process per command for nothing. `PreCompress` is left alone too: it fired twice in a two-turn session, so it is not a signal that compaction happened, and `hook-precompact` would clear the dedup ledger every turn.