### PR TITLE
fix(completion): suggest search limit flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - OpenClaw: `@vshulcz/openclaw-deja`, the recall plugin as a package — `openclaw plugins install clawhub:@vshulcz/openclaw-deja` — with `before_prompt_build` recall and `deja_recall`, `deja_fix`, `deja_blame` as tools; it reads what `deja install openclaw-auto` wrote and adds only what is missing. (#3047)
 
+### Fixed
+- Search: offer `--limit` in bash, zsh, fish, and PowerShell completions. (#1929)
+
 ## [0.19.3] - 2026-09-04
 
 A release about the moment memory is worth most: the turn a command fails, the

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -59,7 +59,7 @@ _deja_completion() {
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
     if (( COMP_CWORD == 1 )); then
-        COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --session --rebuild" -- "$cur") )
+        COMPREPLY=( $(compgen -W "$commands --version -version --json --re --all --no-embed --harness --project --since --role --session --rebuild --limit" -- "$cur") )
         return
     fi
 
@@ -154,7 +154,7 @@ _deja_completion() {
             if [[ "$prev" == "--harness" ]]; then
                 COMPREPLY=( $(compgen -W "$harnesses" -- "$cur") )
             else
-                COMPREPLY=( $(compgen -W "--json --re --all --no-embed --harness --project --since --role --session --rebuild" -- "$cur") )
+                COMPREPLY=( $(compgen -W "--json --re --all --no-embed --harness --project --since --role --session --rebuild --limit" -- "$cur") )
             fi
             ;;
     esac
@@ -276,7 +276,7 @@ _deja() {
     check|ctx|embed|hook-precompact|hook-prompt|mcp|share|sources|statusline|update|version|warmup)
       ;;
     *)
-      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]'
+      _arguments '--json[print JSON]' '--re[interpret query as a regular expression]' '--all[include all results]' '--no-embed[skip semantic reranking]' '--harness=[filter by harness]:harness:($harnesses)' '--project=[filter by project]:project:' '--since=[filter by age]:duration:' '--role=[filter by role]:role:(%ROLES%)' '--session=[only one session]:id:' '--rebuild[force a full rebuild]' '--limit=[max sessions to return (1-100)]:count:'
       ;;
   esac
 }
@@ -299,6 +299,8 @@ complete -c deja -n '__deja_needs_command' -l since -r
 complete -c deja -n '__deja_needs_command' -l role -r -a '%ROLES%'
 complete -c deja -n '__deja_needs_command' -l session -r
 complete -c deja -n '__deja_needs_command' -l rebuild
+complete -c deja -n '__deja_needs_command' -l limit -r -d 'Max sessions to return (1-100)'
+complete -c deja -n '__fish_seen_subcommand_from search' -l limit -r -d 'Max sessions to return (1-100)'
 
 complete -c deja -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish powershell pwsh'
 complete -c deja -n '__fish_seen_subcommand_from blame' -l all
@@ -373,7 +375,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
     $handoffTargets = @('%HANDOFF_TARGETS%' -split ' ' | Where-Object { $_ })
     $defaultOptions = @(
         '--json', '--re', '--all', '--no-embed', '--harness', '--project',
-        '--since', '--role', '--session', '--rebuild'
+        '--since', '--role', '--session', '--rebuild', '--limit'
     )
 
     $elements = @($commandAst.CommandElements | ForEach-Object { $_.Extent.Text })

--- a/cmd/deja/completion_limit_test.go
+++ b/cmd/deja/completion_limit_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCompletionSearchLimit(t *testing.T) {
+	withTempStores(t)
+	// Check the search declarations, not merely the presence of --limit:
+	// show already has its own, separate limit option.
+	for _, tc := range []struct {
+		shell, start, end, want string
+	}{
+		{"bash", "        *)", "    esac", "--limit"},
+		{"zsh", "    *)", "  esac", "--limit=[max sessions to return (1-100)]:count:"},
+		{"fish", "complete -c deja -n '__deja_needs_command' -l limit", "\n", "-r"},
+		{"fish", "complete -c deja -n '__fish_seen_subcommand_from search' -l limit", "\n", "-r"},
+		{"powershell", "$defaultOptions = @(", ")", "'--limit'"},
+	} {
+		t.Run(tc.shell+"/"+tc.start, func(t *testing.T) {
+			_, section, ok := strings.Cut(emittedCompletion(t, tc.shell), tc.start)
+			if !ok {
+				t.Fatalf("missing search declaration %q", tc.start)
+			}
+			section, _, _ = strings.Cut(section, tc.end)
+			if !strings.Contains(section, tc.want) {
+				t.Errorf("search declaration %q missing %q", section, tc.want)
+			}
+		})
+	}
+}
+
+func TestBashCompletionLimitScope(t *testing.T) {
+	withTempStores(t)
+	t.Setenv("BASH_ENV", "")
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not on PATH")
+	}
+	for _, tc := range []struct {
+		words string
+		want  bool
+	}{
+		{"deja --li", true},
+		{"deja search --li", true},
+		{"deja search query --li", true},
+		{"deja query --li", true},
+		{"deja show session --li", true},
+		{"deja last --li", false},
+		{"deja doctor --li", false},
+		{"deja search --harness --li", false},
+	} {
+		t.Run(tc.words, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			// words contains only the fixed test cases above, never user input.
+			drive := "\nCOMP_WORDS=(" + tc.words + ")\nCOMP_CWORD=$((${#COMP_WORDS[@]}-1))\n_deja_completion\nprintf '%s\\n' \"${COMPREPLY[@]}\"\n"
+			out, err := exec.CommandContext(ctx, bash, "--noprofile", "--norc", "-c", emittedCompletion(t, "bash")+drive).CombinedOutput()
+			if err != nil {
+				t.Fatalf("bash completion failed: %v\n%s", err, out)
+			}
+			got := false
+			for _, candidate := range strings.Fields(string(out)) {
+				got = got || candidate == "--limit"
+			}
+			if got != tc.want {
+				t.Errorf("offers --limit = %v, want %v; candidates: %s", got, tc.want, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Added search --limit completion support for Bash, zsh, fish, and PowerShell with focused regression tests and changelog entry.

## Summary
- add --limit to search completions for Bash, zsh, fish, and PowerShell
- add focused scope and declaration tests
- record the fix in the changelog

## Testing
- go test ./... -race -count=1
- go vet ./...
- go build ./cmd/deja
- cmd/deja coverage: 90.0%

Fixes #1929

### Verification
- focused completion tests passed
- go test ./... -race passed
- go vet ./... passed
- go build passed
- cmd/deja coverage 90.0 percent; total 90.1 percent
- git diff --check passed

> Prepared by IssuePilot with Codex. This is a draft and requires human review.