### PR TITLE
feat(mcp): a slash command for the harnesses deja ships no command file into

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -156,7 +156,7 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 	case "initialize":
 		return map[string]any{
 			"protocolVersion": mcpProtocolVersion,
-			"capabilities":    map[string]any{"tools": map[string]any{}, "resources": map[string]any{}},
+			"capabilities":    map[string]any{"tools": map[string]any{}, "resources": map[string]any{}, "prompts": map[string]any{}},
 			"serverInfo":      map[string]any{"name": "deja", "version": version},
 			"instructions":    mcpInstructions(dir),
 		}, 0, ""
@@ -174,6 +174,10 @@ func handleMCP(dir string, req rpcRequest) (any, int, string) {
 		// templates, and the empty list is the shape that says so —
 		// an error here reads as a broken capability.
 		return map[string]any{"resourceTemplates": []map[string]any{}}, 0, ""
+	case "prompts/list":
+		return map[string]any{"prompts": []map[string]any{dejaPrompt()}}, 0, ""
+	case "prompts/get":
+		return mcpPromptGet(dir, req.Params)
 	case "resources/list":
 		return mcpResourcesList(dir)
 	case "resources/read":

--- a/cmd/deja/mcp_contract_test.go
+++ b/cmd/deja/mcp_contract_test.go
@@ -401,22 +401,23 @@ func TestMCPPingAndResourceTemplates(t *testing.T) {
 	}
 }
 
-// TestMCPUndeclaredMethodStillErrors is the control for the case above: the
-// fix must add exactly the two spec methods, not turn the default branch
-// into a catch-all that answers anything.
+// TestMCPUndeclaredMethodStillErrors is the control for the case above: each
+// fix must add exactly the spec methods deja declares a capability for, not
+// turn the default branch into a catch-all that answers anything.
 func TestMCPUndeclaredMethodStillErrors(t *testing.T) {
 	hermeticEnv(t)
 
-	resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}`)
+	// A method deja declares no capability for.
+	resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"logging/setLevel","params":{"level":"debug"}}`)
 	if len(resp) != 1 {
 		t.Fatalf("got %d responses, want 1", len(resp))
 	}
 	e, ok := resp[0]["error"].(map[string]any)
 	if !ok {
-		t.Fatalf("prompts/list did not error: %#v", resp[0])
+		t.Fatalf("logging/setLevel did not error: %#v", resp[0])
 	}
 	if code, _ := e["code"].(float64); code != -32601 {
-		t.Errorf("prompts/list error code = %v, want -32601", e["code"])
+		t.Errorf("logging/setLevel error code = %v, want -32601", e["code"])
 	}
 }
 

--- a/cmd/deja/mcp_prompts.go
+++ b/cmd/deja/mcp_prompts.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// A slash command, in the only form a harness can offer without deja shipping a
+// file into it. Gemini and qwen both ask an MCP server for prompts/list on
+// startup (measured on gemini-cli 0.55.1 and qwen-code 0.20.0 against a
+// recording server) and put what comes back behind a slash; deja answered
+// -32601, so the one surface a person drives by hand was missing everywhere
+// except the harnesses deja writes a command file for. Codex asks for tools and
+// never for prompts, so it gains nothing here.
+const dejaPromptName = "deja"
+
+func dejaPrompt() map[string]any {
+	return map[string]any{
+		"name":        dejaPromptName,
+		"title":       "Search past sessions",
+		"description": "Search this machine's past coding sessions — an error, a decision, a file — and paste what they settled into the conversation.",
+		"arguments": []map[string]any{{
+			"name":        "query",
+			"description": "An exact error string, function name or path, or the question in your own words.",
+			"required":    true,
+		}},
+	}
+}
+
+// mcpPromptGet runs the search and hands back its result as the message the
+// user is about to send. The alternative — telling the model to call the tool —
+// costs a round trip to reach the same rows, and the point of typing the
+// command is that the answer is already there.
+func mcpPromptGet(dir string, params json.RawMessage) (any, int, string) {
+	var p struct {
+		Name      string            `json:"name"`
+		Arguments map[string]string `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, -32602, "invalid params"
+	}
+	if p.Name != dejaPromptName {
+		return nil, -32602, fmt.Sprintf("unknown prompt %q", p.Name)
+	}
+	query := strings.TrimSpace(p.Arguments["query"])
+	if query == "" {
+		return nil, -32602, "query required"
+	}
+	args, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, -32603, err.Error()
+	}
+	text, err := callMCPTool(dir, "recall", args)
+	if err != nil {
+		return nil, -32602, err.Error()
+	}
+	if strings.TrimSpace(text) == "" {
+		// Said in words rather than left blank: a host pastes this straight
+		// into the conversation, and an empty paste reads as a broken command
+		// rather than as an answer.
+		text = "deja: nothing in this machine's past sessions matches " + quoted(query)
+	}
+	return map[string]any{
+		"description": "What this machine's past sessions say about " + quoted(query),
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": map[string]any{"type": "text", "text": text},
+		}},
+	}, 0, ""
+}
+
+// quoted wraps a query for a one-line message without a formatter that would
+// escape the user's own punctuation.
+func quoted(s string) string {
+	return "\"" + s + "\""
+}

--- a/cmd/deja/mcp_prompts_test.go
+++ b/cmd/deja/mcp_prompts_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The slash command, in the only form deja can offer a harness it ships no
+// command file into. Gemini and qwen both ask an MCP server for prompts/list on
+// startup and put what comes back behind a slash; deja answered -32601, so
+// typing the command found nothing.
+func TestMCPPromptRunsTheSearch(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "app", "sess-alpha",
+		"the frobnicator crash in parser.go", "fixed the frobnicator by widening the guard")
+
+	list := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}`)
+	res, _ := list[0]["result"].(map[string]any)
+	prompts, _ := res["prompts"].([]any)
+	if len(prompts) != 1 {
+		t.Fatalf("prompts = %#v, want the one command", res)
+	}
+	p, _ := prompts[0].(map[string]any)
+	if p["name"] != "deja" {
+		t.Errorf("prompt name = %v, want deja", p["name"])
+	}
+	args, _ := p["arguments"].([]any)
+	if len(args) != 1 {
+		t.Fatalf("arguments = %#v, want one query", p["arguments"])
+	}
+	a, _ := args[0].(map[string]any)
+	if a["name"] != "query" || a["required"] != true {
+		t.Errorf("argument = %#v, want a required query", a)
+	}
+
+	// And getting it runs the search rather than telling the model to.
+	got := driveMCP(t, `{"jsonrpc":"2.0","id":2,"method":"prompts/get","params":{"name":"deja","arguments":{"query":"frobnicator"}}}`)
+	gres, ok := got[0]["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("prompts/get failed: %#v", got[0])
+	}
+	msgs, _ := gres["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("messages = %#v, want one", gres["messages"])
+	}
+	m, _ := msgs[0].(map[string]any)
+	if m["role"] != "user" {
+		t.Errorf("role = %v, want user", m["role"])
+	}
+	content, _ := m["content"].(map[string]any)
+	text, _ := content["text"].(string)
+	// Something only the seeded session holds — echoing the query back would
+	// pass while the search never ran.
+	if !strings.Contains(text, "widening the guard") {
+		t.Errorf("the command did not carry the search result: %q", text)
+	}
+	if strings.Contains(text, "nothing in this machine") {
+		t.Errorf("the command answered as if the store were empty: %q", text)
+	}
+}
+
+// A command typed with nothing after it, and one that names a prompt deja does
+// not have: both are the user's mistake and both must say so rather than paste
+// an empty message into the conversation.
+func TestMCPPromptRefusesWhatItCannotAnswer(t *testing.T) {
+	hermeticEnv(t)
+
+	for _, tc := range []struct{ name, req string }{
+		{"no query", `{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"deja","arguments":{}}}`},
+		{"unknown prompt", `{"jsonrpc":"2.0","id":1,"method":"prompts/get","params":{"name":"nope","arguments":{"query":"x"}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := driveMCP(t, tc.req)
+			if _, ok := resp[0]["error"].(map[string]any); !ok {
+				t.Fatalf("answered instead of refusing: %#v", resp[0])
+			}
+		})
+	}
+}
+
+// The capability has to be declared or a host never asks: gemini and qwen read
+// initialize before they call prompts/list.
+func TestMCPDeclaresPrompts(t *testing.T) {
+	hermeticEnv(t)
+	resp := driveMCP(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	res, _ := resp[0]["result"].(map[string]any)
+	caps, _ := res["capabilities"].(map[string]any)
+	if _, ok := caps["prompts"]; !ok {
+		t.Errorf("capabilities = %#v, want prompts declared", caps)
+	}
+}


### PR DESCRIPTION
Measured against a recording MCP server: gemini-cli 0.55.1 and qwen-code 0.20.0 both call `prompts/list` on startup, and qwen also calls `resources/list`. deja answered `prompts/list` with -32601, so the one surface a person drives by hand existed only where deja writes a command file.

It now offers one command, `deja`, taking a required `query`, and `prompts/get` runs the recall and returns the result as the message about to be sent — rather than telling the model to call the tool, which costs a round trip to reach the same rows.

Checked end to end against the real server: `initialize` declares the capability, `prompts/list` returns the command, and `prompts/get` on a seeded store comes back with the line that session settled.

Codex 0.149.0 asks for `tools/list` and never for prompts, so it gains nothing from this.