### PR TITLE
feat(openclaw): the recall plugin as a package OpenClaw can install by name

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -61,6 +61,40 @@ jobs:
             console.log("hooks still declared: " + hooks.join(", "));
           '
 
+  openclaw:
+    name: openclaw-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/openclaw
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The plugin has to parse
+        run: node --check index.mjs && node --check lib.mjs
+
+      - name: The manifest declares every tool the runtime registers
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const manifest = JSON.parse(fs.readFileSync("openclaw.plugin.json", "utf8"));
+            const src = fs.readFileSync("index.mjs", "utf8");
+            const registered = [...src.matchAll(/name: "(deja_[a-z]+)"/g)].map((m) => m[1]);
+            const declared = manifest.contracts.tools;
+            const missing = registered.filter((t) => !declared.includes(t));
+            if (!registered.length || missing.length) {
+              console.error("contracts.tools is missing: " + missing.join(", "));
+              process.exit(1);
+            }
+            console.log("declared: " + declared.join(", "));
+          '
+
+      - run: npm test
+
   dsh:
     name: dsh-deja
     runs-on: ubuntu-latest
@@ -250,7 +284,7 @@ jobs:
           node -e '
             const fs = require("node:fs");
             let bad = 0;
-            for (const dir of ["extensions/opencode", "extensions/dsh"]) {
+            for (const dir of ["extensions/opencode", "extensions/dsh", "extensions/openclaw"]) {
               const pkg = JSON.parse(fs.readFileSync(dir + "/package.json", "utf8"));
               const repo = pkg.repository || {};
               if (!String(repo.url || "").includes("vshulcz/deja-vu")) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- OpenClaw: `@vshulcz/openclaw-deja`, the recall plugin as a package — `openclaw plugins install clawhub:@vshulcz/openclaw-deja` — with `before_prompt_build` recall and `deja_recall`, `deja_fix`, `deja_blame` as tools; it reads what `deja install openclaw-auto` wrote and adds only what is missing. (#3047)
+
 ## [0.19.3] - 2026-09-04
 
 A release about the moment memory is worth most: the turn a command fails, the

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -100,6 +100,9 @@
 <p>The session log, per agent, and a session key to resume by. Its default backend is <code>claude-cli</code>, so a Claude Code hook already reaches it there; the other providers get nothing between sessions unless a plugin puts it in front of the model.</p>
 
 <h2>Adding recall</h2>
+<p>From ClawHub, without the deja CLI on hand:</p>
+<pre>openclaw plugins install clawhub:@vshulcz/openclaw-deja</pre>
+<p>The package brings the binary along, recalls before each turn and registers <code>deja_recall</code>, <code>deja_fix</code> and <code>deja_blame</code>. Or, with the CLI installed:</p>
 <pre>deja install openclaw-auto</pre>
 <p>Three things are written, and all three are reversible with <code>deja uninstall openclaw</code>:</p>
 <ul>

--- a/docs/registry/openclaw.html
+++ b/docs/registry/openclaw.html
@@ -64,6 +64,7 @@
 <p>against a 2026.8.2 store and openclaw source</p>
 <p>(<code>src/config/sessions/session-accessor.sqlite-*.ts</code>, <code>paths.ts</code>).</p>
 <ul>
+<li><strong>Plugin package</strong>: <code>openclaw plugins install clawhub:@vshulcz/openclaw-deja</code> (also on npm) — <code>before_prompt_build</code> recall plus <code>deja_recall</code>, <code>deja_fix</code>, <code>deja_blame</code>; stands down on whatever <code>deja install openclaw-auto</code> already wired.</li>
 <li><strong>MCP</strong>: <code>deja install openclaw</code> wires deja into <code>openclaw.json</code> under</li>
 </ul>
 <p><code>mcp.servers</code> (OpenClaw&#39;s own layout, not the common <code>mcpServers</code> root).</p>

--- a/docs/registry/openclaw.md
+++ b/docs/registry/openclaw.md
@@ -28,6 +28,7 @@ transcripts (`.deleted`/`.reset`/`.bak` suffixes) and the
 against a 2026.8.2 store and openclaw source
 (`src/config/sessions/session-accessor.sqlite-*.ts`, `paths.ts`).
 
+- **Plugin package**: `openclaw plugins install clawhub:@vshulcz/openclaw-deja` (also on npm) — `before_prompt_build` recall plus `deja_recall`, `deja_fix`, `deja_blame`; stands down on whatever `deja install openclaw-auto` already wired.
 - **MCP**: `deja install openclaw` wires deja into `openclaw.json` under
   `mcp.servers` (OpenClaw's own layout, not the common `mcpServers` root).
   Live-verified: `openclaw mcp probe deja` reports the tools and the agent

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -9,6 +9,7 @@ same local index.
 |---|---|---|
 | [`opencode/`](opencode) | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin --profile web add dsh-deja` |
+| [`openclaw/`](openclaw) | ClawHub and npm `@vshulcz/openclaw-deja` | `openclaw plugins install clawhub:@vshulcz/openclaw-deja` |
 | [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
 | [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
 | [`grok/`](grok) | Grok Build plugin `deja` | `grok plugin install deja` |
@@ -36,6 +37,7 @@ Publishing by hand is still possible when a fix should not wait for a release:
 ```
 cd extensions/opencode && npm publish --access public
 cd extensions/dsh      && npm publish --access public
+cd extensions/openclaw && npm publish --access public && clawhub package publish .
 ```
 
 The Grok plugin is published by a catalog entry, not by us: the entry in

--- a/extensions/openclaw/LICENSE
+++ b/extensions/openclaw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/openclaw/README.md
+++ b/extensions/openclaw/README.md
@@ -1,0 +1,64 @@
+# @vshulcz/openclaw-deja
+
+OpenClaw remembers its own sessions. This plugin answers the other question:
+what was done in the twenty-one other coding agents on this machine — Claude
+Code, Codex, Cursor, Gemini and Zed among them — including the months before
+OpenClaw was installed.
+
+It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that
+indexes the transcripts those agents already wrote to disk. No LLM, no
+embeddings, nothing leaves the machine.
+
+## Install
+
+```bash
+openclaw plugins install clawhub:@vshulcz/openclaw-deja
+```
+
+The deja binary comes with the package; a deja you installed yourself
+(`brew install deja-vu`) always wins — see [Which binary](#which-binary).
+
+`deja install openclaw-auto` wires OpenClaw too, and is the shorter path if you
+have the CLI: it adds deja's MCP server and writes a plugin of its own. Having
+both is fine: this package reads what the installer wrote and contributes only
+what is missing.
+
+## What it does
+
+- **Before each turn** (`before_prompt_build`): the prompt is matched against
+  the index and, when a past session answers it, that session goes in front of
+  the model. Silence is the common case.
+- **Tools**: `deja_recall` (search the history), `deja_fix` (what was run after
+  this error before), `deja_blame` (which sessions touched a file and what they
+  concluded).
+
+## Config
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "deja-vu": {
+        "enabled": true,
+        "config": { "autoRecall": true, "tools": true, "bin": "/opt/homebrew/bin/deja" }
+      }
+    }
+  }
+}
+```
+
+All three are optional. `autoRecall: false` keeps the tools and drops the
+per-turn recall; `tools: false` the reverse.
+
+## Which binary
+
+In order: `bin` from the config, `DEJA_BIN`, `deja` on `PATH`, the usual
+install locations, and last the copy bundled through `@vshulcz/deja-vu`.
+
+## Privacy
+
+deja reads session files where the agents wrote them and builds a local index
+under `~/.cache/deja` (or `DEJA_INDEX_DIR`). Keys and tokens are stripped as
+the index is built. Nothing is uploaded.
+
+Part of [deja-vu](https://github.com/vshulcz/deja-vu). MIT.

--- a/extensions/openclaw/index.mjs
+++ b/extensions/openclaw/index.mjs
@@ -1,0 +1,200 @@
+// deja-vu for OpenClaw: recall from the coding sessions already on this
+// machine before each turn, and three tools to ask the history directly.
+import { execFile } from "node:child_process"
+import { accessSync, constants, existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import {
+  argv,
+  configPath,
+  contributions,
+  installerPluginPath,
+  mcpWired,
+  promptText,
+  sessionKey,
+} from "./lib.mjs"
+
+const require = createRequire(import.meta.url)
+const run_ = promisify(execFile)
+
+const WINDOWS = process.platform === "win32"
+const PLATFORM = WINDOWS ? "windows" : process.platform
+const ARCH = process.arch === "x64" ? "amd64" : process.arch
+const EXE = WINDOWS ? "deja.exe" : "deja"
+
+const NOTHING = "Nothing in this machine's history matches that."
+const MISSING =
+  "deja is not installed on this machine, so there is no history to search. " +
+  "Install it with: brew install deja-vu (or: go install github.com/vshulcz/deja-vu/cmd/deja@latest)"
+
+// wellKnown lists the places a user's own install lands, for a gateway started
+// from a launcher whose PATH never sourced a shell profile.
+function wellKnown() {
+  const home = homedir()
+  if (WINDOWS) {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local")
+    return [join(local, "deja", "bin", EXE), join(home, ".local", "bin", EXE)]
+  }
+  return [join(home, ".local", "bin", EXE), "/usr/local/bin/deja", "/opt/homebrew/bin/deja", "/usr/bin/deja"]
+}
+
+// resolveDeja: what the user pointed at, then the deja they installed and keep
+// current, and only last the copy npm brought with this package — pinning
+// them to our bundled copy would freeze their memory at whatever version this
+// package was released against.
+function resolveDeja(setting) {
+  const candidates = [setting, process.env.DEJA_BIN, EXE, ...wellKnown()]
+  try {
+    candidates.push(require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${EXE}`))
+  } catch {}
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if (candidate.includes("/") || candidate.includes("\\")) {
+      try {
+        accessSync(candidate, constants.X_OK)
+      } catch {
+        continue
+      }
+    }
+    return candidate
+  }
+  return EXE
+}
+
+// deja is asked for text, never for control flow: memory is optional
+// everywhere, and a throw here would end someone's turn.
+async function run(bin, args, input, cwd, timeout = 20000) {
+  try {
+    const child = run_(bin, args, {
+      encoding: "utf8",
+      timeout,
+      cwd,
+      maxBuffer: 8 * 1024 * 1024,
+    })
+    if (input !== undefined) child.child.stdin.end(input)
+    const { stdout } = await child
+    return stdout.trim()
+  } catch {
+    return ""
+  }
+}
+
+// installerWiring reads what `deja install` left for OpenClaw: the MCP server
+// in openclaw.json and the plugin `--auto` writes. A read that fails means
+// "not wired": the worst case is doing the work twice, not skipping it.
+function installerWiring() {
+  const wiring = { mcp: false, recall: false }
+  try {
+    wiring.recall = existsSync(installerPluginPath(process.env, homedir()))
+  } catch {}
+  try {
+    const path = configPath(process.env, homedir())
+    if (existsSync(path)) wiring.mcp = mcpWired(readFileSync(path, "utf8"))
+  } catch {}
+  return wiring
+}
+
+const RECALL_SCHEMA = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Error text, identifier, command, or a short description of the problem. Several words are ANDed." },
+    limit: { type: "integer", description: "How many sessions to return. Default 5." },
+  },
+  required: ["query"],
+}
+const FIX_SCHEMA = {
+  type: "object",
+  properties: { error: { type: "string", description: "The failing output, copied as it was printed." } },
+  required: ["error"],
+}
+const BLAME_SCHEMA = {
+  type: "object",
+  properties: { path: { type: "string", description: "Path to the file, absolute or relative to the project." } },
+  required: ["path"],
+}
+
+function text(s) {
+  return { content: [{ type: "text", text: s }], details: {} }
+}
+
+export default {
+  id: "deja-vu",
+  name: "deja-vu",
+  description: "Memory from the coding sessions already on this machine",
+  register(api) {
+    const config = (api && api.pluginConfig) || {}
+    const bin = resolveDeja(config.bin)
+    const adds = contributions(installerWiring(), config)
+    let installed = true
+
+    const ask = async (args, input, timeout) => {
+      const out = await run(bin, args, input, process.cwd(), timeout)
+      return out
+    }
+    const answer = (out) => text(out || (installed ? NOTHING : MISSING))
+
+    if (adds.tools) {
+      api.registerTool({
+        name: "deja_recall",
+        description:
+          "Search this machine's own past AI coding sessions — every agent used on it, including months before deja was installed. Use before debugging an error or re-implementing something that may already exist, and whenever the user implies the work happened before.",
+        parameters: RECALL_SCHEMA,
+        async execute(_id, params) {
+          const limit = String(Math.min(Math.max(Number(params.limit) || 5, 1), 20))
+          return answer(await ask(argv("search", ["--limit", limit], params.query), undefined, 120000))
+        },
+      })
+      api.registerTool({
+        name: "deja_fix",
+        description:
+          "What this machine ran after that same error before, in the sessions where the error did not come back. Paste the failing output verbatim rather than a paraphrase.",
+        parameters: FIX_SCHEMA,
+        async execute(_id, params) {
+          return answer(await ask(argv("fix", [], params.error), undefined, 120000))
+        },
+      })
+      api.registerTool({
+        name: "deja_blame",
+        description:
+          "The past sessions that discussed a file, so you know why it is shaped the way it is before editing, refactoring or deleting it. Session history, not git authorship.",
+        parameters: BLAME_SCHEMA,
+        async execute(_id, params) {
+          return answer(await ask(argv("blame", [], params.path), undefined, 120000))
+        },
+      })
+    }
+
+    if (adds.recall) {
+      api.on(
+        "before_prompt_build",
+        async (event, ctx) => {
+          const prompt = promptText(event)
+          if (!prompt) return
+          const key = sessionKey(event, ctx)
+          const recall = await ask(
+            ["hook-prompt", "--plain"],
+            JSON.stringify({ prompt, session_id: key, cwd: process.cwd() }),
+            10000,
+          )
+          // Silence is the common case — the hook speaks only when the user's
+          // own history answers what they just asked.
+          if (!recall) return
+          return { prependContext: recall }
+        },
+        { timeoutMs: 15000 },
+      )
+    }
+
+    // A missing binary is reported once, through the host, not on every turn.
+    run(bin, ["--version"]).then((v) => {
+      if (v) return
+      installed = false
+      try {
+        api.logger && api.logger.warn && api.logger.warn("deja-vu: " + MISSING)
+      } catch {}
+    })
+  },
+}

--- a/extensions/openclaw/lib.mjs
+++ b/extensions/openclaw/lib.mjs
@@ -1,0 +1,112 @@
+import { join } from "node:path"
+
+// The pure half of the plugin: everything that reads deja's output or decides
+// what this package adds, with no process and no host. Kept apart from
+// index.mjs so it can be tested without OpenClaw.
+
+// installerPluginPath is where `deja install openclaw-auto` writes its own
+// plugin. OpenClaw loads that directory and this package side by side, and
+// both would push recall in front of the model, so whoever finds the other
+// stands down on recall. Mirrors OpenClawStateDir() in the installer:
+// OPENCLAW_STATE_DIR wins, else ~/.openclaw.
+export function installerPluginPath(env, home) {
+  const base = (env && env.OPENCLAW_STATE_DIR) || join(home || "", ".openclaw")
+  return join(base, "extensions", "deja", "index.mjs")
+}
+
+// configPath is OpenClaw's config, where `deja install openclaw` registers the
+// MCP server.
+export function configPath(env, home) {
+  const base = (env && env.OPENCLAW_STATE_DIR) || join(home || "", ".openclaw")
+  return join(base, "openclaw.json")
+}
+
+// mcpWired reports whether that config already runs deja as an MCP server.
+// The tools this package registers do the same things, so when the server is
+// there they are a second copy in the model's tool list. The file may be
+// JSONC; a config this cannot read is treated as not wired — losing the tools
+// on a file we misread is worse than listing them twice.
+export function mcpWired(text) {
+  try {
+    const config = JSON.parse(stripJSONComments(String(text || "")))
+    const servers = config && config.mcp && config.mcp.servers
+    return Boolean(servers && servers.deja)
+  } catch {
+    return false
+  }
+}
+
+// stripJSONComments removes // and /* */ outside strings.
+export function stripJSONComments(text) {
+  let out = ""
+  let inString = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (inString) {
+      out += c
+      if (c === "\\") {
+        out += text[++i] || ""
+      } else if (c === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (c === '"') {
+      inString = true
+      out += c
+      continue
+    }
+    if (c === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i++
+      out += "\n"
+      continue
+    }
+    if (c === "/" && text[i + 1] === "*") {
+      i += 2
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++
+      i++
+      continue
+    }
+    out += c
+  }
+  return out
+}
+
+// contributions decides what this package adds, given what `deja install`
+// already wired and what the user turned off in the plugin config: fill the
+// gaps, never repeat the installer.
+export function contributions(wiring, config = {}) {
+  const wired = wiring || {}
+  return {
+    tools: config.tools !== false && !wired.mcp,
+    recall: config.autoRecall !== false && !wired.recall,
+  }
+}
+
+// argv builds the call for a query somebody typed. A query that starts with a
+// dash is read by deja as a flag and the call fails, which run() turns into
+// "nothing in the history" — a wrong answer where an error would at least be
+// visible. `--` ends the flags; sent only when the query needs it.
+export function argv(cmd, flags, text) {
+  const arg = String(text)
+  return arg.startsWith("-") ? [cmd, ...flags, "--", arg] : [cmd, ...flags, arg]
+}
+
+// promptText is what the person typed on this turn, from the shapes OpenClaw
+// hands before_prompt_build. Empty when there is nothing to rank against.
+export function promptText(event) {
+  const p = event && event.prompt
+  if (typeof p === "string") return p.trim()
+  if (Array.isArray(p)) return p.filter((x) => typeof x === "string").join("\n").trim()
+  return ""
+}
+
+// sessionKey is what recall dedups on: a hit shown once in a session is not
+// shown again. Without a key every turn could repeat the same session.
+export function sessionKey(event, ctx) {
+  return (
+    (ctx && (ctx.sessionKey || ctx.sessionId)) ||
+    (event && (event.sessionId || event.session_id || (event.session && event.session.id))) ||
+    ""
+  )
+}

--- a/extensions/openclaw/openclaw.plugin.json
+++ b/extensions/openclaw/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "deja-vu",
+  "name": "deja-vu",
+  "description": "Memory from the coding sessions already on this machine — recalled before each turn, searchable as tools",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["deja_recall", "deja_fix", "deja_blame"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "bin": {
+        "type": "string",
+        "description": "Path to the deja binary. Default: the deja on PATH, then the copy bundled with this package."
+      },
+      "autoRecall": {
+        "type": "boolean",
+        "description": "Put relevant history in front of the model before each turn. Default true."
+      },
+      "tools": {
+        "type": "boolean",
+        "description": "Register deja_recall, deja_fix and deja_blame. Default true."
+      }
+    }
+  }
+}

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vshulcz/openclaw-deja",
   "version": "0.19.3",
-  "description": "deja-vu memory for OpenClaw: the coding sessions already on this machine — OpenClaw, Claude Code, Codex, Cursor and 18 more — recalled before each turn and searchable as tools. A local index, no LLM.",
+  "description": "deja-vu memory for OpenClaw: the coding sessions already on this machine \u2014 OpenClaw, Claude Code, Codex, Cursor and 18 more \u2014 recalled before each turn and searchable as tools. A local index, no LLM.",
   "type": "module",
   "main": "index.mjs",
   "files": [
@@ -39,10 +39,16 @@
     "openclaw": ">=2026.7.1"
   },
   "openclaw": {
-    "extensions": ["./index.mjs"],
+    "extensions": [
+      "./index.mjs"
+    ],
     "compat": {
       "pluginApi": ">=2026.7.1",
       "minGatewayVersion": "2026.7.1"
+    },
+    "build": {
+      "openclawVersion": "2026.7.1",
+      "pluginSdkVersion": "2026.7.1"
     }
   },
   "scripts": {

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@vshulcz/openclaw-deja",
+  "version": "0.19.3",
+  "description": "deja-vu memory for OpenClaw: the coding sessions already on this machine — OpenClaw, Claude Code, Codex, Cursor and 18 more — recalled before each turn and searchable as tools. A local index, no LLM.",
+  "type": "module",
+  "main": "index.mjs",
+  "files": [
+    "index.mjs",
+    "lib.mjs",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vshulcz/deja-vu.git",
+    "directory": "extensions/openclaw"
+  },
+  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/openclaw",
+  "bugs": {
+    "url": "https://github.com/vshulcz/deja-vu/issues"
+  },
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "memory",
+    "recall",
+    "session-history",
+    "agent"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@vshulcz/deja-vu": "^0.19.0"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.7.1"
+  },
+  "openclaw": {
+    "extensions": ["./index.mjs"],
+    "compat": {
+      "pluginApi": ">=2026.7.1",
+      "minGatewayVersion": "2026.7.1"
+    }
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/extensions/openclaw/test/pure.test.mjs
+++ b/extensions/openclaw/test/pure.test.mjs
@@ -1,0 +1,35 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { argv, configPath, contributions, installerPluginPath, mcpWired, promptText, sessionKey } from "../lib.mjs"
+
+test("a query that starts with a dash gets the flag terminator", () => {
+  assert.deepEqual(argv("search", ["--limit", "5"], "--json"), ["search", "--limit", "5", "--", "--json"])
+  assert.deepEqual(argv("search", ["--limit", "5"], "pgbouncer"), ["search", "--limit", "5", "pgbouncer"])
+})
+
+test("the installer's plugin and config are looked for where the installer writes them", () => {
+  assert.equal(installerPluginPath({}, "/home/u"), "/home/u/.openclaw/extensions/deja/index.mjs")
+  assert.equal(installerPluginPath({ OPENCLAW_STATE_DIR: "/srv/oc" }, "/home/u"), "/srv/oc/extensions/deja/index.mjs")
+  assert.equal(configPath({}, "/home/u"), "/home/u/.openclaw/openclaw.json")
+})
+
+test("an MCP server the installer wrote means the tools are already there", () => {
+  assert.equal(mcpWired('{"mcp":{"servers":{"deja":{"command":"deja","args":["mcp"]}}}}'), true)
+  assert.equal(mcpWired('// comment\n{"mcp":{"servers":{"other":{}}}}'), false)
+  assert.equal(mcpWired("not json"), false)
+})
+
+test("contributions fill the gaps and never repeat the installer", () => {
+  assert.deepEqual(contributions({ mcp: false, recall: false }), { tools: true, recall: true })
+  assert.deepEqual(contributions({ mcp: true, recall: true }), { tools: false, recall: false })
+  assert.deepEqual(contributions({ mcp: false, recall: false }, { autoRecall: false }), { tools: true, recall: false })
+})
+
+test("the prompt and session key are read from the shapes the host sends", () => {
+  assert.equal(promptText({ prompt: "  fix the pool  " }), "fix the pool")
+  assert.equal(promptText({ prompt: ["a", "b"] }), "a\nb")
+  assert.equal(promptText({}), "")
+  assert.equal(sessionKey({ sessionId: "e1" }, { sessionKey: "c1" }), "c1")
+  assert.equal(sessionKey({ session: { id: "e2" } }, {}), "e2")
+  assert.equal(sessionKey({}, {}), "")
+})

--- a/scripts/extension-drift.mjs
+++ b/scripts/extension-drift.mjs
@@ -17,7 +17,7 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 
-export const PACKAGES = ["extensions/opencode", "extensions/dsh"];
+export const PACKAGES = ["extensions/opencode", "extensions/dsh", "extensions/openclaw"];
 
 // npmLatest is the version npm serves as `latest`, or "" when the package has
 // never been published or npm cannot be reached. Unreachable is not drift: a

--- a/scripts/extension_drift_test.mjs
+++ b/scripts/extension_drift_test.mjs
@@ -8,6 +8,7 @@ import { PACKAGES, compareVersions, stranded } from "./extension-drift.mjs";
 const names = {
   "extensions/opencode": { name: "opencode-deja" },
   "extensions/dsh": { name: "dsh-deja" },
+  "extensions/openclaw": { name: "@vshulcz/openclaw-deja" },
 };
 const readPkg = (dir) => names[dir];
 
@@ -34,9 +35,9 @@ test("what cannot be answered is not drift", () => {
   assert.deepEqual(stranded(PACKAGES, readPkg, () => "0.99.0", ""), []);
 });
 
-test("both packages are reported when both are stranded", () => {
+test("every package is reported when all are stranded", () => {
   const bad = stranded(PACKAGES, readPkg, () => "0.21.0", "0.19.2");
-  assert.deepEqual(bad.map((p) => p.name).sort(), ["dsh-deja", "opencode-deja"]);
+  assert.deepEqual(bad.map((p) => p.name).sort(), ["@vshulcz/openclaw-deja", "dsh-deja", "opencode-deja"]);
 });
 
 test("versions order by number", () => {

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -73,7 +73,7 @@ run("npm publish --access public", mainDir);
 // independently before this, so a release whose version is behind what npm
 // already has would move the `latest` tag backwards: skip those and say so,
 // and the lines converge on their own as soon as deja passes them.
-const extensions = ["opencode", "dsh"];
+const extensions = ["opencode", "dsh", "openclaw"];
 const published = [];
 for (const name of extensions) {
   const dir = path.join("extensions", name);

--- a/scripts/release_npm_test.mjs
+++ b/scripts/release_npm_test.mjs
@@ -38,7 +38,7 @@ test("the extension packages are published from the release version", () => {
   // plugin that ships the wrong binary as its fallback.
   assert.match(source, /outPkg\.version = version/);
   assert.match(source, /outPkg\.dependencies\["@vshulcz\/deja-vu"\] = `\^\$\{version\}`/);
-  assert.match(source, /const extensions = \["opencode", "dsh"\]/);
+  assert.match(source, /const extensions = \["opencode", "dsh", "openclaw"\]/);
 });
 
 test("a release behind npm skips instead of moving latest backwards", () => {


### PR DESCRIPTION
`extensions/openclaw/` — the OpenClaw plugin `deja install openclaw-auto` generates, as a package with a manifest, so `openclaw plugins install clawhub:@vshulcz/openclaw-deja` (and `npm:`) resolve it and ClawHub can list it. Same shape as the opencode package: `before_prompt_build` recall via `hook-prompt --plain`, tools `deja_recall` / `deja_fix` / `deja_blame` declared in `contracts.tools`, binary resolved in the order config → `DEJA_BIN` → PATH → usual install dirs → the copy bundled through `@vshulcz/deja-vu`. It reads what the installer wrote (`~/.openclaw/extensions/deja`, the MCP server in `openclaw.json`) and contributes only what is missing, so having both never doubles the recall or the tools.

Checked on OpenClaw 2026.7.1-2: `openclaw plugins install ./extensions/openclaw` loads it (status `loaded`, hook registered; tools skipped on this machine because the installer's MCP server is already in the config), and with an empty state dir `register()` hands the host all three tools and the hook; `deja_fix`, `deja_recall` with a flag-shaped query and the hook return real answers from the binary.

Release: `scripts/release-npm.mjs` publishes it with the other harness packages; the ClawHub release is `clawhub package publish extensions/openclaw` after that. CI gets an `openclaw-deja` job (parse, manifest-declares-every-tool, tests).

Closes #3047