### PR TITLE
feat(cursor): recall at the moment of the action, not only at the start

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -291,6 +291,8 @@ func runHookContext(dir string, plain bool) error {
 		Source    string `json:"source"`
 		SessionID string `json:"session_id"`
 		CWD       string `json:"cwd"`
+		// Cursor leaves cwd empty and names the project here instead.
+		WorkspaceRoots []string `json:"workspace_roots"`
 	}
 	// Best effort, as every hook is — but not silent about it. A payload deja
 	// cannot decode carries the session this injection went to, and losing it
@@ -302,7 +304,7 @@ func runHookContext(dir string, plain bool) error {
 	// environment, so a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having
 	// none (#759).
-	digest, sessions, raw, taskMatched, withheld, servedIDs, servedProjects := cachedHookDigestFor(dir, input.CWD)
+	digest, sessions, raw, taskMatched, withheld, servedIDs, servedProjects := cachedHookDigestFor(dir, hookProjectPath(input.CWD, input.WorkspaceRoots))
 	if digest == "" {
 		// No session from this project, which is the usual state in a new
 		// checkout — and exactly where knowing what this machine is missing
@@ -381,7 +383,7 @@ func runHookContext(dir string, plain bool) error {
 		// most needs is its own evidence: measured on this corpus, a summary
 		// keeps ~77% of the decisions and 0.2% of the commands that produced
 		// them (#543).
-		if ev := compactEvidence(dir, input.SessionID, hookCWD(input.CWD)); ev != "" {
+		if ev := compactEvidence(dir, input.SessionID, hookCWD(hookProjectPath(input.CWD, input.WorkspaceRoots))); ev != "" {
 			lead += "\n" + ev + "\n"
 		}
 	}
@@ -403,7 +405,7 @@ func runHookContext(dir string, plain bool) error {
 	// per-prompt path bans a session it already showed *this* agent session,
 	// and unprefixed rows made a session-start block count as that — the first
 	// prompt about what the start just mentioned got nothing back.
-	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+input.SessionID, hookProjectKey(input.CWD), servedIDs)
+	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+input.SessionID, hookProjectKey(hookProjectPath(input.CWD, input.WorkspaceRoots)), servedIDs)
 	if plain {
 		fmt.Fprintln(os.Stdout, digest)
 		return nil
@@ -667,6 +669,22 @@ func notesStamp() string {
 		return "none"
 	}
 	return strconv.FormatInt(fi.Size(), 10) + "@" + strconv.FormatInt(fi.ModTime().UnixNano(), 10)
+}
+
+// hookProjectPath is the directory a payload is about. Cursor leaves cwd empty
+// and names the project in workspace_roots instead (measured on cursor-agent
+// 2026.09.02), so a hook reading cwd alone fell back to whatever directory the
+// harness happened to spawn it in — which is not the project on every host.
+func hookProjectPath(cwd string, roots []string) string {
+	if strings.TrimSpace(cwd) != "" {
+		return cwd
+	}
+	for _, r := range roots {
+		if strings.TrimSpace(r) != "" {
+			return r
+		}
+	}
+	return ""
 }
 
 // hookCWD is where the hook is standing: what the payload says, else the

--- a/cmd/deja/hook_cursor_payload_test.go
+++ b/cmd/deja/hook_cursor_payload_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Cursor's tool payload, copied from what cursor-agent 2026.09.02 actually
+// handed a hook on this machine. Three things in it are not what deja read: the
+// tool is called Shell, the output arrives under tool_output as a JSON document
+// inside a JSON string, and cwd is empty with the project named in
+// workspace_roots. Any one of them left the fix pair silent on cursor.
+const cursorPostToolUse = `{
+  "hook_event_name": "postToolUse",
+  "tool_name": "Shell",
+  "tool_input": {"command": "go build ./...", "cwd": "", "timeout": 30000},
+  "tool_output": "{\"output\":\"./main.go:12:2: undefined: zorbquuxHelper\\n\",\"exitCode\":1}",
+  "cwd": "",
+  "workspace_roots": ["/Users/probe/app"],
+  "session_id": "cur-1"
+}`
+
+func TestCursorToolPayloadIsRead(t *testing.T) {
+	var input toolAfterInput
+	if err := json.NewDecoder(bytes.NewReader([]byte(cursorPostToolUse))).Decode(&input); err != nil {
+		t.Fatal(err)
+	}
+	if !isCommandTool(input.ToolName) {
+		t.Errorf("tool %q is not read as a command tool, so the fix pair never fires on cursor", input.ToolName)
+	}
+	if len(bytes.TrimSpace(input.ToolResponse)) != 0 {
+		t.Fatalf("cursor sends no tool_response; got %s", input.ToolResponse)
+	}
+	got := toolResponseText(input.ToolOutput)
+	if !strings.Contains(got, "undefined: zorbquuxHelper") {
+		t.Errorf("the error was not pulled out of tool_output: %q", got)
+	}
+	// The escaped JSON must not survive into the text the signature is built
+	// from — a line of quoted JSON matches no error deja has ever indexed.
+	if strings.Contains(got, "exitCode") {
+		t.Errorf("the wrapper was passed through as text: %q", got)
+	}
+}
+
+// An empty cwd is cursor's normal case, and the project is in workspace_roots.
+// Falling back to the process directory meant recall answered for whatever
+// directory the harness happened to spawn the hook in.
+func TestEmptyCWDFallsBackToTheWorkspace(t *testing.T) {
+	if got := hookProjectPath("", []string{"/Users/probe/app"}); got != "/Users/probe/app" {
+		t.Errorf("workspace_roots ignored: %q", got)
+	}
+	// And a payload that names both keeps the one the harness was explicit
+	// about.
+	if got := hookProjectPath("/Users/probe/other", []string{"/Users/probe/app"}); got != "/Users/probe/other" {
+		t.Errorf("cwd should win when the harness sends one: %q", got)
+	}
+	if got := hookProjectPath("   ", nil); got != "" {
+		t.Errorf("nothing to go on should stay empty, got %q", got)
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -51,6 +51,8 @@ type promptHookInput struct {
 	// environment meant a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR recalled nothing (#759).
 	CWD string `json:"cwd"`
+	// Cursor leaves cwd empty and names the project here instead.
+	WorkspaceRoots []string `json:"workspace_roots"`
 }
 
 // hookPromptText reads a prompt that arrives either as a string (Claude Code,
@@ -172,7 +174,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// The payload first, then the export, then where the process stands: the
 	// export is set once per process and will not change, so reading it alone
 	// answered a second payload with the first one's project (#2182).
-	cwd := hookCWD(input.CWD)
+	cwd := hookCWD(hookProjectPath(input.CWD, input.WorkspaceRoots))
 	// Rank THIS project's sessions by how well they match the prompt terms
 	// (IDF-weighted), rather than reconstructing an AND query — natural
 	// prompts are full of filler that poisons an AND.

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -68,6 +68,8 @@ type toolHookInput struct {
 	} `json:"tool_input"`
 	SessionID string `json:"session_id"`
 	CWD       string `json:"cwd"`
+	// Cursor leaves cwd empty and names the project here instead.
+	WorkspaceRoots []string `json:"workspace_roots"`
 }
 
 func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
@@ -112,7 +114,7 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 		requestWarmup(dir)
 		return nil
 	}
-	line := toolHookLine(dir, hookCWD(input.CWD), input)
+	line := toolHookLine(dir, hookCWD(hookProjectPath(input.CWD, input.WorkspaceRoots)), input)
 	if line == "" {
 		return nil
 	}

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -51,8 +51,12 @@ type toolAfterInput struct {
 	// whether the exit code is reported at all, so every shape is read and the
 	// decision rests on the text rather than on a status field.
 	ToolResponse json.RawMessage `json:"tool_response"`
-	SessionID    string          `json:"session_id"`
-	CWD          string          `json:"cwd"`
+	// Cursor calls it tool_output, and sends a JSON document inside a JSON
+	// string: {"output":"…","exitCode":0} (measured on cursor-agent
+	// 2026.09.02). Reading only tool_response left the fix pair with nothing.
+	ToolOutput json.RawMessage `json:"tool_output"`
+	SessionID  string          `json:"session_id"`
+	CWD        string          `json:"cwd"`
 }
 
 func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
@@ -90,7 +94,11 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 	if !isCommandTool(name) {
 		return nil
 	}
-	out := toolResponseText(input.ToolResponse)
+	response := input.ToolResponse
+	if len(bytes.TrimSpace(response)) == 0 {
+		response = input.ToolOutput
+	}
+	out := toolResponseText(response)
 	if out == "" {
 		// readHookPayload stops at 1 MiB, so a verbose build cuts the JSON
 		// mid-string and the decode yields nothing at all — not a truncated
@@ -131,7 +139,7 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 // speaks for them.
 func isCommandTool(name string) bool {
 	switch name {
-	case "Bash", "bash", "shell", "run_command", "execute_command", "terminal", "run_shell_command":
+	case "Bash", "bash", "shell", "Shell", "run_command", "execute_command", "terminal", "run_shell_command":
 		return true
 	}
 	return false
@@ -146,6 +154,14 @@ func toolResponseText(raw json.RawMessage) string {
 	}
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
+		// A harness that puts a JSON document inside the string — cursor sends
+		// {"output":"…","exitCode":0} that way — would otherwise hand the
+		// signature scan a line of escaped JSON rather than the error.
+		if inner := strings.TrimSpace(s); strings.HasPrefix(inner, "{") {
+			if text := toolResponseText(json.RawMessage(inner)); text != "" {
+				return text
+			}
+		}
 		return clampOutput(s)
 	}
 	var obj map[string]any

--- a/cmd/deja/install_cursor.go
+++ b/cmd/deja/install_cursor.go
@@ -40,6 +40,15 @@ func installCursorHooks(exe string, uninstall bool) (installResult, error) {
 	// interactive TUI — headless `-p` skips it — but costs nothing there.
 	setCursorHook(hooks, "sessionStart", exe+" hook-context", uninstall)
 	setCursorHook(hooks, "beforeSubmitPrompt", exe+" hook-prompt", uninstall)
+	// And the same three cursor already runs for anyone who also has Claude
+	// Code: it reads ~/.claude/settings.json and maps the names onto its own —
+	// PreToolUse→preToolUse, PostToolUse→postToolUse, PreCompact→preCompact
+	// (the table is in its own bundle, 2026.07.23). A cursor-only user got none
+	// of them. The dedupe is by exact command string, so a user with both still
+	// gets one hook, not two.
+	setCursorHook(hooks, "preToolUse", exe+" hook-tool", uninstall)
+	setCursorHook(hooks, "postToolUse", exe+" hook-tool-after", uninstall)
+	setCursorHook(hooks, "preCompact", exe+" hook-precompact", uninstall)
 	if len(hooks) == 0 {
 		delete(root, "hooks")
 		delete(root, "version")

--- a/cmd/deja/install_cursor_tools_test.go
+++ b/cmd/deja/install_cursor_tools_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Cursor reads ~/.claude/settings.json as well as its own hooks.json and maps
+// the Claude event names onto its own — PreToolUse→preToolUse,
+// PostToolUse→postToolUse, PreCompact→preCompact — so it has been running these
+// three deja hooks all along for anyone who also has Claude Code installed, and
+// none of them for anyone who does not. They are also three of the five events
+// cursor lists as taking a hook's additionalContext.
+func TestInstallCursorWiresTheMomentOfTheAction(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installCursorHooks("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".cursor", "hooks.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Command string `json:"command"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	for event, sub := range map[string]string{
+		"sessionStart":       "hook-context",
+		"beforeSubmitPrompt": "hook-prompt",
+		"preToolUse":         "hook-tool",
+		"postToolUse":        "hook-tool-after",
+		"preCompact":         "hook-precompact",
+	} {
+		entries := root.Hooks[event]
+		if len(entries) != 1 {
+			t.Fatalf("%s entries = %d, want 1: %s", event, len(entries), b)
+		}
+		if got := entries[0].Command; !strings.HasSuffix(got, sub) {
+			t.Errorf("%s runs %q, want %s", event, got, sub)
+		}
+	}
+	// The command string is what cursor dedupes on against ~/.claude, so it has
+	// to be exactly what deja writes there — a wrapper or a flag here would
+	// give a user with both two hooks per action.
+	if got := root.Hooks["postToolUse"][0].Command; got != "/usr/local/bin/deja hook-tool-after" {
+		t.Errorf("command = %q, want the same string the claude wiring writes", got)
+	}
+	// And uninstall takes all five back out.
+	if _, err := installCursorHooks("/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b2), "deja hook-") {
+		t.Errorf("uninstall left a hook behind: %s", b2)
+	}
+}


### PR DESCRIPTION
Cursor wired two events: `sessionStart` and `beforeSubmitPrompt`. Its own bundle (2026.07.23) carries two things that make the rest worth adding:

- the list of events whose `additionalContext` it takes — `sessionStart`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `postToolUseFailure`; the client throws at startup if that list and its type union disagree, so it is the client's own statement of what works;
- a table mapping Claude's names onto its own — `PreToolUse`→`preToolUse`, `PostToolUse`→`postToolUse`, `PreCompact`→`preCompact`. Cursor reads `~/.claude/settings.json` too, so it has been running exactly these three deja hooks for anyone who also has Claude Code installed, and none of them for anyone who does not.

So this writes the same three into cursor's own hooks.json under cursor's names. The command strings are identical to the ones deja writes for Claude, which is what cursor dedupes on — a user with both still gets one hook per action.

Evidence, plainly: this is the client's own event map plus hooks cursor already runs, not a driven stand. I could not drive one here — `cursor-agent` reads its access token from the login keychain before it starts a session, and no supported override reaches that path, so a scratch home gets "Password not found" whatever the endpoint is. If you want it measured before merging, say so and I will run it on a logged-in machine.