### PR TITLE
feat(antigravity): serve again what a compaction threw away

### DIFF
--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -55,6 +55,10 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	if workspace == "" {
 		workspace = workspaceFromConversation(input.TranscriptPath, input.ConversationID)
 	}
+	// A compaction throws away the blocks this conversation was shown while the
+	// record of having sent them outlives them, so the memory it just lost is
+	// the memory recall refuses to send again.
+	forgetOnCheckpoint(dir, input.ConversationID, newestCheckpoint(input.TranscriptPath))
 	// Past the first invocation the digest is already in the transcript, and
 	// the harness has no per-prompt event of its own — so this is where the
 	// question gets answered. Silence is the usual result, and the prompt

--- a/cmd/deja/hook_antigravity_checkpoint_test.go
+++ b/cmd/deja/hook_antigravity_checkpoint_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Antigravity compacts without an event of its own: it truncates the
+// conversation and writes a CHECKPOINT step saying the earlier parts are gone.
+// Until that is noticed, the blocks are missing from the context while the
+// record of having sent them outlives them — the one state where recall stays
+// silent about exactly what the agent no longer has.
+func TestACompactedConversationIsToldAgain(t *testing.T) {
+	tmp := hermeticEnv(t)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	seedClaude(t, claude, "cpapp", "sess-cp",
+		"why does the packer refuse the manifest",
+		"it refused until glimcheckneedle was set in the environment")
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	transcript := filepath.Join(tmp, "transcript.jsonl")
+	write := func(steps ...string) {
+		if err := os.WriteFile(transcript, []byte(strings.Join(steps, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	question := `{"step_index":0,"type":"USER_INPUT","status":"DONE","content":"<USER_REQUEST>\nwhy does the packer refuse the manifest\n</USER_REQUEST>"}`
+	write(question)
+
+	call := func(n int) string {
+		payload, err := json.Marshal(map[string]any{
+			"invocationNum":  n,
+			"conversationId": "conv-cp",
+			"transcriptPath": transcript,
+			"workspacePaths": []string{filepath.Join(os.TempDir(), "cpapp")},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out bytes.Buffer
+		if err := runHookAntigravity(dir, bytes.NewReader(payload), &out); err != nil {
+			t.Fatal(err)
+		}
+		var resp antigravityHookResponse
+		if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+			t.Fatalf("the hook did not answer with JSON: %q", out.String())
+		}
+		if len(resp.InjectSteps) == 0 {
+			return ""
+		}
+		return resp.InjectSteps[0].EphemeralMessage
+	}
+
+	if first := call(0); !strings.Contains(first, antigravityLead) {
+		t.Fatalf("the conversation did not open with the digest: %q", first)
+	}
+	// Said once. What comes back on the next call is the question's own
+	// answer, which is a different block and the right one to send.
+	if again := call(0); strings.Contains(again, antigravityLead) {
+		t.Fatalf("the digest went in twice without a compaction: %q", again)
+	}
+
+	// Now antigravity truncates the conversation and says so.
+	write(question,
+		`{"step_index":1,"type":"CHECKPOINT","source":"SYSTEM","created_at":"2026-09-04T12:00:00Z","content":"{{ CHECKPOINT 0 }}\n**The earlier parts of this conversation have been truncated due to its long length.**"}`)
+
+	if after := call(0); !strings.Contains(after, antigravityLead) {
+		t.Errorf("what the compaction threw away was not offered again: %q", after)
+	}
+	// And one compaction is one repeat: the marker is remembered, so the
+	// digest does not come back on every call after it.
+	if again := call(0); strings.Contains(again, antigravityLead) {
+		t.Errorf("the same compaction was answered twice: %q", again)
+	}
+}
+
+// The marker itself: a conversation with no checkpoint has nothing to forget,
+// and the same checkpoint is only acted on once.
+func TestACheckpointIsActedOnOnce(t *testing.T) {
+	dir := t.TempDir() + "/index.db"
+	if forgetOnCheckpoint(dir, "conv-1", "") {
+		t.Error("a conversation that has not been compacted was treated as if it had")
+	}
+	if forgetOnCheckpoint(dir, "", "2026-09-04T12:00:00Z") {
+		t.Error("a payload with no conversation id was acted on")
+	}
+	if !forgetOnCheckpoint(dir, "conv-1", "2026-09-04T12:00:00Z") {
+		t.Fatal("the first compaction was not acted on")
+	}
+	if forgetOnCheckpoint(dir, "conv-1", "2026-09-04T12:00:00Z") {
+		t.Error("the same compaction was acted on twice")
+	}
+	// A later compaction in the same conversation is a new one.
+	if !forgetOnCheckpoint(dir, "conv-1", "2026-09-04T13:00:00Z") {
+		t.Error("a second compaction was mistaken for the first")
+	}
+}

--- a/cmd/deja/hook_antigravity_prompt.go
+++ b/cmd/deja/hook_antigravity_prompt.go
@@ -30,8 +30,9 @@ const (
 
 // transcriptStep is as much of an antigravity step as this hook reads.
 type transcriptStep struct {
-	Type    string `json:"type"`
-	Content string `json:"content"`
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	CreatedAt string `json:"created_at"`
 }
 
 // transcriptTailSteps decodes the end of a transcript, newest step first. A
@@ -261,4 +262,43 @@ func antigravityFixPair(dir, output, conversationID, workspace string) string {
 		return ""
 	}
 	return resp.HookSpecificOutput.AdditionalContext
+}
+
+// newestCheckpoint is when this conversation was last compacted, or "" if it
+// has not been. Antigravity has no compaction event — the five it offers are
+// PreToolUse, PostToolUse, PreInvocation, PostInvocation and Stop — but it
+// truncates the conversation and writes a CHECKPOINT step saying so, and the
+// hook is handed the transcript on every call.
+func newestCheckpoint(path string) string {
+	for _, step := range transcriptTailSteps(path) {
+		if step.Type == checkpointStepType {
+			return step.CreatedAt
+		}
+	}
+	return ""
+}
+
+const checkpointStepType = "CHECKPOINT"
+
+// forgetOnCheckpoint clears what this conversation was shown once it has been
+// compacted, so the memory it just lost can be served again. Without it the
+// blocks are gone from the context while the record of having sent them
+// outlives them, which is the one state where recall is silent about exactly
+// what the agent no longer has.
+//
+// The marker is kept under a key of its own, so forgetting the conversation's
+// rows does not forget that this compaction was handled.
+func forgetOnCheckpoint(dir, conversationID, marker string) bool {
+	if strings.TrimSpace(conversationID) == "" || strings.TrimSpace(marker) == "" {
+		return false
+	}
+	key := "agy-compact:" + conversationID
+	token := "checkpoint:" + shortHash(marker)
+	if alreadyInjected(dir, key)[token] {
+		return false
+	}
+	rememberInjectedIDs(dir, key, token)
+	forgetInjected(dir, conversationID)
+	forgetInjected(dir, antigravityDigestKey(conversationID))
+	return true
 }


### PR DESCRIPTION
The last channel antigravity has, and the one it does not announce.

It offers five hook events — PreToolUse, PostToolUse, PreInvocation, PostInvocation, Stop — and none of them is about compaction. But it does compact: the conversation is truncated and a `CHECKPOINT` step is written where the removed part was, saying "the earlier parts of this conversation have been truncated due to its long length". Found by reading the transcripts on this machine, where 21 of them carry one.

Until that is noticed, the blocks are gone from the context while the record of having sent them outlives them — the one state where recall is silent about exactly what the agent no longer has. The hook is handed the transcript on every call, so the marker is read there and the conversation's ledger cleared once per compaction; the marker itself is kept under a key of its own, so forgetting the rows does not forget that this compaction was handled.

Driven through the hook: the digest opens the conversation, the call after it answers the question instead of repeating the digest, and after a checkpoint the digest is offered again — once, not on every call that follows.

That closes the channel list for this harness:

| what | antigravity | deja |
| --- | --- | --- |
| session start | PreInvocation, first call | the digest, once per conversation |
| per prompt | no event; the question is in the transcript | #3059 |
| before a tool | PreToolUse fires, its `reason` never reaches the model | not wired, deliberately |
| after a failure | PostToolUse must answer with an empty object | the next PreInvocation, #3077 |
| compaction | no event; a CHECKPOINT step | this |
| subagent | no event | — |

The `PreToolUse` line is measured twice over: a hook that allowed the call and returned a token to echo, and one that returned a fact about the command the model could not otherwise know. Neither reached the reply.