### PR TITLE
fix(grok): read grok's payload, and reach the agents it spawns

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -44,6 +44,15 @@ type precompactHookInput struct {
 	CWD            string `json:"cwd"`
 	HookEventName  string `json:"hook_event_name"`
 	Trigger        string `json:"trigger"`
+	// Grok spells all of this in camelCase. See hook_grok.go.
+	grokEnvelope
+}
+
+// adopt fills in what grok spells differently, so the session this compaction
+// belongs to is the one deja forgets.
+func (i *precompactHookInput) adopt() {
+	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
+	i.TranscriptPath = adoptGrok(i.TranscriptPath, i.grokEnvelope.TranscriptPath)
 }
 
 // hookStdinWait bounds how long any hook waits for its payload.
@@ -122,6 +131,7 @@ func endsAValue(b []byte) bool {
 func runHookPrecompact(dir string) {
 	var input precompactHookInput
 	_ = json.Unmarshal(readHookStdin(), &input)
+	input.adopt()
 	// Compaction throws away the blocks this session was shown, and the list
 	// that stops them repeating outlives them — so the memory the agent just
 	// lost is exactly the memory recall refuses to send again. Forget what this
@@ -293,6 +303,8 @@ func runHookContext(dir string, plain bool) error {
 		CWD       string `json:"cwd"`
 		// Cursor leaves cwd empty and names the project here instead.
 		WorkspaceRoots []string `json:"workspace_roots"`
+		// Grok spells all of this in camelCase. See hook_grok.go.
+		grokEnvelope
 	}
 	// Best effort, as every hook is — but not silent about it. A payload deja
 	// cannot decode carries the session this injection went to, and losing it
@@ -300,6 +312,8 @@ func runHookContext(dir string, plain bool) error {
 	// that sent nothing at all (#2161).
 	payload := readHookStdin()
 	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
+	input.SessionID = adoptGrok(input.SessionID, input.grokEnvelope.SessionID)
+	input.WorkspaceRoots = adoptGrokRoots(input.WorkspaceRoots, input.grokEnvelope.WorkspaceRoot)
 	// The harness tells us which project this is; deja read only the
 	// environment, so a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -313,7 +313,7 @@ func runHookContext(dir string, plain bool) error {
 	payload := readHookStdin()
 	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
 	input.SessionID = adoptGrok(input.SessionID, input.grokEnvelope.SessionID)
-	input.WorkspaceRoots = adoptGrokRoots(input.WorkspaceRoots, input.grokEnvelope.WorkspaceRoot)
+	input.WorkspaceRoots = adoptGrokRoots(input.WorkspaceRoots, input.WorkspaceRoot)
 	// The harness tells us which project this is; deja read only the
 	// environment, so a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR got no memory at all — indistinguishable from having

--- a/cmd/deja/hook_grok.go
+++ b/cmd/deja/hook_grok.go
@@ -1,0 +1,44 @@
+package main
+
+// Grok Build sends its hook payload in camelCase throughout, where every other
+// harness deja wires sends snake_case — sessionId, workspaceRoot,
+// transcriptPath, toolName, toolInput, measured on 1.0.5. Only cwd and prompt
+// happen to be spelled the same, which is why grok looked wired: the recall it
+// produced was for the right project and the right question, under no session
+// at all.
+//
+// A session with no name of its own shares the empty key in the dedup ledger
+// with every other session on the machine, so the second grok session looks
+// like it has already been shown everything the first one was, and a compaction
+// forgets nothing because there is nothing filed under its name.
+//
+// The structs below embed this one, so a payload decodes into both spellings at
+// once, and each adopts grok's where the common spelling arrived empty.
+type grokEnvelope struct {
+	SessionID      string `json:"sessionId"`
+	WorkspaceRoot  string `json:"workspaceRoot"`
+	TranscriptPath string `json:"transcriptPath"`
+	ToolName       string `json:"toolName"`
+	ToolInput      struct {
+		Command  string `json:"command"`
+		FilePath string `json:"file_path"`
+	} `json:"toolInput"`
+}
+
+// adoptGrok returns the value every other harness sends, or grok's when that
+// one is absent.
+func adoptGrok(common, grok string) string {
+	if common != "" {
+		return common
+	}
+	return grok
+}
+
+// adoptGrokRoots is the same for the project path, which grok names once where
+// cursor sends a list.
+func adoptGrokRoots(common []string, grok string) []string {
+	if len(common) > 0 || grok == "" {
+		return common
+	}
+	return []string{grok}
+}

--- a/cmd/deja/hook_grok_test.go
+++ b/cmd/deja/hook_grok_test.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Grok Build spells every hook field in camelCase. Measured on 1.0.5: the
+// payload names the project under `cwd` like everyone else, which is why the
+// recall it produced looked right — and names the session under `sessionId`,
+// which deja was not reading, so every grok session on the machine shared the
+// empty key in the dedup ledger.
+func TestGrokPayloadFilesRecallUnderItsOwnSession(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "grokterm", []string{
+		`{"type":"user","sessionId":"grokterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	payload := `{"hookEventName":"user_prompt_submit","prompt":"do we need pgbouncer here","sessionId":"grok-1"}`
+	var first bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &first, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(first.String(), "transaction mode") {
+		t.Fatalf("nothing was recalled to begin with:\n%q", first.String())
+	}
+	// The whole point: the serving is filed under the session grok named. Under
+	// the empty key it is filed against every other grok session at once.
+	if got := alreadyInjected(index.DefaultDir(), "grok-1"); len(got) == 0 {
+		t.Fatal("the serving was not filed under the session grok named")
+	}
+	if got := alreadyInjected(index.DefaultDir(), ""); len(got) != 0 {
+		t.Errorf("the serving was filed under no session at all: %v", got)
+	}
+
+	// And a compaction in that session forgets it, so what the compaction threw
+	// away can be sent again.
+	withHookStdin(t, `{"sessionId":"grok-1","hookEventName":"pre_compact"}`)
+	runHookPrecompact(index.DefaultDir())
+	if got := alreadyInjected(index.DefaultDir(), "grok-1"); len(got) != 0 {
+		t.Errorf("compaction left this session's seen list behind: %v", got)
+	}
+	var second bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &second, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(second.String(), "transaction mode") {
+		t.Errorf("after compaction the memory was still withheld:\n%q", second.String())
+	}
+}
+
+// Grok names the project twice, under `cwd` and under `workspaceRoot`. A
+// session started outside a workspace can leave the first empty, and the
+// project is what the ranking runs inside — with neither read, the recall is
+// for no project at all.
+func TestGrokWorkspaceRootNamesTheProject(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "grokroot", []string{
+		`{"type":"user","sessionId":"grokroot","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Somewhere else entirely, so only the payload can name the project.
+	elsewhere := filepath.Join(t.TempDir(), "unrelated")
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(elsewhere)
+	root := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := `{"hookEventName":"user_prompt_submit","prompt":"do we need pgbouncer here",` +
+		`"sessionId":"grok-2","workspaceRoot":` + strconv.Quote(root) + `}`
+	var out bytes.Buffer
+	if err := runHookPromptMode(index.DefaultDir(), strings.NewReader(payload), &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "transaction mode") {
+		t.Errorf("the project grok named in workspaceRoot was not recalled for:\n%q", out.String())
+	}
+}
+
+// Grok discards what a hook prints — measured on 1.0.5 for session start, the
+// user prompt, and both tool events. The one reply it acts on is a PreToolUse
+// that rewrites the tool's input, which is exactly the shape the spawn hook
+// already answers in. So the subagent is the one place in grok where deja can
+// still put memory in front of a model, and it works only if the spawn is
+// recognised under grok's name for it and read out of grok's spelling of the
+// payload.
+func TestGrokSpawnCarriesMemoryIntoTheSubagent(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "app", "past.jsonl"), "past", []string{
+		`{"type":"user","sessionId":"past","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the pgbouncer prepared statement error again"}}`,
+		`{"type":"assistant","sessionId":"past","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":"We decided to set default_query_exec_mode=exec for pgbouncer, because prepared statements do not survive transaction pooling."}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "src", "app")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	payload := `{"hookEventName":"pre_tool_use","toolName":"spawn_subagent","toolInput":` +
+		`{"prompt":"Investigate the pgbouncer prepared statement failure in the orders service.",` +
+		`"subagent_type":"general-purpose","description":"pgbouncer dig"},"sessionId":"grok-parent"}`
+	out := toolHookRun(t, payload)
+	if out == "" {
+		t.Fatal("a grok spawn whose subject the store answers carried nothing")
+	}
+	var resp spawnHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("not the PreToolUse shape: %v (%q)", err, out)
+	}
+	// Grok validates the rewritten input against the tool's schema and blocks
+	// the call outright when it does not fit, so a dropped field is worse here
+	// than a missing memory.
+	for _, f := range []string{"prompt", "subagent_type", "description"} {
+		if _, ok := resp.HookSpecificOutput.UpdatedInput[f]; !ok {
+			t.Errorf("updatedInput dropped %q", f)
+		}
+	}
+	var prompt string
+	if err := json.Unmarshal(resp.HookSpecificOutput.UpdatedInput["prompt"], &prompt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(prompt, "Investigate the pgbouncer prepared statement failure") {
+		t.Errorf("the parent's instructions were not kept intact: %q", prompt)
+	}
+	if !strings.Contains(prompt, "default_query_exec_mode") {
+		t.Errorf("the recall did not reach the subagent's prompt: %q", prompt)
+	}
+}
+
+// The same action, in grok's spelling: the tool it names and the command it
+// carries have to be read out of `toolName` and `toolInput` for the hook to
+// know what is about to run.
+func TestGrokToolPayloadNamesTheCommand(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"a", "b"} {
+		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the suite"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./... -count=1"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	out := toolHookRun(t, `{"hookEventName":"pre_tool_use","toolName":"run_terminal_command",`+
+		`"toolInput":{"command":"go test ./... -count=1","description":"suite"},"sessionId":"grok-3"}`)
+	if out == "" {
+		t.Fatal("a command run in two sessions produced no line from grok's payload")
+	}
+	var resp sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("hook output is not the PreToolUse shape: %v (%q)", err, out)
+	}
+	if !strings.Contains(resp.HookSpecificOutput.AdditionalContext, "2 sessions") {
+		t.Errorf("the line does not say how widely it ran: %q", resp.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+// The name grok gives the tool that spawns an agent. The wiring reaches it
+// because grok maps the Claude names onto its own, but the hook still has to
+// recognise what arrives.
+func TestGrokSpawnToolIsRecognised(t *testing.T) {
+	if !isSpawnTool("spawn_subagent") {
+		t.Error("grok's spawn was not recognised as one")
+	}
+	for _, name := range []string{"run_terminal_command", "search_replace", "write"} {
+		if isSpawnTool(name) {
+			t.Errorf("%q is not a spawn", name)
+		}
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -53,6 +53,15 @@ type promptHookInput struct {
 	CWD string `json:"cwd"`
 	// Cursor leaves cwd empty and names the project here instead.
 	WorkspaceRoots []string `json:"workspace_roots"`
+	// Grok spells all of this in camelCase. See hook_grok.go.
+	grokEnvelope
+}
+
+// adopt fills in what grok spells differently, so this prompt's recall is filed
+// under the session that asked for it.
+func (i *promptHookInput) adopt() {
+	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
+	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.grokEnvelope.WorkspaceRoot)
 }
 
 // hookPromptText reads a prompt that arrives either as a string (Claude Code,
@@ -145,6 +154,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// could not read (#2773). The prompt is what this hook recalls from, so a
 	// payload it cannot read at all injects nothing and this never fires.
 	unreadable := json.NewDecoder(bytes.NewReader(payload)).Decode(&input) != nil
+	input.adopt()
 	// The kill switch. It reached the session-start hook and nothing else, so
 	// this hook — every user message, and the wiring for seven harnesses —
 	// kept injecting on a machine with recall off (#2701).

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -61,7 +61,7 @@ type promptHookInput struct {
 // under the session that asked for it.
 func (i *promptHookInput) adopt() {
 	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
-	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.grokEnvelope.WorkspaceRoot)
+	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.WorkspaceRoot)
 }
 
 // hookPromptText reads a prompt that arrives either as a string (Claude Code,

--- a/cmd/deja/hook_spawn.go
+++ b/cmd/deja/hook_spawn.go
@@ -33,7 +33,7 @@ var spawnPromptFields = []string{"prompt", "instructions", "task"}
 // hook with its own matcher may spell it differently.
 func isSpawnTool(name string) bool {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "task", "agent", "subagent":
+	case "task", "agent", "subagent", "spawn_subagent":
 		return true
 	}
 	return false
@@ -47,8 +47,18 @@ func isSpawnTool(name string) bool {
 func runHookSpawn(dir string, input toolHookInput, raw []byte, stdout io.Writer) error {
 	var payload struct {
 		ToolInput map[string]json.RawMessage `json:"tool_input"`
+		// Grok spells it camelCase. See hook_grok.go — and a rewritten tool
+		// input is the one hook reply grok acts on, so reading its spelling is
+		// the whole of what makes memory reach a subagent there.
+		ToolInputCamel map[string]json.RawMessage `json:"toolInput"`
 	}
-	if err := json.Unmarshal(raw, &payload); err != nil || len(payload.ToolInput) == 0 {
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil
+	}
+	if len(payload.ToolInput) == 0 {
+		payload.ToolInput = payload.ToolInputCamel
+	}
+	if len(payload.ToolInput) == 0 {
 		return nil
 	}
 	field, text := spawnPrompt(payload.ToolInput)

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -70,12 +70,26 @@ type toolHookInput struct {
 	CWD       string `json:"cwd"`
 	// Cursor leaves cwd empty and names the project here instead.
 	WorkspaceRoots []string `json:"workspace_roots"`
+	// Grok spells all of this in camelCase. See hook_grok.go.
+	grokEnvelope
+}
+
+// adopt fills in what grok spells differently. Without the tool name and its
+// command this hook cannot tell a spawn from an edit, and has nothing to look
+// the action up by.
+func (i *toolHookInput) adopt() {
+	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
+	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.grokEnvelope.WorkspaceRoot)
+	i.ToolName = adoptGrok(i.ToolName, i.grokEnvelope.ToolName)
+	i.ToolInput.Command = adoptGrok(i.ToolInput.Command, i.grokEnvelope.ToolInput.Command)
+	i.ToolInput.FilePath = adoptGrok(i.ToolInput.FilePath, i.grokEnvelope.ToolInput.FilePath)
 }
 
 func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 	raw := readHookPayload(stdin, hookStdinWait)
 	var input toolHookInput
 	_ = json.NewDecoder(bytes.NewReader(raw)).Decode(&input)
+	input.adopt()
 	// The kill switch, before anything is read. It reached the session-start
 	// hook and nothing else, so a machine with recall off still had text drawn
 	// from its own indexed sessions injected here (#2701).
@@ -149,12 +163,20 @@ func runHookTool(dir string, stdin io.Reader, stdout io.Writer) error {
 // changed — Read, Glob and NotebookRead carry a file_path too, and a hook wired
 // with a wide matcher would otherwise fire on every one of them.
 func toolHookLine(dir, cwd string, input toolHookInput) string {
-	switch input.ToolName {
-	case "Bash":
+	// The names are each harness's own. A harness that calls its shell
+	// run_terminal_command rather than Bash was matched by the wiring — grok
+	// maps the Claude names onto its own — and then dropped here, so the hook
+	// fired on every action it took and had nothing to say about any of them.
+	if isCommandTool(input.ToolName) {
 		if cmd := strings.TrimSpace(input.ToolInput.Command); cmd != "" {
 			return commandHookLine(dir, cwd, cmd)
 		}
-	case "Edit", "Write", "MultiEdit", "NotebookEdit":
+		return ""
+	}
+	switch input.ToolName {
+	case "Edit", "Write", "MultiEdit", "NotebookEdit",
+		// Grok's editor and its file writer.
+		"search_replace", "write":
 		if path := strings.TrimSpace(input.ToolInput.FilePath); path != "" {
 			return fileHookLine(dir, cwd, path)
 		}

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -79,7 +79,7 @@ type toolHookInput struct {
 // the action up by.
 func (i *toolHookInput) adopt() {
 	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
-	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.grokEnvelope.WorkspaceRoot)
+	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.WorkspaceRoot)
 	i.ToolName = adoptGrok(i.ToolName, i.grokEnvelope.ToolName)
 	i.ToolInput.Command = adoptGrok(i.ToolInput.Command, i.grokEnvelope.ToolInput.Command)
 	i.ToolInput.FilePath = adoptGrok(i.ToolInput.FilePath, i.grokEnvelope.ToolInput.FilePath)

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -139,7 +139,8 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 // speaks for them.
 func isCommandTool(name string) bool {
 	switch name {
-	case "Bash", "bash", "shell", "Shell", "run_command", "execute_command", "terminal", "run_shell_command":
+	case "Bash", "bash", "shell", "Shell", "run_command", "execute_command", "terminal",
+		"run_shell_command", "run_terminal_command":
 		return true
 	}
 	return false

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1626,6 +1626,7 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 				if msg := hookStatusMessage(event); msg != "" {
 					h["statusMessage"] = msg
 				}
+				adoptMatcher(entry, hs, matcher)
 			}
 			kept = append(kept, hAny)
 		}
@@ -1660,6 +1661,26 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 		delete(root, "hooks")
 	}
 	return root
+}
+
+// adoptMatcher brings an entry deja already owns up to the matcher this build
+// wires. Without it a matcher is written once and never again: grok's session
+// hook carried `startup|resume` copied from Claude Code, grok names its sources
+// `new` and `load`, and the corrected matcher would have reached only machines
+// installing deja for the first time.
+//
+// It moves only when deja's hook is alone in the entry. A matcher covers every
+// hook beside it, so rewriting a shared one would silently change when someone
+// else's hook runs.
+func adoptMatcher(entry map[string]any, hooks []any, matcher string) {
+	if len(hooks) != 1 {
+		return
+	}
+	if matcher == "" {
+		delete(entry, "matcher")
+		return
+	}
+	entry["matcher"] = matcher
 }
 
 // combinedStatusline builds a command that runs the existing statusline and

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -18,6 +18,22 @@ import (
 // A file of deja's own rather than a shared settings file: the directory is
 // scanned, so there is nothing to merge into and nothing of the user's to
 // preserve.
+//
+// What grok does with a hook's answer is not what the other harnesses do, and
+// it decides what is worth wiring here. Measured on 1.0.5 against a stubbed
+// proxy, reading the request the model was actually sent: session start, the
+// user prompt and both tool events are passive — whatever the hook prints is
+// discarded, in `hookSpecificOutput.additionalContext`, as a flat
+// `additionalContext`, and with the event name in either spelling. Two replies
+// do reach the model: a PreToolUse `deny`, which deja never sends because it
+// does not block work, and `Stop`, which reaches it by keeping the agent
+// working for up to eight more rounds — a recall is not worth that.
+//
+// The exception is the one that matters. A PreToolUse reply carrying
+// `updatedInput` is applied, and it is what puts memory inside a spawned
+// agent's prompt (hook_spawn.go). So in grok the hooks below are wired for
+// their side effects — warming the index, forgetting what a compaction threw
+// away — and for the spawn, which is the one place deja still speaks.
 func grokHooksPath() string {
 	return filepath.Join(sources.GrokHome(), "hooks", "deja.json")
 }
@@ -43,10 +59,22 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
-	root = updateClaudeHook(root, "SessionStart", exe+" hook-context", "startup|resume", false)
-	root = updateClaudeHook(root, "PreCompact", exe+" hook-precompact", "manual|auto", false)
+	// No matcher. Grok's own docs name the session sources `startup` and
+	// `resume`, but 1.0.5 sends `new` for a fresh session and `load` for a
+	// resumed one, so the matcher deja copied from Claude Code matched neither
+	// and this hook had never once fired on grok. That is the expensive kind of
+	// silence: hook-context is what starts the index warming, so grok was the
+	// one harness where the first recall of a session paid for the rebuild
+	// inline. An empty matcher takes whatever source grok names next, and
+	// PreCompact drops its documented `manual|auto` for the same reason — every
+	// trigger it can name is a compaction, which is the one deja wants.
+	root = updateClaudeHook(root, "SessionStart", exe+" hook-context", "", false)
+	root = updateClaudeHook(root, "PreCompact", exe+" hook-precompact", "", false)
 	root = updateClaudeHook(root, "UserPromptSubmit", exe+" hook-prompt", "", false)
 	// Scoped to the tools that change something, so it never fires on a read.
+	// Grok maps the Claude names onto its own, so `Bash` here reaches
+	// run_terminal_command, `Write` reaches write and `Agent` reaches
+	// spawn_subagent — the one of them whose reply grok acts on.
 	root = updateClaudeHook(root, "PreToolUse", exe+" hook-tool", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", false)
 	next, err := marshalConfigLike(old, root)
 	if err != nil {

--- a/cmd/deja/install_grok_auto_test.go
+++ b/cmd/deja/install_grok_auto_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -62,6 +63,96 @@ func TestGrokAutoWritesEveryHookEvent(t *testing.T) {
 	}
 	if _, err := os.Stat(grokHooksPath()); !os.IsNotExist(err) {
 		t.Fatalf("hooks file survived uninstall: %v", err)
+	}
+}
+
+// grokHookEntries reads the groups grok would load for one event.
+func grokHookEntries(t *testing.T, event string) []struct {
+	Matcher string `json:"matcher"`
+	Hooks   []struct {
+		Type    string `json:"type"`
+		Command string `json:"command"`
+	} `json:"hooks"`
+} {
+	t.Helper()
+	b, err := os.ReadFile(grokHooksPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatalf("hooks file is not valid JSON: %v\n%s", err, b)
+	}
+	return root.Hooks[event]
+}
+
+// Grok's docs name the session sources `startup` and `resume`; 1.0.5 sends
+// `new` for a fresh session and `load` for a resumed one. deja copied the
+// Claude Code matcher, which matched neither, so this hook had never once
+// fired on grok — and it is the hook that starts the index warming, so grok
+// was the harness where the first recall of every session waited for a
+// rebuild. No matcher takes whatever source grok names next.
+func TestGrokSessionHookTakesWhateverSourceGrokNames(t *testing.T) {
+	hermeticEnv(t)
+	if _, err := installGrokAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	groups := grokHookEntries(t, "SessionStart")
+	if len(groups) == 0 {
+		t.Fatal("no SessionStart hook")
+	}
+	if m := groups[0].Matcher; m != "" {
+		t.Errorf("SessionStart still filters on %q, which grok's own sources do not match", m)
+	}
+}
+
+// A matcher deja got wrong is written once and, without this, never corrected:
+// every machine that had already installed deja would keep the broken one.
+func TestAnOldGrokMatcherIsCorrectedOnReinstall(t *testing.T) {
+	hermeticEnv(t)
+	stale := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[` +
+		`{"type":"command","command":"/bin/deja hook-context"}]}]}}`
+	if err := os.MkdirAll(filepath.Dir(grokHooksPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(grokHooksPath(), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGrokAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	groups := grokHookEntries(t, "SessionStart")
+	if len(groups) != 1 {
+		t.Fatalf("reinstall did not take over the existing entry: %d groups", len(groups))
+	}
+	if m := groups[0].Matcher; m != "" {
+		t.Errorf("the stale matcher survived a reinstall: %q", m)
+	}
+}
+
+// The matcher covers every hook in its entry, so one deja shares with someone
+// else's hook is not deja's to rewrite.
+func TestASharedEntryKeepsItsMatcher(t *testing.T) {
+	entry := map[string]any{"matcher": "startup|resume"}
+	hooks := []any{
+		map[string]any{"type": "command", "command": "/bin/deja hook-context"},
+		map[string]any{"type": "command", "command": "/usr/local/bin/notify"},
+	}
+	adoptMatcher(entry, hooks, "")
+	if entry["matcher"] != "startup|resume" {
+		t.Errorf("a matcher shared with another hook was rewritten: %v", entry["matcher"])
+	}
+	adoptMatcher(entry, hooks[:1], "")
+	if _, ok := entry["matcher"]; ok {
+		t.Errorf("deja's own entry kept a matcher this build no longer wires: %v", entry["matcher"])
 	}
 }
 


### PR DESCRIPTION
Closes #3084.

Four fixes, each measured on Grok Build 1.0.5 against a stubbed proxy:

- `SessionStart` drops the `startup|resume` matcher, which grok's own sources (`new`, `load`) never matched. `PreCompact` drops its matcher for the same reason — every trigger it can name is a compaction.
- `updateClaudeHook` now brings an existing entry up to the matcher this build wires, so the correction reaches machines that already installed deja. Only when deja's hook is alone in the entry: a matcher covers every hook beside it.
- The hook inputs read grok's camelCase spelling, so a session is filed under its own name and a compaction forgets what it threw away.
- `spawn_subagent` is recognised as a spawn and its `toolInput` is read. A `PreToolUse` rewrite is the one reply grok acts on, so this is what puts memory in a spawned agent's prompt there — verified end to end by reading the subagent's own request off the stubbed proxy.

The tool hook also learns grok's shell and editor names; `run_terminal_command` joins the shell tools the post-tool hook already knows.

Every fix has a test that goes red when the fix is reverted.
