### PR TITLE
docs: lead with the memory every agent shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
   </picture>
 </p>
 
-<p align="center"><b>Memory for coding agents, starting with the history you already have.</b></p>
+<p align="center"><b>The one memory your coding agents share, built from the history already on your disk.</b></p>
 
-<p align="center">Your agent is about to re-debug something you fixed in March. deja indexes the
-sessions Claude Code, Codex, Cursor and every other agent on this machine already wrote to
-disk, and hands the right one back when it is needed.</p>
+<p align="center">Your agent is about to re-debug something you fixed in March — in a different agent.
+deja indexes the sessions Claude Code, Codex, Cursor and every other agent on this machine
+already wrote to disk, and hands the right one back in whichever agent asks.</p>
 
 <p align="center"><img src="assets/demo.gif" width="720" alt="The same question put to the same agent twice: without memory it has no record of it, with deja it answers with the decision from eight months earlier"></p>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,10 +5,10 @@
   </picture>
 </p>
 
-<p align="center"><b>给编程智能体的记忆，从你已经有的历史开始。</b></p>
+<p align="center"><b>所有编程智能体共用的一份记忆，来自你磁盘上已有的历史。</b></p>
 
-<p align="center">你的智能体正准备重新调试一个你三月份就修好的问题。deja 索引 Claude Code、Codex、Cursor
-以及这台机器上其他所有智能体本来就写在磁盘上的会话，并在需要时把对的那一条交回来。</p>
+<p align="center">你的智能体正准备重新调试一个你三月份就修好的问题——当时是在另一个智能体里修的。deja 索引 Claude Code、Codex、Cursor
+以及这台机器上其他所有智能体本来就写在磁盘上的会话，无论哪个智能体来问，都把对的那一条交回来。</p>
 
 <p align="center"><img src="assets/demo.gif" width="720" alt="同一个问题问同一个智能体两次：没有记忆时它毫无印象，有 deja 时它用八个月前的结论作答"></p>
 

--- a/cmd/deja/readme_harness_count_test.go
+++ b/cmd/deja/readme_harness_count_test.go
@@ -181,7 +181,7 @@ func TestNpmReadmeLeadsWithWhatTheMainOneLeadsWith(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, line := range []string{
-		"Your agent is about to re-debug something you fixed in March.",
+		"Your agent is about to re-debug something you fixed in March — in a different agent.",
 		"deja starts full",
 	} {
 		if !strings.Contains(string(main), line) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,15 +4,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
-<title>deja-vu — memory for coding agents</title>
+<title>deja-vu — the one memory your coding agents share</title>
 <meta name="theme-color" content="#0b0f10">
-<meta name="description" content="Persistent memory for coding agents, built from the history they already wrote — including everything from before you installed it. Claude Code, Codex and 21 more agents.">
+<meta name="description" content="One memory shared by Claude Code, Codex and 21 more agents, built from the sessions they already wrote to disk — including everything from before you installed it.">
 <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
 <meta property="og:type" content="website">
-<meta property="og:title" content="deja-vu — search every session your coding agents ever wrote">
-<meta property="og:description" content="Memory tools start empty and record forward. deja starts full: it indexes the coding-agent sessions already on your disk, from before you installed it.">
+<meta property="og:title" content="deja-vu — the one memory your coding agents share">
+<meta property="og:description" content="Fix it in Codex, and Claude Code remembers. deja indexes the sessions 23 coding agents already wrote to your disk, from before you installed it, and hands them back in any of them.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -309,9 +309,9 @@ footer a:hover{color:var(--ph-hi)}
   <div>
     <p id="recall-line" hidden></p>
     <h1>Your agent is about to re-debug something you fixed in <em>March</em>.</h1>
-    <p class="lede">deja indexes the sessions your coding agents already wrote to disk —
-      months of history from before you installed it — and hands the right one back
-      before you ask.</p>
+    <p class="lede">Fix it in Codex, and Claude Code remembers. deja indexes the sessions all
+      23 of your coding agents already wrote to disk — months of history from before you
+      installed it — and hands the right one back in whichever agent asks.</p>
     <div class="cmdline">
       <span class="p">$</span>
       <code id="i1">curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</code>

--- a/npm/README.md
+++ b/npm/README.md
@@ -5,11 +5,12 @@
   </picture>
 </p>
 
-<p align="center"><strong>Your agent is about to re-debug something you fixed in March.</strong></p>
+<p align="center"><strong>Your agent is about to re-debug something you fixed in March — in a different agent.</strong></p>
 
 Every memory tool starts empty and records forward. **deja starts full.** It
-indexes the sessions your coding agents already wrote to disk — months of
-history from before you installed it — and serves them back over MCP.
+indexes the sessions all 23 of your coding agents already wrote to disk — months
+of history from before you installed it — and serves them back over MCP, in
+whichever agent asks.
 
 Twenty-three coding agents write every conversation to local files: Claude Code,
 Codex, Cursor, opencode, Gemini CLI, Cline, Copilot CLI, VS Code Copilot Chat, Roo Code, aider,


### PR DESCRIPTION
The tagline, the first paragraph, the site head tags and the hero lede now say what the 23-agent count is for: one memory every agent on the machine reads, so a session written by Codex is what Claude Code recalls. The npm README and README.zh follow; the two tests that pin these lines are updated with them.

Closes #3109
