### PR TITLE
fix(qwen): move the fix pair to PostToolUseFailure and unwrap qwen's report

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -55,8 +55,13 @@ type toolAfterInput struct {
 	// string: {"output":"…","exitCode":0} (measured on cursor-agent
 	// 2026.09.02). Reading only tool_response left the fix pair with nothing.
 	ToolOutput json.RawMessage `json:"tool_output"`
-	SessionID  string          `json:"session_id"`
-	CWD        string          `json:"cwd"`
+	// Qwen Code has a separate event for a failed tool, and its payload carries
+	// the command's output under `error` rather than tool_response — measured
+	// on qwen-code 0.20.0. Without this the hook fires at the failure and finds
+	// nothing to look up.
+	Error     json.RawMessage `json:"error"`
+	SessionID string          `json:"session_id"`
+	CWD       string          `json:"cwd"`
 }
 
 func runHookToolAfter(dir string, stdin io.Reader, stdout io.Writer) error {
@@ -105,6 +110,9 @@ func runHookToolAfterMode(dir string, stdin io.Reader, stdout io.Writer, plain b
 	if len(bytes.TrimSpace(response)) == 0 {
 		response = input.ToolOutput
 	}
+	if len(bytes.TrimSpace(response)) == 0 {
+		response = input.Error
+	}
 	out := toolResponseText(response)
 	if out == "" {
 		// readHookPayload stops at 1 MiB, so a verbose build cuts the JSON
@@ -119,6 +127,12 @@ func runHookToolAfterMode(dir string, stdin io.Reader, stdout io.Writer, plain b
 	if out == "" {
 		return nil
 	}
+	// The same labelled report gemini and qwen wrap a command's output in,
+	// arriving as a plain string rather than under llmContent: qwen's failure
+	// payload carries it in `error`. With the frame in place the error reads as
+	// `Output: ./main.go:9:2: …` and hashes to a signature no session recorded.
+	// Output without the frame comes back untouched.
+	out = unwrapGeminiShellOutput(out)
 	line := fixPairLine(dir, out)
 	if line == "" {
 		return nil

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -409,21 +409,37 @@ func installGeminiAuto(exe string, uninstall bool) (installResult, error) {
 // SessionStart used to be dropped here: qwen ran it and consumed nothing, so
 // deja retired the entry rather than leave a hook answering into the void. That
 // is no longer true — on qwen-code 0.20.0 the digest reaches the model, and so
-// does what a PostToolUse hook returns. PreToolUse fires and its output does
+// does what a hook returns after a tool. PreToolUse fires and its output does
 // not, so it stays unwired.
+//
+// The failure is its own event. Measured on 0.20.0 against a recording
+// endpoint: PostToolUse fires only when the tool succeeded — qwen guards it
+// with `!toolResult.error` and calls firePostToolUseFailureHook otherwise — so
+// the fix pair sat on the one event that never fires at a failure, which is the
+// moment it exists for.
 var qwenHookWiring = []struct{ Event, Sub, Matcher string }{
 	{"SessionStart", "hook-context", ""},
 	{"UserPromptSubmit", "hook-prompt", ""},
 	// The fix pair, at the failure. Matched on the tool that runs a command so
 	// it never spawns on a read.
-	{"PostToolUse", "hook-tool-after", "run_shell_command"},
+	{"PostToolUseFailure", "hook-tool-after", "run_shell_command"},
+	// Compaction throws away the blocks this session was shown while the list
+	// that stops them repeating outlives them, so without this the memory qwen
+	// just lost is the memory recall refuses to send again.
+	{"PreCompact", "hook-precompact", ""},
 }
+
+// qwenRetiredEvents are events deja used to write for qwen and no longer does.
+// The PostToolUse entry fired only after a tool that succeeded, so it looked
+// up a repair for commands that did not need one and stayed quiet for the ones
+// that did; leaving it behind would keep that cost on every green command.
+var qwenRetiredEvents = map[string]bool{"PostToolUse": true}
 
 func installQwenAuto(exe string, uninstall bool) (installResult, error) {
 	path := filepath.Join(sources.QwenConfigDir(), "settings.json")
 	var res installResult
 	for i, h := range qwenHookWiring {
-		r, err := installSettingsHookCmd(path, h.Event, h.Matcher, 60000, exe+" "+h.Sub, uninstall)
+		r, err := installSettingsHookRetiring(path, h.Event, h.Matcher, 60000, exe+" "+h.Sub, uninstall, qwenRetiredEvents)
 		if err != nil {
 			return installResult{}, err
 		}
@@ -669,7 +685,10 @@ func dejaHookEntry(entry map[string]any) bool {
 		cmd, _ := m["command"].(string)
 		// Any deja subcommand counts: the point is to find wiring we wrote,
 		// whatever the old binary called.
-		for _, sub := range []string{"hook-context", "hook-prompt", "hook-precompact", "hook-goose", "hook-antigravity"} {
+		// Both tool subcommands are spelled out: the match wants the whole
+		// token, so "hook-tool" does not find "hook-tool-after".
+		for _, sub := range []string{"hook-context", "hook-prompt", "hook-precompact", "hook-goose", "hook-antigravity",
+			"hook-tool", "hook-tool-after", "hook-spawn"} {
 			if isDejaHookCommand(cmd, "deja "+sub) {
 				return true
 			}

--- a/cmd/deja/install_qwen_tools_test.go
+++ b/cmd/deja/install_qwen_tools_test.go
@@ -2,67 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
-
-// Qwen consumes what a PostToolUse hook returns, and deja was not listening: a
-// qwen session ran a failing command and heard nothing, while the store held
-// the command that settled the same error. Measured on qwen-code 0.20.0 against
-// a stub endpoint — the hook fires and its context reaches the model, unlike
-// PreToolUse, which fires and whose output does not.
-func TestInstallQwenWiresTheFixPair(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	t.Setenv("DEJA_QWEN_ROOT", "")
-	if _, err := installQwenAuto("/usr/local/bin/deja", false); err != nil {
-		t.Fatal(err)
-	}
-	b, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	var root struct {
-		Hooks map[string][]struct {
-			Matcher string `json:"matcher"`
-			Hooks   []struct {
-				Command string `json:"command"`
-			} `json:"hooks"`
-		} `json:"hooks"`
-	}
-	if err := json.Unmarshal(b, &root); err != nil {
-		t.Fatal(err)
-	}
-	entries := root.Hooks["PostToolUse"]
-	if len(entries) != 1 {
-		t.Fatalf("PostToolUse entries = %d, want 1: %s", len(entries), b)
-	}
-	if got := entries[0].Hooks[0].Command; !strings.HasSuffix(got, "hook-tool-after") {
-		t.Errorf("PostToolUse runs %q, want the fix pair", got)
-	}
-	if m := entries[0].Matcher; m != "run_shell_command" {
-		t.Errorf("matcher = %q, want the tool that runs commands", m)
-	}
-	// PreToolUse fires on qwen too, and what it returns never reaches the
-	// model — a process per command for nothing.
-	if len(root.Hooks["PreToolUse"]) != 0 {
-		t.Errorf("PreToolUse is wired, and its output is not context: %s", b)
-	}
-	// Reinstalling must not double any of them.
-	if _, err := installQwenAuto("/usr/local/bin/deja", false); err != nil {
-		t.Fatal(err)
-	}
-	b2, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(b) != string(b2) {
-		t.Errorf("a second install changed the file:\n%s\n%s", b, b2)
-	}
-}
 
 // Qwen frames a command's output as a labelled report before handing it to the
 // model. The "Output:" label in front of the first line is what stopped a build

--- a/cmd/deja/qwen_failure_hook_test.go
+++ b/cmd/deja/qwen_failure_hook_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Qwen fires PostToolUse only when the tool succeeded — its own code guards the
+// call with `!toolResult.error` and calls the failure hook otherwise — so the
+// fix pair sat on the one event that never fires at a failure. Measured on
+// qwen-code 0.20.0: a failing run_shell_command fires PostToolUseFailure, and
+// what that hook returns is appended to the tool result the model reads.
+func TestQwenWiresTheFixPairToTheFailureEvent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if _, err := installQwenAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("settings are not JSON qwen can read: %v\n%s", err, b)
+	}
+	find := func(event string) (string, string, bool) {
+		for _, e := range cfg.Hooks[event] {
+			for _, h := range e.Hooks {
+				if strings.Contains(h.Command, "/bin/deja") {
+					return h.Command, e.Matcher, true
+				}
+			}
+		}
+		return "", "", false
+	}
+	cmd, matcher, ok := find("PostToolUseFailure")
+	if !ok {
+		t.Fatalf("no deja hook on PostToolUseFailure:\n%s", b)
+	}
+	if !strings.Contains(cmd, "hook-tool-after") {
+		t.Fatalf("the failure event runs %q, not the fix pair", cmd)
+	}
+	if matcher != "run_shell_command" {
+		t.Fatalf("the fix pair fires for every tool (matcher %q), not just the one that runs commands", matcher)
+	}
+	if _, _, ok := find("PostToolUse"); ok {
+		t.Fatalf("the old PostToolUse hook is still there; it fires only when the command worked:\n%s", b)
+	}
+	if cmd, _, ok := find("PreCompact"); !ok || !strings.Contains(cmd, "hook-precompact") {
+		t.Fatalf("nothing forgets after a compaction:\n%s", b)
+	}
+	// PreToolUse fires on qwen too, and what it returns never reaches the
+	// model — a process per command for nothing.
+	if len(cfg.Hooks["PreToolUse"]) != 0 {
+		t.Errorf("PreToolUse is wired, and its output is not context:\n%s", b)
+	}
+	// Reinstalling must not double any of them.
+	if _, err := installQwenAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b2, err := os.ReadFile(filepath.Join(home, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != string(b2) {
+		t.Errorf("a second install changed the file:\n%s\n%s", b, b2)
+	}
+}
+
+// An install that ran before the fix left the PostToolUse entry behind; a
+// re-install has to take it, or a repair lookup keeps running after every
+// command that worked.
+func TestQwenReinstallRetiresTheOldPostToolUseHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := filepath.Join(home, ".qwen", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// What the older deja wrote, beside a hook of the user's own.
+	before := `{"hooks":{"PostToolUse":[` +
+		`{"matcher":"run_shell_command","hooks":[{"type":"command","command":"/bin/deja hook-tool-after","timeout":60000}]},` +
+		`{"matcher":"write_file","hooks":[{"type":"command","command":"my-own-hook","timeout":1000}]}]}}`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installQwenAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	got := string(b)
+	if strings.Contains(got, `"command":"/bin/deja hook-tool-after","timeout":60000}]},{"matcher":"write_file"`) {
+		t.Fatalf("deja's old PostToolUse entry survived:\n%s", got)
+	}
+	if strings.Count(got, "hook-tool-after") != 1 {
+		t.Fatalf("the fix pair is wired %d times:\n%s", strings.Count(got, "hook-tool-after"), got)
+	}
+	if !strings.Contains(got, "my-own-hook") {
+		t.Fatalf("the user's own PostToolUse hook was taken with it:\n%s", got)
+	}
+}
+
+// Qwen sends the command's output under `error`, inside a block it wrote
+// itself. Both halves matter: reading only tool_response finds nothing, and
+// scanning the frame hashes `Output: <error>` — a signature no session ever
+// recorded — so the pair went quiet for every qwen failure.
+func TestFixPairReadsQwensFramedFailure(t *testing.T) {
+	seedFixPair(t, "./main.go:9:2: undefined: glimwraxHelper", "glimwraxctl --sync && go build ./...")
+	payload := `{"session_id":"qwen-1","cwd":"/work/app","hook_event_name":"PostToolUseFailure",` +
+		`"tool_name":"run_shell_command","tool_input":{"command":"go build ./..."},` +
+		`"error":"Command: go build ./...\nDirectory: (root)\nOutput: ./main.go:9:2: undefined: glimwraxHelper\nError: (none)\nExit Code: 1\n"}`
+	var out bytes.Buffer
+	if err := runHookToolAfterMode(os.Getenv("DEJA_INDEX_DIR"), strings.NewReader(payload), &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "glimwraxctl --sync") {
+		t.Fatalf("the repair did not survive qwen's framing:\n%s", out.String())
+	}
+}
+
+// Output that never carried the frame passes through untouched. Plenty of real
+// output has a line starting with "Error:" without being a report at all — node
+// prints one for every uncaught throw — so the unwrap is reached only for text
+// that opens with "Command:", the way qwen's report does.
+func TestFixPairLeavesUnframedOutputAlone(t *testing.T) {
+	seedFixPair(t, "Error: Cannot find module 'glimwrax'", "npm ci")
+	node := `npm ERR! code ELIFECYCLE\nError: Cannot find module 'glimwrax'\n    at Function.Module._resolveFilename`
+	payload := `{"session_id":"qwen-2","cwd":"/work/app","hook_event_name":"PostToolUseFailure",` +
+		`"tool_name":"run_shell_command","tool_input":{"command":"npm start"},"error":"` + node + `"}`
+	var out bytes.Buffer
+	if err := runHookToolAfterMode(os.Getenv("DEJA_INDEX_DIR"), strings.NewReader(payload), &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "npm ci") {
+		t.Fatalf("a stack trace was mistaken for a frame and lost its error line:\n%s", out.String())
+	}
+}

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -113,6 +113,17 @@
 # or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh</pre>
 
+<h2>What gets wired</h2>
+<p><code>deja install qwen-auto</code> writes four hooks into <code>~/.qwen/settings.json</code>, next to whatever else is in it:</p>
+<ul>
+<li>The project digest at <code>SessionStart</code>: what this project's past sessions settled, before you type anything.</li>
+<li>Recall on <code>UserPromptSubmit</code>, silent when the history has no answer.</li>
+<li>The repair on <code>PostToolUseFailure</code>, for <code>run_shell_command</code> only: when a command fails with an error that has been solved here before, what followed it last time arrives on the failing tool result itself.</li>
+<li>Forgetting on <code>PreCompact</code>, so the blocks a compacted thread just lost can be said again.</li>
+</ul>
+<p>Measured on Qwen Code 0.20.0 by reading the requests it sent. <code>PostToolUse</code> fires only when the tool succeeded — Qwen guards it and calls <code>PostToolUseFailure</code> otherwise — so the repair used to sit on the one event that never fires at a failure; an install over an older one drops that entry. <code>PreToolUse</code> runs but its output is discarded. The failure payload carries the command's output under <code>error</code>, inside a <code>Command: / Output: / Exit Code:</code> block Qwen writes itself, and deja unwraps it before matching.</p>
+<p>Costs on that version, on a seeded store: 2.3 KB at session start, 397 bytes for a repair block, 0 bytes and about 30 ms when there is nothing to say.</p>
+
 <h2>The part that is not about this harness</h2>
 <p>The index covers every agent's transcripts on the machine — twenty-three of them today, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in one tool answers a question asked in another, including sessions from before any of this was installed. That is the reason to index rather than to capture.</p>
 <p>Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>). An injection is capped at 1,536 bytes per prompt and about 4 KB per tool call — <a href="token-cost.html">what memory costs</a> has the measured comparison.</p>

--- a/docs/registry/qwen.html
+++ b/docs/registry/qwen.html
@@ -56,7 +56,7 @@
 <li>System, tool-result, and other control records do not become messages.</li>
 <li>Project path encoding is ambiguous because <code>-</code> represents both a separator and a hyphen. deja checks the local filesystem before using a two-segment fallback.</li>
 </ul>
-<p><strong>Last verified:</strong> 2026-07-17</p>
+<p><strong>Last verified:</strong> 2026-09-07</p>
 
 <hr>
 <p>deja reads this format and twenty-two others, and turns what it finds into memory your

--- a/docs/registry/qwen.md
+++ b/docs/registry/qwen.md
@@ -30,4 +30,4 @@ encoded path and prints `cd <project> && qwen -r <id>`.
 - System, tool-result, and other control records do not become messages.
 - Project path encoding is ambiguous because `-` represents both a separator and a hyphen. deja checks the local filesystem before using a two-segment fallback.
 
-**Last verified:** 2026-07-17
+**Last verified:** 2026-09-07

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -556,7 +556,7 @@
         "fixtures/registry/qwen/projects/-workspace-registry-demo/chats/registry-qwen.jsonl"
       ],
       "parser_source": "internal/sources/qwen.go",
-      "last_verified": "2026-07-17",
+      "last_verified": "2026-09-07",
       "display_name": "Qwen Code",
       "capabilities": {
         "mcp": true,


### PR DESCRIPTION
Measured on qwen-code 0.20.0 against a recording endpoint.

`PostToolUse` fires only when the tool succeeded — qwen guards it with `!toolResult.error` and calls `firePostToolUseFailureHook` otherwise — so the fix pair sat on the event that never fires at a failure. On `PostToolUseFailure` what the hook returns is appended to the tool result the model reads. The failure payload also carries the command's output under `error`, inside qwen's own `Command: / Directory: / Output: / Error: / Exit Code:` block, which hashed to a signature no session ever recorded; it goes through the same unwrap the gemini `llmContent` path uses. `PreCompact` is wired too, and the old `PostToolUse` entry is dropped on install.

Costs on a seeded stand: 2.3 KB at session start, 397 bytes for a repair block, 0 bytes and ~30 ms when there is nothing to say. `PreToolUse` still unwired — it fires and its output is discarded.

Docs and registry updated with the code.