### PR TITLE
feat(install): the proof opens with the questions this machine asked more than once

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -396,7 +396,7 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 // few real sessions deja already indexed from this machine's history, so the
 // value is visible before the first agent session ever runs.
 func printInstallProof(dir string) {
-	printMemoryProofOf(dir, "deja already knows this machine:", nil, recurringErrorLine(dir))
+	printMemoryProofOf(dir, "deja already knows this machine:", nil, installLead(dir))
 }
 
 // printMemoryProofOf is the proof narrowed to the rows a caller can honestly

--- a/cmd/deja/install_lead.go
+++ b/cmd/deja/install_lead.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+	"github.com/vshulcz/deja-vu/internal/search"
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+// installLead is what the install says under "deja already knows this
+// machine:" before the listing — the questions this machine has asked more
+// than once, then the error it keeps hitting. Both come from the store the
+// install just built; neither is new data (#3064, #2967).
+func installLead(dir string) string {
+	return joinNotesWith("\n  ", repeatQuestionsLine(dir), recurringErrorLine(dir))
+}
+
+// repeatQuestionsLine reads the whole store once. That is an install-time
+// cost, paid after the build, on the one screen every user reads.
+func repeatQuestionsLine(dir string) string {
+	if !index.HasManifest(dir) {
+		return ""
+	}
+	ss, err := index.SearchWithRecovery(dir, search.Options{All: true}, io.Discard)
+	if err != nil {
+		return ""
+	}
+	// The listing below obeys the trust policy; a count over sessions the
+	// rule keeps out of recall would contradict it (#937).
+	kept, _ := policyFilterSessionsSplit(policy.ActivationSearch, ss)
+	example, n := stats.RepeatQuestionExample(kept)
+	return repeatQuestionsText(n, example)
+}
+
+func repeatQuestionsText(n int, example string) string {
+	if n == 0 {
+		return ""
+	}
+	line := fmt.Sprintf("%d question%s asked more than once on this machine", n, pluralS(n))
+	if example != "" {
+		line += fmt.Sprintf(" — one of them: %q", example)
+	}
+	return line + " — next time the agent hears the earlier answer first"
+}
+
+// joinNotesWith joins the non-empty notes with sep.
+func joinNotesWith(sep string, notes ...string) string {
+	out := ""
+	for _, n := range notes {
+		if n == "" {
+			continue
+		}
+		if out != "" {
+			out += sep
+		}
+		out += n
+	}
+	return out
+}

--- a/cmd/deja/install_lead_test.go
+++ b/cmd/deja/install_lead_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/stats"
+)
+
+func TestRepeatQuestionExampleNamesTheMostRepeatedQuestion(t *testing.T) {
+	ask := func(text string) model.Session {
+		return model.Session{Messages: []model.Message{{Role: "user", Text: text}}}
+	}
+	ss := []model.Session{
+		ask("why does the retry loop drop the last attempt?"),
+		ask("Why does the retry loop drop the last attempt"),
+		ask("why does the retry loop drop the last attempt?"),
+		ask("how do I run the integration tests here?"),
+		ask("how do I run the integration tests here"),
+		ask("what is the deploy command for staging?"),
+	}
+	example, n := stats.RepeatQuestionExample(ss)
+	if n != 2 {
+		t.Fatalf("repeated = %d, want 2", n)
+	}
+	if !strings.Contains(example, "retry loop") {
+		t.Fatalf("example = %q, want the question asked three times", example)
+	}
+	if _, n := stats.RepeatQuestionExample(ss[5:]); n != 0 {
+		t.Fatalf("a question asked once counted as repeated")
+	}
+}
+
+func TestInstallLeadOpensWithTheRepeatCount(t *testing.T) {
+	got := repeatQuestionsText(26, "prepared statement errors behind pgbouncer")
+	for _, want := range []string{"26 questions asked more than once", `"prepared statement errors behind pgbouncer"`, "earlier answer first"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("lead %q lacks %q", got, want)
+		}
+	}
+	if got := repeatQuestionsText(1, "x"); !strings.HasPrefix(got, "1 question asked") {
+		t.Fatalf("singular: %q", got)
+	}
+	if got := repeatQuestionsText(0, ""); got != "" {
+		t.Fatalf("no repeats still spoke: %q", got)
+	}
+	if got := joinNotesWith("\n  ", "", "b", "", "c"); got != "b\n  c" {
+		t.Fatalf("join = %q", got)
+	}
+}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -423,10 +423,20 @@ const askedMaxRunes = 240
 
 // RepeatQuestions is a corpus proxy because the usage sidecar does not store query text.
 func RepeatQuestions(ss []model.Session) int {
+	_, n := RepeatQuestionExample(ss)
+	return n
+}
+
+// RepeatQuestionExample is the count of questions asked in more than one
+// session, and the one asked most often, as the person typed it the last
+// time — the line the install opens with (#3064). "" and 0 when nothing
+// repeats.
+func RepeatQuestionExample(ss []model.Session) (example string, repeated int) {
 	// Exact stem match only: questionStemFor already folds case and
 	// punctuation, and a pairwise similarity pass is quadratic in corpora
 	// with tens of thousands of user messages.
 	counts := map[string]int{}
+	texts := map[string]string{}
 	for _, s := range ss {
 		seen := map[string]bool{}
 		for _, m := range s.Messages {
@@ -448,15 +458,24 @@ func RepeatQuestions(ss []model.Session) int {
 			}
 			seen[stem] = true
 			counts[stem]++
+			texts[stem] = strings.TrimSpace(m.Text)
 		}
 	}
-	count := 0
-	for _, n := range counts {
+	best := ""
+	for stem, n := range counts {
 		if n > 1 {
-			count++
+			repeated++
+		}
+		// Ties go to the stem that sorts first, so the example is stable
+		// across runs on the same store.
+		if n > 1 && (best == "" || n > counts[best] || (n == counts[best] && stem < best)) {
+			best = stem
 		}
 	}
-	return count
+	if best == "" {
+		return "", repeated
+	}
+	return TrimRunes(texts[best], 72), repeated
 }
 
 func questionStemFor(text string) string {


### PR DESCRIPTION
Under "deja already knows this machine:" the install now says `26 questions asked more than once on this machine — one of them: "…" — next time the agent hears the earlier answer first`, then the recurring-error line from #2967, then the sessions. `stats.RepeatQuestionExample` is the existing repeat count plus the most-repeated question as last typed (ties resolved by stem order, so the example is stable); `RepeatQuestions` wraps it. The line reads the whole store once, after the build, under the same trust-policy filter as the listing.

Tests: `TestRepeatQuestionExampleNamesTheMostRepeatedQuestion`, `TestInstallLeadOpensWithTheRepeatCount`.

Closes #3064