### PR TITLE
feat(hook): the first session after a build hears what was indexed

### DIFF
--- a/cmd/deja/hook_built_note.go
+++ b/cmd/deja/hook_built_note.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// builtNote is the one line the first session start after a build says
+// about what the build found. Someone who installed deja from a marketplace
+// never runs `deja install` and never sees the proof the CLI prints; for
+// them the index was built in silence and recall stayed invisible until it
+// happened to fire (#3073). Once per index, JSON path only.
+func builtNote(dir string) string {
+	if !index.HasManifest(dir) {
+		return ""
+	}
+	marker := dir + ".builtnote"
+	if _, err := os.Stat(marker); err == nil {
+		return ""
+	}
+	pol := policy.Load()
+	allow := func(project string) bool { return pol.Allows(policy.ActivationSearch, project) }
+	sessions, harnesses, repeated := index.BuiltSummary(dir, allow)
+	if sessions == 0 {
+		// Nothing to report yet; the note waits for the build that finds
+		// history rather than spending its one appearance on an empty store.
+		return ""
+	}
+	_ = os.WriteFile(marker, []byte("1"), 0o600)
+	line := fmt.Sprintf("deja indexed %s session%s from %d agent%s on this machine",
+		formatStatNumber(sessions), pluralS(sessions), harnesses, pluralS(harnesses))
+	if repeated > 0 {
+		line += fmt.Sprintf(" — %d question%s asked more than once; the earlier answers now arrive before you re-ask",
+			repeated, pluralS(repeated))
+	} else {
+		line += " — what they decided now arrives before you re-ask"
+	}
+	return line
+}

--- a/cmd/deja/hook_built_note_test.go
+++ b/cmd/deja/hook_built_note_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The first session start that finds a manifest says what the build found,
+// once; the next one does not (#3073).
+func TestTheFirstSessionAfterTheBuildHearsWhatWasIndexed(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	q := `{"type":"user","message":{"role":"user","content":"why does the retry loop drop the last attempt"},"timestamp":"2026-03-01T10:00:00Z","sessionId":"%s","cwd":"/proj"}`
+	for _, id := range []string{"s1", "s2"} {
+		line := strings.Replace(q, "%s", id, 1)
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+
+	read := func() string {
+		out, err := captureRun(t, "hook-context")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var resp struct {
+			SystemMessage string `json:"systemMessage"`
+		}
+		if err := json.Unmarshal([]byte(out), &resp); err != nil {
+			t.Fatalf("hook output is not JSON: %q", out)
+		}
+		return resp.SystemMessage
+	}
+	first := read()
+	if !strings.Contains(first, "deja indexed 2 sessions from 1 agent") {
+		t.Fatalf("the first session after the build was not told what was indexed: %q", first)
+	}
+	if !strings.Contains(first, "1 question asked more than once") {
+		t.Fatalf("the repeat count is missing: %q", first)
+	}
+	if second := read(); strings.Contains(second, "deja indexed") {
+		t.Fatalf("the built note repeated: %q", second)
+	}
+}
+
+func TestTheBuiltNoteNeverReachesTheModel(t *testing.T) {
+	hermeticEnv(t)
+	t.Setenv("DEJA_WARMUP_SENTINEL", "")
+	oldSpawn := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = oldSpawn })
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"type":"user","message":{"role":"user","content":"pool exhausted"},"timestamp":"2026-07-01T10:00:00Z","sessionId":"s1","cwd":"/proj"}`
+	if err := os.WriteFile(filepath.Join(store, "s1.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_PROJECT_DIR", "/proj")
+	out, err := captureRun(t, "hook-context", "--plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "deja indexed") {
+		t.Fatalf("the built note went into the model's context:\n%s", out)
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -333,9 +333,10 @@ func runHookContext(dir string, plain bool) error {
 			// build runs it is all there is: without this the whole rebuild
 			// passed in silence on any machine with facts to report (#927).
 			resp.SystemMessage = joinNotes(rewireNote(rewired), joinNotes(stuckWiringNote(stuckWiring), joinNotes(withheldEverythingNote(dir, withheld), buildNotice(dir))))
-			// Last, after anything that needs acting on: once a week, what
-			// the week looked like (#3065).
-			resp.SystemMessage = joinNotes(resp.SystemMessage, weekNote(dir))
+			// Last, after anything that needs acting on: what the build
+			// found, once (#3073), then once a week what the week looked
+			// like (#3065).
+			resp.SystemMessage = joinNotes(resp.SystemMessage, joinNotes(builtNote(dir), weekNote(dir)))
 			if b, err := json.Marshal(resp); err == nil {
 				fmt.Fprintln(os.Stdout, string(b))
 			}
@@ -496,6 +497,9 @@ func runHookContext(dir string, plain bool) error {
 	if note := unreadableStoreNote(dir); storeNoteIsNews(dir, note) {
 		resp.SystemMessage = joinNotes(note, resp.SystemMessage)
 	}
+	// What the build found, once (#3073), then once a week what the week
+	// looked like (#3065) — after everything that needs acting on.
+	resp.SystemMessage = joinNotes(resp.SystemMessage, joinNotes(builtNote(dir), weekNote(dir)))
 	// An index that is behind and cannot be written stays behind. "the agent
 	// starts already knowing them" was printed over a picture missing today's
 	// work, and this path said nothing — search names the same state (#1005).

--- a/internal/index/built_summary.go
+++ b/internal/index/built_summary.go
@@ -1,0 +1,36 @@
+package index
+
+// BuiltSummary is what a store holds, read from the manifest alone: how many
+// sessions, from how many harnesses, and how many questions were asked in
+// more than one session — the same hashes FindAskedTwice reads, counted
+// rather than picked. allow is the trust gate FindAskedTwice takes; nil
+// counts every session.
+func BuiltSummary(dir string, allow func(project string) bool) (sessions, harnesses, repeated int) {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return 0, 0, 0
+	}
+	byHash := map[uint64]int{}
+	seenHarness := map[string]bool{}
+	for _, meta := range m.Sessions {
+		if allow != nil && !allow(meta.Project) {
+			continue
+		}
+		sessions++
+		if meta.Harness != "" {
+			seenHarness[meta.Harness] = true
+		}
+		for _, h := range meta.Asked {
+			byHash[h]++
+		}
+	}
+	for _, n := range byHash {
+		if n > 1 {
+			repeated++
+		}
+	}
+	return sessions, len(seenHarness), repeated
+}


### PR DESCRIPTION
`deja indexed 1,444 sessions from 19 agents on this machine — 27 questions asked more than once; the earlier answers now arrive before you re-ask` — once per index (`<index>.builtnote`), JSON path only, after the notes that need acting on and before the week note. Read from the manifest alone: `index.BuiltSummary` counts sessions, distinct harnesses and the `Asked` hashes that appear in more than one session (the same hashes `FindAskedTwice` reads), under the search trust gate; no session is loaded, so the cost is a manifest read. An empty store keeps the note for the build that finds history.

Tests: `TestTheFirstSessionAfterTheBuildHearsWhatWasIndexed` (spoken once, silent the second time), `TestTheBuiltNoteNeverReachesTheModel` (plain path).

Closes #3073