### PR TITLE
feat(search): DEJA_TRACE names where a slow search spent its time

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -377,6 +377,11 @@ func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool
 	if dir == "" {
 		dir = DefaultDir()
 	}
+	// The wait before an answer is made of three things — taking the lock,
+	// walking the stores to see what changed, and ingesting whatever did — and
+	// from the outside they are one number. A reader who sees seconds here can
+	// say which one it was rather than guessing (#3021).
+	mark := searchTrace()
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
 		return false, err
@@ -386,11 +391,14 @@ func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool
 		return true, nil
 	}
 	defer unlock()
+	mark("lock")
 	// Read first, walk second: this is the path every search takes, and
 	// re-deriving state for unchanged transcripts was costing 700 ms of the
 	// second it takes to answer a query.
 	m, err := readManifest(dir)
+	mark("manifest")
 	want := currentFilesReusing("", priorFiles(m, err))
+	mark("walk stores")
 	if err != nil || m.Version != version || m.Scope != "" || !recordsIntact(dir, m) {
 		// No usable index yet (or a rebuild-grade problem): the caller cannot
 		// serve anything sensible stale, so build synchronously.
@@ -420,10 +428,28 @@ func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool
 		}
 	}
 	if !removedAny && canAppendIncremental(changed, m.Files) {
-		return false, updateIndex(dir, o.Harness, "", want, false, progress)
+		mark("decide append")
+		err := updateIndex(dir, o.Harness, "", want, false, progress)
+		mark("append")
+		return false, err
 	}
 	// Caller detaches the rebuild (it owns the executable path).
+	mark("hand to warmup")
 	return true, nil
+}
+
+// searchTrace returns a stage marker that prints when DEJA_TRACE=1, and costs a
+// comparison otherwise. Same shape and same variable as the session-start hook,
+// so one instruction covers both paths.
+func searchTrace() func(string) {
+	if os.Getenv("DEJA_TRACE") != "1" {
+		return func(string) {}
+	}
+	last := time.Now()
+	return func(stage string) {
+		fmt.Fprintf(os.Stderr, "trace %-16s %6.1fms\n", stage, float64(time.Since(last).Microseconds())/1000)
+		last = time.Now()
+	}
 }
 
 func rebuild(dir string, harness string, scope string, files map[string]FileState, progress io.Writer) error {

--- a/internal/index/search_trace_test.go
+++ b/internal/index/search_trace_test.go
@@ -1,0 +1,98 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A reader who waits seconds for an answer can say which part of the wait it
+// was: taking the lock, walking the stores, or ingesting what changed. Without
+// this the three are one number and a report can only guess (#3021).
+func TestSearchTraceNamesTheStages(t *testing.T) {
+	root := t.TempDir()
+	setHome(t, root)
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	store := filepath.Join(root, "claude", "-work-app")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(root, "claude"))
+	line := `{"type":"user","sessionId":"s1","timestamp":"2026-01-02T03:04:05Z","cwd":"/work/app",` +
+		`"message":{"role":"user","content":"tracedneedle in the loader"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(root, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// One more turn, so the search has something to ingest inline.
+	more := `{"type":"assistant","sessionId":"s1","timestamp":"2026-01-02T03:05:05Z","cwd":"/work/app",` +
+		`"message":{"role":"assistant","content":"tracedneedle answered"}}` + "\n"
+	f, err := os.OpenFile(filepath.Join(store, "s1.jsonl"), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(more); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("DEJA_TRACE", "1")
+	got := captureStderr(t, func() {
+		if _, err := EnsureForSearchStale(dir, query.Options{Query: "tracedneedle"}, nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, stage := range []string{"walk stores", "append"} {
+		if !strings.Contains(got, stage) {
+			t.Errorf("the trace does not name %q:\n%s", stage, got)
+		}
+	}
+
+	// And it is silent otherwise: this runs on every search.
+	t.Setenv("DEJA_TRACE", "")
+	quiet := captureStderr(t, func() {
+		if _, err := EnsureForSearchStale(dir, query.Options{Query: "tracedneedle"}, nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.Contains(quiet, "trace ") {
+		t.Errorf("the trace printed without being asked:\n%s", quiet)
+	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				b.Write(buf[:n])
+			}
+			if err != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}


### PR DESCRIPTION
Groundwork for #3021, where a search unrelated to a live session waits seconds on it. The wait is made of three things — taking the lock, walking the stores to see what changed, and ingesting whatever did — and from outside they are one number, so a report can only guess which one it was.

`DEJA_TRACE=1` already did this for the session-start hook. It now covers the path every CLI search takes:

    trace lock                0.2ms
    trace manifest            1.4ms
    trace walk stores         9.2ms
    trace decide append       2.4ms
    trace append             43.6ms

Silent unless asked, since this runs on every search.

I could not reproduce #3021 here: a 16 MB live claude transcript beside 600 other sessions, one turn appended, an unrelated query — 45 ms, of which 9 ms is the walk. The reporter is on Windows with a Grok stream and a much larger store, so this is what will say whether the seconds are the walk or the ingest before anyone changes either.