### PR TITLE
fix(zed): ship the /deja fix, and fail CI when a change outruns the version

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -139,6 +139,9 @@ jobs:
         working-directory: extensions/zed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The guard below reads history, not just the tree.
+          fetch-depth: 0
 
       - name: Install the target Zed compiles extensions to
         run: rustup target add wasm32-wasip1
@@ -153,6 +156,26 @@ jobs:
             echo "extension.toml id is '$id'; zed-industries/extensions lists it as deja-context-server"
             exit 1
           }
+
+      - name: A change to the extension must move its version
+        run: |
+          # Zed installs whatever version the registry lists, so a fix that
+          # lands here without a bump reaches nobody. `/deja` was fixed in
+          # #3020 and sat unpublished behind 0.1.0 until this check existed.
+          version_commit=$(git log -1 --format=%H -G'^version = ' -- extension.toml)
+          source_commit=$(git log -1 --format=%H -- src Cargo.toml)
+          if [ -z "$version_commit" ] || [ -z "$source_commit" ]; then
+            echo "cannot read the history of extensions/zed; not failing on that"
+            exit 0
+          fi
+          if git merge-base --is-ancestor "$source_commit" "$version_commit"; then
+            exit 0
+          fi
+          echo "extensions/zed changed after its version last moved:"
+          echo "  source  $(git log -1 --format='%h %s' "$source_commit")"
+          echo "  version $(git log -1 --format='%h %s' "$version_commit")"
+          echo "Bump version in extension.toml, or Zed users keep the build they already have."
+          exit 1
 
   kimi:
     name: kimi-deja

--- a/extensions/zed/extension.toml
+++ b/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "deja-context-server"
 name = "deja"
 description = "deja-vu memory for Zed: search and recall the sessions your other coding agents already wrote, from inside Zed"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = ["vshulcz <vshulcz@gmail.com>"]
 repository = "https://github.com/vshulcz/deja-vu"


### PR DESCRIPTION
Found while taking Zed through the harness pass.

`/deja` was fixed in #3020 — it names `search` instead of handing the query over as deja's first word, and puts `--` in front of a query that starts with one. The extension installed here still runs `Command::new(binary).arg(query)`, so `/deja version` prints a version number and `/deja --limit 3` reaches deja's flag parsing.

The reason is not the code. `extension.toml` has said `0.1.0` since the extension was added, and Zed installs whatever version the registry names, so the fix has been sitting in the repository unreachable. Same shape as #2993: a fix that never left the building.

- the version moves to 0.1.1, so the next submission carries the fix;
- CI fails when `extensions/zed/src` or its `Cargo.toml` changed after the version last moved, with the two commits named.

The guard was checked against the two states it exists for: it passes on this branch and fails on the commit before the bump.

Submitting the new version to `zed-industries/extensions` is a separate, outward step and is not part of this PR.