### PR TITLE
fix(friction): a compiler error is one wall wherever the line moves

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -156,6 +156,24 @@ func ipv4At(l string, i int) (int, bool) {
 	return pos, true
 }
 
+// filePosition is a compiler's way of saying where: a path, a line, and often a
+// column, before the error itself. `./main.go:12:2: undefined: helper` and
+// `tsc: src/app.ts:88:5: error TS2304` are the shape.
+var filePosition = regexp.MustCompile(`(^|\s)([^\s:]*[./][^\s:]*):([0-9]{1,6})(:([0-9]{1,6}))?:`)
+
+// maskFilePosition replaces the line and column a compiler prints with a
+// placeholder. Adding an import moves every error in the file down a line, and
+// without this the same undefined symbol at line 4 and at line 9 are two walls
+// — each below the second sighting a fix pair needs and the three sessions
+// `deja friction` needs, so the repair for a wall this machine has hit ten
+// times is never offered. The path stays: which file it was is the useful half,
+// and the reader is shown the line as it was printed either way, because this
+// runs on the signature and not on the text (#2369 draws the same line for
+// ports and pids).
+func maskFilePosition(l string) string {
+	return filePosition.ReplaceAllString(l, "${1}${2}:<n>:")
+}
+
 // maskVolatileNumbers replaces long digit runs with a placeholder, so one
 // failure is one wall across the numbers a machine hands out: a port, a pid, an
 // epoch, a goroutine id. Without it `dial tcp 10.0.0.7:5432: connect:
@@ -169,6 +187,7 @@ func ipv4At(l string, i int) (int, bool) {
 // epochs and ids are longer than that; 404 and 500 are not.
 func maskVolatileNumbers(l string) string {
 	l = maskIPv4(l)
+	l = maskFilePosition(l)
 	var b strings.Builder
 	b.Grow(len(l))
 	for i := 0; i < len(l); {

--- a/internal/index/friction_position_test.go
+++ b/internal/index/friction_position_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Adding an import moves every error in the file down a line. Keyed by that
+// line, the same undefined symbol is a new wall each time — below the second
+// sighting a fix pair needs and the three sessions `deja friction` needs, so
+// the repair for something this machine hits weekly is never offered.
+func TestACompilerErrorIsOneWallWhereverTheLineMoves(t *testing.T) {
+	at4, ok := FrictionLine("./main.go:4:2: undefined: glimwraxHelper")
+	if !ok {
+		t.Fatal("a compile error is not read as friction at all")
+	}
+	at9, ok := FrictionLine("./main.go:9:2: undefined: glimwraxHelper")
+	if !ok {
+		t.Fatal("the same error one line down is not read as friction")
+	}
+	if frictionHash(at4) != frictionHash(at9) {
+		t.Errorf("the same error at two lines is two walls:\n  %q\n  %q", at4, at9)
+	}
+
+	// The reader still sees where it was: the position is masked for the
+	// signature, not taken out of the line.
+	if !strings.Contains(at4, "4:2") {
+		t.Errorf("the line the reader is shown lost its position: %q", at4)
+	}
+
+	// A different symbol is a different wall, and so is a different file.
+	other, _ := FrictionLine("./main.go:4:2: undefined: otherHelper")
+	if frictionHash(at4) == frictionHash(other) {
+		t.Error("two different symbols were folded into one wall")
+	}
+	elsewhere, _ := FrictionLine("./cmd/run.go:4:2: undefined: glimwraxHelper")
+	if frictionHash(at4) == frictionHash(elsewhere) {
+		t.Error("the same symbol in two files was folded into one wall")
+	}
+}
+
+// And the pair survives it: the command that settled the error at one line is
+// offered when the same error comes back further down the file.
+func TestAFixPairSurvivesTheLineMoving(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "command", Text: "go build ./...", Time: now},
+		{Role: "tool-output", Text: "./main.go:4:2: undefined: glimwraxHelper", Time: now},
+		{Role: "command", Text: "glimwraxctl --sync && go build ./...", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "ok", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 {
+		t.Fatalf("want one pair, got %d", len(pairs))
+	}
+	line, ok := FrictionLine("./main.go:9:2: undefined: glimwraxHelper")
+	if !ok {
+		t.Fatal("the moved error is not friction")
+	}
+	if pairs[0].Sig != frictionHash(line) {
+		t.Error("the repair is filed under a signature the same error one line down does not reach")
+	}
+}


### PR DESCRIPTION
Found while wiring antigravity: a seeded repair for `./main.go:9:2: undefined: glimwraxHelper` said nothing about the same failure at `./main.go:4:2`, because the line and column are part of the signature.

That is the wrong grouping for the thing deja is for. Adding an import moves every error in the file down a line, so one wall becomes a new wall on every edit — each below the second sighting a fix pair needs and the three sessions `deja friction` needs, and the repair for something this machine hits weekly is never offered.

The position is masked the way #2369 masks ports and pids, and in the same place: on the signature, not on the text. The path stays — which file it was is the useful half — and the reader is shown the line exactly as it was printed.

A different symbol is still a different wall, and so is the same symbol in another file.