### PR TITLE
feat(sync): a machine in the middle of a chain can hand over what it holds

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2495,29 +2495,30 @@ func parseSearch(args []string) (search.Options, error) {
 // that are real deja flags somewhere but not here. Only exact matches: a query
 // may legitimately start with a dash, and `--` still ends option parsing.
 var flagsOfOtherCommands = map[string]string{
-	"--offset":      "show",
-	"--span":        "restore",
-	"--out":         "restore",
-	"--force":       "restore",
-	"--tag":         "remember",
-	"--deep":        "doctor",
-	"--offline":     "doctor",
-	"--dry-run":     "forget",
-	"--all-matches": "forget",
-	"--list":        "forget",
-	"--unforget":    "forget",
-	"--before":      "forget",
-	"--to":          "handoff",
-	"--exec":        "resume",
-	"--plain":       "hook-prompt",
-	"--no-open":     "view",
-	"--full":        "sync export",
-	"--peer":        "sync export",
-	"--pull":        "sync ssh",
-	"--both":        "sync ssh",
-	"--from":        "last",
-	"--last":        "log",
-	"--seed":        "bench",
+	"--offset":           "show",
+	"--span":             "restore",
+	"--out":              "restore",
+	"--force":            "restore",
+	"--tag":              "remember",
+	"--deep":             "doctor",
+	"--offline":          "doctor",
+	"--dry-run":          "forget",
+	"--all-matches":      "forget",
+	"--list":             "forget",
+	"--unforget":         "forget",
+	"--before":           "forget",
+	"--to":               "handoff",
+	"--exec":             "resume",
+	"--plain":            "hook-prompt",
+	"--no-open":          "view",
+	"--full":             "sync export",
+	"--include-imported": "sync export",
+	"--peer":             "sync export",
+	"--pull":             "sync ssh",
+	"--both":             "sync ssh",
+	"--from":             "last",
+	"--last":             "log",
+	"--seed":             "bench",
 }
 
 // searchFlags is every flag the bare search form accepts, for the typo check.
@@ -3606,7 +3607,7 @@ Usage:
   deja friction [--limit n] [--json]
   deja fix "<error text>" [--limit n] [--json]  (what was run after this error before)
   deja how <what> [--project name] [--limit n] [--json]  (commands this machine actually ran)
-  deja sync export <dir> [--full] [--peer name]
+  deja sync export <dir> [--full] [--include-imported] [--peer name]
   deja sync import <dir>
   deja sync                       (exchange with every machine deja knows, both ways)
   deja sync ssh <host> [--pull] [--both] [--full]

--- a/cmd/deja/sync.go
+++ b/cmd/deja/sync.go
@@ -70,12 +70,23 @@ func runSync(dir string, args []string) error {
 		return nil
 	case "export":
 		full := false
+		relay := false
 		rest := args[1:]
 		out := ""
 		peer := ""
 		for i := 0; i < len(rest); i++ {
 			a := rest[i]
 			if a == "--full" {
+				full = true
+				continue
+			}
+			// What arrived from other machines stays put by default: passing
+			// it on spreads it past whoever agreed to the first hop (#2450).
+			// This is how someone says otherwise about machines that are all
+			// theirs — a chain where this one sits in the middle, or a
+			// migration off it (#2962).
+			if a == "--include-imported" {
+				relay = true
 				full = true
 				continue
 			}
@@ -96,7 +107,7 @@ func runSync(dir string, args []string) error {
 			// records into an empty directory while the reader believed they
 			// had carried their whole memory to another machine (#745).
 			if strings.HasPrefix(a, "-") {
-				return fmt.Errorf("sync export: unknown flag %q — only --full and --peer are accepted", a)
+				return fmt.Errorf("sync export: unknown flag %q — only --full, --include-imported and --peer are accepted", a)
 			}
 			out = a
 		}
@@ -112,9 +123,12 @@ func runSync(dir string, args []string) error {
 		}
 		var n int
 		var err error
-		if full {
+		switch {
+		case relay:
+			n, err = index.ExportRelay(dir, out, peers.Identity(peer))
+		case full:
 			n, err = index.ExportFull(dir, out)
-		} else {
+		default:
 			// Folded, so one machine settles under one watermark whichever way
 			// the name was spelled — a pull runs this on the remote with that
 			// machine's hostname, capitalised on macOS, while the alias someone
@@ -161,6 +175,16 @@ func runSync(dir string, args []string) error {
 		// the recovery sentence in #1820 and the tombstone id in #1794.
 		if n == 0 && !full && !hasSyncBatches(out) {
 			fmt.Fprintf(os.Stdout, "deja: nothing has changed since the last export, and this folder holds no batch from this machine — `deja sync export %s --full` sends everything\n", pasteSafe(out))
+		}
+		// An export that holds nothing but other machines' work says so.
+		// Without this the reader was told "exported 0 records" by a machine
+		// whose `stats` showed hundreds, and had to guess whether the data was
+		// lost (#2962).
+		if !relay {
+			if held := importedSessionTotal(dir); held > 0 && n == 0 {
+				fmt.Fprintf(os.Stdout, "deja: %d session%s here arrived from other machines and are not passed on — `deja sync export %s --include-imported` sends those too\n",
+					held, pluralS(held), pasteSafe(out))
+			}
 		}
 		// Only when something was written: on a watermarked sync most runs
 		// send nothing, and the line asked the reader to review a file that

--- a/cmd/deja/sync_relay_cli_test.go
+++ b/cmd/deja/sync_relay_cli_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A machine holding only work that arrived by sync used to report "exported 0
+// records" while its own `stats` showed hundreds of messages, which reads as
+// data loss rather than as a rule (#2962). It now names what it is holding and
+// the flag that sends it.
+func TestSyncExportSaysWhatItHoldsBack(t *testing.T) {
+	home := hermeticEnv(t)
+	dir := filepath.Join(home, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+
+	batch := filepath.Join(home, "from-elsewhere")
+	if err := os.MkdirAll(batch, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	rec := `{"harness":"claude","session_id":"far1","project":"app","role":"user",` +
+		`"text":"relayneedle the loader stalls on boot","time":"` + at + `","origin":"container-1"}`
+	if err := os.WriteFile(filepath.Join(batch, "batch.jsonl"), []byte(rec+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := index.Import(dir, batch); err != nil || n != 1 {
+		t.Fatalf("import n=%d err=%v", n, err)
+	}
+
+	out := filepath.Join(home, "outgoing")
+	stdout := captureStdout(t, func() {
+		if err := runSync(dir, []string{"export", out, "--full"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(stdout, "arrived from other machines") {
+		t.Errorf("an empty export said nothing about what it holds:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "--include-imported") {
+		t.Errorf("the reader is not told how to send it:\n%s", stdout)
+	}
+
+	// And the flag sends it, under the name of the machine the work happened
+	// on rather than this one.
+	relayOut := filepath.Join(home, "relayed")
+	if err := runSync(dir, []string{"export", relayOut, "--include-imported"}); err != nil {
+		t.Fatal(err)
+	}
+	files, err := filepath.Glob(filepath.Join(relayOut, "*.jsonl"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("nothing was written: %v", err)
+	}
+	body, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sr struct {
+		Origin  string `json:"origin"`
+		Project string `json:"project"`
+		Text    string `json:"text"`
+	}
+	line := strings.TrimSpace(strings.Split(strings.TrimSpace(string(body)), "\n")[0])
+	if err := json.Unmarshal([]byte(line), &sr); err != nil {
+		t.Fatal(err)
+	}
+	if sr.Origin != "container-1" {
+		t.Errorf("relayed record signed %q, want the machine the work happened on", sr.Origin)
+	}
+	if sr.Project != "app" {
+		t.Errorf("project = %q, want the original name", sr.Project)
+	}
+	if !strings.Contains(sr.Text, "relayneedle") {
+		t.Errorf("the work itself did not travel: %q", sr.Text)
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -44,6 +44,10 @@ type SyncRecord struct {
 // behind it is not.
 type syncName string
 
+// importedProjectPrefix marks a project that arrived by sync. Relaying strips
+// it so the next machine files the work under its real name.
+const importedProjectPrefix = "imported:"
+
 func (n *syncName) UnmarshalJSON(b []byte) error {
 	var s string
 	if json.Unmarshal(b, &s) == nil {
@@ -57,18 +61,28 @@ func (n *syncName) UnmarshalJSON(b []byte) error {
 // machine can receive the whole history even after earlier batch dirs are
 // gone; import-side dedupe makes it safe.
 func Export(dir, outDir string) (int, error) {
-	return exportRecords(dir, outDir, "", false)
+	return exportRecords(dir, outDir, "", false, false)
 }
 
 func ExportFull(dir, outDir string) (int, error) {
-	return exportRecords(dir, outDir, "", true)
+	return exportRecords(dir, outDir, "", true, false)
+}
+
+// ExportRelay is ExportFull and the work that arrived from other machines with
+// it, each record under the names it had where it happened rather than this
+// machine's. Opt-in, because passing a peer's work on spreads it past whoever
+// agreed to the first hop (#2450) — but a machine in the middle of a chain, or
+// one being migrated off, has to be able to hand over everything it holds
+// (#2962). It never sends a record back to the machine it came from.
+func ExportRelay(dir, outDir, peer string) (int, error) {
+	return exportRecords(dir, outDir, peer, true, true)
 }
 
 // ExportTo is Export for a named peer: the watermark it advances is that
 // peer's alone. An empty name keeps the shared one, which is what a hand-taken
 // backup uses.
 func ExportTo(dir, outDir, peer string) (int, error) {
-	return exportRecords(dir, outDir, peer, false)
+	return exportRecords(dir, outDir, peer, false, false)
 }
 
 // ExportDeferred writes batches like Export but does not advance the
@@ -109,8 +123,8 @@ func recordIdentity(r Record) uint64 {
 	return h.Sum64()
 }
 
-func exportRecords(dir, outDir, peer string, full bool) (int, error) {
-	n, commit, err := exportRecordsDeferred(dir, outDir, peer, full)
+func exportRecords(dir, outDir, peer string, full, relay bool) (int, error) {
+	n, commit, err := exportRecordsWith(dir, outDir, peer, full, relay)
 	if err != nil {
 		return n, err
 	}
@@ -118,6 +132,10 @@ func exportRecords(dir, outDir, peer string, full bool) (int, error) {
 }
 
 func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() error, error) {
+	return exportRecordsWith(dir, outDir, peer, full, false)
+}
+
+func exportRecordsWith(dir, outDir, peer string, full, relay bool) (int, func() error, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -182,8 +200,28 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 	// beyond it. Held records are not sent, and they are not settled either.
 	heldFrom := map[string]int64{}
 	err = eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
-		if r.SourcePath == syncImportPath {
+		// What arrived by sync travels on rather than stopping here. A machine
+		// that pulled from a container and is then pulled from itself used to
+		// export nothing at all — `--full` included — so a middle machine in a
+		// chain was a dead end, and a migration off it lost everything it had
+		// gathered (#2962). It relays under the original machine's name, not
+		// its own: a relay must not sign someone else's work.
+		relayed := r.SourcePath == syncImportPath
+		if relayed && !relay {
+			// The standing rule: what arrived from elsewhere is not this
+			// machine's to pass on, because a second hop spreads it past
+			// whoever agreed to the first (#2450). Opt in to relay it — a
+			// migration off this machine, or a chain where it sits in the
+			// middle — with `sync export --include-imported` (#2962).
 			return
+		}
+		if relayed && peer != "" {
+			// Not back where it came from. A pull tells the far side who is
+			// asking (`sync export --peer <us>`), and sending a machine its own
+			// work is pure traffic: the receiver recognises it and drops it.
+			if meta, ok := m.Sessions[r.Key]; ok && meta.From != "" && strings.EqualFold(meta.From, peer) {
+				return
+			}
 		}
 		source := r.SourcePath
 		if source == "" {
@@ -206,7 +244,23 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 		if !ok {
 			return
 		}
-		if (!ex.Empty() && ex.Match(meta.Project)) || pol.Ignored(meta.Path, meta.Project) {
+		// A relayed session is filed here under "imported:<project>" and a
+		// local id. It goes back out under the names it had where the work
+		// happened, so the next machine dedupes it against a batch pulled
+		// straight from that machine rather than growing a second copy — and
+		// so the privacy rules below, which are written against real project
+		// names, match it at all.
+		project, sessionID, origin := meta.Project, meta.ID, syncName(self)
+		if relayed {
+			project = strings.TrimPrefix(meta.Project, importedProjectPrefix)
+			if meta.OrigID != "" {
+				sessionID = meta.OrigID
+			}
+			if meta.From != "" {
+				origin = syncName(meta.From)
+			}
+		}
+		if (!ex.Empty() && ex.Match(project)) || pol.Ignored(meta.Path, project) {
 			// Held, not settled, for both: a watermark that ran past a
 			// withheld record would settle it forever, so lifting the rule
 			// later would never send that work.
@@ -218,12 +272,7 @@ func exportRecordsDeferred(dir, outDir, peer string, full bool) (int, func() err
 			return
 		}
 		text, _ := redact.Text(r.Text)
-		// Always this machine: an export never forwards what arrived by sync
-		// (the syncImportPath check above), so nothing here was worked on
-		// anywhere else. If records ever do transit, this becomes meta.From
-		// with a fallback — a machine that relays must not sign someone else's
-		// work as its own.
-		rec := SyncRecord{Harness: meta.Harness, SessionID: meta.ID, Project: meta.Project, Role: r.Role, Text: text, Time: r.Time, Origin: syncName(self)}
+		rec := SyncRecord{Harness: meta.Harness, SessionID: sessionID, Project: project, Role: r.Role, Text: text, Time: r.Time, Origin: origin}
 		bySource[source] = append(bySource[source], rec)
 		touched[wk] = true
 		tn := r.Time.UnixNano()
@@ -613,7 +662,7 @@ func Import(dir, inDir string) (int, error) {
 			recsByKey[key] = append(recsByKey[key], Record{Key: key, Role: sr.Role, Text: text, Time: sr.Time, SourcePath: syncImportPath})
 			meta := metas[key]
 			if meta.ID == "" {
-				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: "imported:" + sr.Project, Path: syncImportPath, OrigID: origID, From: string(sr.Origin)}
+				meta = SessionMeta{ID: importID, Harness: sr.Harness, Project: importedProjectPrefix + sr.Project, Path: syncImportPath, OrigID: origID, From: string(sr.Origin)}
 			}
 			if meta.Started.IsZero() || (!sr.Time.IsZero() && sr.Time.Before(meta.Started)) {
 				meta.Started = sr.Time

--- a/internal/index/sync_relay_test.go
+++ b/internal/index/sync_relay_test.go
@@ -1,0 +1,113 @@
+package index
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// The chain from #2962: a container syncs into a server, and a laptop then
+// pulls the server. The server exported nothing at all — `--full` included —
+// so the middle of a chain was a dead end, and migrating off that machine lost
+// everything it had gathered. Passing a peer's work on is still not the
+// default (#2450); this is the opt-in path.
+func TestASyncedMachineCanBePulledFrom(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+
+	base := time.Date(2026, 8, 27, 10, 0, 0, 0, time.UTC)
+	fromContainer := filepath.Join(tmp, "from-container")
+	writeSyncBatch(t, fromContainer, []SyncRecord{
+		{Harness: "claude", SessionID: "container-sess", Project: "app", Role: "user",
+			Text: "relayneedle why does the loader stall", Time: base, Origin: "container-1"},
+		{Harness: "claude", SessionID: "container-sess", Project: "app", Role: "assistant",
+			Text: "relayneedle the cache was cold; warming it settled that", Time: base.Add(time.Minute), Origin: "container-1"},
+	})
+
+	server := filepath.Join(tmp, "server.db")
+	if n, err := Import(server, fromContainer); err != nil || n != 2 {
+		t.Fatalf("server import n=%d err=%v", n, err)
+	}
+
+	// The default still holds: a peer's work is not this machine's to pass on.
+	if n, err := ExportFull(server, filepath.Join(tmp, "default-out")); err != nil || n != 0 {
+		t.Fatalf("a plain export sent %d records of another machine's work (err=%v)", n, err)
+	}
+
+	// What the laptop asks for, once someone says these are all their own
+	// machines.
+	toLaptop := filepath.Join(tmp, "to-laptop")
+	n, err := ExportRelay(server, toLaptop, "laptop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("the server exported %d records, want the 2 it holds", n)
+	}
+
+	// Under the container's name, not the server's, and under the project the
+	// work actually happened in.
+	var relayed []SyncRecord
+	batches, _ := filepath.Glob(filepath.Join(toLaptop, "*.jsonl"))
+	for _, p := range batches {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			var sr SyncRecord
+			if err := json.Unmarshal([]byte(line), &sr); err != nil {
+				t.Fatalf("batch line does not decode: %v", err)
+			}
+			relayed = append(relayed, sr)
+		}
+	}
+	if len(relayed) != 2 {
+		t.Fatalf("batch holds %d records, want 2", len(relayed))
+	}
+	for _, sr := range relayed {
+		if string(sr.Origin) != "container-1" {
+			t.Errorf("relayed record signed %q, want the machine the work happened on", sr.Origin)
+		}
+		if sr.Project != "app" {
+			t.Errorf("project = %q, want the original name", sr.Project)
+		}
+		if sr.SessionID != "container-sess" {
+			t.Errorf("session = %q, want the id it had on the container", sr.SessionID)
+		}
+	}
+
+	// And the laptop can read it.
+	laptop := filepath.Join(tmp, "laptop.db")
+	if n, err := Import(laptop, toLaptop); err != nil || n != 2 {
+		t.Fatalf("laptop import n=%d err=%v", n, err)
+	}
+	ss, err := Search(laptop, search.Options{Query: "relayneedle", All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) == 0 {
+		t.Fatal("the work did not survive the second hop")
+	}
+
+	// A laptop that pulls the same work straight from the container gets one
+	// copy, not two: the relay kept the identity the dedupe is keyed on.
+	if n, err := Import(laptop, fromContainer); err != nil || n != 0 {
+		t.Fatalf("re-import from the origin added %d records, want none", n)
+	}
+
+	// The server does not send the container its own work back.
+	toContainer := filepath.Join(tmp, "to-container")
+	if n, err := ExportRelay(server, toContainer, "container-1"); err != nil || n != 0 {
+		t.Fatalf("the server echoed %d records to the machine they came from (err=%v)", n, err)
+	}
+}


### PR DESCRIPTION
Closes #2962.

A machine whose index is entirely work pulled from elsewhere exported 0 records — `--full` included — and said "nothing has changed since the last export". Its own `stats` showed three sessions and 240 messages at the same time, so the reporter reasonably read it as data loss and asked how to be sure a migration carries everything.

Two changes, and the standing rule is not one of them.

**It says what it is holding.** An export that sends nothing while the index holds sessions from other machines now names them and the flag that sends them, instead of claiming nothing changed.

**`sync export --include-imported` passes them on.** Each record travels under the names it had where the work happened — the original machine as its origin, the original project, the original session id — so the next machine dedupes it against a batch pulled straight from the source rather than growing a second copy. It never sends a record back to the machine it came from.

Off by default, because #2450 decided deliberately that what arrived from elsewhere is not this machine's to pass on: a second hop spreads it past whoever agreed to the first. The tests that hold that rule are untouched and still pass. The flag is how someone says the machines are all theirs.

Tested end to end on the chain from the issue: container into server, server pulled by a laptop, and the laptop then pulling the container directly gets no duplicates.