### PR TITLE
chore: pin the manifests to 0.19.3

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/claude-plugin/plugin.json
+++ b/claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -12,7 +12,7 @@ import (
 // only offers an update for a plugin it installed from its own marketplace, so
 // for a repository or zip install nothing tells the user their copy is behind.
 // deja knows both numbers, and doctor is where someone looks.
-const kimiPluginVersion = "0.19.2"
+const kimiPluginVersion = "0.19.3"
 
 // kimiPluginInstalledVersion returns the version of the installed copy, or ""
 // when the plugin is not there.

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Codex: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and eighteen more — searchable and recalled, including work from before it was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.2",
+    "version": "0.19.3",
     "description": "Search Claude Code, Codex and Cursor session history locally",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip",
-            "hash": "d5897addafc95c45451a7e1ee7a8222101375a3fa9faaa0b6521c80f9e39a1f1"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.3/deja-vu_0.19.3_windows_amd64.zip",
+            "hash": "564183a59a64b93e1e54d68893c6857b40f431abbcf32e6a009a1669fddba174"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip",
-            "hash": "c4b3e8550396e8af74e737b3ed63aa4f749c4327301fd0395d9b40b946a517ab"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.3/deja-vu_0.19.3_windows_arm64.zip",
+            "hash": "32a9c05514e75721a0139cf0ac388c8511e2ef45ffca2d32f6bcb54e1f26b338"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.2
+PackageVersion: 0.19.3
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -10,10 +10,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_amd64.zip
-  InstallerSha256: D5897ADDAFC95C45451A7E1EE7A8222101375A3FA9FAAA0B6521C80F9E39A1F1
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.3/deja-vu_0.19.3_windows_amd64.zip
+  InstallerSha256: 564183A59A64B93E1E54D68893C6857B40F431ABBCF32E6A009A1669FDDBA174
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.2/deja-vu_0.19.2_windows_arm64.zip
-  InstallerSha256: C4B3E8550396E8AF74E737B3ED63AA4F749C4327301FD0395D9B40B946A517AB
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.3/deja-vu_0.19.3_windows_arm64.zip
+  InstallerSha256: 32A9C05514E75721A0139CF0AC388C8511E2EF45FFCA2D32F6BCB54E1F26B338
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.2
+PackageVersion: 0.19.3
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.2/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.3/LICENSE
 ShortDescription: Search Claude Code, Codex and Cursor session history locally
 Tags:
 - aider
@@ -19,6 +19,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.2
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.3
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.2
+PackageVersion: 0.19.3
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and eighteen more — including work from before it was installed.",
   "author": {
     "name": "vshulcz",


### PR DESCRIPTION
Regenerated by `scripts/pinmanifests` from the checksums the v0.19.3 build produced. The release job writes these in the runner and attaches them, but does not commit them, so main carries the previous version until this lands.