### PR TITLE
feat(qwen): the digest and the repair both reach the model

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -176,25 +176,48 @@ func toolResponseText(raw json.RawMessage) string {
 	return clampOutput(b.String())
 }
 
-// unwrapGeminiShellOutput strips the frame gemini puts around a command's
-// output before handing it to the model: an <untrusted_context> fence, an
-// "Output:" marker on the first line and a trailing process-group note. The
-// marker is the one that matters — with it in front, the first line of a build
-// failure stops looking like an error, and the fix pair went silent on a
-// failure it answers the moment the marker is gone (gemini-cli 0.55.1).
+// unwrapGeminiShellOutput strips the frame gemini and qwen put around a
+// command's output before handing it to the model. Gemini fences it in
+// <untrusted_context> with an "Output:" marker; qwen writes a labelled report —
+// Command, Directory, Output, Error, Exit Code, Signal, PGID. The marker is
+// what matters: with it in front, the first line of a build failure stops
+// looking like an error, and the fix pair went silent on a failure it answers
+// the moment the marker is gone (gemini-cli 0.55.1, qwen-code 0.20.0).
 func unwrapGeminiShellOutput(s string) string {
-	if !strings.Contains(s, "<untrusted_context>") {
+	if !strings.Contains(s, "Output:") {
 		return s
 	}
 	var kept []string
 	for _, line := range strings.Split(s, "\n") {
 		t := strings.TrimSpace(line)
-		if t == "<untrusted_context>" || t == "</untrusted_context>" || strings.HasPrefix(t, "Process Group PGID:") {
+		if t == "<untrusted_context>" || t == "</untrusted_context>" || framingLabel(t) {
 			continue
 		}
-		kept = append(kept, strings.TrimPrefix(line, "Output: "))
+		// The label introduces the payload on its first line only; what follows
+		// is the command's own output, untouched.
+		for _, label := range []string{"Output: ", "Error: "} {
+			if strings.HasPrefix(line, label) {
+				line = line[len(label):]
+				break
+			}
+		}
+		if strings.TrimSpace(line) == "(none)" {
+			continue
+		}
+		kept = append(kept, line)
 	}
 	return strings.Join(kept, "\n")
+}
+
+// framingLabel reports whether a line is part of the shell report rather than
+// the command's output.
+func framingLabel(t string) bool {
+	for _, label := range []string{"Command: ", "Directory: ", "Exit Code: ", "Signal: ", "Process Group PGID:"} {
+		if strings.HasPrefix(t, label) {
+			return true
+		}
+	}
+	return false
 }
 
 // after returns what follows key where it is used as one, or "" when the key is

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -137,6 +137,19 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 	}
 }
 
+// adoptHookTimeout sets the timeout on the hook deja owns inside an entry,
+// leaving any line a reader wrote around it alone.
+func adoptHookTimeout(entry map[string]any, cmd string, timeout int) {
+	hs, _ := entry["hooks"].([]any)
+	for _, hAny := range hs {
+		h, _ := hAny.(map[string]any)
+		if h == nil || h["type"] != "command" || hookCommandKindOf(h["command"], cmd) != hookDejas {
+			continue
+		}
+		h["timeout"] = timeout
+	}
+}
+
 // adoptCodexHookEntry rewrites the command and status message of an entry deja
 // already owns.
 func adoptCodexHookEntry(entry map[string]any, cmd, event string) {
@@ -389,21 +402,39 @@ func installGeminiAuto(exe string, uninstall bool) (installResult, error) {
 	return installGeminiExtension(exe, uninstall)
 }
 
-// Qwen took two wrong readings to get right. Its `timeout` is MILLISECONDS,
-// like Gemini's — the 10 deja used to write killed the hook ten milliseconds
-// in, which is indistinguishable from a harness that has no hooks. And while
-// SessionStart does fire, only UserPromptSubmit consumes additionalContext
-// (appendUserPromptExpansionAdditionalContext), and Qwen checks that the
-// hookEventName in the reply matches the event — so the SessionStart-shaped
-// output of `hook-context` was dropped without a word.
+// Qwen's `timeout` is MILLISECONDS, like Gemini's — the 10 deja used to write
+// killed the hook ten milliseconds in, which is indistinguishable from a
+// harness that has no hooks.
+//
+// SessionStart used to be dropped here: qwen ran it and consumed nothing, so
+// deja retired the entry rather than leave a hook answering into the void. That
+// is no longer true — on qwen-code 0.20.0 the digest reaches the model, and so
+// does what a PostToolUse hook returns. PreToolUse fires and its output does
+// not, so it stays unwired.
+var qwenHookWiring = []struct{ Event, Sub, Matcher string }{
+	{"SessionStart", "hook-context", ""},
+	{"UserPromptSubmit", "hook-prompt", ""},
+	// The fix pair, at the failure. Matched on the tool that runs a command so
+	// it never spawns on a read.
+	{"PostToolUse", "hook-tool-after", "run_shell_command"},
+}
+
 func installQwenAuto(exe string, uninstall bool) (installResult, error) {
-	// Older deja wrote SessionStart here, which qwen never consumed. Naming
-	// it as retired means an upgrade removes the dead entry instead of
-	// leaving qwen to run a hook that answers into the void.
-	return installSettingsHookRetiring(
-		filepath.Join(sources.QwenConfigDir(), "settings.json"),
-		"UserPromptSubmit", "", 60000, exe+" hook-prompt", uninstall,
-		map[string]bool{"SessionStart": true})
+	path := filepath.Join(sources.QwenConfigDir(), "settings.json")
+	var res installResult
+	for i, h := range qwenHookWiring {
+		r, err := installSettingsHookCmd(path, h.Event, h.Matcher, 60000, exe+" "+h.Sub, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		// What the target reports is the first change made, the way the other
+		// multi-write targets do: "unchanged" from a later event must not
+		// overwrite the first one's "updated".
+		if i == 0 || (res.Action == "unchanged" && r.Action != "unchanged") {
+			res = r
+		}
+	}
+	return res, nil
 }
 
 // installSettingsHook merges one hook entry into a settings.json that the
@@ -492,6 +523,12 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 			}
 			found = true
 			adoptCodexHookEntry(entry, cmd, event)
+			// The timeout too. Qwen and gemini read it in milliseconds, and the
+			// 10 an older deja wrote kills the hook ten milliseconds in — which
+			// looks exactly like a harness with no hooks. Adopting the entry
+			// without this left everyone who installed before the fix with a
+			// hook that could never answer.
+			adoptHookTimeout(entry, cmd, timeout)
 		}
 		kept = append(kept, entryAny)
 	}

--- a/cmd/deja/install_gemini_test.go
+++ b/cmd/deja/install_gemini_test.go
@@ -114,8 +114,10 @@ func TestKimiInstallsNoHooks(t *testing.T) {
 
 // Qwen was written off as having no hooks twice over: its timeout is in
 // milliseconds, so the 10 deja used to write killed the hook instantly, and
-// only UserPromptSubmit consumes additionalContext — a SessionStart-shaped
-// reply is dropped because the event name does not match.
+// SessionStart was thought to consume nothing. On qwen-code 0.20.0 it does —
+// measured against a stub endpoint, a session with only UserPromptSubmit wired
+// put a deja block in 0 of 2 requests and one with SessionStart added put it in
+// 2 of 2.
 func TestQwenHooksUserPromptSubmitInMilliseconds(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -139,8 +141,12 @@ func TestQwenHooksUserPromptSubmitInMilliseconds(t *testing.T) {
 	if err := json.Unmarshal(b, &root); err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := root.Hooks["SessionStart"]; ok {
-		t.Fatal("SessionStart fires but never takes the context: wrong event")
+	start := root.Hooks["SessionStart"]
+	if len(start) == 0 || len(start[0].Hooks) == 0 {
+		t.Fatalf("no SessionStart hook, so a qwen session opens with no digest: %s", b)
+	}
+	if !strings.HasSuffix(start[0].Hooks[0].Command, "hook-context") {
+		t.Fatalf("SessionStart runs %q, want the digest", start[0].Hooks[0].Command)
 	}
 	groups := root.Hooks["UserPromptSubmit"]
 	if len(groups) == 0 || len(groups[0].Hooks) == 0 {

--- a/cmd/deja/install_qwen_tools_test.go
+++ b/cmd/deja/install_qwen_tools_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Qwen consumes what a PostToolUse hook returns, and deja was not listening: a
+// qwen session ran a failing command and heard nothing, while the store held
+// the command that settled the same error. Measured on qwen-code 0.20.0 against
+// a stub endpoint — the hook fires and its context reaches the model, unlike
+// PreToolUse, which fires and whose output does not.
+func TestInstallQwenWiresTheFixPair(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_QWEN_ROOT", "")
+	if _, err := installQwenAuto("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	entries := root.Hooks["PostToolUse"]
+	if len(entries) != 1 {
+		t.Fatalf("PostToolUse entries = %d, want 1: %s", len(entries), b)
+	}
+	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "hook-tool-after") {
+		t.Errorf("PostToolUse runs %q, want the fix pair", got)
+	}
+	if m := entries[0].Matcher; m != "run_shell_command" {
+		t.Errorf("matcher = %q, want the tool that runs commands", m)
+	}
+	// PreToolUse fires on qwen too, and what it returns never reaches the
+	// model — a process per command for nothing.
+	if len(root.Hooks["PreToolUse"]) != 0 {
+		t.Errorf("PreToolUse is wired, and its output is not context: %s", b)
+	}
+	// Reinstalling must not double any of them.
+	if _, err := installQwenAuto("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != string(b2) {
+		t.Errorf("a second install changed the file:\n%s\n%s", b, b2)
+	}
+}
+
+// Qwen frames a command's output as a labelled report before handing it to the
+// model. The "Output:" label in front of the first line is what stopped a build
+// failure reading as an error, so the fix pair said nothing about a failure the
+// store had already settled.
+func TestQwenShellReportIsUnwrapped(t *testing.T) {
+	raw := json.RawMessage(`{"llmContent":"Command: go build ./...\nDirectory: (root)\nOutput: ./main.go:12:2: undefined: zorbquuxHelper\nError: (none)\nExit Code: 0\nSignal: 0\nProcess Group PGID: 2726"}`)
+	got := strings.TrimSpace(toolResponseText(raw))
+	if got != "./main.go:12:2: undefined: zorbquuxHelper" {
+		t.Errorf("qwen's shell report was not unwrapped: %q", got)
+	}
+}

--- a/cmd/deja/wiring_state_test.go
+++ b/cmd/deja/wiring_state_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -25,8 +26,8 @@ func TestWiringRefreshesAfterUpgrade(t *testing.T) {
 	}
 	recordWiring([]string{"qwen-auto"}, false)
 
-	// Rewind: the wiring an older deja wrote, under an event qwen never
-	// consumes, with a timeout it reads as ten milliseconds.
+	// Rewind: the wiring an older deja wrote — the old binary path, and a
+	// timeout qwen reads as ten milliseconds.
 	settings := filepath.Join(home, ".qwen", "settings.json")
 	stale := map[string]any{"hooks": map[string]any{
 		"SessionStart": []any{map[string]any{"hooks": []any{map[string]any{
@@ -55,11 +56,23 @@ func TestWiringRefreshesAfterUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	hooks, _ := got["hooks"].(map[string]any)
-	if _, dead := hooks["SessionStart"]; dead {
-		t.Fatalf("the abandoned event survived: %s", raw)
-	}
 	if _, live := hooks["UserPromptSubmit"]; !live {
 		t.Fatalf("the working hook was not restored: %s", raw)
+	}
+	// The stale entry is taken over rather than left as it was: same event,
+	// this binary, and a timeout in the units qwen actually reads.
+	start, _ := hooks["SessionStart"].([]any)
+	if len(start) != 1 {
+		t.Fatalf("SessionStart entries = %d, want the stale one adopted: %s", len(start), raw)
+	}
+	entry, _ := start[0].(map[string]any)
+	inner, _ := entry["hooks"].([]any)
+	h, _ := inner[0].(map[string]any)
+	if cmd, _ := h["command"].(string); strings.HasPrefix(cmd, "/old/deja") {
+		t.Fatalf("the old binary path survived the upgrade: %s", raw)
+	}
+	if to, _ := h["timeout"].(float64); to < 1000 {
+		t.Fatalf("timeout = %v, still the value qwen reads as ten milliseconds: %s", to, raw)
 	}
 	// And the record now says this binary owns it, so the repair does not
 	// repeat on every session start.


### PR DESCRIPTION
Qwen was wired for one event, `UserPromptSubmit`, on the reading that SessionStart fired and consumed nothing. On qwen-code 0.20.0 that is no longer true, and `PostToolUse` consumes what a hook returns as well.

Measured against a stub endpoint, a session running a command whose error the store had already settled:

- with the wiring as it was, 0 of 2 requests carried a deja block;
- with SessionStart restored, 2 of 2 did;
- with PostToolUse added, the repair arrived in the request after the failing command.

`PreToolUse` stays unwired: it fires, and what it returns never reaches the model.

Two things were in the way. Qwen frames a command output as a labelled report — `Command:`, `Directory:`, `Output:`, `Error:`, `Exit Code:` — and with the `Output:` label in front, a build failure stops reading as an error, so the fix pair said nothing (same shape as gemini's `<untrusted_context>` fence, now handled together). And adopting an existing entry rewrote its command but not its timeout, so the 10 an older deja wrote — which qwen reads as ten milliseconds — survived every upgrade and killed the hook before it could answer.