### PR TITLE
feat(pi): the recall extension as a pi package

### DIFF
--- a/.github/workflows/extensions.yml
+++ b/.github/workflows/extensions.yml
@@ -95,6 +95,38 @@ jobs:
 
       - run: npm test
 
+  pi:
+    name: pi-deja
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: extensions/pi
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+
+      - name: The extension has to load under node's type stripping, the way pi loads it
+        run: |
+          node --check lib.mjs
+          node --experimental-strip-types -e "const m = await import('./index.ts'); if (typeof m.default !== 'function') throw new Error('no default export')"
+
+      - name: The manifest carries the gallery keyword and the entry it points at exists
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            if (!pkg.keywords.includes("pi-package")) throw new Error("pi-package keyword missing: the gallery lists by it");
+            for (const key of ["pi", "omp"]) {
+              for (const e of pkg[key].extensions) if (!fs.existsSync(e)) throw new Error(key + ".extensions names a missing file: " + e);
+            }
+            console.log("ok:", pkg.pi.extensions.join(","));
+          '
+
+      - run: npm test
+
   dsh:
     name: dsh-deja
     runs-on: ubuntu-latest
@@ -307,7 +339,7 @@ jobs:
           node -e '
             const fs = require("node:fs");
             let bad = 0;
-            for (const dir of ["extensions/opencode", "extensions/dsh", "extensions/openclaw"]) {
+            for (const dir of ["extensions/opencode", "extensions/dsh", "extensions/openclaw", "extensions/pi"]) {
               const pkg = JSON.parse(fs.readFileSync(dir + "/package.json", "utf8"));
               const repo = pkg.repository || {};
               if (!String(repo.url || "").includes("vshulcz/deja-vu")) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- pi and omp: `@vshulcz/pi-deja`, the recall extension as a pi package — `pi install npm:@vshulcz/pi-deja` — session-start digest, per-prompt recall and `/deja`; it stands down when `deja install pi-auto` already wrote its extension. (#3092)
+
+### Added
 - OpenClaw: `@vshulcz/openclaw-deja`, the recall plugin as a package — `openclaw plugins install clawhub:@vshulcz/openclaw-deja` — with `before_prompt_build` recall and `deja_recall`, `deja_fix`, `deja_blame` as tools; it reads what `deja install openclaw-auto` wrote and adds only what is missing. (#3047)
 
 ## [0.19.3] - 2026-09-04

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -100,6 +100,9 @@
 <p>Neither has hooks. Both have an extension API, and extensions under the agent's <code>extensions/</code> directory are auto-discovered — so installing is one file and no settings edit, and removing it is deleting the file.</p>
 
 <h2>Adding recall</h2>
+<p>From npm, without the deja CLI on hand:</p>
+<pre>pi install npm:@vshulcz/pi-deja</pre>
+<p>The package brings the binary along: a digest at session start, recall on every prompt, <code>/deja</code> to search by hand. Or, with the CLI installed:</p>
 <pre>deja install pi-auto
 deja install omp-auto</pre>
 <p>Each writes the MCP server, so the model can call the <code>deja</code> tool itself — search past sessions, read one in full, see a file's history, ask what fixed an error, ask how a command is really run here, store a decision — and one extension:</p>

--- a/docs/registry/pi.html
+++ b/docs/registry/pi.html
@@ -84,6 +84,8 @@
 <p>Both ISO-8601 strings (<code>&#34;timestamp&#34;</code> in the envelope) and Unix milliseconds (<code>&#34;timestamp&#34;</code> inside <code>message</code>) are observed. The parser uses the envelope timestamp.</p>
 <h2 id="session-identity">Session identity</h2>
 <p>The <code>id</code> field from the session header line is used as the session ID. The UUID also appears in the filename.</p>
+<h2 id="package">Package</h2>
+<p><code>pi install npm:@vshulcz/pi-deja</code> installs the recall extension as a pi package (<code>pi-package</code> keyword, <code>pi.extensions</code>); it stands down when <code>deja install pi-auto</code> already wrote <code>~/.pi/agent/extensions/deja.ts</code>.</p>
 <h2 id="mcp">MCP</h2>
 <p>pi does not include built-in MCP but supports it via the <code>pi-mcp-adapter</code> package (<code>pi install npm:pi-mcp-adapter</code>). The adapter reads <code>~/.pi/agent/mcp.json</code> with the standard <code>mcpServers</code> shape. <code>deja install pi</code> writes to that file.</p>
 <h2 id="known-quirks-and-drift">Known quirks and drift</h2>

--- a/docs/registry/pi.md
+++ b/docs/registry/pi.md
@@ -67,6 +67,10 @@ Both ISO-8601 strings (`"timestamp"` in the envelope) and Unix milliseconds (`"t
 
 The `id` field from the session header line is used as the session ID. The UUID also appears in the filename.
 
+## Package
+
+`pi install npm:@vshulcz/pi-deja` installs the recall extension as a pi package (`pi-package` keyword, `pi.extensions`); it stands down when `deja install pi-auto` already wrote `~/.pi/agent/extensions/deja.ts`.
+
 ## MCP
 
 pi does not include built-in MCP but supports it via the `pi-mcp-adapter` package (`pi install npm:pi-mcp-adapter`). The adapter reads `~/.pi/agent/mcp.json` with the standard `mcpServers` shape. `deja install pi` writes to that file.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -10,6 +10,7 @@ same local index.
 | [`opencode/`](opencode) | npm `opencode-deja` | `opencode plugin opencode-deja` |
 | [`dsh/`](dsh) | npm `dsh-deja` | `dsh plugin --profile web add dsh-deja` |
 | [`openclaw/`](openclaw) | ClawHub and npm `@vshulcz/openclaw-deja` | `openclaw plugins install clawhub:@vshulcz/openclaw-deja` |
+| [`pi/`](pi) | npm `@vshulcz/pi-deja` (`pi-package`, also read by omp) | `pi install npm:@vshulcz/pi-deja` |
 | [`zed/`](zed) | Zed extension `deja-context-server` | Zed → Extensions → deja |
 | [`kimi/`](kimi) | Kimi Code plugin `deja` | `/plugins install https://github.com/vshulcz/deja-vu` |
 | [`grok/`](grok) | Grok Build plugin `deja` | `grok plugin install deja` |
@@ -38,6 +39,7 @@ Publishing by hand is still possible when a fix should not wait for a release:
 cd extensions/opencode && npm publish --access public
 cd extensions/dsh      && npm publish --access public
 cd extensions/openclaw && npm publish --access public && clawhub package publish .
+cd extensions/pi       && npm publish --access public
 ```
 
 The Grok plugin is published by a catalog entry, not by us: the entry in

--- a/extensions/pi/LICENSE
+++ b/extensions/pi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Vladislav Shulcz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/pi/README.md
+++ b/extensions/pi/README.md
@@ -1,0 +1,49 @@
+# @vshulcz/pi-deja
+
+pi remembers its own sessions. This extension answers the other question: what
+was done in the twenty-one other coding agents on this machine — Claude Code,
+Codex, Cursor, Gemini, OpenClaw and Hermes among them — including the months
+before pi was installed.
+
+It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that
+indexes the transcripts those agents already wrote to disk. No LLM, no
+embeddings, nothing leaves the machine.
+
+## Install
+
+```bash
+pi install npm:@vshulcz/pi-deja
+```
+
+The deja binary comes with the package; a deja you installed yourself
+(`brew install deja-vu`) always wins — see [Which binary](#which-binary).
+
+`deja install pi-auto` wires pi too, and is the shorter path if you have the
+CLI: it adds deja's MCP server and writes an extension of its own. When that
+extension is present this package stands down, so having both never injects
+twice.
+
+omp loads `pi.extensions` manifests and emits the same `before_agent_start`
+event, so `pi install`'s omp counterpart picks this package up as well.
+
+## What it does
+
+- **Session start**: a digest of what earlier sessions in this project decided
+  goes to the model before your first prompt; the receipt shows in the footer.
+- **Every prompt** (`before_agent_start`): the prompt is matched against the
+  index and, when a past session answers it, that session goes to the model
+  with the prompt. Silence is the common case.
+- **`/deja <query>`**: search the history by hand.
+
+## Which binary
+
+In order: `DEJA_BIN`, `deja` on `PATH`, the usual install locations, and last
+the copy bundled through `@vshulcz/deja-vu`.
+
+## Privacy
+
+deja reads session files where the agents wrote them and builds a local index
+under `~/.cache/deja` (or `DEJA_INDEX_DIR`). Keys and tokens are stripped as
+the index is built. Nothing is uploaded.
+
+Part of [deja-vu](https://github.com/vshulcz/deja-vu). MIT.

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -1,0 +1,155 @@
+// deja-vu for pi: recall from the coding sessions already on this machine at
+// session start and on every prompt, and /deja to search them by hand.
+import { execFileSync } from "node:child_process";
+import { accessSync, constants, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { argv, contextText, installerExtensionPath, sessionKey } from "./lib.mjs";
+
+const require = createRequire(import.meta.url);
+
+const WINDOWS = process.platform === "win32";
+const PLATFORM = WINDOWS ? "windows" : process.platform;
+const ARCH = process.arch === "x64" ? "amd64" : process.arch;
+const EXE = WINDOWS ? "deja.exe" : "deja";
+
+// wellKnown lists the places a user's own install lands, for a pi started
+// from a launcher whose PATH never sourced a shell profile.
+function wellKnown(): string[] {
+  const home = homedir();
+  if (WINDOWS) {
+    const local = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+    return [join(local, "deja", "bin", EXE), join(home, ".local", "bin", EXE)];
+  }
+  return [join(home, ".local", "bin", EXE), "/usr/local/bin/deja", "/opt/homebrew/bin/deja", "/usr/bin/deja"];
+}
+
+// resolveDeja: what the user pointed at, then the deja they installed and keep
+// current, and only last the copy npm brought with this package — pinning
+// them to our bundled copy would freeze their memory at whatever version this
+// package was released against.
+function resolveDeja(): string {
+  const candidates: string[] = [process.env.DEJA_BIN || "", EXE, ...wellKnown()];
+  try {
+    candidates.push(require.resolve(`@vshulcz/deja-vu-${PLATFORM}-${ARCH}/bin/${EXE}`));
+  } catch {}
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (candidate.includes("/") || candidate.includes("\\")) {
+      try {
+        accessSync(candidate, constants.X_OK);
+      } catch {
+        continue;
+      }
+    }
+    return candidate;
+  }
+  return EXE;
+}
+
+const DEJA = resolveDeja();
+
+// deja is asked for text, never for control flow: memory is optional
+// everywhere, and a throw here would end someone's turn.
+function run(args: string[], input: string, timeout = 10000): string {
+  try {
+    return execFileSync(DEJA, args, {
+      input,
+      encoding: "utf8",
+      timeout,
+      maxBuffer: 4 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+export default function (pi: any) {
+  // `deja install pi-auto` writes an extension of its own; when it is there,
+  // it already does everything below, and two copies would inject the
+  // recall twice and register /deja twice.
+  try {
+    if (existsSync(installerExtensionPath(process.env, homedir()))) return;
+  } catch {}
+
+  let injected = false;
+  let toldBuilding = false;
+
+  // pi keeps a footer status line: while the first index builds, that is
+  // where the user can see it happening instead of wondering why recall is
+  // quiet. Cleared as soon as the build finishes.
+  const showBuild = (ctx: any) => {
+    const status = run(["warmup-status"], "");
+    if (status) {
+      ctx.ui.setStatus("deja", status);
+      return true;
+    }
+    ctx.ui.setStatus("deja", "");
+    return false;
+  };
+
+  pi.on("session_start", async (_event: any, ctx: any) => {
+    try {
+      showBuild(ctx);
+    } catch {
+      // memory is optional: never break the session over it
+    }
+  });
+
+  // pi surfaces registered commands in the prompt box, which is how someone
+  // who never read the docs finds this at all.
+  pi.registerCommand("deja", {
+    description: "Search your own past coding sessions",
+    handler: async (args: string, ctx: any) => {
+      const query = (args || "").trim();
+      if (!query) {
+        ctx.ui.notify("Usage: /deja <what you are looking for>", "info");
+        return;
+      }
+      // The user is waiting on this one, so it may outlive the hook budget:
+      // a first search can rebuild the index.
+      const found = run(argv("search", [], query), "", 120000);
+      ctx.ui.notify(found || "Nothing in your history matches " + query, "info");
+    },
+  });
+
+  pi.on("before_agent_start", async (event: any, ctx: any) => {
+    try {
+      if (!injected) {
+        const { context: digest, receipt } = contextText(run(["hook-context"], ""));
+        if (digest) {
+          injected = true;
+          ctx.ui.setStatus("deja", "");
+          // The receipt is what tells the user memory arrived; without it the
+          // recall is invisible and reads as the model guessing.
+          if (receipt) ctx.ui.notify(receipt, "info");
+          // pi keeps the footer until it is cleared, so the session carries a
+          // quiet reminder that memory is on rather than a one-off toast.
+          const stats = run(["statusline"], "");
+          if (stats) ctx.ui.setStatus("deja", stats);
+          return { message: { customType: "deja-recall", content: digest, display: false } };
+        }
+        // Nothing to recall: either there is no history yet, or the first
+        // index is still building. Only the second is worth saying, once.
+        if (!toldBuilding && showBuild(ctx)) {
+          toldBuilding = true;
+          ctx.ui.notify(run(["warmup-status"], ""), "info");
+        }
+        return;
+      }
+      const key = sessionKey(event, ctx);
+      const raw = run(["hook-prompt"], JSON.stringify({ prompt: event.prompt || "", session_id: key }));
+      if (!raw) return;
+      const resp = JSON.parse(raw);
+      if (resp && resp.systemMessage) ctx.ui.notify(resp.systemMessage, "info");
+      const extra = resp && resp.hookSpecificOutput && resp.hookSpecificOutput.additionalContext;
+      if (!extra) return;
+      return { message: { customType: "deja-recall", content: extra, display: false } };
+    } catch {
+      // memory is optional: never break the session over it
+    }
+  });
+}

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -72,7 +72,7 @@ export default function (pi: any) {
   // it already does everything below, and two copies would inject the
   // recall twice and register /deja twice.
   try {
-    if (existsSync(installerExtensionPath(process.env, homedir()))) return;
+    if (existsSync(installerExtensionPath(homedir()))) return;
   } catch {}
 
   let injected = false;

--- a/extensions/pi/lib.mjs
+++ b/extensions/pi/lib.mjs
@@ -7,10 +7,10 @@ import { join } from "node:path"
 // installerExtensionPath is where `deja install pi-auto` writes its own
 // extension. pi loads that file and this package side by side, and both
 // would inject recall and register /deja, so this package stands down when
-// the installer's copy is present. Mirrors PiConfigDir() in the installer.
-export function installerExtensionPath(env, home) {
-  const base = (env && env.PI_HOME) || join(home || "", ".pi", "agent")
-  return join(base, "extensions", "deja.ts")
+// the installer's copy is present. Mirrors PiConfigDir() in the installer,
+// which is ~/.pi/agent with no override — pi has none either.
+export function installerExtensionPath(home) {
+  return join(home || "", ".pi", "agent", "extensions", "deja.ts")
 }
 
 // contextText pulls the recall out of whatever hook-context printed. deja
@@ -41,11 +41,7 @@ export function argv(cmd, flags, text) {
 
 // sessionKey is what per-prompt recall dedups on: a hit shown once in a
 // session is not shown again. Without one it repeats itself every message.
+// Same order as the extension `deja install pi-auto` writes.
 export function sessionKey(event, ctx) {
-  return (
-    (event && (event.sessionId || event.session_id)) ||
-    (ctx && ctx.session && ctx.session.id) ||
-    (ctx && ctx.sessionId) ||
-    ""
-  )
+  return (event && (event.sessionId || event.session_id)) || (ctx && ctx.session && ctx.session.id) || ""
 }

--- a/extensions/pi/lib.mjs
+++ b/extensions/pi/lib.mjs
@@ -1,0 +1,51 @@
+import { join } from "node:path"
+
+// The pure half of the extension: everything that reads deja's output or
+// decides what this package adds, with no process and no host, so it can be
+// tested without pi.
+
+// installerExtensionPath is where `deja install pi-auto` writes its own
+// extension. pi loads that file and this package side by side, and both
+// would inject recall and register /deja, so this package stands down when
+// the installer's copy is present. Mirrors PiConfigDir() in the installer.
+export function installerExtensionPath(env, home) {
+  const base = (env && env.PI_HOME) || join(home || "", ".pi", "agent")
+  return join(base, "extensions", "deja.ts")
+}
+
+// contextText pulls the recall out of whatever hook-context printed. deja
+// answers in the Claude Code hook shape; older builds and `--plain` print
+// bare text, so both are accepted.
+export function contextText(raw) {
+  const text = String(raw || "").trim()
+  if (!text) return { context: "", receipt: "" }
+  try {
+    const parsed = JSON.parse(text)
+    return {
+      context: parsed?.hookSpecificOutput?.additionalContext || "",
+      receipt: parsed?.systemMessage || "",
+    }
+  } catch {
+    return { context: text, receipt: "" }
+  }
+}
+
+// argv builds the call for a query somebody typed. A query that starts with
+// a dash is read by deja as a flag and the call fails, which run() turns into
+// "nothing in the history" — a wrong answer where an error would at least be
+// visible. `--` ends the flags; sent only when the query needs it.
+export function argv(cmd, flags, text) {
+  const arg = String(text)
+  return arg.startsWith("-") ? [cmd, ...flags, "--", arg] : [cmd, ...flags, arg]
+}
+
+// sessionKey is what per-prompt recall dedups on: a hit shown once in a
+// session is not shown again. Without one it repeats itself every message.
+export function sessionKey(event, ctx) {
+  return (
+    (event && (event.sessionId || event.session_id)) ||
+    (ctx && ctx.session && ctx.session.id) ||
+    (ctx && ctx.sessionId) ||
+    ""
+  )
+}

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@vshulcz/pi-deja",
+  "version": "0.19.3",
+  "description": "deja-vu memory for pi: the coding sessions already on this machine — pi, Claude Code, Codex, Cursor and 18 more — recalled at session start and on every prompt, searchable with /deja. A local index, no LLM.",
+  "type": "module",
+  "files": [
+    "index.ts",
+    "lib.mjs",
+    "README.md",
+    "LICENSE"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vshulcz/deja-vu.git",
+    "directory": "extensions/pi"
+  },
+  "homepage": "https://vshulcz.github.io/deja-vu/guide/memory-for-pi.html",
+  "bugs": {
+    "url": "https://github.com/vshulcz/deja-vu/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-extension",
+    "pi-coding-agent",
+    "omp",
+    "memory",
+    "recall",
+    "session-history",
+    "agent"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@vshulcz/deja-vu": "^0.19.0"
+  },
+  "pi": {
+    "extensions": ["./index.ts"],
+    "image": "https://raw.githubusercontent.com/vshulcz/deja-vu/assets/listings/recall-card.png"
+  },
+  "omp": {
+    "extensions": ["./index.ts"]
+  },
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/extensions/pi/test/pure.test.mjs
+++ b/extensions/pi/test/pure.test.mjs
@@ -3,8 +3,7 @@ import assert from "node:assert/strict"
 import { argv, contextText, installerExtensionPath, sessionKey } from "../lib.mjs"
 
 test("the installer's extension is looked for where the installer writes it", () => {
-  assert.equal(installerExtensionPath({}, "/home/u"), "/home/u/.pi/agent/extensions/deja.ts")
-  assert.equal(installerExtensionPath({ PI_HOME: "/srv/pi" }, "/home/u"), "/srv/pi/extensions/deja.ts")
+  assert.equal(installerExtensionPath("/home/u"), "/home/u/.pi/agent/extensions/deja.ts")
 })
 
 test("hook-context is read in both shapes deja prints", () => {

--- a/extensions/pi/test/pure.test.mjs
+++ b/extensions/pi/test/pure.test.mjs
@@ -1,0 +1,25 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { argv, contextText, installerExtensionPath, sessionKey } from "../lib.mjs"
+
+test("the installer's extension is looked for where the installer writes it", () => {
+  assert.equal(installerExtensionPath({}, "/home/u"), "/home/u/.pi/agent/extensions/deja.ts")
+  assert.equal(installerExtensionPath({ PI_HOME: "/srv/pi" }, "/home/u"), "/srv/pi/extensions/deja.ts")
+})
+
+test("hook-context is read in both shapes deja prints", () => {
+  assert.deepEqual(contextText('{"hookSpecificOutput":{"additionalContext":"digest"},"systemMessage":"deja recalled 2"}'), { context: "digest", receipt: "deja recalled 2" })
+  assert.deepEqual(contextText("bare text"), { context: "bare text", receipt: "" })
+  assert.deepEqual(contextText(""), { context: "", receipt: "" })
+})
+
+test("a query that starts with a dash gets the flag terminator", () => {
+  assert.deepEqual(argv("search", [], "--json"), ["search", "--", "--json"])
+  assert.deepEqual(argv("search", [], "pgbouncer"), ["search", "pgbouncer"])
+})
+
+test("the session key comes from the event first, then the context", () => {
+  assert.equal(sessionKey({ sessionId: "e1" }, { session: { id: "c1" } }), "e1")
+  assert.equal(sessionKey({}, { session: { id: "c1" } }), "c1")
+  assert.equal(sessionKey({}, {}), "")
+})

--- a/scripts/extension-drift.mjs
+++ b/scripts/extension-drift.mjs
@@ -17,7 +17,7 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 
-export const PACKAGES = ["extensions/opencode", "extensions/dsh", "extensions/openclaw"];
+export const PACKAGES = ["extensions/opencode", "extensions/dsh", "extensions/openclaw", "extensions/pi"];
 
 // npmLatest is the version npm serves as `latest`, or "" when the package has
 // never been published or npm cannot be reached. Unreachable is not drift: a

--- a/scripts/extension_drift_test.mjs
+++ b/scripts/extension_drift_test.mjs
@@ -9,6 +9,7 @@ const names = {
   "extensions/opencode": { name: "opencode-deja" },
   "extensions/dsh": { name: "dsh-deja" },
   "extensions/openclaw": { name: "@vshulcz/openclaw-deja" },
+  "extensions/pi": { name: "@vshulcz/pi-deja" },
 };
 const readPkg = (dir) => names[dir];
 
@@ -37,7 +38,7 @@ test("what cannot be answered is not drift", () => {
 
 test("every package is reported when all are stranded", () => {
   const bad = stranded(PACKAGES, readPkg, () => "0.21.0", "0.19.2");
-  assert.deepEqual(bad.map((p) => p.name).sort(), ["@vshulcz/openclaw-deja", "dsh-deja", "opencode-deja"]);
+  assert.deepEqual(bad.map((p) => p.name).sort(), ["@vshulcz/openclaw-deja", "@vshulcz/pi-deja", "dsh-deja", "opencode-deja"]);
 });
 
 test("versions order by number", () => {

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -73,7 +73,7 @@ run("npm publish --access public", mainDir);
 // independently before this, so a release whose version is behind what npm
 // already has would move the `latest` tag backwards: skip those and say so,
 // and the lines converge on their own as soon as deja passes them.
-const extensions = ["opencode", "dsh", "openclaw"];
+const extensions = ["opencode", "dsh", "openclaw", "pi"];
 const published = [];
 for (const name of extensions) {
   const dir = path.join("extensions", name);

--- a/scripts/release_npm_test.mjs
+++ b/scripts/release_npm_test.mjs
@@ -38,7 +38,7 @@ test("the extension packages are published from the release version", () => {
   // plugin that ships the wrong binary as its fallback.
   assert.match(source, /outPkg\.version = version/);
   assert.match(source, /outPkg\.dependencies\["@vshulcz\/deja-vu"\] = `\^\$\{version\}`/);
-  assert.match(source, /const extensions = \["opencode", "dsh", "openclaw"\]/);
+  assert.match(source, /const extensions = \["opencode", "dsh", "openclaw", "pi"\]/);
 });
 
 test("a release behind npm skips instead of moving latest backwards", () => {


### PR DESCRIPTION
`extensions/pi/` — the extension `deja install pi-auto` generates, as an npm package with the `pi-package` keyword and a `pi.extensions` manifest (plus `omp.extensions`; omp reads the same manifest and emits the same `before_agent_start`), so `pi install npm:@vshulcz/pi-deja` resolves it and the gallery can list it. Same hooks as the generated file: session-start digest with the receipt in the footer, per-prompt recall keyed by session, `/deja`. The binary is resolved `DEJA_BIN` → PATH → usual install dirs → the copy bundled through `@vshulcz/deja-vu`, and the extension returns before registering anything when `~/.pi/agent/extensions/deja.ts` from the installer exists, so both never inject twice.

Checked with a stand-in host against the real binary: the two hooks and the command register; the first `before_agent_start` returns the digest (2,378 chars here) and the second the per-prompt recall; `/deja --json` reaches the store; with the installer's file present nothing registers. `index.ts` loads under node's type stripping, which is what the CI job checks, along with the keyword and the manifest entries.

Release: `scripts/release-npm.mjs` publishes it with the other harness packages; drift guard and the repository-field check cover it.

Closes #3092