### PR TITLE
feat(dsh): declare the DSH release the plugin was measured on

### DIFF
--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -41,6 +41,12 @@
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"
+    },
+    "compatibility": {
+      "dsh": "0.1.1-rc.2",
+      "dshReleases": {
+        "0.1.1-rc.2": "compatible"
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
dsh.compatibility.dshReleases names 0.1.1-rc.2 as compatible — the release the plugin was measured against — and nothing else; the catalogue reads that field from the pinned commit.

Closes #3128
