### PR TITLE
feat(antigravity): the repair arrives at the failing command

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -52,6 +52,9 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if len(input.WorkspacePaths) > 0 {
 		workspace = input.WorkspacePaths[0]
 	}
+	if workspace == "" {
+		workspace = workspaceFromConversation(input.TranscriptPath, input.ConversationID)
+	}
 	// Past the first invocation the digest is already in the transcript, and
 	// the harness has no per-prompt event of its own — so this is where the
 	// question gets answered. Silence is the usual result, and the prompt

--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -68,8 +68,15 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	// continued one — so the conversation's own ledger decides, and the
 	// counter only says which call inside the turn we are on.
 	if input.InvocationNum > 0 || digestAlreadyInjected(dir, input.ConversationID) {
-		block := antigravityPromptBlock(dir, latestUserRequest(input.TranscriptPath),
+		// A command that just failed is the more urgent memory, and it is only
+		// reachable from here: PostToolUse is handed the error and its contract
+		// allows no answer at all.
+		block := antigravityFixPair(dir, latestToolFailure(input.TranscriptPath),
 			input.ConversationID, workspace)
+		if block == "" {
+			block = antigravityPromptBlock(dir, latestUserRequest(input.TranscriptPath),
+				input.ConversationID, workspace)
+		}
 		if block == "" {
 			fmt.Fprintln(stdout, "{}")
 			return nil

--- a/cmd/deja/hook_antigravity_failure_test.go
+++ b/cmd/deja/hook_antigravity_failure_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Antigravity hands PostToolUse the error and then allows it no answer — its
+// contract is an empty object. The moment a command fails is reachable only
+// from the invocation that follows it, and the failure is in the transcript:
+// a step that says which code the command exited with, and the output under it.
+func TestAFailedCommandIsReadFromTheTranscript(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name string, steps ...string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(strings.Join(steps, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	failed := write("failed.jsonl",
+		`{"step_index":0,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nbuild it\n</USER_REQUEST>"}`,
+		`{"step_index":1,"type":"GENERIC","status":"DONE","content":"Created At: now\nCompleted At: now\n\nThe command exited with code 1.\nOutput:\n./main.go:9:2: undefined: glimwraxHelper\n"}`)
+	got := latestToolFailure(failed)
+	if !strings.Contains(got, "undefined: glimwraxHelper") {
+		t.Errorf("the error was not read out of the step: %q", got)
+	}
+	// The harness's own framing is not part of the error.
+	if strings.Contains(got, "Created At") || strings.Contains(got, "exited with code") {
+		t.Errorf("the step's framing came back as the error: %q", got)
+	}
+
+	// A command that worked is not a failure.
+	ok := write("ok.jsonl",
+		`{"step_index":0,"type":"GENERIC","status":"DONE","content":"Created At: now\n\nThe command exited with code 0.\nOutput:\nhi\n"}`)
+	if got := latestToolFailure(ok); got != "" {
+		t.Errorf("a successful command read as a failure: %q", got)
+	}
+
+	// And a failure the agent has already moved past is not the moment either:
+	// only the newest tool step counts.
+	stale := write("stale.jsonl",
+		`{"step_index":0,"type":"GENERIC","status":"DONE","content":"The command exited with code 1.\nOutput:\nthe old error\n"}`,
+		`{"step_index":1,"type":"GENERIC","status":"DONE","content":"The command exited with code 0.\nOutput:\nfine now\n"}`)
+	if got := latestToolFailure(stale); got != "" {
+		t.Errorf("a failure that was already worked past came back: %q", got)
+	}
+
+	// Nothing to read is silence, not a guess.
+	if got := latestToolFailure(filepath.Join(dir, "missing.jsonl")); got != "" {
+		t.Errorf("a missing transcript answered %q", got)
+	}
+}
+
+// And the hook speaks it: after a failed command, the next invocation carries
+// what this machine ran the last time the same error came up.
+func TestTheInvocationAfterAFailureCarriesTheRepair(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaudeFixPair(t, claude, "agyfix")
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	transcript := filepath.Join(tmp, "transcript.jsonl")
+	steps := []string{
+		`{"step_index":0,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nbuild it\n</USER_REQUEST>"}`,
+		`{"step_index":1,"type":"GENERIC","status":"DONE","content":"The command exited with code 1.\nOutput:\n./main.go:9:2: undefined: glimwraxHelper\n"}`,
+	}
+	if err := os.WriteFile(transcript, []byte(strings.Join(steps, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"invocationNum":  1,
+		"conversationId": "conv-fx",
+		"transcriptPath": transcript,
+		"workspacePaths": []string{filepath.Join(os.TempDir(), "agyfix")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runHookAntigravity(dir, bytes.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "glimwraxctl") {
+		t.Errorf("the repair did not arrive at the failure:\n%s", out.String())
+	}
+}
+
+// seedClaudeFixPair writes a session that hit an error and then ran the command
+// that settled it — the shape a fix pair is built from.
+func seedClaudeFixPair(t *testing.T, root, project string) {
+	t.Helper()
+	dir := filepath.Join(root, "-"+project)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(os.TempDir(), project)
+	rec := func(kind string, content any, at string) string {
+		b, _ := json.Marshal(map[string]any{
+			"type": kind, "sessionId": "fix1", "cwd": cwd, "timestamp": at,
+			"message": map[string]any{"role": kind, "content": content},
+		})
+		return string(b)
+	}
+	lines := []string{
+		rec("user", "the build stops on an undefined symbol", "2026-09-01T10:00:00Z"),
+		rec("assistant", []any{map[string]any{"type": "tool_use", "id": "t1", "name": "Bash",
+			"input": map[string]string{"command": "go build ./..."}}}, "2026-09-01T10:00:10Z"),
+		rec("user", []any{map[string]any{"type": "tool_result", "tool_use_id": "t1",
+			"content": "./main.go:9:2: undefined: glimwraxHelper"}}, "2026-09-01T10:00:20Z"),
+		rec("assistant", []any{map[string]any{"type": "tool_use", "id": "t2", "name": "Bash",
+			"input": map[string]string{"command": "glimwraxctl --sync && go build ./..."}}}, "2026-09-01T10:00:40Z"),
+		rec("user", []any{map[string]any{"type": "tool_result", "tool_use_id": "t2",
+			"content": "ok"}}, "2026-09-01T10:01:00Z"),
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fix1.jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/deja/hook_antigravity_prompt.go
+++ b/cmd/deja/hook_antigravity_prompt.go
@@ -28,20 +28,27 @@ const (
 	userRequestClose          = "</USER_REQUEST>"
 )
 
-// latestUserRequest returns the newest user turn in an antigravity transcript,
-// or "" when the file holds none it can read.
-func latestUserRequest(path string) string {
+// transcriptStep is as much of an antigravity step as this hook reads.
+type transcriptStep struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+// transcriptTailSteps decodes the end of a transcript, newest step first. A
+// partial first line from the tail cut simply fails to decode, which is the
+// right answer for it.
+func transcriptTailSteps(path string) []transcriptStep {
 	if strings.TrimSpace(path) == "" {
-		return ""
+		return nil
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		return ""
+		return nil
 	}
 	defer func() { _ = f.Close() }()
 	fi, err := f.Stat()
 	if err != nil {
-		return ""
+		return nil
 	}
 	size := fi.Size()
 	offset := int64(0)
@@ -50,21 +57,29 @@ func latestUserRequest(path string) string {
 	}
 	buf := make([]byte, size-offset)
 	if _, err := f.ReadAt(buf, offset); err != nil {
-		return ""
+		return nil
 	}
 	lines := strings.Split(string(buf), "\n")
-	// Newest first, and a partial first line from the tail cut simply fails to
-	// decode — which is the right answer for it.
+	out := make([]transcriptStep, 0, len(lines))
 	for i := len(lines) - 1; i >= 0; i-- {
 		line := strings.TrimSpace(lines[i])
 		if line == "" {
 			continue
 		}
-		var step struct {
-			Type    string `json:"type"`
-			Content string `json:"content"`
+		var step transcriptStep
+		if json.Unmarshal([]byte(line), &step) != nil {
+			continue
 		}
-		if json.Unmarshal([]byte(line), &step) != nil || step.Type != "USER_INPUT" {
+		out = append(out, step)
+	}
+	return out
+}
+
+// latestUserRequest returns the newest user turn in an antigravity transcript,
+// or "" when the file holds none it can read.
+func latestUserRequest(path string) string {
+	for _, step := range transcriptTailSteps(path) {
+		if step.Type != "USER_INPUT" {
 			continue
 		}
 		if q := userRequestText(step.Content); q != "" {
@@ -180,4 +195,70 @@ func workspaceFromConversation(transcriptPath, conversationID string) string {
 		}
 	}
 	return best
+}
+
+// latestToolFailure is the output of the newest tool step that ended badly, or
+// "" when the last thing the agent did was not a failure. PostToolUse gets the
+// error but its contract allows no answer at all (checked on antigravity-cli
+// 1.1.13: it must return an empty object), so the moment a command fails is
+// reachable only from the invocation that follows it.
+//
+// Only the newest tool step is read: a failure two steps back has already been
+// answered or worked around, and injecting it again would be talking about
+// something the agent has moved on from.
+func latestToolFailure(path string) string {
+	for _, step := range transcriptTailSteps(path) {
+		if step.Type != "GENERIC" {
+			continue
+		}
+		body := step.Content
+		if !strings.Contains(body, exitedWithCode) {
+			// The newest tool step said nothing about an exit code, so there
+			// is no failure to speak about.
+			return ""
+		}
+		if strings.Contains(body, exitedWithCode+" 0.") {
+			return ""
+		}
+		if i := strings.Index(body, toolOutputMarker); i >= 0 {
+			return strings.TrimSpace(body[i+len(toolOutputMarker):])
+		}
+		return strings.TrimSpace(body)
+	}
+	return ""
+}
+
+const (
+	exitedWithCode   = "The command exited with code"
+	toolOutputMarker = "Output:"
+)
+
+// antigravityFixPair is the repair this machine ran after the same failure, or
+// "" when the store holds none. It drives the ordinary post-tool hook, so the
+// budget, the dedupe and the "waiting for a second sighting" rule are the ones
+// every other harness gets.
+func antigravityFixPair(dir, output, conversationID, workspace string) string {
+	if strings.TrimSpace(output) == "" {
+		return ""
+	}
+	payload, err := json.Marshal(map[string]any{
+		"hook_event_name": "PostToolUse",
+		"tool_name":       "Bash",
+		"tool_input":      map[string]string{"command": ""},
+		"tool_response":   map[string]string{"output": output},
+		"session_id":      conversationID,
+		"cwd":             workspace,
+	})
+	if err != nil {
+		return ""
+	}
+	var out bytes.Buffer
+	if err := runHookToolAfter(dir, bytes.NewReader(payload), &out); err != nil {
+		return ""
+	}
+	var resp sessionStartHookResponse
+	if json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp) != nil {
+		return ""
+	}
+	return resp.HookSpecificOutput.AdditionalContext
 }

--- a/cmd/deja/hook_antigravity_prompt.go
+++ b/cmd/deja/hook_antigravity_prompt.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -139,3 +140,44 @@ func antigravityDigestKey(conversationID string) string {
 // antigravityDigestToken is what the ledger row says: this conversation has
 // been handed the digest.
 const antigravityDigestToken = "agy-digest"
+
+// workspaceFromConversation is where this conversation was started. The CLI
+// leaves workspacePaths empty unless it was given --add-dir (measured on
+// antigravity-cli 1.1.13: an ordinary `agy -p` inside a project sends []), and
+// the hook's own working directory is the plugin folder — so without this the
+// digest is scoped to a directory nobody works in and recalls the wrong
+// project's history, or none.
+//
+// Antigravity keeps the answer beside the transcript: a cache mapping each
+// directory to the conversation it last opened there. The payload names the
+// conversation, so the map is read backwards.
+func workspaceFromConversation(transcriptPath, conversationID string) string {
+	if strings.TrimSpace(transcriptPath) == "" || strings.TrimSpace(conversationID) == "" {
+		return ""
+	}
+	// <product root>/brain/<conversation>/.system_generated/logs/transcript.jsonl
+	root := transcriptPath
+	for range 5 {
+		root = filepath.Dir(root)
+	}
+	b, err := os.ReadFile(filepath.Join(root, "cache", "last_conversations.json"))
+	if err != nil {
+		return ""
+	}
+	var byDir map[string]string
+	if json.Unmarshal(b, &byDir) != nil {
+		return ""
+	}
+	// The longest match, so a conversation opened in a subdirectory is filed
+	// under that subdirectory rather than under its parent.
+	best := ""
+	for dir, conv := range byDir {
+		if conv != conversationID {
+			continue
+		}
+		if len(dir) > len(best) {
+			best = dir
+		}
+	}
+	return best
+}

--- a/cmd/deja/hook_antigravity_workspace_test.go
+++ b/cmd/deja/hook_antigravity_workspace_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An ordinary `agy -p` inside a project sends no workspace at all, and the hook
+// runs with its working directory set to the plugin folder — so without another
+// source the digest is scoped to a directory nobody works in. Antigravity keeps
+// the answer beside the transcript: a cache of which conversation each
+// directory last opened.
+func TestTheWorkspaceIsFoundWhenThePayloadOmitsIt(t *testing.T) {
+	root := t.TempDir()
+	product := filepath.Join(root, "antigravity-cli")
+	transcript := filepath.Join(product, "brain", "conv-7", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(product, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	byDir := map[string]string{
+		"/Users/probe/app":       "conv-7",
+		"/Users/probe/app/inner": "conv-7",
+		"/Users/probe/other":     "conv-9",
+	}
+	b, err := json.Marshal(byDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The deepest directory that opened this conversation, so a session
+	// started in a subdirectory is not filed under its parent. Asked twenty
+	// times, because a map is walked in no particular order and "whichever
+	// came first" would pass a single call about half the time.
+	for i := 0; i < 20; i++ {
+		if got := workspaceFromConversation(transcript, "conv-7"); got != "/Users/probe/app/inner" {
+			t.Fatalf("workspace = %q on attempt %d", got, i+1)
+		}
+	}
+	// Another conversation is another directory.
+	if got := workspaceFromConversation(transcript, "conv-9"); got != "/Users/probe/other" {
+		t.Errorf("workspace for the other conversation = %q", got)
+	}
+	// And what it cannot answer it leaves empty rather than guessing.
+	if got := workspaceFromConversation(transcript, "conv-none"); got != "" {
+		t.Errorf("an unknown conversation resolved to %q", got)
+	}
+	if got := workspaceFromConversation("", "conv-7"); got != "" {
+		t.Errorf("no transcript path resolved to %q", got)
+	}
+	if got := workspaceFromConversation(filepath.Join(root, "nope", "brain", "c", "a", "b", "t.jsonl"), "conv-7"); got != "" {
+		t.Errorf("a missing cache resolved to %q", got)
+	}
+}
+
+// And the hook uses it: a payload with no workspace must still recall the
+// project the conversation belongs to, not the plugin directory it happens to
+// run in.
+func TestTheHookRecallsTheProjectWhenThePayloadOmitsIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "wsapp", "sess-ws",
+		"why does the widget loader stall", "it stalled until zorbwaxneedle was set")
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	product := filepath.Join(tmp, "antigravity-cli")
+	transcript := filepath.Join(product, "brain", "conv-ws", ".system_generated", "logs", "transcript.jsonl")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(product, "cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// seedClaude files its sessions under /tmp/<project>, which is the path
+	// the conversation cache has to name for the two to meet.
+	project := filepath.Join(os.TempDir(), "wsapp")
+	b, err := json.Marshal(map[string]string{project: "conv-ws"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "last_conversations.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"invocationNum":  0,
+		"conversationId": "conv-ws",
+		"transcriptPath": transcript,
+		"workspacePaths": []string{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := runHookAntigravity(dir, bytes.NewReader(payload), &out); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "zorbwaxneedle") {
+		t.Errorf("the conversation's own project was not recalled:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
The last of the three channels antigravity can carry, measured on antigravity-cli 1.1.13.

`PostToolUse` is handed the error — the payload has an `error` field — and then its contract allows no answer at all: it must return an empty object. So the moment a command fails is reachable only from the `PreInvocation` that follows it, and the failure is already in the transcript the payload names: a step reporting which code the command exited with, and the output under it.

Only the newest tool step is read. A failure two steps back has been answered or worked around, and injecting it again would be talking about something the agent has moved on from.

It drives the ordinary post-tool hook rather than reimplementing anything, so the budget, the dedupe and the "found something, waiting for a second sighting" wording are the ones every other harness gets. The failure takes precedence over the question when both are available: a command that just went wrong is the more urgent memory, and the question will still be there on the next call.

Before and after, live, read out of antigravity's own transcript — a project that fails to build, with the repair for that exact error in another project's history:

    before   digest 1 | fix pair 0
    after    digest 1 | fix pair 1

Two things the stand taught, both worth knowing for the next pass: a run without `--add-dir` executes commands in antigravity's own scratch directory, so a build in the project has to be asked for explicitly; and deja keys a Go compile error by its line and column, so `main.go:4:2` and `main.go:9:2` are different errors — a seeded repair has to carry the error the build actually prints.