### PR TITLE
feat(openclaw): a local session opens knowing what this project settled

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -140,6 +140,30 @@ func runHookPrecompact(dir string) {
 	requestWarmup(dir)
 }
 
+// sessionHadDigest reports whether this session has already had its one
+// session-start attempt, for a host that fires that event every turn. Antigravity
+// keeps the same record under a key of its own; this one is for hosts that come
+// in through the ordinary session-start hook.
+func sessionHadDigest(dir, sessionID string) bool {
+	if strings.TrimSpace(sessionID) == "" {
+		return false
+	}
+	return alreadyInjected(dir, onceDigestKey(sessionID))[onceDigestToken]
+}
+
+func rememberSessionDigest(dir, sessionID string) {
+	if strings.TrimSpace(sessionID) == "" {
+		return
+	}
+	rememberInjectedIDs(dir, onceDigestKey(sessionID), onceDigestToken)
+}
+
+func onceDigestKey(sessionID string) string { return "once:" + sessionID }
+
+// onceDigestToken is what the ledger row says: this session has had its
+// session-start attempt.
+const onceDigestToken = "once-digest"
+
 // joinNotes puts a maintenance line ahead of the memory line without letting
 // an empty one leave a stray separator.
 func joinNotes(a, b string) string {
@@ -305,6 +329,14 @@ func runHookContext(dir string, plain bool) error {
 		WorkspaceRoots []string `json:"workspace_roots"`
 		// Grok spells all of this in camelCase. See hook_grok.go.
 		grokEnvelope
+		// Once is set by a host whose session-start event is really a per-turn
+		// one. OpenClaw's before_agent_start fires on every agent run, so
+		// without this the project digest would go in front of the model on
+		// every message rather than at the start of the session. The session
+		// gets one attempt: the digest describes the project rather than the
+		// question, so a first turn with nothing to say has nothing new to say
+		// on the second either.
+		Once bool `json:"deja_once"`
 	}
 	// Best effort, as every hook is — but not silent about it. A payload deja
 	// cannot decode carries the session this injection went to, and losing it
@@ -313,6 +345,12 @@ func runHookContext(dir string, plain bool) error {
 	payload := readHookStdin()
 	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
 	input.SessionID = adoptGrok(input.SessionID, input.grokEnvelope.SessionID)
+	if input.Once {
+		if sessionHadDigest(dir, input.SessionID) {
+			return nil
+		}
+		rememberSessionDigest(dir, input.SessionID)
+	}
 	input.WorkspaceRoots = adoptGrokRoots(input.WorkspaceRoots, input.WorkspaceRoot)
 	// The harness tells us which project this is; deja read only the
 	// environment, so a host that sends the payload without exporting

--- a/cmd/deja/hook_context_once_test.go
+++ b/cmd/deja/hook_context_once_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Some hosts have no session-start event, only a per-turn one that stands in
+// for it — OpenClaw's before_agent_start fires on every agent run. deja_once is
+// what keeps the project digest to the first of them; without it the same block
+// goes in front of the model on every message.
+func TestDejaOnceKeepsTheDigestToTheFirstTurn(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "onceterm", []string{
+		`{"type":"user","sessionId":"onceterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	ask := func(sid string, once bool) string {
+		t.Helper()
+		payload := `{"session_id":"` + sid + `","cwd":"` + cwd + `","source":"startup"`
+		if once {
+			payload += `,"deja_once":true`
+		}
+		payload += `}`
+		withHookStdin(t, payload)
+		return captureStdout(t, func() { _ = runHookContext(index.DefaultDir(), true) })
+	}
+
+	if first := ask("once-1", true); strings.TrimSpace(first) == "" {
+		t.Fatal("the session opened with nothing, so there is no repeat to test")
+	}
+	if again := ask("once-1", true); strings.TrimSpace(again) != "" {
+		t.Errorf("the digest went in a second time in the same session:\n%q", again)
+	}
+	// Another session is another reader.
+	if other := ask("once-2", true); strings.TrimSpace(other) == "" {
+		t.Error("a second session was refused the digest the first one had")
+	}
+	// And a host whose session start really is once per session is unchanged.
+	if a, b := ask("plain-1", false), ask("plain-1", false); strings.TrimSpace(a) == "" ||
+		strings.TrimSpace(b) == "" {
+		t.Errorf("the ordinary session-start path went quiet: %q then %q", a, b)
+	}
+}

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -155,10 +155,46 @@ import { execFileSync } from "node:child_process";
 
 const DEJA = %q;
 
+// Memory is optional: a hook that throws must never take the turn down with it.
+function ask(args, payload) {
+  try {
+    return execFileSync(DEJA, args, {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      timeout: 10000,
+      maxBuffer: 4 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
 export default {
   id: %q,
   name: "deja recall",
   register(api) {
+    // What this project settled, at the start of the session. The bootstrap
+    // hook does this in gateway mode and does not run under the local agent,
+    // where a session had no memory of the project at all until it happened to
+    // ask a question the store answered.
+    //
+    // before_agent_start fires once per agent run rather than once per session,
+    // so deja_once is what keeps the digest to the first of them.
+    api.on(
+      "before_agent_start",
+      async (_event, ctx) => {
+        const digest = ask(["hook-context", "--plain"], {
+          session_id: ctx?.sessionKey || ctx?.sessionId || "",
+          cwd: process.cwd(),
+          source: "startup",
+          deja_once: true,
+        });
+        if (!digest) return;
+        return { prependContext: digest };
+      },
+      { timeoutMs: 15000 },
+    );
     api.on(
       "before_prompt_build",
       async (event) => {
@@ -168,19 +204,11 @@ export default {
         // session id. A payload without one turns that off: measured on a real
         // store, half of all injections were then a word-for-word repeat.
         const sessionID = event?.sessionId || event?.session_id || event?.session?.id || "";
-        let recall = "";
-        try {
-          recall = execFileSync(DEJA, ["hook-prompt", "--plain"], {
-            input: JSON.stringify({ prompt, session_id: sessionID, cwd: process.cwd() }),
-            encoding: "utf8",
-            timeout: 10000,
-            maxBuffer: 4 * 1024 * 1024,
-            stdio: ["pipe", "pipe", "ignore"],
-          }).trim();
-        } catch {
-          // Memory is optional: never take the turn down with it.
-          return;
-        }
+        const recall = ask(["hook-prompt", "--plain"], {
+          prompt,
+          session_id: sessionID,
+          cwd: process.cwd(),
+        });
         // Silence is the common case — the hook speaks only when the user's
         // own history answers what they just asked.
         if (!recall) return;

--- a/cmd/deja/install_openclaw_start_test.go
+++ b/cmd/deja/install_openclaw_start_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// OpenClaw's bootstrap hook recalls once against the session and only in
+// gateway mode, so a local run had no memory of the project at all until it
+// happened to ask a question the store answered. before_agent_start is the
+// plugin's session-start channel and its prependContext reaches the model
+// (measured on OpenClaw 2026.7.1-2, read off the provider request).
+//
+// It fires once per agent run rather than once per session, which is why the
+// payload carries deja_once: without it the project digest would go in front of
+// the model on every message.
+func TestOpenClawPluginOpensWithTheProjectDigest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub deja is a shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is needed to run the plugin openclaw would run")
+	}
+	home := t.TempDir()
+	stub := filepath.Join(home, "deja")
+	calls := filepath.Join(home, "calls")
+	script := "#!/bin/sh\nin=$(cat)\nprintf '%s\\n' \"$in\" >> " + calls + "\n" +
+		"case \"$1\" in hook-context) printf 'DIGEST for this project' ;; esac\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := filepath.Join(home, "index.mjs")
+	if err := os.WriteFile(plugin, []byte(openclawPluginJS(stub)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	driver := `
+import plugin from "` + plugin + `";
+let handler;
+plugin.register({ on: (name, fn) => { if (name === "before_agent_start") handler = fn } });
+if (!handler) { console.log("NOHOOK"); process.exit(0) }
+const out = await handler({ prompt: "hello" }, { sessionKey: "agent:main:explicit:s1" });
+console.log(JSON.stringify(out ?? null));
+`
+	run := filepath.Join(home, "drive.mjs")
+	if err := os.WriteFile(run, []byte(driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, run).CombinedOutput()
+	if err != nil {
+		t.Fatalf("driving the plugin: %v\n%s", err, out)
+	}
+	first := strings.TrimSpace(strings.Split(strings.TrimSpace(string(out)), "\n")[0])
+	if first == "NOHOOK" {
+		t.Fatal("the plugin registers no before_agent_start handler, so a local " +
+			"session still opens with no memory of the project")
+	}
+	var got map[string]string
+	if err := json.Unmarshal([]byte(first), &got); err != nil {
+		t.Fatalf("handler returned %s", first)
+	}
+	if !strings.Contains(got["prependContext"], "DIGEST") {
+		t.Errorf("the digest did not come back as prependContext, which is the "+
+			"only field openclaw reads here: %s", first)
+	}
+	asked, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatalf("the plugin never called deja: %v", err)
+	}
+	var payload struct {
+		SessionID string `json:"session_id"`
+		Once      bool   `json:"deja_once"`
+		CWD       string `json:"cwd"`
+	}
+	if err := json.Unmarshal([]byte(strings.Split(strings.TrimSpace(string(asked)), "\n")[0]), &payload); err != nil {
+		t.Fatalf("payload is not JSON: %v (%s)", err, asked)
+	}
+	if !payload.Once {
+		t.Error("the payload does not ask for one digest per session, so it would " +
+			"go in on every message")
+	}
+	if payload.SessionID == "" {
+		t.Error("the payload names no session, and the guard that keeps the digest " +
+			"to one turn is keyed on it")
+	}
+	if payload.CWD == "" {
+		t.Error("the payload names no project, so the digest would be for whatever " +
+			"deja's own working directory happens to be")
+	}
+}


### PR DESCRIPTION
Closes #3086.

`before_agent_start` is the plugin's session-start channel and what it returns as `prependContext` is in the provider request — so a local openclaw run now opens with the project digest instead of nothing. It fires once per agent run, so the payload carries `deja_once`, which gives a session one attempt at the digest and silence after it.

Cost, mean of five runs against a copy of the real index: 74 ms and 1.6 KB on the first turn, 25 ms and nothing on every turn after.

Proof it arrives, read off the stubbed provider rather than the plugin's stdout: turn 1's request carries the block, turn 2's does not.

Nothing is wired for the fix pair here on purpose. `after_tool_call` returns void, and a `tool_result_persist` rewrite does not reach the turn that produced it — checked from a bare probe plugin and from deja's own, on a command that really failed. #3086 has the detail.
