### PR TITLE
feat(deepseek): a dsh session opens knowing what this project settled

### DIFF
--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -117,19 +117,44 @@ import { execFileSync } from "node:child_process";
 
 const DEJA = %q;
 
-function recall(prompt) {
+// Memory is optional: a plugin that throws in an assembly ends the turn, so
+// every call deja makes is swallowed to "".
+function ask(args, payload) {
   try {
-    return execFileSync(DEJA, ["hook-prompt", "--plain"], {
-      input: JSON.stringify({ prompt, cwd: process.cwd() }),
+    return execFileSync(DEJA, args, {
+      input: JSON.stringify(payload),
       encoding: "utf8",
       timeout: 10000,
       maxBuffer: 4 * 1024 * 1024,
       stdio: ["pipe", "pipe", "ignore"],
     }).trim();
   } catch {
-    // Memory is optional: a plugin that throws here ends the turn.
     return "";
   }
+}
+
+function recall(prompt) {
+  return ask(["hook-prompt", "--plain"], { prompt, cwd: process.cwd() });
+}
+
+function sessionId(agent) {
+  return (agent && (agent.sessionId || (agent.session && agent.session.id))) || "";
+}
+
+// The project digest, once at the start of the session. deja_once keys the
+// one-shot on the session id in deja's ledger, which survives a resume in a new
+// process; the Set is the in-process guard that keeps the long-lived web and
+// tui profiles from spawning deja on every assembly of a session already shown.
+function projectDigest(agent, seen) {
+  const sid = sessionId(agent);
+  if (sid && seen.has(sid)) return "";
+  if (sid) seen.add(sid);
+  return ask(["hook-context", "--plain"], {
+    session_id: sid,
+    cwd: process.cwd(),
+    source: "startup",
+    deja_once: true,
+  });
 }
 
 function userText(message) {
@@ -167,13 +192,30 @@ function lastHumanText(agent) {
 function apply(ctx) {
   let asked = "";
   let recalled = "";
+  const digestSeen = new Set();
 
   // A second copy of this file in the same profile — the npm package next to
   // the installer's, a --patch overlay naming it again — makes the host throw
   // "prompt context deja:recall is already registered", and that takes the
   // whole profile down: no agent at all, over an optional memory plugin.
   // One registration is all recall needs, so the loser stands down quietly.
+  //
+  // Two contexts are registered. deja:project is what this project settled,
+  // once at the start of the session, ordered ahead of the per-prompt recall so
+  // it reads as background rather than an answer to the question.
+  // agent/session-start is emit-only — its return reaches nothing — so the
+  // digest rides the same assembly seam the recall does, gated to one turn per
+  // session.
   try {
+    ctx.systemPrompt.context({
+      name: "deja:project",
+      order: 110,
+      text: (assembly) => {
+        const agent = assembly && assembly.agent;
+        if (!agent) return "";
+        return projectDigest(agent, digestSeen);
+      },
+    });
     ctx.systemPrompt.context({
       name: "deja:recall",
       order: 120,

--- a/cmd/deja/install_deepseek_start_test.go
+++ b/cmd/deja/install_deepseek_start_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// dsh's per-prompt recall answers the question just asked; the project digest —
+// what this project settled, regardless of the question — had no channel, so a
+// dsh session opened knowing nothing about the project until it happened to ask
+// something the store answered. agent/session-start is emit-only, so the digest
+// rides the same systemPrompt.context seam the recall does, gated to one turn
+// per session.
+func TestDeepSeekAutoOpensWithTheProjectDigest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DSH_HOME", filepath.Join(home, ".dsh"))
+	if _, err := installDeepSeekAuto("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	js, err := os.ReadFile(filepath.Join(home, ".dsh", "plugins", "deja", "auto.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(js)
+	if !strings.Contains(s, `name: "deja:project"`) {
+		t.Errorf("no project-digest context is registered:\n%s", s)
+	}
+	if !strings.Contains(s, `"hook-context", "--plain"`) {
+		t.Errorf("the digest never asks deja for the project's history:\n%s", s)
+	}
+	if !strings.Contains(s, "deja_once: true") {
+		t.Errorf("the digest is not gated to one turn, so it repeats every assembly:\n%s", s)
+	}
+}
+
+// The plugin's contract exercised the way the host uses it: two assemblies of
+// one session get the digest exactly once, a second session gets its own, and
+// the digest asks deja with deja_once and the session id.
+func TestDeepSeekAutoDigestContract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub deja is a shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is needed to run the plugin dsh would run")
+	}
+	home := t.TempDir()
+	stub := filepath.Join(home, "deja")
+	calls := filepath.Join(home, "calls")
+	script := "#!/bin/sh\nin=$(cat)\nprintf '%s %s\\n' \"$1\" \"$in\" >> " + calls + "\n" +
+		"case \"$1\" in hook-context) printf 'DIGEST for this project' ;; esac\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := filepath.Join(home, "auto.js")
+	if err := os.WriteFile(plugin, []byte(dshAutoJS(stub)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	driver := `
+import plugin from "` + plugin + `";
+const contexts = [];
+plugin({ systemPrompt: { context: (c) => contexts.push(c) } });
+const digest = contexts.find((c) => c.name === "deja:project");
+if (!digest) { console.log("NODIGEST"); process.exit(0) }
+const a = { sessionId: "sess-A", session: { events: [] } };
+const b = { sessionId: "sess-B", session: { events: [] } };
+console.log(JSON.stringify(digest.text({ agent: a })));
+console.log(JSON.stringify(digest.text({ agent: a })));
+console.log(JSON.stringify(digest.text({ agent: b })));
+`
+	run := filepath.Join(home, "drive.mjs")
+	if err := os.WriteFile(run, []byte(driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, run).CombinedOutput()
+	if err != nil {
+		t.Fatalf("driving the plugin: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if lines[0] == "NODIGEST" {
+		t.Fatal("the plugin registers no deja:project context, so a session opens with no memory of the project")
+	}
+	if len(lines) < 3 {
+		t.Fatalf("driver said %q", out)
+	}
+	if !strings.Contains(lines[0], "DIGEST") {
+		t.Errorf("the session's first turn carried no digest: %q", lines[0])
+	}
+	if strings.Contains(lines[1], "DIGEST") {
+		t.Errorf("the digest came back on the same session's second turn: %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "DIGEST") {
+		t.Errorf("a second session was refused the digest the first one had: %q", lines[2])
+	}
+	// One session, one call: the in-process guard must keep the long-lived web
+	// and tui profiles from spawning deja on every assembly.
+	asked, err := os.ReadFile(calls)
+	if err != nil {
+		t.Fatalf("the plugin never called deja: %v", err)
+	}
+	if n := strings.Count(string(asked), "hook-context"); n != 2 {
+		t.Errorf("expected one hook-context per session (2 total), got %d:\n%s", n, asked)
+	}
+	if !strings.Contains(string(asked), `"deja_once":true`) {
+		t.Errorf("the digest payload does not ask for one per session:\n%s", asked)
+	}
+	if !strings.Contains(string(asked), `"session_id":"sess-A"`) {
+		t.Errorf("the digest payload names no session, and the guard is keyed on it:\n%s", asked)
+	}
+}

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -258,6 +258,39 @@ function userText(message) {
 // needs. installedByCLI() below is the first line of defence; this is the one
 // that holds when the installer wrote to a different DSH_HOME than the profile
 // boots from.
+// autoDigest puts what this project settled in front of the model once at the
+// start of the session — the question-independent counterpart to autoRecall.
+// dsh's own agent/session-start is emit-only, its return reaches nothing, so
+// the digest rides the same assembly seam the recall does. deja_once keys the
+// one-shot on the session id in deja's ledger, which survives a resume in a new
+// process; the Set is the in-process guard that keeps the long-lived web and
+// tui profiles from spawning deja on every assembly of a session already shown.
+function autoDigest(ctx) {
+  const seen = new Set();
+
+  guarded(() =>
+    ctx.systemPrompt.context({
+      name: "deja:project",
+      order: 110,
+      text: (assembly) => {
+        const agent = assembly && assembly.agent;
+        if (!agent) return "";
+        const sid = sessionId(agent);
+        if (sid && seen.has(sid)) return "";
+        if (sid) seen.add(sid);
+        return run(
+          ["hook-context", "--plain"],
+          JSON.stringify({ session_id: sid, cwd: process.cwd(), source: "startup", deja_once: true }),
+        );
+      },
+    }),
+  );
+}
+
+function sessionId(agent) {
+  return (agent && (agent.sessionId || (agent.session && agent.session.id))) || "";
+}
+
 function autoRecall(ctx) {
   let asked = "";
   let recalled = "";
@@ -339,7 +372,10 @@ function apply(ctx, config) {
   );
   if (adds.tools) tools(ctx);
   if (adds.command) command(ctx);
-  if (adds.recall) autoRecall(ctx);
+  if (adds.recall) {
+    autoDigest(ctx);
+    autoRecall(ctx);
+  }
 }
 
 apply.inject = ["tools", "commands", "systemPrompt"];

--- a/extensions/dsh/test/pure.test.js
+++ b/extensions/dsh/test/pure.test.js
@@ -84,6 +84,14 @@ test("automatic recall does not use the pre-step waterfall", () => {
   assert.match(source, /ctx\.systemPrompt\.context\(/);
 });
 
+test("the project digest opens the session once and asks deja for it", () => {
+  // agent/session-start is emit-only, so the digest rides the same assembly
+  // seam the recall does; deja_once is what keeps it to one turn per session.
+  assert.match(source, /name: "deja:project"/);
+  assert.match(source, /"hook-context", "--plain"/);
+  assert.match(source, /deja_once: true/);
+});
+
 // dsh refuses a name one of its registries already holds — "prompt context
 // deja:recall is already registered", "command deja is already registered" —
 // and the failure is not local: the whole profile fails to load, so a second
@@ -113,7 +121,7 @@ test("every registration the plugin makes goes through the guard", () => {
       `${m[0]} is not wrapped in guarded()`,
     );
   }
-  assert.equal(total, 8, "six tools, the command and the recall");
+  assert.equal(total, 9, "six tools, the command, the project digest and the recall");
 });
 
 test("a name the host already holds does not take the profile down", () => {
@@ -195,7 +203,7 @@ test("nothing installed by the CLI: the package contributes everything", () => {
   // The tool count is not asserted: registering them needs the dsh-tools peer,
   // which the host provides and this test does not have.
   assert.deepEqual(ctx.seen.commands, ["deja"]);
-  assert.deepEqual(ctx.seen.context, ["deja:recall"]);
+  assert.deepEqual(ctx.seen.context, ["deja:project", "deja:recall"]);
 });
 
 test("the CLI's install stands the command and the tools down", () => {
@@ -208,7 +216,7 @@ test("the CLI's install stands the command and the tools down", () => {
   });
   assert.equal(ctx.seen.tools, 0);
   assert.deepEqual(ctx.seen.commands, []);
-  assert.deepEqual(ctx.seen.context, ["deja:recall"], "recall was not installed by the CLI, so it stays here");
+  assert.deepEqual(ctx.seen.context, ["deja:project", "deja:recall"], "recall was not installed by the CLI, so it stays here");
 });
 
 test("the CLI's auto file stands the package's recall down", () => {


### PR DESCRIPTION
Closes #3093.

A second `systemPrompt.context` contributor, `deja:project`, ordered ahead of the per-prompt recall so it reads as background rather than an answer. It carries `hook-context --plain` with `deja_once`, which gives the session one digest and silence after — plus an in-process Set so the long-lived web and tui profiles don't spawn deja on every assembly of a session already shown. `agent/session-start` is emit-only, which is why the digest rides the assembly seam instead.

Both implementations updated in parity: the CLI-generated `dshAutoJS` and the published `extensions/dsh` package (pure.test.js expectations moved with it).

Cost, mean of five on a current-format index: 55 ms and ~0.6 KB on the first assembly of a session, 37 ms and nothing on every one after. The plugin contract is exercised with a Node driver (digest once per session, a second session gets its own, payload carries `deja_once` and the session id); the assembly seam's delivery to the request was established for the recall contributor on this same version.
