### PR TITLE
feat(cline): the repair for a failed command, in the same turn

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -60,6 +60,13 @@ type toolAfterInput struct {
 }
 
 func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
+	return runHookToolAfterMode(dir, stdin, stdout, false)
+}
+
+// plain=true prints the block itself rather than the PostToolUse envelope, for
+// a host that puts it somewhere of its own. cline's message builder appends it
+// to the failing tool result the model is about to read.
+func runHookToolAfterMode(dir string, stdin io.Reader, stdout io.Writer, plain bool) error {
 	var input toolAfterInput
 	raw := readHookPayload(stdin, hookStdinWait)
 	_ = json.NewDecoder(bytes.NewReader(raw)).Decode(&input)
@@ -123,6 +130,10 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 	rememberInjectedIDs(dir, input.SessionID, token)
 	payload := frameRecall(truncateToolLine(line, toolAfterMaxBytes))
 	usage.RecordResult(dir, usage.KindTool, len(payload), 1, false)
+	if plain {
+		fmt.Fprint(stdout, payload)
+		return nil
+	}
 	var resp sessionStartHookResponse
 	resp.HookSpecificOutput.HookEventName = "PostToolUse"
 	resp.HookSpecificOutput.AdditionalContext = payload
@@ -140,7 +151,7 @@ func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
 func isCommandTool(name string) bool {
 	switch name {
 	case "Bash", "bash", "shell", "Shell", "run_command", "execute_command", "terminal",
-		"run_shell_command", "run_terminal_command":
+		"run_shell_command", "run_terminal_command", "run_commands":
 		return true
 	}
 	return false

--- a/cmd/deja/hook_tool_after_plain_test.go
+++ b/cmd/deja/hook_tool_after_plain_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// cline's run tool is run_commands. Without it in this set the fix-pair hook
+// drops every cline command failure before it looks anything up.
+func TestRunCommandsIsACommandTool(t *testing.T) {
+	for _, name := range []string{"run_commands", "Bash", "run_terminal_command"} {
+		if !isCommandTool(name) {
+			t.Errorf("%q is a command tool and was not recognised", name)
+		}
+	}
+	for _, name := range []string{"editor", "read_files", "search_codebase"} {
+		if isCommandTool(name) {
+			t.Errorf("%q is not a command tool", name)
+		}
+	}
+}
+
+// --plain prints the block itself, not the PostToolUse envelope: a host that
+// puts the repair somewhere of its own — cline appends it to the failing tool
+// result — cannot read a hook JSON wrapper.
+func TestFixPairPlainDropsTheEnvelope(t *testing.T) {
+	seedFixPair(t, "panic: sql: database is closed", "make clean && make CGO_ENABLED=0")
+	payload := postToolPayload("run_commands", "make", "", "panic: sql: database is closed", "plain-1")
+
+	var plain bytes.Buffer
+	if err := runHookToolAfterMode(os.Getenv("DEJA_INDEX_DIR"), strings.NewReader(payload), &plain, true); err != nil {
+		t.Fatal(err)
+	}
+	got := plain.String()
+	if !strings.Contains(got, "make clean && make CGO_ENABLED=0") {
+		t.Fatalf("--plain did not deliver the repair:\n%s", got)
+	}
+	if strings.Contains(got, "hookSpecificOutput") || strings.Contains(got, "PostToolUse") {
+		t.Fatalf("--plain still wrapped the block in the hook envelope:\n%s", got)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(got), "<deja-recall>") {
+		t.Fatalf("--plain is not the bare block:\n%s", got)
+	}
+
+	// The envelope form still wraps, for the hosts that read it.
+	var wrapped bytes.Buffer
+	if err := runHookToolAfterMode(os.Getenv("DEJA_INDEX_DIR"), strings.NewReader(
+		postToolPayload("run_commands", "make", "", "panic: sql: database is closed", "plain-2"),
+	), &wrapped, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(wrapped.String(), "hookSpecificOutput") {
+		t.Fatalf("the default form dropped the envelope:\n%s", wrapped.String())
+	}
+}

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -96,6 +96,52 @@ function userText(message) {
   return text.replace(/<\/?user_input[^>]*>/g, "").trim();
 }
 
+// The tools whose failure a shell error signature describes. cline's is
+// run_commands; the others let the same builder answer a harness that renamed
+// it. A file edit fails in ways this line cannot read, so it is left out.
+const COMMAND_TOOLS = new Set([
+  "run_commands", "execute_command", "run_command", "Bash", "bash", "shell", "terminal",
+]);
+
+// commandFailure finds the newest command tool_result that failed, as build()
+// sees it: {type:"tool_result", name, content:[{query,result,error,success}]}.
+// Returns the message index, the failing entry, and the text to look up — or
+// null when the last command did not fail.
+function commandFailure(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (!m || !Array.isArray(m.content)) continue;
+    for (const part of m.content) {
+      if (!part || part.type !== "tool_result" || !COMMAND_TOOLS.has(part.name)) continue;
+      const entries = Array.isArray(part.content) ? part.content : [];
+      for (const e of entries) {
+        if (!e || e.success !== false) continue;
+        const output = typeof e.result === "string" ? e.result : typeof e.error === "string" ? e.error : "";
+        if (!output.trim()) continue;
+        return { at: i, entry: e, id: part.tool_use_id || "", name: part.name, command: e.query || "", output };
+      }
+    }
+    // Only the most recent tool result is worth a repair; stop at the first
+    // message that carries one, failed or not.
+    if (m.content.some((p) => p && p.type === "tool_result")) break;
+  }
+  return null;
+}
+
+// appendRepair returns a copy of a tool_result part with the repair added to
+// the failing entry's result text. Editing result rather than adding a part of
+// a new shape keeps what cline serializes onto the wire valid.
+function appendRepair(part, line) {
+  return {
+    ...part,
+    content: (Array.isArray(part.content) ? part.content : []).map((e) =>
+      e && e.success === false && typeof e.result === "string"
+        ? { ...e, result: e.result + "\n\n" + line }
+        : e,
+    ),
+  };
+}
+
 export default {
   name: "deja",
   manifest: { capabilities: ["rules", "commands", "skills"] },
@@ -107,39 +153,80 @@ export default {
     // first call, which would inject into the copy nobody sends.
     let asked = "";
     let recalled = "";
+    // The repair for each failed command, kept by its tool_use id: build() runs
+    // many times for one turn, and hook-tool-after must be asked once, not on
+    // every rebuild of the same array.
+    const repairs = new Map();
     api.registerMessageBuilder({
       id: "deja:prompt",
       source: "deja-vu",
       build: (messages) => {
         if (!Array.isArray(messages)) return;
+        let out = null;
+        const edit = () => out || (out = messages.slice());
+
+        // The question just asked, answered from history. Prepended to the last
+        // user message.
         let at = -1;
         for (let i = messages.length - 1; i >= 0; i--) {
-          if (messages[i] && messages[i].role === "user") {
+          if (messages[i] && messages[i].role === "user" && userText(messages[i])) {
             at = i;
             break;
           }
         }
-        if (at < 0) return;
-        const prompt = userText(messages[at]);
-        if (!prompt) return;
-        if (prompt !== asked) {
-          asked = prompt;
-          recalled = run(["hook-prompt", "--plain"], JSON.stringify({
-            prompt,
-            session_id: sessionID,
-            cwd: process.cwd(),
-          }));
+        if (at >= 0) {
+          const prompt = userText(messages[at]);
+          if (prompt !== asked) {
+            asked = prompt;
+            recalled = run(["hook-prompt", "--plain"], JSON.stringify({
+              prompt,
+              session_id: sessionID,
+              cwd: process.cwd(),
+            }));
+          }
+          // Silence is the common case: the hook only speaks when the history
+          // actually answers the question.
+          if (recalled) {
+            edit();
+            out[at] = {
+              ...messages[at],
+              content: [{ type: "text", text: recalled }, ...messages[at].content],
+            };
+          }
         }
-        // Silence is the common case: the hook only speaks when the history
-        // actually answers the question.
-        const recall = recalled;
-        if (!recall) return;
-        const out = messages.slice();
-        out[at] = {
-          ...messages[at],
-          content: [{ type: "text", text: recall }, ...messages[at].content],
-        };
-        return out;
+
+        // The command that just failed, and what this machine ran after that
+        // same error before. cline's PreToolUse hook cannot carry this — it
+        // keeps only cancel and overrideInput — but the builder's return is
+        // what gets sent, so the repair rides beside the failing result in the
+        // same turn rather than a turn later. Silence unless the store holds a
+        // pair.
+        const fail = commandFailure(messages);
+        if (fail) {
+          if (!repairs.has(fail.id)) {
+            repairs.set(fail.id, run(["hook-tool-after", "--plain"], JSON.stringify({
+              tool_name: fail.name,
+              tool_response: fail.output,
+              session_id: sessionID,
+              cwd: process.cwd(),
+            })));
+          }
+          const line = repairs.get(fail.id);
+          if (line) {
+            edit();
+            const m = out[fail.at];
+            out[fail.at] = {
+              ...m,
+              content: m.content.map((p) =>
+                p === fail.entry || (p && p.type === "tool_result" && p.tool_use_id === fail.id)
+                  ? appendRepair(p, line)
+                  : p,
+              ),
+            };
+          }
+        }
+
+        return out || undefined;
       },
     });
     api.registerRule({

--- a/cmd/deja/install_cline_fixpair_test.go
+++ b/cmd/deja/install_cline_fixpair_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// cline's PreToolUse hook cannot carry context — it keeps only cancel and
+// overrideInput — so the repair for a command that just failed had no channel.
+// The message builder is the one that works: it is handed the messages on their
+// way to the model, including the failed command's tool_result, and its return
+// is what gets sent (verified on CLI 3.0.57 by reading the wire request). So the
+// repair rides beside the failing result in the same turn.
+func TestClineFixPairSource(t *testing.T) {
+	js := clinePluginJS("/bin/deja")
+	for _, want := range []string{
+		`"hook-tool-after", "--plain"`,
+		"commandFailure",
+		"appendRepair",
+		"run_commands",
+	} {
+		if !strings.Contains(js, want) {
+			t.Errorf("the fix-pair path is missing %q:\n%s", want, js)
+		}
+	}
+}
+
+// The builder appends the repair to the failing command's tool_result and
+// leaves a result that did not fail alone. Driven the way cline drives it.
+func TestClineFixPairAppendsToTheFailingResult(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub deja is a shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is needed to run the plugin cline would run")
+	}
+	home := t.TempDir()
+	stub := filepath.Join(home, "deja")
+	// Answers only hook-tool-after, and only for the seeded error, so the
+	// no-failure case is checked on the same stub.
+	script := "#!/bin/sh\nin=$(cat)\ncase \"$1\" in\n" +
+		"hook-tool-after) case \"$in\" in *glimwrax*) printf 'RAN NEXT: glimwraxctl --sync' ;; esac ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := filepath.Join(home, "index.mjs")
+	if err := os.WriteFile(plugin, []byte(clinePluginJS(stub)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	driver := `
+import plugin from "` + plugin + `";
+let build;
+const api = {
+  registerMessageBuilder: (b) => { build = b.build; },
+  registerRule: () => {}, registerCommand: () => {},
+};
+plugin.setup(api, { session: { sessionId: "s1" } });
+
+// A turn whose last message is a failed run_commands result, and one that
+// succeeded, in the same array.
+const messages = [
+  { role: "user", content: [{ type: "text", text: "build the project" }] },
+  { role: "assistant", content: [{ type: "tool_use", id: "call_ok", name: "run_commands", input: { commands: ["ls"] } }] },
+  { role: "user", content: [{ type: "tool_result", tool_use_id: "call_ok", name: "run_commands",
+      content: [{ query: "ls", result: "main.go", success: true }] }] },
+  { role: "assistant", content: [{ type: "tool_use", id: "call_1", name: "run_commands", input: { commands: ["go build ./..."] } }] },
+  { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", name: "run_commands",
+      content: [{ query: "go build ./...", result: "./main.go:9:2: undefined: glimwraxHelper", error: "exit 1", success: false }] }] },
+];
+const out = build(messages);
+if (!out) { console.log("NOEDIT"); process.exit(0); }
+const failing = out.find((m) => Array.isArray(m.content) && m.content.some((p) => p.type === "tool_result" && p.tool_use_id === "call_1"));
+const ok = out.find((m) => Array.isArray(m.content) && m.content.some((p) => p.type === "tool_result" && p.tool_use_id === "call_ok"));
+const failText = JSON.stringify(failing);
+const okText = JSON.stringify(ok);
+console.log("FAIL_HAS_REPAIR:" + failText.includes("RAN NEXT: glimwraxctl --sync"));
+console.log("OK_UNTOUCHED:" + !okText.includes("RAN NEXT"));
+// Original error still present, not replaced.
+console.log("ERROR_KEPT:" + failText.includes("undefined: glimwraxHelper"));
+`
+	run := filepath.Join(home, "drive.mjs")
+	if err := os.WriteFile(run, []byte(driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command(node, run).CombinedOutput()
+	if err != nil {
+		t.Fatalf("driving the plugin: %v\n%s", err, out)
+	}
+	s := string(out)
+	if strings.Contains(s, "NOEDIT") {
+		t.Fatal("the builder returned no edit, so the repair never reached the failing result")
+	}
+	for _, want := range []string{"FAIL_HAS_REPAIR:true", "OK_UNTOUCHED:true", "ERROR_KEPT:true"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected %q in driver output:\n%s", want, s)
+		}
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -239,11 +239,12 @@ var commands = map[string]command{
 		}
 		return runHookTool(dir, os.Stdin, os.Stdout)
 	},
-	"hook-tool-after": func(dir string, _ []string) error {
+	"hook-tool-after": func(dir string, rest []string) error {
 		if sayIfTypedByHand("hook-tool-after") {
 			return nil
 		}
-		return runHookToolAfter(dir, os.Stdin, os.Stdout)
+		plain := len(rest) > 0 && (rest[0] == "--plain" || rest[0] == "-plain")
+		return runHookToolAfterMode(dir, os.Stdin, os.Stdout, plain)
 	},
 	"check": func(dir string, rest []string) error {
 		return runCheck(dir, rest, os.Stdin, os.Stdout)


### PR DESCRIPTION
Closes #3097.

The message builder is the one cline channel that can carry the fix pair: it is handed the failed command's `tool_result` and its return is what gets sent. So on a turn whose last command failed, the builder asks `hook-tool-after` and appends the repair to that result's text, beside the error, in the same turn. Cached by `tool_use` id so the builder's many calls per turn ask deja once; silence unless the store holds a pair; a result that succeeded is left alone.

Supporting changes: `hook-tool-after` learns cline's shell tool `run_commands`, and grows a `--plain` mode (the block itself, not the PostToolUse envelope) so it can be appended to the tool result.

Verified on Cline CLI 3.0.57 by reading the wire request: the repair `glimwraxctl --sync && go build ./...` — a command that exists only in the stand's seeded history — landed inside the failing `tool_result` on the next request. Cost: ~22 ms per failed command against the real index, cached so repeated builds in a turn cost nothing more, and silent when there's no pair. Each fix has a test that goes red when reverted (the JS builder via a node driver, the Go side — `run_commands` and `--plain` — as unit tests).
