### PR TITLE
docs(packages): the openclaw and pi packages count twenty-three, and a test that keeps extensions/ counted

### DIFF
--- a/cmd/deja/package_harness_count_test.go
+++ b/cmd/deja/package_harness_count_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The harness packages under extensions/ describe deja to npm, ClawHub and
+// the pi gallery, and each says the count in its own way: "twenty-two other
+// coding agents" (the host excluded), or "pi, Claude Code, Codex, Cursor and
+// 19 more" (the named ones excluded). The day copilot-chat made it
+// twenty-three, the seven files the README test pins were updated and these
+// were not (#3099). Same rule, one directory over.
+func TestPackagesCountTheOtherHarnesses(t *testing.T) {
+	root := filepath.Join("..", "..")
+	n := registryHarnessCount(t, root)
+	other, words := harnessCountWords(t, root, -1)
+	dirs, err := filepath.Glob(filepath.Join(root, "extensions", "*", "package.json"))
+	if err != nil || len(dirs) == 0 {
+		t.Fatalf("no packages under extensions/: %v", err)
+	}
+	more := regexp.MustCompile(`([^—.:"]*?)\band (\d+) more\b`)
+	for _, pkg := range dirs {
+		for _, name := range []string{"package.json", "README.md"} {
+			path := filepath.Join(filepath.Dir(pkg), name)
+			b, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+			text := strings.ToLower(string(b))
+			rel, _ := filepath.Rel(root, path)
+			// "N other coding agents": the count less the host.
+			for _, w := range words {
+				if w != other && strings.Contains(text, w+" other") {
+					t.Errorf("%s says %q other agents; the registry has %d, so %q", rel, w, n, other)
+				}
+			}
+			// "A, B, C and N more": the named ones plus N is the count.
+			for _, m := range more.FindAllStringSubmatch(text, -1) {
+				got, _ := strconv.Atoi(m[2])
+				named := len(strings.Split(strings.TrimSpace(m[1]), ","))
+				if named+got != n {
+					t.Errorf("%s names %d agents and %d more, %d in all; the registry has %d", rel, named, got, named+got, n)
+				}
+			}
+		}
+	}
+}

--- a/extensions/openclaw/README.md
+++ b/extensions/openclaw/README.md
@@ -1,7 +1,7 @@
 # @vshulcz/openclaw-deja
 
 OpenClaw remembers its own sessions. This plugin answers the other question:
-what was done in the twenty-one other coding agents on this machine — Claude
+what was done in the twenty-two other coding agents on this machine — Claude
 Code, Codex, Cursor, Gemini and Zed among them — including the months before
 OpenClaw was installed.
 

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vshulcz/openclaw-deja",
   "version": "0.19.3",
-  "description": "deja-vu memory for OpenClaw: the coding sessions already on this machine \u2014 OpenClaw, Claude Code, Codex, Cursor and 18 more \u2014 recalled before each turn and searchable as tools. A local index, no LLM.",
+  "description": "deja-vu memory for OpenClaw: the coding sessions already on this machine \u2014 OpenClaw, Claude Code, Codex, Cursor and 19 more \u2014 recalled before each turn and searchable as tools. A local index, no LLM.",
   "type": "module",
   "main": "index.mjs",
   "files": [

--- a/extensions/pi/README.md
+++ b/extensions/pi/README.md
@@ -1,7 +1,7 @@
 # @vshulcz/pi-deja
 
 pi remembers its own sessions. This extension answers the other question: what
-was done in the twenty-one other coding agents on this machine — Claude Code,
+was done in the twenty-two other coding agents on this machine — Claude Code,
 Codex, Cursor, Gemini, OpenClaw and Hermes among them — including the months
 before pi was installed.
 

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vshulcz/pi-deja",
   "version": "0.19.3",
-  "description": "deja-vu memory for pi: the coding sessions already on this machine — pi, Claude Code, Codex, Cursor and 18 more — recalled at session start and on every prompt, searchable with /deja. A local index, no LLM.",
+  "description": "deja-vu memory for pi: the coding sessions already on this machine — pi, Claude Code, Codex, Cursor and 19 more — recalled at session start and on every prompt, searchable with /deja. A local index, no LLM.",
   "type": "module",
   "files": [
     "index.ts",


### PR DESCRIPTION
The opencode and dsh packages were already right (`twenty-two other` = 23 less the host); the two I added last said `18 more` and `twenty-one other`. Both updated. `TestPackagesCountTheOtherHarnesses` walks every `extensions/*/package.json` and README for the "N other" and "A, B, C and N more" forms against the registry count; on main it fails on exactly those four lines. The repository description was set to "18 more" by hand.

Closes #3099