### PR TITLE
docs(packages): homepage points at the page that documents each package

### DIFF
--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/vshulcz/deja-vu.git",
     "directory": "extensions/dsh"
   },
-  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/dsh",
+  "homepage": "https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html",
   "bugs": {
     "url": "https://github.com/vshulcz/deja-vu/issues"
   },

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/vshulcz/deja-vu.git",
     "directory": "extensions/openclaw"
   },
-  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/openclaw",
+  "homepage": "https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html",
   "bugs": {
     "url": "https://github.com/vshulcz/deja-vu/issues"
   },

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/vshulcz/deja-vu.git",
     "directory": "extensions/opencode"
   },
-  "homepage": "https://github.com/vshulcz/deja-vu/tree/main/extensions/opencode",
+  "homepage": "https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html",
   "bugs": {
     "url": "https://github.com/vshulcz/deja-vu/issues"
   },

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git+https://github.com/vshulcz/deja-vu.git"
   },
-  "homepage": "https://github.com/vshulcz/deja-vu",
+  "homepage": "https://vshulcz.github.io/deja-vu/",
   "bugs": {
     "url": "https://github.com/vshulcz/deja-vu/issues"
   },


### PR DESCRIPTION
`homepage` in the npm manifests now names the site page for that package — the home for `@vshulcz/deja-vu`, the per-harness guide for opencode, dsh and openclaw — instead of the GitHub tree, which `repository` already names and the extensions workflow checks. Package tests and the release/drift scripts unchanged and green.

Closes #3082