### PR TITLE
feat(cli): --json for files

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
@@ -46,8 +48,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	var terms []string
 	limit := 10
 	project := ""
+	asJSON := false
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
+		case "--json":
+			asJSON = true
 		case "--limit":
 			// A flag typed with nothing after it used to be dropped in silence,
 			// and so did an unknown one and an empty --project: the answer came
@@ -83,7 +88,7 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if len(terms) == 0 {
-		return fmt.Errorf("usage: deja files <topic> [--project name] [--limit n]")
+		return fmt.Errorf("usage: deja files <topic> [--project name] [--limit n] [--json]")
 	}
 	q := strings.Join(terms, " ")
 	o := search.Options{Query: q, All: true, Project: project}
@@ -106,6 +111,20 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	// (#1026).
 	hits, hidden := policyFilterSessionsCounted(policy.ActivationSearch, hits)
 	if len(hits) == 0 {
+		// The prose branches below each name *why* the list is empty, and a
+		// consumer needs the same distinction: `files: []` on its own reads as
+		// "looked, nothing there" when it can mean a rule withheld every
+		// session (#1930, the same argument `how --json` makes for carrying
+		// withheld and ignored).
+		if asJSON {
+			return writeFilesJSON(stdout, filesJSON{
+				SchemaVersion: jsonout.Version,
+				Query:         q,
+				Withheld:      hidden,
+				Ignored:       index.IgnoredWithAllTerms(dir, query.Tokens(q)),
+				Files:         []filesRowJSON{},
+			})
+		}
 		// The topic did match — a rule withheld it. Saying "no sessions
 		// mention it" reads as looked-and-absent, the same misread search and
 		// last already avoid by naming the rule (#686, #680).
@@ -237,6 +256,21 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		}
 	}
 	if len(near) == 0 {
+		// Sessions matched and no file sat near the topic. Still an envelope:
+		// the counts beside the empty list are what distinguish this from a
+		// topic nobody discussed, and `filtered` distinguishes it again from
+		// files that were recorded and are not on this disk today.
+		if asJSON {
+			return writeFilesJSON(stdout, filesJSON{
+				SchemaVersion:   jsonout.Version,
+				Query:           q,
+				SessionsScanned: scanned,
+				Matched:         matched,
+				ReadCapped:      matched > filesMaxSessions,
+				Filtered:        filtered,
+				Files:           []filesRowJSON{},
+			})
+		}
 		// "Recorded nothing" and "recorded files this build will not show" are
 		// different answers, and only the first is a fact about the past.
 		if filtered > 0 {
@@ -280,6 +314,32 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		cut = len(rows)
 		rows = rows[:limit]
 	}
+	if asJSON {
+		out := make([]filesRowJSON, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, filesRowJSON{
+				Path:     r.path,
+				Near:     r.n,
+				Sessions: nearSessions[r.path],
+				Total:    total[r.path],
+			})
+		}
+		return writeFilesJSON(stdout, filesJSON{
+			SchemaVersion:   jsonout.Version,
+			Query:           q,
+			SessionsScanned: scanned,
+			Matched:         matched,
+			// Two different truncations, and a consumer that conflated them
+			// would report the wrong thing. `truncated` is the caller's
+			// --limit biting on the file list; `read_capped` is the read
+			// budget biting on the sessions behind it, which is what
+			// filesReadNote says in the prose.
+			Truncated:  cut > 0,
+			ReadCapped: matched > filesMaxSessions,
+			Filtered:   filtered,
+			Files:      out,
+		})
+	}
 	fmt.Fprintf(stdout, "files touched while working on %q — %d session%s%s\n", q, scanned, plural(scanned), filesReadNote(matched))
 	// The path column was a fixed 56, which on a 60-column pane leaves nothing
 	// for the count and wraps every row (#604). Budgeted against the window
@@ -304,6 +364,52 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintf(os.Stderr, "deja: showing %d of %d — raise --limit for the rest\n", len(rows), cut)
 	}
 	return nil
+}
+
+// filesJSON is the `deja files --json` envelope. See docs/json-output.md.
+//
+// The counts beside the list are the ones a caller cannot recover from it. An
+// empty `files` can mean the topic was not discussed, that a rule withheld
+// every session, or that a tree is kept out of recall, and the prose path
+// distinguishes all three; the envelope has to as well (#1930).
+type filesJSON struct {
+	SchemaVersion int    `json:"schema_version"`
+	Query         string `json:"query"`
+	// SessionsScanned is the sessions actually read, ReadCapped whether the
+	// read budget cut that short, and Matched how many mentioned the topic in
+	// the first place. Reporting only the first would let a store where 301
+	// sessions matched report 250 as though that were the number.
+	SessionsScanned int  `json:"sessions_scanned"`
+	Matched         int  `json:"matched"`
+	ReadCapped      bool `json:"read_capped"`
+	// Truncated is the caller's --limit biting on the file list, which is a
+	// different cut from ReadCapped and would be wrong to fold into it.
+	Truncated bool `json:"truncated"`
+	// Filtered is recorded paths dropped because they are not under a
+	// repository on this disk -- moved, archived, or an unmounted volume.
+	Filtered int `json:"filtered"`
+	Withheld int `json:"withheld"`
+	Ignored  int `json:"ignored"`
+
+	Files []filesRowJSON `json:"files"`
+}
+
+// filesRowJSON is one file. The three counts are what the ranking is built
+// from, so a consumer can re-rank or threshold without re-deriving them: Near
+// is touches close to the topic, Sessions how many separate sessions those
+// came from, and Total touches anywhere in the sessions read -- the
+// denominator that makes a file specific to the topic rather than merely busy.
+type filesRowJSON struct {
+	Path     string `json:"path"`
+	Near     int    `json:"near"`
+	Sessions int    `json:"sessions"`
+	Total    int    `json:"total"`
+}
+
+func writeFilesJSON(stdout io.Writer, v filesJSON) error {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
 }
 
 // filesReadNote names the read budget when it bit, so the session counts above

--- a/cmd/deja/files_test.go
+++ b/cmd/deja/files_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
@@ -115,5 +118,106 @@ func TestLowerAllDropsShortWords(t *testing.T) {
 	got := lowerAll([]string{"Sing", "Box", "in", "GO"})
 	if len(got) != 2 || got[0] != "sing" || got[1] != "box" {
 		t.Fatalf("got %v", got)
+	}
+}
+
+// `deja files --json` (#1930). Every sibling command has one; this one printed
+// prose only, so a caller scripting against it had to parse a padded column.
+func TestFilesJSONEnvelope(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", "..", "fixtures", "synthetic", "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+
+	out, err := captureRun(t, "files", "--json", "parser")
+	if err != nil {
+		t.Fatalf("files --json err=%v out=%q", err, out)
+	}
+	var env struct {
+		SchemaVersion   int    `json:"schema_version"`
+		Query           string `json:"query"`
+		SessionsScanned int    `json:"sessions_scanned"`
+		Matched         int    `json:"matched"`
+		ReadCapped      bool   `json:"read_capped"`
+		Truncated       bool   `json:"truncated"`
+		Filtered        int    `json:"filtered"`
+		Withheld        int    `json:"withheld"`
+		Ignored         int    `json:"ignored"`
+		Files           []struct {
+			Path     string `json:"path"`
+			Near     int    `json:"near"`
+			Sessions int    `json:"sessions"`
+			Total    int    `json:"total"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("files --json is not valid JSON: %v\n%s", err, out)
+	}
+	if env.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version=%d want %d", env.SchemaVersion, jsonout.Version)
+	}
+	if env.Query != "parser" {
+		t.Fatalf("query=%q want %q", env.Query, "parser")
+	}
+	// The list may legitimately be empty on this fixture; what must hold is
+	// that every row is well formed and that `total` is never smaller than
+	// `near`, since near-touches are a subset of the touches counted.
+	for _, f := range env.Files {
+		if f.Path == "" {
+			t.Fatalf("row with no path: %+v", f)
+		}
+		if f.Total < f.Near {
+			t.Fatalf("total %d < near %d for %s", f.Total, f.Near, f.Path)
+		}
+		if f.Sessions <= 0 {
+			t.Fatalf("row claims no sessions: %+v", f)
+		}
+	}
+}
+
+// A miss must still be an envelope, not prose on stdout: a consumer that got
+// one shape on a hit and a sentence on a miss would have to sniff the output
+// before parsing it.
+func TestFilesJSONOnAMissIsStillAnEnvelope(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(t.TempDir(), "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(t.TempDir(), "index.db"))
+
+	out, err := captureRun(t, "files", "--json", "nothing-mentions-this-topic")
+	if err != nil {
+		t.Fatalf("files --json on a miss err=%v out=%q", err, out)
+	}
+	var env struct {
+		SchemaVersion int   `json:"schema_version"`
+		Files         []any `json:"files"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatalf("miss is not valid JSON: %v\n%s", err, out)
+	}
+	if env.SchemaVersion != jsonout.Version {
+		t.Fatalf("schema_version=%d want %d", env.SchemaVersion, jsonout.Version)
+	}
+	if len(env.Files) != 0 {
+		t.Fatalf("miss returned %d files", len(env.Files))
+	}
+}
+
+// `files` refuses unknown flags by design (#1628); --json must not have opened
+// a hole in that.
+func TestFilesStillRefusesUnknownFlags(t *testing.T) {
+	if err := runFiles(t.TempDir(), []string{"--jsonn", "topic"}, io.Discard); err == nil {
+		t.Fatal("unknown flag accepted")
+	}
+	if err := runFiles(t.TempDir(), []string{"--json"}, io.Discard); err == nil {
+		t.Fatal("--json with no topic accepted")
 	}
 }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -577,6 +577,57 @@ says in a sentence.
 `last` is omitted rather than zero-valued when a command carries no recorded
 time. An empty result keeps the envelope and returns `commands: []`.
 
+## `deja files <topic> --json`
+
+Which files a piece of work touched:
+
+```json
+{
+  "schema_version": 2,
+  "query": "singbox",
+  "sessions_scanned": 34,
+  "matched": 34,
+  "read_capped": false,
+  "truncated": true,
+  "filtered": 2,
+  "withheld": 0,
+  "ignored": 0,
+  "files": [
+    {
+      "path": "/srv/app/internal/singbox/render.go",
+      "near": 18,
+      "sessions": 6,
+      "total": 21
+    }
+  ]
+}
+```
+
+`near` is touches close to the topic, `sessions` how many separate sessions
+those came from, and `total` touches anywhere in the sessions read. The ranking
+is built from those three, so a caller can re-rank or threshold without
+re-deriving them — `total` is the denominator that makes a file specific to the
+topic rather than merely busy.
+
+Two different cuts, kept apart because a consumer that folded them together
+would report the wrong one:
+
+- `truncated` — the caller's `--limit` bit on the file list. The note naming it
+  goes to **stderr**, so stdout alone could not otherwise tell ten files from
+  ninety.
+- `read_capped` — the read budget bit on the sessions behind the list.
+  `sessions_scanned` is what deja got to and `matched` how many mentioned the
+  topic at all; on a store where 301 sessions matched, reporting only the first
+  would present 250 as though it were the number.
+
+`filtered` counts recorded paths dropped because they are not under a
+repository on this disk today — moved, archived, or an unmounted volume. It
+separates "recorded nothing" from "recorded files this build will not show".
+
+`withheld` and `ignored` are what the policy rules took out before any of this
+was counted, on the same terms as `how`: an empty `files` otherwise reads as
+"nothing matched" when it can mean every matching session was withheld.
+
 ## `deja stats --impact --json`
 
 What deja has actually served on this machine, measured from the usage log:


### PR DESCRIPTION
## Summary

`deja files <topic> --json`. Closes #1930.

The envelope follows `docs/json-output.md` and carries the counts a caller cannot recover from the list:

```json
{
  "schema_version": 2,
  "query": "singbox",
  "sessions_scanned": 34,
  "matched": 34,
  "read_capped": false,
  "truncated": true,
  "filtered": 2,
  "withheld": 0,
  "ignored": 0,
  "files": [
    { "path": "/srv/app/internal/singbox/render.go", "near": 18, "sessions": 6, "total": 21 }
  ]
}
```

Each row keeps the three numbers the ranking is built from — `near`, `sessions`, `total` — so a consumer can re-rank or threshold without re-deriving them. `total` is the denominator that makes a file specific to the topic rather than merely busy.

**All four exits emit the envelope, not just the one with rows.** Writing the tests is what found that: my first version handled the no-hits path and the ranked path and left `N sessions mention "x", none of them recorded a file near it` printing prose under `--json`, so a caller got JSON on a hit and a sentence on that miss. An empty `files` means four different things — nobody discussed it, a rule withheld every session, a tree is kept out of recall, or the paths recorded are not on this disk today — and the counts beside it are what tell those apart. That is the same argument `how --json` makes for carrying `withheld` and `ignored`.

**`truncated` and `read_capped` are kept separate on purpose.** One is the caller's `--limit` biting on the file list; the other is the read budget biting on the sessions behind it. Folding them into one flag would report the wrong cut, and the prose path already distinguishes them (`filesReadNote`).

## Test plan

```sh
go build ./cmd/deja
go vet ./...                      # clean
go test ./cmd/deja -race -count=1 # ok, 218s
gofmt -s                          # clean on both changed files
```

Per-package coverage, measured directly as CONTRIBUTING asks:

```
go test ./cmd/deja/ -coverprofile=coverage.out
ok  github.com/vshulcz/deja-vu/cmd/deja  coverage: 90.0% of statements
```

90.0% against the `[cmd/deja]=88` floor in `ci.yml`. `runFiles` itself is 92.1%, `writeFilesJSON` 100%.

Three tests: the envelope on a hit (schema version, query, and that `total >= near` for every row, since near-touches are a subset), the envelope on a miss (same shape, empty list), and that `--json` did not open a hole in the unknown-flag refusal from #1628 — `--jsonn` and a bare `--json` with no topic both still error.

## Notes

`docs/json-output.md` gains a `deja files --json` section next to the others, including why the two truncation flags are distinct.

Verified by hand as the issue suggests: `deja files sometopic --json | jq .` parses.