### PR TITLE
feat(antigravity): answer the question, not just open with the digest

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -10,12 +10,18 @@ import (
 )
 
 // Antigravity's PreInvocation hook runs before every model call and injects
-// whatever steps the hook prints. That is one call per turn, not per session,
-// so the digest goes in on the first invocation only — invocationNum tells us
-// which one we are on.
+// whatever steps the hook prints. It is the only place a hook can speak here:
+// PreToolUse fires but its reason never reaches the model, and PostToolUse must
+// answer with an empty object (checked on antigravity-cli 1.1.13). So this one
+// event carries both channels — the digest on the first invocation, and the
+// question's own answer on the ones after it.
 type antigravityHookInput struct {
 	InvocationNum  int      `json:"invocationNum"`
 	WorkspacePaths []string `json:"workspacePaths"`
+	// The transcript is where the question lives: antigravity has no
+	// per-prompt event, so the newest user turn is read from here.
+	TranscriptPath string `json:"transcriptPath"`
+	ConversationID string `json:"conversationId"`
 }
 
 type antigravityInjectStep struct {
@@ -32,12 +38,10 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	// close the pipe, which cost 20 s per turn on a host that holds it (#846).
 	payload := readHookPayload(stdin, hookStdinWait)
 	decoded := json.Unmarshal(payload, &input) == nil && len(payload) > 0
-	// invocationNum is 1-based; anything past the first turn already has the
-	// digest in its transcript. A payload deja could not read leaves it at 0,
-	// which reads as the first turn — so bounding the read without this would
-	// turn "blocks once per turn" into "injects the whole digest before every
-	// model call" (#846).
-	if !decoded || input.InvocationNum > 1 {
+	// A payload deja could not read leaves invocationNum at 0, which reads as
+	// the first call — so bounding the read without this would turn "once per
+	// turn" into "before every model call" (#846).
+	if !decoded {
 		fmt.Fprintln(stdout, "{}")
 		return nil
 	}
@@ -48,6 +52,35 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if len(input.WorkspacePaths) > 0 {
 		workspace = input.WorkspacePaths[0]
 	}
+	// Past the first invocation the digest is already in the transcript, and
+	// the harness has no per-prompt event of its own — so this is where the
+	// question gets answered. Silence is the usual result, and the prompt
+	// path's dedupe keeps an answer to one per question rather than one per
+	// model call.
+	//
+	// The count starts at zero and restarts on every turn (measured on
+	// antigravity-cli 1.1.13: one two-turn conversation ran 0..21 and then 0
+	// again). Reading it as 1-based put the digest in twice per turn, and
+	// reading it as per-conversation put it in again on every turn of a
+	// continued one — so the conversation's own ledger decides, and the
+	// counter only says which call inside the turn we are on.
+	if input.InvocationNum > 0 || digestAlreadyInjected(dir, input.ConversationID) {
+		block := antigravityPromptBlock(dir, latestUserRequest(input.TranscriptPath),
+			input.ConversationID, workspace)
+		if block == "" {
+			fmt.Fprintln(stdout, "{}")
+			return nil
+		}
+		b, err := json.Marshal(antigravityHookResponse{
+			InjectSteps: []antigravityInjectStep{{EphemeralMessage: block}},
+		})
+		if err != nil {
+			fmt.Fprintln(stdout, "{}")
+			return nil
+		}
+		fmt.Fprintln(stdout, string(b))
+		return nil
+	}
 	// The payload, and nothing written back into the environment: deja used to
 	// export the workspace here, which carried this call's project into the
 	// next one in the same process and decided nothing else (#2185).
@@ -57,6 +90,7 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 		return nil
 	}
 	digest = frameRecall(startLead(antigravityLead) + digest)
+	rememberDigestInjected(dir, input.ConversationID)
 	usage.RecordDigestPolicySessionsFrom(dir, usage.KindHook, digest, "", sessions, raw,
 		policy.Load().Describe(policy.ActivationAuto), ids, projects)
 	b, err := json.Marshal(antigravityHookResponse{

--- a/cmd/deja/hook_antigravity_prompt.go
+++ b/cmd/deja/hook_antigravity_prompt.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// Antigravity has no per-prompt event. PreInvocation is the only place a hook
+// can speak, and it fires before every model call — several times inside one
+// user turn — so deja answered on the first invocation and then stayed silent
+// for the rest of the conversation. Everything after the opening question got
+// nothing, which is most of a session.
+//
+// The question is in the transcript the payload names: antigravity writes each
+// turn as a step, and a user turn is a USER_INPUT step wrapping the text in
+// <USER_REQUEST>. Reading the newest one turns PreInvocation into the
+// per-prompt channel the harness does not offer, and the prompt hook's own
+// dedupe keeps it to one answer per question rather than one per model call.
+const (
+	// antigravityTranscriptTail bounds the read. This runs before every model
+	// call, and the newest turn is at the end of the file — a conversation's
+	// transcript grows all day and no part of this needs its beginning.
+	antigravityTranscriptTail = 128 << 10
+	userRequestOpen           = "<USER_REQUEST>"
+	userRequestClose          = "</USER_REQUEST>"
+)
+
+// latestUserRequest returns the newest user turn in an antigravity transcript,
+// or "" when the file holds none it can read.
+func latestUserRequest(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	fi, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	size := fi.Size()
+	offset := int64(0)
+	if size > antigravityTranscriptTail {
+		offset = size - antigravityTranscriptTail
+	}
+	buf := make([]byte, size-offset)
+	if _, err := f.ReadAt(buf, offset); err != nil {
+		return ""
+	}
+	lines := strings.Split(string(buf), "\n")
+	// Newest first, and a partial first line from the tail cut simply fails to
+	// decode — which is the right answer for it.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		var step struct {
+			Type    string `json:"type"`
+			Content string `json:"content"`
+		}
+		if json.Unmarshal([]byte(line), &step) != nil || step.Type != "USER_INPUT" {
+			continue
+		}
+		if q := userRequestText(step.Content); q != "" {
+			return q
+		}
+	}
+	return ""
+}
+
+// userRequestText pulls the person's words out of the step antigravity writes,
+// which wraps them in a tag and appends metadata blocks of its own.
+func userRequestText(content string) string {
+	open := strings.Index(content, userRequestOpen)
+	if open < 0 {
+		return strings.TrimSpace(content)
+	}
+	rest := content[open+len(userRequestOpen):]
+	if close := strings.Index(rest, userRequestClose); close >= 0 {
+		rest = rest[:close]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// antigravityPromptBlock is what the per-prompt path would inject for this
+// question, or "" for the silence that is its usual answer. It drives the
+// ordinary prompt hook rather than reimplementing the ranking: the budget, the
+// dedupe and the kill switch are the ones every other harness gets.
+func antigravityPromptBlock(dir, question, conversationID, workspace string) string {
+	if strings.TrimSpace(question) == "" {
+		return ""
+	}
+	payload, err := json.Marshal(map[string]string{
+		"prompt":     question,
+		"session_id": conversationID,
+		"cwd":        workspace,
+	})
+	if err != nil {
+		return ""
+	}
+	var out bytes.Buffer
+	if err := runHookPromptMode(dir, bytes.NewReader(payload), &out, false); err != nil {
+		return ""
+	}
+	var resp sessionStartHookResponse
+	if json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp) != nil {
+		return ""
+	}
+	return resp.HookSpecificOutput.AdditionalContext
+}
+
+// digestAlreadyInjected reports whether this conversation has had the project
+// digest. Antigravity's invocation counter restarts every turn, so without a
+// record of its own the digest would go in again on every turn of a long
+// conversation.
+func digestAlreadyInjected(dir, conversationID string) bool {
+	if strings.TrimSpace(conversationID) == "" {
+		return false
+	}
+	return alreadyInjected(dir, antigravityDigestKey(conversationID))[antigravityDigestToken]
+}
+
+func rememberDigestInjected(dir, conversationID string) {
+	if strings.TrimSpace(conversationID) == "" {
+		return
+	}
+	rememberInjectedIDs(dir, antigravityDigestKey(conversationID), antigravityDigestToken)
+}
+
+func antigravityDigestKey(conversationID string) string {
+	return "agy:" + conversationID
+}
+
+// antigravityDigestToken is what the ledger row says: this conversation has
+// been handed the digest.
+const antigravityDigestToken = "agy-digest"

--- a/cmd/deja/hook_antigravity_prompt_test.go
+++ b/cmd/deja/hook_antigravity_prompt_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Antigravity writes each turn into a transcript and hands the hook its path.
+// That file is where the question is: the harness has no per-prompt event, so
+// without reading it deja can only ever speak once per conversation.
+func TestTheNewestQuestionIsReadFromTheTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	lines := []string{
+		`{"step_index":0,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nthe first question about the toolbar\n</USER_REQUEST>\n"}`,
+		`{"step_index":1,"type":"GENERIC","status":"DONE","content":"Created At: whenever"}`,
+		`{"step_index":2,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nwhy does the frobnicator stall\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nlocal time\n</ADDITIONAL_METADATA>\n"}`,
+		`{"step_index":3,"type":"EPHEMERAL_MESSAGE","status":"DONE","content":"a block deja injected"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := latestUserRequest(path); got != "why does the frobnicator stall" {
+		t.Errorf("latest question = %q", got)
+	}
+	// The metadata antigravity appends is not the person's words.
+	if strings.Contains(latestUserRequest(path), "ADDITIONAL_METADATA") {
+		t.Error("the harness's own metadata came back as part of the question")
+	}
+	// A file that holds no user turn, and one that is not there at all, are
+	// both answered with silence rather than with a guess.
+	empty := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(empty, []byte(`{"step_index":0,"type":"GENERIC","content":"x"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := latestUserRequest(empty); got != "" {
+		t.Errorf("a transcript with no question answered %q", got)
+	}
+	if got := latestUserRequest(filepath.Join(dir, "missing.jsonl")); got != "" {
+		t.Errorf("a missing transcript answered %q", got)
+	}
+}
+
+// The counter antigravity sends starts at zero and restarts on every turn
+// (measured on antigravity-cli 1.1.13). Read as 1-based it put the digest in
+// twice per turn, and read as per-conversation it put it in again on every turn
+// — so the conversation's own ledger is what decides.
+func TestTheDigestLandsOncePerConversation(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	const conv = "conv-42"
+	if digestAlreadyInjected(dir, conv) {
+		t.Fatal("a fresh conversation already counts as served")
+	}
+	rememberDigestInjected(dir, conv)
+	if !digestAlreadyInjected(dir, conv) {
+		t.Error("the digest was not recorded, so the next turn sends it again")
+	}
+	// Another conversation is another reader.
+	if digestAlreadyInjected(dir, "conv-43") {
+		t.Error("one conversation's digest counted for another")
+	}
+	// A payload with no conversation id must not silence the digest for
+	// everyone: no id, no record.
+	rememberDigestInjected(dir, "")
+	if digestAlreadyInjected(dir, "") {
+		t.Error("an empty conversation id was recorded")
+	}
+}
+
+// The whole point of reading the transcript: the second call of a turn answers
+// the question rather than repeating the digest.
+func TestTheSecondCallAnswersTheQuestion(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "app", "sess-old",
+		"why does the frobnicator stall on startup",
+		"it stalled because ZORBWAX_LIMIT was unset; exporting ZORBWAX_LIMIT=4 cleared it")
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	transcript := filepath.Join(tmp, "transcript.jsonl")
+	line := `{"step_index":0,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nwhy does the frobnicator stall on startup\n</USER_REQUEST>\n"}`
+	if err := os.WriteFile(transcript, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := map[string]any{
+		"invocationNum":  1,
+		"conversationId": "conv-1",
+		"transcriptPath": transcript,
+		"workspacePaths": []string{filepath.Join(os.TempDir(), "app")},
+	}
+	b, _ := json.Marshal(payload)
+	var out bytes.Buffer
+	if err := runHookAntigravity(dir, bytes.NewReader(b), &out); err != nil {
+		t.Fatal(err)
+	}
+	var resp antigravityHookResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+		t.Fatalf("the hook did not answer with JSON: %q", out.String())
+	}
+	if len(resp.InjectSteps) == 0 {
+		t.Fatalf("the question went unanswered on the call after the digest: %q", out.String())
+	}
+	block := resp.InjectSteps[0].EphemeralMessage
+	if !strings.Contains(block, "frobnicator") {
+		t.Errorf("the block does not carry the answer: %q", block)
+	}
+	// And it is the question's own answer rather than the project digest
+	// again — the digest carries this session too, so asserting on the text
+	// alone would pass with the once-per-conversation behaviour this replaces.
+	if strings.Contains(block, antigravityLead) {
+		t.Errorf("the call after the digest was handed the digest again: %q", block)
+	}
+}

--- a/cmd/deja/hook_antigravity_stdin_test.go
+++ b/cmd/deja/hook_antigravity_stdin_test.go
@@ -62,8 +62,10 @@ func TestHookAntigravityBoundsStdinWithoutInjectingOnEveryTurn(t *testing.T) {
 	}{
 		{"unreadable payload", "not json at all", false},
 		{"empty payload", "", false},
-		{"seventh turn", `{"invocationNum":7}`, false},
-		{"first turn", `{"invocationNum":1}`, true},
+		{"seventh call", `{"invocationNum":7}`, false},
+		// Zero is the first call, not one: the harness counts from there and
+		// restarts every turn (measured on antigravity-cli 1.1.13).
+		{"first call", `{"invocationNum":0}`, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer

--- a/cmd/deja/install_antigravity_test.go
+++ b/cmd/deja/install_antigravity_test.go
@@ -80,7 +80,7 @@ func TestHookAntigravityInjectsOnlyOnFirstInvocation(t *testing.T) {
 	}
 	// No index: still valid JSON, never a bare error the host would choke on.
 	out.Reset()
-	if err := runHookAntigravity(dir, strings.NewReader(`{"invocationNum":1}`), &out); err != nil {
+	if err := runHookAntigravity(dir, strings.NewReader(`{"invocationNum":0}`), &out); err != nil {
 		t.Fatalf("hook: %v", err)
 	}
 	var resp antigravityHookResponse
@@ -126,7 +126,7 @@ func TestHookAntigravityScopesToWorkspacePath(t *testing.T) {
 	// Marshalled rather than pasted: a Windows path is full of backslashes,
 	// and hand-built JSON turns them into escape sequences the decoder refuses
 	// — the payload then names no workspace and the recall comes back empty.
-	payload, err := json.Marshal(map[string]any{"invocationNum": 1, "workspacePaths": []string{beta}})
+	payload, err := json.Marshal(map[string]any{"invocationNum": 0, "workspacePaths": []string{beta}})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Measured on antigravity-cli 1.1.13, against a scratch customization root and a seeded store.

The harness offers five hook events — `PreToolUse`, `PostToolUse`, `PreInvocation`, `PostInvocation`, `Stop` — and only one of them can put anything in front of the model. `PreToolUse` fires but its `reason` never reaches the model, and `PostToolUse` must answer with an empty object. So `PreInvocation` carries both channels or there is only one.

Two things were wrong with how deja used it.

**The counter is zero-based and restarts every turn.** deja read it as 1-based and as if it ran for the life of the conversation, so `invocationNum` 0 and 1 both took the digest branch. Measured over one two-turn conversation: the counter ran 0..21 and then 0 again, and the same 1029-byte digest went in on all four calls of a two-turn probe — 4116 bytes of duplicate context. The conversation now has a ledger row of its own, and the counter only says which call inside the turn we are on.

**The question was never answered.** With no per-prompt event, deja spoke once and then stayed silent for the rest of the conversation. The payload names a transcript, and antigravity writes each user turn into it as a `USER_INPUT` step wrapping the text in `<USER_REQUEST>`; reading the newest one turns `PreInvocation` into the per-prompt channel. It drives the ordinary prompt hook rather than reimplementing anything, so the budget, the dedupe and the kill switch are the ones every other harness gets.

Before and after, same stand, two turns of one conversation:

    before   digest 1029 B | digest 1029 B | digest 1029 B | digest 1029 B
    after    digest 1029 B | answer  846 B | silent        | silent

End to end on a real run: asked "why does the frobnicator stall on startup", the model answered with `ZORBWAX_LIMIT`, which exists only in the seeded history, and closed with its own "deja-vu recalled … reusing it" line.

Cost per call on that store: 9 ms for the digest, 17 ms for the question when it answers, 16 ms when it does not — against a budget of 132 ms and 1.9 KB per prompt. Fewer bytes overall than before, since the digest is no longer sent twice a turn.