### PR TITLE
feat(hook): once a week, session start says what the week looked like

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -333,6 +333,9 @@ func runHookContext(dir string, plain bool) error {
 			// build runs it is all there is: without this the whole rebuild
 			// passed in silence on any machine with facts to report (#927).
 			resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring), joinNotes(withheldEverythingNote(dir, withheld), buildNotice(dir))))
+			// Last, after anything that needs acting on: once a week, what
+			// the week looked like (#3065).
+			resp.SystemMessage = joinNotes(resp.SystemMessage, weekNote(dir))
 			if b, err := json.Marshal(resp); err == nil {
 				fmt.Fprintln(os.Stdout, string(b))
 			}

--- a/cmd/deja/hook_week_note.go
+++ b/cmd/deja/hook_week_note.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// weekNoteEvery is how often the session-start hook says what the week
+// looked like. A machine where deja served forty recalls this week looks,
+// from the agent's UI, exactly like one where it served none; brief and
+// stats know the difference, and nobody runs them (#3065).
+const weekNoteEvery = 7 * 24 * time.Hour
+
+// weekNote is that one line, or "". It goes out on the JSON path only — the
+// plain path is the model's context, where a receipt to the person is noise.
+//
+// The first session after install starts the clock rather than reporting:
+// "deja this week: 1 recall" a minute after the install would be the hook
+// counting itself.
+func weekNote(dir string) string {
+	return weekNoteAt(dir, time.Now())
+}
+
+func weekNoteAt(dir string, now time.Time) string {
+	p := dir + ".weeknote"
+	if b, err := os.ReadFile(p); err == nil {
+		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil && now.Sub(time.Unix(ts, 0)) < weekNoteEvery {
+			return ""
+		}
+	} else {
+		_ = os.WriteFile(p, []byte(strconv.FormatInt(now.Unix(), 10)), 0o600)
+		return ""
+	}
+	// Served and injected both are memory the agent got; the brief's own
+	// week line counts them the same way.
+	served, _, injected, _ := usage.Week(dir)
+	recalls := served + injected
+	if recalls == 0 {
+		// A quiet week is not news; the clock restarts so the next week that
+		// has something to say is the one reported.
+		_ = os.WriteFile(p, []byte(strconv.FormatInt(now.Unix(), 10)), 0o600)
+		return ""
+	}
+	_ = os.WriteFile(p, []byte(strconv.FormatInt(now.Unix(), 10)), 0o600)
+	line := fmt.Sprintf("deja this week: %d recall%s", recalls, pluralS(recalls))
+	if dv := usage.DejaVuWeek(dir); dv > 0 {
+		line += fmt.Sprintf(", %d déjà vu", dv)
+	}
+	return line + " — deja stats --card"
+}

--- a/cmd/deja/hook_week_note_test.go
+++ b/cmd/deja/hook_week_note_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+func TestWeekNoteStartsTheClockThenSpeaksOnceAWeek(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	usage.RecordResult(dir, usage.KindHook, 900, 2, false)
+	usage.RecordResult(dir, usage.KindHook, 400, 1, false)
+	now := time.Now()
+	// The first session after install starts the clock and says nothing, or
+	// the note would count the hook that just ran.
+	if got := weekNoteAt(dir, now); got != "" {
+		t.Fatalf("first session spoke: %q", got)
+	}
+	if got := weekNoteAt(dir, now.Add(3*24*time.Hour)); got != "" {
+		t.Fatalf("mid-week spoke: %q", got)
+	}
+	got := weekNoteAt(dir, now.Add(8*24*time.Hour))
+	if !strings.HasPrefix(got, "deja this week: 2 recalls") || !strings.Contains(got, "deja stats --card") {
+		t.Fatalf("week note = %q", got)
+	}
+	if again := weekNoteAt(dir, now.Add(8*24*time.Hour+time.Hour)); again != "" {
+		t.Fatalf("spoke twice in a week: %q", again)
+	}
+}
+
+func TestWeekNoteKeepsQuietOnAnEmptyWeek(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.WriteFile(dir+".weeknote", []byte(strconv.FormatInt(past.Unix(), 10)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := weekNoteAt(dir, time.Now()); got != "" {
+		t.Fatalf("an empty week was reported: %q", got)
+	}
+}


### PR DESCRIPTION
`deja this week: 41 recalls, 3 déjà vu — deja stats --card` as the last `systemMessage` note on the JSON path, at most once every seven days per index (`<index>.weeknote` marker). The first session after install starts the clock and says nothing, so the note never counts the hook that just ran; an empty week restarts the clock silently. Counts served and injected memory together, as the card's week figure does. Never on the plain path.

Tests: `TestWeekNoteStartsTheClockThenSpeaksOnceAWeek`, `TestWeekNoteKeepsQuietOnAnEmptyWeek`.

Closes #3065