### PR TITLE
fix(stats): the card leads with the questions asked more than once, and its rows stop sharing the footer line

### DIFF
--- a/cmd/deja/statscard.go
+++ b/cmd/deja/statscard.go
@@ -74,14 +74,23 @@ func renderStatsCard(r stats.Report) string {
 
 	renderAgents(&b, r, 470, 120)
 
-	// Counts only, no content: see longestLine in statscard_term.go and #1180.
+	// The supporting row sits above the footer with the gap the other rows
+	// keep; it shared the footer's line before (#3060). Counts only, no
+	// content: see longestLine in statscard_term.go and #1180.
+	const rowY = 448
 	if r.Longest.Messages > 0 {
-		cardText(&b, pad, 472, 11, "700", "THE LONGEST SESSION", "#55626a", "letter-spacing=\"1.5\"")
-		cardText(&b, pad+170, 472, 12, "400",
+		cardText(&b, pad, rowY, 11, "700", "THE LONGEST SESSION", "#55626a", "letter-spacing=\"1.5\"")
+		cardText(&b, pad+170, rowY, 12, "400",
 			formatStatNumber(r.Longest.Messages)+" messages", "#8b989a")
 	}
-	if n := r.RepeatQuestions; n > 0 {
-		cardText(&b, w-pad, 472, 12, "400",
+	// Whatever the hero did not take: the week's recalls when the repeat count
+	// leads, the repeat count otherwise.
+	if n := r.WeekRecalls; n > 0 && r.RepeatQuestions > 0 {
+		cardText(&b, w-pad, rowY, 12, "400",
+			formatStatNumber(n)+" recalls handed to your agents this week", "#8b989a",
+			"text-anchor=\"end\"")
+	} else if n := r.RepeatQuestions; n > 0 {
+		cardText(&b, w-pad, rowY, 12, "400",
 			formatStatNumber(n)+" questions asked more than once", "#8b989a",
 			"text-anchor=\"end\"")
 	}
@@ -91,7 +100,9 @@ func renderStatsCard(r stats.Report) string {
 		foot += " · v" + version
 	}
 	cardText(&b, pad, h-18, 11, "400", foot, "#55626a")
-	cardText(&b, w-pad, h-18, 12, "700", "vshulcz.github.io/deja-vu", "#8787af", "text-anchor=\"end\"")
+	// The repository, not the site: a card gets posted, and the reader of a
+	// post goes to the code. The site stays on the --share path.
+	cardText(&b, w-pad, h-18, 12, "700", "github.com/vshulcz/deja-vu", "#8787af", "text-anchor=\"end\"")
 	b.WriteString("</g>\n")
 	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="url(#scan)"/>`+"\n", w, h)
 	b.WriteString("</svg>\n")

--- a/cmd/deja/statscard_lead_test.go
+++ b/cmd/deja/statscard_lead_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+// The repeat count comes from the corpus, so a fresh install has it; the
+// week's recalls need the usage sidecar. The card leads with the figure it
+// can always show, and the week moves to the supporting row.
+func TestCardLeadsWithRepeatQuestions(t *testing.T) {
+	value, caption := heroStat(stats.Report{RepeatQuestions: 26, WeekRecalls: 428})
+	if value != "26" || !strings.Contains(caption, "more than once") {
+		t.Fatalf("hero = %q %q, want the repeat count", value, caption)
+	}
+	// The caption sits left of the agents column at 15 px; past about forty
+	// characters it runs into "WHERE IT CAME FROM".
+	for _, r := range []stats.Report{{RepeatQuestions: 26}, {WeekRecalls: 428}, {TotalSessions: 12}, {PolicyWithheld: 3}} {
+		if _, c := heroStat(r); len(c) > 44 {
+			t.Fatalf("caption %q is %d characters, past the agents column", c, len(c))
+		}
+	}
+	svg := renderStatsCard(stats.Report{RepeatQuestions: 26, WeekRecalls: 428, TotalSessions: 10})
+	if !strings.Contains(svg, "428 recalls handed to your agents this week") {
+		t.Fatalf("the week's recalls left the card:\n%s", svg)
+	}
+	if !strings.Contains(svg, "github.com/vshulcz/deja-vu") {
+		t.Fatalf("the footer no longer points at the repository:\n%s", svg)
+	}
+}
+
+// Two rows of text at the same y read as one smeared row (#3060): every
+// text element in the bottom band has to sit on its own line, or on the
+// footer's line only if it is the footer.
+func TestCardRowsNeverShareTheFooterLine(t *testing.T) {
+	r := stats.Report{RepeatQuestions: 26, WeekRecalls: 428, TotalSessions: 10}
+	r.Longest.Messages = 45051
+	svg := renderStatsCard(r)
+	re := regexp.MustCompile(`<text[^>]*\by="(\d+)"[^>]*>([^<]*)`)
+	byY := map[int][]string{}
+	for _, m := range re.FindAllStringSubmatch(svg, -1) {
+		y, _ := strconv.Atoi(m[1])
+		byY[y] = append(byY[y], m[2])
+	}
+	// The footer's line carries the footer and nothing else.
+	for y, texts := range byY {
+		foot, other := 0, 0
+		for _, tx := range texts {
+			if strings.HasPrefix(tx, "$ deja") || strings.HasPrefix(tx, "github.com") {
+				foot++
+			} else {
+				other++
+			}
+		}
+		if foot > 0 && other > 0 {
+			t.Fatalf("y=%d carries the footer and %v", y, texts)
+		}
+	}
+	// And the supporting row is not on the footer's line.
+	foot := regexp.MustCompile(`y="(\d+)"[^>]*>\$ deja stats`).FindStringSubmatch(svg)
+	row := regexp.MustCompile(`y="(\d+)"[^>]*>THE LONGEST SESSION`).FindStringSubmatch(svg)
+	if foot == nil || row == nil {
+		t.Fatalf("footer or row missing:\n%s", svg)
+	}
+	fy, _ := strconv.Atoi(foot[1])
+	ry, _ := strconv.Atoi(row[1])
+	if fy-ry < 12 {
+		t.Fatalf("row at y=%d sits on the footer at y=%d", ry, fy)
+	}
+}

--- a/cmd/deja/statscard_term.go
+++ b/cmd/deja/statscard_term.go
@@ -209,10 +209,13 @@ func wrapTo(s string, width int) [2]string {
 // same job.
 func heroStat(r stats.Report) (string, string) {
 	switch {
-	case r.WeekRecalls > 0:
-		return formatStatNumber(r.WeekRecalls), "recalls handed to your agents this week"
+	// The repeat count first: it comes from the corpus, so a machine that
+	// installed deja an hour ago has it, and it is the one figure on the card
+	// that is about the person's own history rather than about deja.
 	case r.RepeatQuestions > 0:
 		return formatStatNumber(r.RepeatQuestions), "questions you asked more than once"
+	case r.WeekRecalls > 0:
+		return formatStatNumber(r.WeekRecalls), "recalls handed to your agents this week"
 	case r.Recall.Recalls+r.Recall.Injections > 0:
 		handed := r.Recall.Recalls + r.Recall.Injections
 		return formatStatNumber(handed), "recalls handed to your agents"


### PR DESCRIPTION
`heroStat` now picks the repeat count before the week's recalls (the corpus has it on day one; the week needs the usage sidecar), the week moves to the supporting row, that row sits at y=448 instead of on the footer's line, and the footer's right-hand link is the repository. Terminal card shares the order.

Tests: `TestCardLeadsWithRepeatQuestions`, `TestCardRowsNeverShareTheFooterLine` (fails on main with the two rows at y=472), plus a caption-length guard so the hero's sentence stays left of the agents column.

Closes #3060, closes #3066