### PR TITLE
fix(antigravity): recall the project when the payload names no workspace

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -52,6 +52,9 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if len(input.WorkspacePaths) > 0 {
 		workspace = input.WorkspacePaths[0]
 	}
+	if workspace == "" {
+		workspace = workspaceFromConversation(input.TranscriptPath, input.ConversationID)
+	}
 	// Past the first invocation the digest is already in the transcript, and
 	// the harness has no per-prompt event of its own — so this is where the
 	// question gets answered. Silence is the usual result, and the prompt

--- a/cmd/deja/hook_antigravity_prompt.go
+++ b/cmd/deja/hook_antigravity_prompt.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -139,3 +140,44 @@ func antigravityDigestKey(conversationID string) string {
 // antigravityDigestToken is what the ledger row says: this conversation has
 // been handed the digest.
 const antigravityDigestToken = "agy-digest"
+
+// workspaceFromConversation is where this conversation was started. The CLI
+// leaves workspacePaths empty unless it was given --add-dir (measured on
+// antigravity-cli 1.1.13: an ordinary `agy -p` inside a project sends []), and
+// the hook's own working directory is the plugin folder — so without this the
+// digest is scoped to a directory nobody works in and recalls the wrong
+// project's history, or none.
+//
+// Antigravity keeps the answer beside the transcript: a cache mapping each
+// directory to the conversation it last opened there. The payload names the
+// conversation, so the map is read backwards.
+func workspaceFromConversation(transcriptPath, conversationID string) string {
+	if strings.TrimSpace(transcriptPath) == "" || strings.TrimSpace(conversationID) == "" {
+		return ""
+	}
+	// <product root>/brain/<conversation>/.system_generated/logs/transcript.jsonl
+	root := transcriptPath
+	for range 5 {
+		root = filepath.Dir(root)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "cache", "last_conversations.json"))
+	if err != nil {
+		return ""
+	}
+	var byDir map[string]string
+	if json.Unmarshal(b, &byDir) != nil {
+		return ""
+	}
+	// The longest match, so a conversation opened in a subdirectory is filed
+	// under that subdirectory rather than under its parent.
+	best := ""
+	for dir, conv := range byDir {
+		if conv != conversationID {
+			continue
+		}
+		if len(dir) > len(best) {
+			best = dir
+		}
+	}
+	return best
+}

--- a/cmd/deja/hook_antigravity_workspace_test.go
+++ b/cmd/deja/hook_antigravity_workspace_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An ordinary `agy -p` inside a project sends no workspace at all, and the hook
+// runs with its working directory set to the plugin folder — so without another
+// source the digest is scoped to a directory nobody works in. Antigravity keeps
+// the answer beside the transcript: a cache of which conversation each
+// directory last opened.
+func TestTheWorkspaceIsFoundWhenThePayloadOmitsIt(t *testing.T) {
+	root := t.TempDir()
+	product := filepath.Join(root, "antigravity-cli")
+	transcript := filepath.Join(product, "brain", "conv-7", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(product, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	byDir := map[string]string{
+		"/Users/probe/app":       "conv-7",
+		"/Users/probe/app/inner": "conv-7",
+		"/Users/probe/other":     "conv-9",
+	}
+	b, err := json.Marshal(byDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The deepest directory that opened this conversation, so a session
+	// started in a subdirectory is not filed under its parent. Asked twenty
+	// times, because a map is walked in no particular order and "whichever
+	// came first" would pass a single call about half the time.
+	for i := 0; i < 20; i++ {
+		if got := workspaceFromConversation(transcript, "conv-7"); got != "/Users/probe/app/inner" {
+			t.Fatalf("workspace = %q on attempt %d", got, i+1)
+		}
+	}
+	// Another conversation is another directory.
+	if got := workspaceFromConversation(transcript, "conv-9"); got != "/Users/probe/other" {
+		t.Errorf("workspace for the other conversation = %q", got)
+	}
+	// And what it cannot answer it leaves empty rather than guessing.
+	if got := workspaceFromConversation(transcript, "conv-none"); got != "" {
+		t.Errorf("an unknown conversation resolved to %q", got)
+	}
+	if got := workspaceFromConversation("", "conv-7"); got != "" {
+		t.Errorf("no transcript path resolved to %q", got)
+	}
+	if got := workspaceFromConversation(filepath.Join(root, "nope", "brain", "c", "a", "b", "t.jsonl"), "conv-7"); got != "" {
+		t.Errorf("a missing cache resolved to %q", got)
+	}
+}
+
+// And the hook uses it: a payload with no workspace must still recall the
+// project the conversation belongs to, not the plugin directory it happens to
+// run in.
+func TestTheHookRecallsTheProjectWhenThePayloadOmitsIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "wsapp", "sess-ws",
+		"why does the widget loader stall", "it stalled until zorbwaxneedle was set")
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	product := filepath.Join(tmp, "antigravity-cli")
+	transcript := filepath.Join(product, "brain", "conv-ws", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(product, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// seedClaude files its sessions under /tmp/<project>, which is the path
+	// the conversation cache has to name for the two to meet.
+	project := filepath.Join(os.TempDir(), "wsapp")
+	b, err := json.Marshal(map[string]string{project: "conv-ws"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"invocationNum":  0,
+		"conversationId": "conv-ws",
+		"transcriptPath": transcript,
+		"workspacePaths": []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runHookAntigravity(dir, bytes.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "zorbwaxneedle") {
+		t.Errorf("the conversation's own project was not recalled:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
Follow-on from #3059, measured the same way on antigravity-cli 1.1.13.

`workspacePaths` is empty unless the run was given `--add-dir`: an ordinary `agy -p` started inside a project sends `[]`. The hook then had nothing to scope by, and since antigravity runs hooks with the working directory set to the folder holding `hooks.json`, the fallback landed on the plugin directory — so the digest was built for a project nobody works in.

Antigravity already knows the answer and keeps it beside the transcript: `cache/last_conversations.json` maps each directory to the conversation it last opened there. The payload names the conversation, so the map is read backwards, and the deepest matching directory wins — a session started in a subdirectory should not be filed under its parent.

Before and after, live, run the ordinary way inside a seeded project with no `--add-dir`, asking a question whose answer exists only in that project's history:

    before   the answer appears 0 times in the reply
    after    the model answers with it and opens with its own "deja-vu recalled" line

The product root is derived from the transcript path rather than assumed, so the IDE and the 2.0 app resolve to their own caches.