### PR TITLE
fix(pi): the /deja command no longer redeclares its own argument

### DIFF
--- a/cmd/deja/install_pi.go
+++ b/cmd/deja/install_pi.go
@@ -101,8 +101,8 @@ export default function (pi: any) {
       // "--" when the query names one of deja's own flags: searching for
       // "--json" or "--all-matches" otherwise dies in flag parsing and comes
       // back as an empty history.
-      const args = query.startsWith("-") ? ["search", "--", query] : ["search", query];
-      const found = run(args, "", 120000);
+      const commandArgs = query.startsWith("-") ? ["search", "--", query] : ["search", query];
+      const found = run(commandArgs, "", 120000);
       ctx.ui.notify(found || "Nothing in your history matches " + query, "info");
     },
   });

--- a/cmd/deja/install_pi_test.go
+++ b/cmd/deja/install_pi_test.go
@@ -64,6 +64,20 @@ func TestPiExtensionQuotesExecutablePath(t *testing.T) {
 	}
 }
 
+// The command handler takes its argument as `args`, so the search array cannot
+// also be `const args`: pi parses the extension as TypeScript and refuses the
+// whole file with "Identifier 'args' has already been declared", which takes
+// deja's command — and the agent's startup — down with it (#3089).
+func TestPiCommandDoesNotRedeclareItsArgument(t *testing.T) {
+	src := piExtensionTS("/bin/deja")
+	if !strings.Contains(src, "handler: async (args: string") {
+		t.Fatalf("the handler no longer takes args, so this guard is stale:\n%s", src)
+	}
+	if strings.Contains(src, "const args ") || strings.Contains(src, "const args=") {
+		t.Fatalf("the search array shadows the handler's `args` parameter, which pi rejects:\n%s", src)
+	}
+}
+
 // A search the user typed may rebuild the index; a hook may not. One shared
 // timeout made /deja answer "nothing matches" for a query with real hits.
 func TestPiCommandOutlivesTheHookTimeout(t *testing.T) {


### PR DESCRIPTION
Closes #3089.

The generated pi extension took its handler argument as `args` and then built the search array as `const args` in the same scope, so pi parsed the file as TypeScript, hit "Identifier 'args' has already been declared", and started with no deja at all. Renamed the local to `commandArgs`, exactly as the report suggested. cline and deepseek were checked — their handlers take `input`/`invocation`, so the shadow was pi's alone. Test pins that the handler's `args` parameter is never redeclared.
