### PR TITLE
feat(roo): resume CLI tasks and stop Roo asking before every recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ aider &middot; Amp &middot; Antigravity &middot; Claude Code &middot; Cline &mid
 | pi | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | prime-agent (PrimeIntellect) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Qwen Code | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Roo Code | ✅ | ⚠ | ✅ | ✅ | ✕ | paste | — |
+| Roo Code | ✅ | ⚠ | ✅ | ✅ | ✅ | paste | roo CLI (editor tasks reopen in the editor) |
 | Zed | ✅ | ✕ | ✅ | ✅ | ✕ | paste | sqlite3 + zstd |
 
 ✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -254,6 +254,23 @@ func plausibleSession(t *testing.T, harness string) model.Session {
 		// under this harness come from the grok-dev database and cannot resume.
 		s.Path = filepath.Join(t.TempDir(), "sessions", "workspace%2Fp", "abc123", "updates.jsonl")
 	}
+	if harness == "roo" {
+		// Only the CLI's own store resumes, and the command carries the
+		// workspace out of history_item.json — a bare path would fail the
+		// check for the right reason and the wrong one at once.
+		root := filepath.Join(t.TempDir(), "vscode-mock", "global-storage")
+		id := "01a07bf9-8882-7703-a3fa-245deb8ea752"
+		dir := filepath.Join(root, "tasks", id)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		item := `{"id":"` + id + `","ts":1,"task":"t","workspace":"/work/app"}`
+		if err := os.WriteFile(filepath.Join(dir, "history_item.json"), []byte(item), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("DEJA_ROO_CLI_ROOT", root)
+		s.Path = filepath.Join(dir, "api_conversation_history.json")
+	}
 	if harness == "openclaw" {
 		dir := filepath.Join(t.TempDir(), "agents", "main", "sessions")
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,6 +101,15 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 		if err != nil {
 			return installResult{}, err
 		}
+		if !uninstall {
+			changed, err := rooAllowDejasTool(p)
+			if err != nil {
+				return installResult{}, err
+			}
+			if changed && res.Action == "unchanged" {
+				res.Action = "updated"
+			}
+		}
 		last = res
 		if res.Action != "unchanged" {
 			wrote = true
@@ -122,6 +133,52 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 		return installResult{Action: "no Roo host found — open Roo in VS Code once, then re-run"}, nil
 	}
 	return last, nil
+}
+
+// rooAllowDejasTool names deja's own tool in the entry's alwaysAllow list, the
+// per-server approval Roo reads before it runs an MCP tool.
+//
+// Without it Roo asks first, every time. In the editor that is a click before
+// each recall; in the CLI's non-interactive mode there is nobody to click, and
+// the run waits: measured on @roo-code/cli 0.1.17 against a recording
+// endpoint, the turn stopped after the first request and never finished, while
+// the same run with the list in place came back with the recall in the next
+// request it sent.
+//
+// Only when the entry says nothing about approvals. A list that is there and
+// does not name deja is the reader's own answer, and re-running install must
+// not overrule it.
+func rooAllowDejasTool(path string) (bool, error) {
+	old, err := readConfig(path)
+	if err != nil || len(bytes.TrimSpace(old)) == 0 {
+		return false, err
+	}
+	// A settings file carrying comments cannot be rewritten without losing
+	// them, and this is an addition rather than the wiring itself — the server
+	// still works, it just asks first.
+	if configIsJSONC(old) {
+		return false, nil
+	}
+	var root map[string]any
+	if err := json.Unmarshal(old, &root); err != nil {
+		return false, nil
+	}
+	servers, _ := root["mcpServers"].(map[string]any)
+	entry, _ := servers[dejaEntryKey(servers)].(map[string]any)
+	if entry == nil {
+		return false, nil
+	}
+	if _, said := entry["alwaysAllow"]; said {
+		return false, nil
+	}
+	entry["alwaysAllow"] = []any{"deja"}
+	next, err := marshalConfigLike(old, root)
+	if err != nil {
+		return false, err
+	}
+	next = append(next, '\n')
+	a, err := writeIfChanged(path, old, next)
+	return a != "unchanged", err
 }
 
 // rooRulesPath is where deja used to write guidance: the global rules

--- a/cmd/deja/resume.go
+++ b/cmd/deja/resume.go
@@ -158,7 +158,15 @@ func resumeCommand(s model.Session) (string, string, error) {
 		}
 		return "", "cline --id " + s.ID, nil
 	case "roo":
-		return "", "", fmt.Errorf("roo tasks reopen from the extension's history UI, not the terminal")
+		// The Roo CLI runs the extension against a VS Code shim and keeps its
+		// tasks in a store of its own, which is the half that reopens from a
+		// terminal: `roo --session-id`, scoped to the workspace the task was
+		// in. Editor tasks live under the host's globalStorage, the CLI never
+		// lists them, and there is still no command for those.
+		if id, ws := sources.RooCLITask(s.Path); id != "" {
+			return ws, "roo --session-id " + id, nil
+		}
+		return "", "", fmt.Errorf("roo tasks from the VS Code extension reopen from its history UI; only the ones the roo CLI created take --session-id")
 	case "zed":
 		// These two used to fall through to "don't know how to resume", which
 		// reads like deja is missing something. Both are settled answers, and

--- a/cmd/deja/roo_cli_test.go
+++ b/cmd/deja/roo_cli_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// rooCLITask writes a task in the shape the Roo CLI leaves behind: its own
+// storage root, a UUID for a name, and the workspace in history_item.json.
+func rooCLITask(t *testing.T, root, id, workspace string) string {
+	t.Helper()
+	dir := filepath.Join(root, "tasks", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, []byte(`[{"role":"user","content":"hi"}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	item := `{"id":"` + id + `","ts":1788785794339,"task":"fix the queue","workspace":"` + workspace + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "history_item.json"), []byte(item), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Roo grew a CLI (@roo-code/cli 0.1.17): it runs the extension against a VS
+// Code shim, keeps its tasks in a store of its own, and takes --session-id.
+// deja used to answer "reopen it from the extension's history UI" for every
+// roo session, including the ones a terminal had just written.
+func TestResumeRooSplitsTheCLIFromTheEditor(t *testing.T) {
+	tmp := t.TempDir()
+	cli := filepath.Join(tmp, "vscode-mock", "global-storage")
+	t.Setenv("DEJA_ROO_CLI_ROOT", cli)
+	work := filepath.Join(tmp, "app")
+	id := "01a07bf9-8882-7703-a3fa-245deb8ea752"
+	path := rooCLITask(t, cli, id, work)
+
+	dir, cmd, err := resumeCommand(model.Session{Harness: "roo", ID: "roo-task-" + id, Project: "app", Path: path})
+	if err != nil {
+		t.Fatalf("roo CLI resume: %v", err)
+	}
+	if cmd != "roo --session-id "+id {
+		t.Fatalf("cmd = %q", cmd)
+	}
+	// The CLI lists only tasks whose workspace it is standing in, so the
+	// command has to carry the directory the task was in.
+	if runtime.GOOS != "windows" && dir != work {
+		t.Fatalf("dir = %q, want the workspace %q", dir, work)
+	}
+
+	// An editor task lives under the host's globalStorage, and the CLI never
+	// lists it: printing a command for it sends someone to "session not found".
+	editor := filepath.Join(tmp, "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline")
+	ext := rooCLITask(t, editor, "01a07c12-d264-733d-9ac4-b376e75a9cf5", work)
+	if _, _, err := resumeCommand(model.Session{Harness: "roo", ID: "roo-task-x", Path: ext}); err == nil {
+		t.Fatal("an editor task produced a terminal command")
+	}
+
+	// And a task named the old way is not one --session-id accepts: it
+	// validates the argument as a UUID before it looks anything up.
+	old := rooCLITask(t, cli, "1767225700000", work)
+	if _, _, err := resumeCommand(model.Session{Harness: "roo", ID: "roo-task-1767225700000", Path: old}); err == nil {
+		t.Fatal("a timestamp-named task produced a --session-id command")
+	}
+}
+
+// Roo asks before it runs an MCP tool unless the server entry names that tool
+// in alwaysAllow. In the editor that is a click before every recall; in the
+// CLI's non-interactive mode nobody can click, and the run waits there.
+func TestInstallRooAllowsDejasOwnTool(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "storage")
+	t.Setenv("DEJA_ROO_ROOTS", root)
+	if err := os.MkdirAll(filepath.Join(root, "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "settings", "mcp_settings.json")
+
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	allow := rooAllowList(t, path)
+	if len(allow) != 1 || allow[0] != "deja" {
+		b, _ := os.ReadFile(path)
+		t.Fatalf("alwaysAllow = %v, want deja's own tool:\n%s", allow, b)
+	}
+
+	// Twice is not twice: a second install leaves the file exactly as it was.
+	before, _ := os.ReadFile(path)
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatalf("a second install changed the file:\n%s\n%s", before, after)
+	}
+}
+
+// A reader who took deja off the list said something, and an install that puts
+// it back overrules them.
+func TestInstallRooLeavesAnApprovalListAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, "storage")
+	t.Setenv("DEJA_ROO_ROOTS", root)
+	if err := os.MkdirAll(filepath.Join(root, "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "settings", "mcp_settings.json")
+	before := `{"mcpServers":{"deja":{"command":"/old/deja","args":["mcp"],"alwaysAllow":[]}}}`
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if allow := rooAllowList(t, path); len(allow) != 0 {
+		t.Fatalf("alwaysAllow = %v, want the empty list the reader left", allow)
+	}
+	// The wiring itself is still adopted — only the approval is theirs.
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), "/bin/deja") {
+		t.Fatalf("the entry was not adopted:\n%s", b)
+	}
+}
+
+func rooAllowList(t *testing.T, path string) []string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg struct {
+		Servers map[string]struct {
+			AlwaysAllow []string `json:"alwaysAllow"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("settings are not JSON Roo can read: %v\n%s", err, b)
+	}
+	return cfg.Servers["deja"].AlwaysAllow
+}

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -98,6 +98,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -98,6 +98,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -71,6 +71,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -34,7 +34,7 @@
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Finding the session where you solved it","description":"How to search chat history across every coding agent on the machine, by the token you remember rather than the topic you half-remember.","url":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Finding a session","item":"https://vshulcz.github.io/deja-vu/guide/find-a-session.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I find the session where I fixed something?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts by the most specific thing you remember — an exact error string, a function name, a file path or a flag. Those match a session even when you have forgotten which tool, project or month it was."}},{"@type":"Question","name":"Can I reopen an old session in the agent that ran it?","acceptedAnswer":{"@type":"Answer","text":"For fifteen of the twenty harnesses deja reads, yes: deja resume <id> hands the id back to that harness and it continues the conversation. The rest have no resume path of their own."}},{"@type":"Question","name":"What if I only remember roughly when it was?","acceptedAnswer":{"@type":"Answer","text":"Time is a hint rather than a filter: a date in the query weighs recent sessions up without hiding older ones, and deja last lists the most recent sessions by project, role or harness."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I find the session where I fixed something?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts by the most specific thing you remember — an exact error string, a function name, a file path or a flag. Those match a session even when you have forgotten which tool, project or month it was."}},{"@type":"Question","name":"Can I reopen an old session in the agent that ran it?","acceptedAnswer":{"@type":"Answer","text":"For nineteen of the twenty-three harnesses deja reads, yes: deja resume <id> hands the id back to that harness and it continues the conversation. The rest have no resume path of their own."}},{"@type":"Question","name":"What if I only remember roughly when it was?","acceptedAnswer":{"@type":"Answer","text":"Time is a hint rather than a filter: a date in the query weighs recent sessions up without hiding older ones, and deja last lists the most recent sessions by project, role or harness."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>
@@ -120,7 +121,7 @@
 <pre>deja show 8f31c0a9      # read the session
 deja ctx  8f31c0a9      # a Markdown digest to paste into whatever you are doing now
 deja resume 8f31c0a9    # reopen it in the agent that ran it</pre>
-<p><code>resume</code> hands the id back to the harness that owns the session, with the project directory where that harness scopes its list to one. It works for fifteen of the twenty harnesses deja reads — Claude Code, Codex, Cursor, opencode, Gemini CLI, Cline, Copilot, Goose, Kimi, Qwen, pi, omp, OpenClaw, Antigravity and Hermes. The remaining five — aider, Grok Build, Roo Code, DeepSeek Harness and Zed — have no resume path of their own, and deja says so rather than pretending.</p>
+<p><code>resume</code> hands the id back to the harness that owns the session, with the project directory where that harness scopes its list to one. It works for nineteen of the twenty-three harnesses deja reads. The remaining four — aider, VS Code Copilot Chat, DeepSeek Harness and Zed — have no resume path of their own, and deja says so rather than pretending. Roo Code is half of each: tasks its CLI created take <code>roo --session-id</code>, and tasks from the editor reopen in the editor.</p>
 <p>Ids are matched by prefix, so the eight characters a result prints are enough to type.</p>
 
 <h2>When the answer is a command rather than a session</h2>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -71,6 +71,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -53,7 +53,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>
@@ -118,7 +119,7 @@
 <tr><td><a href="../registry/pi.html">pi</a></td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td><a href="../registry/prime.html">prime-agent (PrimeIntellect)</a></td><td><code>${DEJA_PRIME_ROOT:-~/.prime/agent/sessions}/**/*.jsonl</code><br><code>${PRIME_AGENT_SESSION_DIR}/**/*.jsonl</code><br><code>${PRIME_AGENT_CODING_AGENT_SESSION_DIR}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td><a href="../registry/qwen.html">Qwen Code</a></td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
-<tr><td><a href="../registry/roo.html">Roo Code</a></td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>⚠</td><td>✅</td><td>✅</td><td>✕</td><td>paste</td><td>—</td></tr>
+<tr><td><a href="../registry/roo.html">Roo Code</a></td><td><code><vscode-globalStorage>/rooveterinaryinc.roo-cline/tasks/*/api_conversation_history.json</code><br><code>${DEJA_ROO_ROOTS}/tasks/*/api_conversation_history.json</code><br><code>~/.vscode-mock/global-storage/tasks/*/api_conversation_history.json</code></td><td>✅</td><td>⚠</td><td>✅</td><td>✅</td><td>✅</td><td>paste</td><td>roo CLI (editor tasks reopen in the editor)</td></tr>
 <tr><td><a href="../registry/zed.html">Zed</a></td><td><code>~/Library/Application Support/Zed/threads/threads.db</code><br><code>${XDG_DATA_HOME}/zed/threads/threads.db</code><br><code>%LOCALAPPDATA%/Zed/threads/threads.db</code><br><code>${DEJA_ZED_ROOT}/threads/threads.db</code><br><code>${DEJA_ZED_DB}</code></td><td>✅</td><td>✕</td><td>✅</td><td>✅</td><td>✕</td><td>paste</td><td>sqlite3 + zstd</td></tr>
 </table>
 <p>✅ works &middot; — possible, not built yet &middot; ✕ the harness has no such mechanism &middot; ⚠ blocked by an upstream bug &middot; ? not investigated</p>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html" aria-current="page">Lost context</a>

--- a/docs/guide/memory-for-amp.html
+++ b/docs/guide/memory-for-amp.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html" aria-current="page">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cline.html
+++ b/docs/guide/memory-for-cline.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html" aria-current="page">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-copilot-chat.html
+++ b/docs/guide/memory-for-copilot-chat.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html" aria-current="page">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-goose.html
+++ b/docs/guide/memory-for-goose.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html" aria-current="page">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html" aria-current="page">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html" aria-current="page">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html" aria-current="page">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-roo.html
+++ b/docs/guide/memory-for-roo.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Memory for Roo Code: recall across Claude Code, Codex and the rest — deja-vu</title>
+<meta name="description" content="Roo Code has no lifecycle hooks yet, so deja arrives as an MCP server it may call, a skill that tells it when to, and a /deja command — plus the approval entry that keeps it from asking first.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Roo Code">
+<meta property="og:description" content="Roo Code has no lifecycle hooks yet, so deja arrives as an MCP server it may call, a skill that tells it when to, and a /deja command — plus the approval entry that keeps it from asking first.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Roo Code">
+<meta name="twitter:description" content="Roo Code has no lifecycle hooks yet, so deja arrives as an MCP server it may call, a skill that tells it when to, and a /deja command — plus the approval entry that keeps it from asking first.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Adding memory to Roo Code", "description": "Roo Code has no lifecycle hooks yet, so deja arrives as an MCP server it may call, a skill that tells it when to, and a /deja command — plus the approval entry that keeps it from asking first.", "url": "https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Memory for Roo Code", "item": "https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does Roo Code remember previous tasks?", "acceptedAnswer": {"@type": "Answer", "text": "It keeps every task on disk and can reopen one from its history, but a new task starts with your rules files and nothing else — not last week's task, and not the session you had open in another agent."}}, {"@type": "Question", "name": "How do I add memory to Roo Code?", "acceptedAnswer": {"@type": "Answer", "text": "deja install roo writes the deja MCP server into mcp_settings.json for every editor Roo has run in, installs the deja-history skill and a /deja command, and names deja's own tool in the entry's alwaysAllow list so Roo does not ask before every recall."}}, {"@type": "Question", "name": "Can Roo Code see what I did in Claude Code or Codex?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, once deja is installed: the index covers the transcripts of twenty-three agents on the machine, including sessions from before deja was installed."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="memory-for-copilot-chat.html">Memory for VS Code Copilot Chat</a>
+<a href="memory-for-openclaw.html">Memory for OpenClaw</a>
+<a href="memory-for-goose.html">Memory for Goose</a>
+<a href="memory-for-cline.html">Memory for Cline</a>
+<a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html" aria-current="page">Memory for Roo Code</a>
+<a href="memory-for-hermes.html">Memory for Hermes</a>
+</details>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Roo Code</h1>
+<p class="pagelede">no hooks yet, so recall arrives as a tool it can reach for<span class="mins" data-mins></span></p>
+
+<p>Roo keeps every task on disk — the transcript under the editor's global storage, and the same files under <code>~/.vscode-mock/global-storage</code> when you drive it from the Roo CLI. A new task reads your rules and nothing else: not the task you closed on Friday, and not the Claude Code or Codex session on the same machine where the problem was already solved.</p>
+
+<h2>Adding recall</h2>
+<pre>deja install roo</pre>
+<p>That writes four things, and only into editors Roo has actually run in:</p>
+<ul>
+<li><b>The MCP server</b>, in <code>mcp_settings.json</code> for each host — VS Code, Insiders, VSCodium, Cursor, Windsurf, and the CLI's own store. One tool with a mode: search past sessions, read one in full, see a file's history, ask what fixed an error, ask how a command is really run here, store a decision.</li>
+<li><b>The approval</b>: deja's own tool named in that entry's <code>alwaysAllow</code>. Roo asks before it runs an MCP tool otherwise — a click before every recall in the editor, and in the CLI's non-interactive mode a run that waits for an answer nobody can give.</li>
+<li><b>The <code>deja-history</code> skill</b> in <code>~/.agents/skills</code>, which Roo reads along with <code>~/.roo/skills</code>. It is what tells the model when to look: before re-debugging an error, when you say "didn't we fix this".</li>
+<li><b>A <code>/deja</code> command</b> in <code>~/.roo/commands</code>, for asking directly.</li>
+</ul>
+
+<h2>Why there is no session-start injection</h2>
+<p>Roo has no lifecycle hooks. A Claude Code-style hooks system is in flight upstream — <a href="https://github.com/RooCodeInc/Roo-Code/pull/10785">PR #10785</a> and two more — and until one of them ships there is no event deja can answer, so recall is something the model reaches for rather than something that arrives. Checked against Roo Code 3.53: nothing in the released extension runs a command at session start, before a tool, or on compaction.</p>
+
+<h2>What it costs</h2>
+<p>Measured against a recording endpoint on Roo Code 3.53 with the CLI: deja's tool declaration is 3.1 KB of the 26 KB of tools Roo sends with every request, and a recall that answers adds about 1.3 KB to the one turn that asked for it. A recall with no answer adds nothing.</p>
+
+<h2>Reopening a session</h2>
+<p><code>deja resume &lt;id&gt;</code> prints <code>roo --session-id &lt;uuid&gt;</code> with the workspace the task was in, for tasks the Roo CLI created — it lists only tasks belonging to the directory it is standing in. Tasks from the editor reopen from Roo's own history view; deja says so rather than printing a command that would not work.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty-three of them, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in Claude Code answers a question asked in Roo, including sessions from before any of this was installed. Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="switching-agents.html">Switching between agents</a> · <a href="../registry/roo.html">The Roo Code session format</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html" aria-current="page">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -34,7 +34,7 @@
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Resuming the session you had yesterday","description":"Find the session across every agent on the machine, then reopen it in the tool that owns it — or take the digest instead of the whole conversation.","url":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Resuming a session","item":"https://vshulcz.github.io/deja-vu/guide/resume-a-session.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I resume a previous coding session?","acceptedAnswer":{"@type":"Answer","text":"deja resume <id> prints the command that reopens that exact conversation, including the directory it must run in. Sixteen of the twenty indexed harnesses support it."}},{"@type":"Question","name":"Can I find a session from a different agent?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja searches every agent's transcripts at once and each hit carries its harness and session id, which the agents' own resume commands cannot do."}},{"@type":"Question","name":"What if I only want the conclusion?","acceptedAnswer":{"@type":"Answer","text":"deja ctx <id-prefix> returns the session as a digest — decisions, files touched, commands run — small enough to paste into a session you are already in."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"How do I resume a previous coding session?","acceptedAnswer":{"@type":"Answer","text":"deja resume <id> prints the command that reopens that exact conversation, including the directory it must run in. Nineteen of the twenty-three indexed harnesses support it."}},{"@type":"Question","name":"Can I find a session from a different agent?","acceptedAnswer":{"@type":"Answer","text":"Yes. deja searches every agent's transcripts at once and each hit carries its harness and session id, which the agents' own resume commands cannot do."}},{"@type":"Question","name":"What if I only want the conclusion?","acceptedAnswer":{"@type":"Answer","text":"deja ctx <id-prefix> returns the session as a digest — decisions, files touched, commands run — small enough to paste into a session you are already in."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>
@@ -105,7 +106,7 @@
 <pre>deja resume &lt;id&gt;</pre>
 <p>It prints the command that reopens that exact conversation, including the directory it has to run in when the tool scopes its session list by working directory:</p>
 <pre>cd '/path/to/project' &amp;&amp; grok --resume 01a03433-0c67-7331-8eb1-cd6173d4c8f9</pre>
-<p>Sixteen of the twenty harnesses deja indexes can be reopened this way. The other four are refusals with a reason rather than silence: aider appends to a transcript file and has no notion of reopening one conversation, Roo and Zed reopen from their own UI rather than a terminal, and neither of DeepSeek Harness's two apps takes a session id. The <a href="../registry/README.html">format registry</a> records which is which, and why.</p>
+<p>Nineteen of the twenty-three harnesses deja indexes can be reopened this way. The other four are refusals with a reason rather than silence: aider appends to a transcript file and has no notion of reopening one conversation, Zed and VS Code Copilot Chat reopen from their own UI rather than a terminal, and neither of DeepSeek Harness's two apps takes a session id. Roo Code splits: what its CLI wrote resumes, what the editor wrote reopens there. The <a href="../registry/README.html">format registry</a> records which is which, and why.</p>
 
 <h2>When resuming is the wrong tool</h2>
 <p>Reopening a session brings back the whole conversation, including the parts that were wrong before they were right. Often what you want is the conclusion, not the road to it:</p>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -67,6 +67,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">18</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-goose.html">Memory for Goose</a>
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -474,6 +474,7 @@ footer a:hover{color:var(--ph-hi)}
     <span><a href="guide/memory-for-opencode.html">opencode</a></span>
     <span><a href="guide/memory-for-gemini.html">Gemini CLI</a></span>
     <span><a href="guide/memory-for-qwen.html">Qwen Code</a></span>
+    <span><a href="guide/memory-for-roo.html">Roo Code</a></span>
     <span><a href="guide/memory-for-kimi.html">Kimi Code</a></span>
     <span><a href="guide/memory-for-dsh.html">DeepSeek Harness</a></span>
     <span><a href="guide/memory-for-grok.html">Grok Build</a></span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,6 +48,7 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 - [Grok Build](https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html)
 - [Gemini CLI](https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html)
 - [Qwen Code](https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html)
+- [Roo Code](https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html)
 - [OpenClaw](https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html)
 - [Goose](https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html)
 - [Cline](https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html)

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -581,27 +581,22 @@
         "fixtures/registry/roo/tasks/1767225700000/api_conversation_history.json"
       ],
       "parser_source": "internal/sources/roo.go",
-      "last_verified": "2026-07-27",
+      "last_verified": "2026-09-07",
       "display_name": "Roo Code",
       "capabilities": {
         "mcp": true,
         "auto": false,
         "skill": true,
         "command": true,
-        "resume": false,
+        "resume": true,
         "handoff": "paste",
-        "prereq": ""
+        "prereq": "roo CLI (editor tasks reopen in the editor)"
       },
       "gaps": {
         "auto": {
           "state": "blocked",
           "why": "Roo's hooks are in flight upstream, not shipped: PR #10785 implements a Claude Code-style hooks system, #11128 is Hooks beta and #11663 Hooks phase 1, all still open, and no release names lifecycle hooks. A user's bug report about PreToolUse coverage (#10834) shows they work on a branch build. Becomes work the day one of those merges",
           "source": "https://github.com/RooCodeInc/Roo-Code/pull/10785"
-        },
-        "resume": {
-          "state": "impossible",
-          "why": "Roo Code is a VS Code extension with no command line at all, so there is nothing for deja to print. Its transcripts are read from disk; reopening one is a thing the editor does, not a command.",
-          "source": "no CLI ships with the extension"
         }
       }
     },

--- a/docs/registry/roo.html
+++ b/docs/registry/roo.html
@@ -46,18 +46,22 @@
 <p>The transcript shape matches Cline&#39;s legacy store (Roo is a Cline fork), so</p>
 <p>the same text-block extraction and <code>&lt;task&gt;</code> envelope unwrapping apply.</p>
 <p>Format verified against Roo-Code source (<code>src/shared/globalFileNames.ts</code>,</p>
-<p><code>src/core/task-persistence</code>); a live-loop validation with the running</p>
-<p>extension is still welcome — Roo is GUI-only, so deja reads its history and</p>
-<p>serves it to other agents rather than injecting into Roo itself.</p>
+<p><code>src/core/task-persistence</code>) and against a live run of the Roo CLI, which</p>
+<p>drives the same extension against a VS Code shim and writes the same files</p>
+<p>under <code>~/.vscode-mock/global-storage</code>.</p>
 <ul>
-<li><strong>MCP</strong>: Roo manages its own MCP servers from the extension UI</li>
+<li><strong>MCP</strong>: <code>deja install roo</code> writes the server into <code>mcp_settings.json</code> for</li>
 </ul>
-<p>(<code>mcp_settings.json</code>); point it at <code>deja mcp</code> manually if desired.</p>
+<p>every host Roo has run in, and names deja&#39;s own tool in that entry&#39;s</p>
+<p><code>alwaysAllow</code> — without it Roo asks before every recall.</p>
 <ul>
-<li><strong>Resume</strong>: extension UI only.</li>
+<li><strong>Resume</strong>: <code>roo --session-id &lt;uuid&gt;</code>, run in the task&#39;s workspace, for tasks</li>
+</ul>
+<p>the CLI created. Editor tasks reopen from the extension&#39;s history UI.</p>
+<ul>
 <li><strong>Handoff</strong>: paste.</li>
 </ul>
-<p><strong>Last verified:</strong> 2026-07-27</p>
+<p><strong>Last verified:</strong> 2026-09-07</p>
 
 <hr>
 <p>deja reads this format and twenty-two others, and turns what it finds into memory your

--- a/docs/registry/roo.md
+++ b/docs/registry/roo.md
@@ -8,13 +8,15 @@
 The transcript shape matches Cline's legacy store (Roo is a Cline fork), so
 the same text-block extraction and `<task>` envelope unwrapping apply.
 Format verified against Roo-Code source (`src/shared/globalFileNames.ts`,
-`src/core/task-persistence`); a live-loop validation with the running
-extension is still welcome — Roo is GUI-only, so deja reads its history and
-serves it to other agents rather than injecting into Roo itself.
+`src/core/task-persistence`) and against a live run of the Roo CLI, which
+drives the same extension against a VS Code shim and writes the same files
+under `~/.vscode-mock/global-storage`.
 
-- **MCP**: Roo manages its own MCP servers from the extension UI
-  (`mcp_settings.json`); point it at `deja mcp` manually if desired.
-- **Resume**: extension UI only.
+- **MCP**: `deja install roo` writes the server into `mcp_settings.json` for
+  every host Roo has run in, and names deja's own tool in that entry's
+  `alwaysAllow` — without it Roo asks before every recall.
+- **Resume**: `roo --session-id <uuid>`, run in the task's workspace, for tasks
+  the CLI created. Editor tasks reopen from the extension's history UI.
 - **Handoff**: paste.
 
-**Last verified:** 2026-07-27
+**Last verified:** 2026-09-07

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -21,6 +21,7 @@ https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html
+https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -23,6 +23,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -227,6 +228,33 @@ func RooCLIRoot() string {
 		return p
 	}
 	return filepath.Join(Home(), ".vscode-mock", "global-storage")
+}
+
+// rooCLISessionID is the shape the Roo CLI accepts after --session-id: it
+// validates the argument as a UUID and refuses anything else, so a task
+// numbered the old way is not one this command can reopen.
+var rooCLISessionID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// RooCLITask reports the session id and workspace of a task the Roo CLI wrote,
+// and empty strings for anything else. The CLI lists tasks from its own storage
+// path alone, so a task from the editor is not something `roo --session-id`
+// can find even though both stores hold the same file names (measured on
+// @roo-code/cli 0.1.17).
+func RooCLITask(path string) (id, workspace string) {
+	root := RooCLIRoot()
+	if root == "" || !strings.HasPrefix(filepath.Clean(path), filepath.Clean(root)+string(filepath.Separator)) {
+		return "", ""
+	}
+	dir := filepath.Dir(path)
+	id = filepath.Base(dir)
+	if !rooCLISessionID.MatchString(id) {
+		return "", ""
+	}
+	var item rooHistoryItem
+	if b, err := os.ReadFile(filepath.Join(dir, "history_item.json")); err == nil {
+		_ = json.Unmarshal(b, &item)
+	}
+	return id, item.Workspace
 }
 
 func RooTaskFiles() []string {


### PR DESCRIPTION
Measured against a recording endpoint, driving the Roo CLI (@roo-code/cli 0.1.17) with the 3.53 extension bundle.

Two things changed. Roo passes MCP tools as native function tools, and it asks for approval before running one unless the server entry names that tool in `alwaysAllow`. In the editor that is a click before every recall; in the CLI's non-interactive mode nobody can click, and the run stops there — before: one request, then it waits; after: the recall comes back and lands in the next request Roo sends, with the invented token in the bytes. `deja install roo` now writes that entry, and leaves any `alwaysAllow` already there alone.

Second, Roo has a CLI now, which the registry said it did not: it runs the extension against a VS Code shim and keeps tasks under `~/.vscode-mock/global-storage`, and `roo --session-id <uuid>` reopens one when run in the task's workspace. `deja resume` prints that for CLI tasks and keeps refusing editor tasks, which the CLI never lists. Verified by running what deja printed: `[Resume Task] / [continuing task]`.

Cost on that setup: deja's tool declaration is 3.1 KB of the 26 KB of tools in every request, a recall that answers adds ~1.3 KB to that one turn, silence adds nothing.

Hooks are still not there — #10785 and the two other hook PRs are open, nothing in 3.53 runs a command at session start, before a tool or on compaction — so the `auto` gap stays blocked.

New guide page, registry and matrix updated with the code.