### PR TITLE
docs: changelog and site for 0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The release where every agent on the machine gets the same memory. Four more
-harnesses are wired for the moments recall is worth most — the first prompt,
-the failing command, the file about to be edited, the turn after a compaction —
-VS Code Copilot Chat joins as the twenty-third, and the agent now says
+## [0.19.4] - 2026-09-07
+
+The release where every agent on the machine gets the same memory. Amp,
+prime-agent and VS Code Copilot Chat are wired from nothing — the last of them
+joining as the twenty-third harness — and the ones that were already wired now
+reach the moments recall is worth most: the first prompt, the failing command,
+the file about to be edited, the turn after a compaction. The agent now says
 "déjà vu" with a date and a session id when it reuses what it was handed.
 
 ### Added
 - VS Code Copilot Chat: its chat sessions are indexed (`chatSessions/*.jsonl`, the append log VS Code writes since 1.109), the twenty-third harness — contributed by @Sora-bluesky. (#3088)
 - VS Code: `deja install vscode` writes the `mcp.json` Copilot Chat reads in agent mode, one per host present (Code, Insiders, VSCodium), and a `deja.instructions.md` applied to every chat so recall arrives without being asked for; measured on VS Code 1.134.0 from the MCP traffic. (#3102, #3107)
 - Amp: `deja install amp` writes the MCP server the way `amp mcp add` does; `amp-auto` adds a plugin under `~/.config/amp/plugins` that hands the project digest to the first turn, per-prompt recall after it, and the repair beside a failed command in the same turn. (#3118)
+- prime-agent (PrimeIntellect): `deja install prime` writes the MCP server into `~/.prime/agent/settings.json` and an extension that opens a session with the project digest, recalls on each prompt, forgets on compaction, and adds `/deja`. Its `tool_call` and `tool_result` events never fire on 0.9.1, so the fix pair is deliberately not wired there. (#3125)
 - Kimi Code: the session digest rides the first prompt and a compaction forgets what it threw away, measured on 0.28.1 — `UserPromptSubmit` is the one event whose output reaches the model. (#3121)
+- Roo Code: `deja install roo` names deja's own tool in the entry's `alwaysAllow`, so Roo stops asking before every recall — without it a non-interactive run waits at the first one forever. `deja resume` prints `roo --session-id <uuid>` for tasks the Roo CLI created, with the workspace it must run in; editor tasks still reopen from the editor. Measured against a recording endpoint on @roo-code/cli 0.1.17 with the 3.53 extension. (#3130)
+- `deja files --json`: the ranked rows a caller had to parse out of padded columns, with the three counts the ranking is built from. (#3106, #3124)
 - pi and omp: `@vshulcz/pi-deja`, the recall extension as a pi package — `pi install npm:@vshulcz/pi-deja` — session-start digest, per-prompt recall and `/deja`. (#3095)
 - pi and omp: a failed command gets its repair in the same turn (`tool_result` is the event whose return reaches the model; omp's bash tool reports the exit code in `details.exitCode`), a compaction forgets, and a file's history arrives when the agent reads it — the step before the edit, since neither harness has a pre-edit hook. (#3112, #3113)
 - Cline: the repair for a failed command arrives in the same turn, appended to the tool result by the message builder; `hook-tool-after` learns cline's `run_commands` and grows `--plain`. (#3098)
-- OpenClaw: `@vshulcz/openclaw-deja`, the recall plugin as a package — `openclaw plugins install clawhub:@vshulcz/openclaw-deja` — and a local session opens with the project digest via `before_agent_start` (74 ms and 1.6 KB on the first turn, nothing after). (#3058, #3087)
+- OpenClaw: `@vshulcz/openclaw-deja`, the recall plugin as a package — `openclaw plugins install clawhub:@vshulcz/openclaw-deja` — and a local session opens with the project digest via `before_agent_start` (74 ms and 1.6 KB on the first turn, nothing after). A compaction now forgets what it threw away, and the digest moved to the phase hook that fires once a turn. (#3058, #3087, #3123)
 - DeepSeek Harness: a session opens knowing what the project settled — a second `systemPrompt.context` contributor ahead of per-prompt recall, once per session. (#3094)
 - Antigravity: `PreInvocation` answers the question instead of only opening with the digest (the invocation counter is zero-based and restarts every turn); the repair arrives at the failing command; what a compaction threw away is served again; and the project is recalled when the payload names no workspace, read from `cache/last_conversations.json`. Measured on antigravity-cli 1.1.13. (#3059, #3063, #3077, #3078)
 - Install: the proof opens with the questions this machine asked more than once, and one of them — `26 questions asked more than once on this machine — one of them: "…"`. (#3071)
@@ -34,7 +40,11 @@ VS Code Copilot Chat joins as the twenty-third, and the agent now says
 - The README, the site and the npm page lead with what the harness count is for: one memory every agent on the machine reads. (#3109)
 
 ### Fixed
+- Qwen Code: the repair sat on `PostToolUse`, which qwen fires only when the tool succeeded — the one event that never comes at a failure. It moves to `PostToolUseFailure`, whose return is appended to the tool result the model reads, and the old entry is dropped on install. The failing output arrives under `error` inside qwen's own `Command: / Output: / Exit Code:` block, which is unwrapped before the signature is taken. Measured on qwen-code 0.20.0. (#3126)
+- Qwen Code: `install qwen-auto` reported "unchanged" while it rewired the hooks, because it returned only the MCP half of the same file. (#3127)
 - Grok Build: `SessionStart` and `PreCompact` matchers that grok never fired are dropped and corrected on machines that already installed deja; hook inputs read grok's camelCase; agents it spawns are reached. (#3085)
+- Codex: the plugin manifest carries its icon, spells the URL keys the way the spec does, and names its hooks file as one path. (#3132)
+- DeepSeek Harness: the plugin declares the DSH release it was measured on. (#3129)
 - Zed: the `/deja` fix from #3020 never shipped because `extension.toml` still said 0.1.0; the version moves and CI fails when a change outruns it. (#3081)
 - pi: the generated `/deja` command declared `args` twice, so pi loaded the extension with no deja at all. (#3096)
 - A compiler error is one wall wherever the line moves: the position is masked on the repair signature, so adding an import no longer turns one recurring error into a new one on every edit. (#3080)
@@ -1117,7 +1127,8 @@ See the release notes: Antigravity harness, share redaction hardening.
 - Stdio MCP memory server with `recall` and `recall_context` tools.
 - Idempotent installers for claude-code, codex, and opencode MCP config.
 
-[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.19.3...HEAD
+[Unreleased]: https://github.com/vshulcz/deja-vu/compare/v0.19.4...HEAD
+[0.19.4]: https://github.com/vshulcz/deja-vu/compare/v0.19.3...v0.19.4
 [0.19.3]: https://github.com/vshulcz/deja-vu/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/vshulcz/deja-vu/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/vshulcz/deja-vu/compare/v0.19.0...v0.19.1

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,7 +79,7 @@ skill 调用的是上面装好的 `deja` 二进制，自己不带。
 
 ## 能得到什么
 
-**在 Codex 里解决，Claude 记得。** 二十二个编程智能体把每一次对话都写进本地文件，
+**在 Codex 里解决，Claude 记得。** 二十三个编程智能体把每一次对话都写进本地文件，
 deja 把这些文件变成一层它们都能读的记忆。
 
 | | |
@@ -151,7 +151,8 @@ $ deja "jwt refresh token"
 
 Claude Code · Cline · Codex CLI · opencode · aider · Gemini CLI · Cursor · Antigravity ·
 Grok Build · Hermes · Goose · Qwen Code · Kimi Code · pi · omp (Oh My Pi) · OpenClaw ·
-Copilot CLI · Roo Code · DeepSeek Harness · Zed。
+Copilot CLI · VS Code Copilot Chat · Amp · prime-agent (PrimeIntellect) · Roo Code ·
+DeepSeek Harness · Zed。
 
 每个工具分别支持 MCP 召回、自动召回、技能、命令、resume 和 handoff 中的哪些，见
 [英文 README 的能力矩阵](README.md#supported-harnesses)。自定义存储位置通过 `DEJA_*_ROOT`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,8 +28,12 @@ the place to discuss design.
   session pulled for one query is lifted for every query. A per-query signal —
   recording what a recall was for, not only that it happened — would let reuse be
   both stronger and precise without lifting an off-topic session.
-- **Point-of-action beyond codex and Claude.** Carry the file's or command's
-  prior decision into other harnesses as their hook contracts allow.
+- **Point-of-action in the harnesses that still refuse it.** The repair beside a
+  failed command and the file's prior decision now reach Claude Code, Codex,
+  Cursor, Gemini, Qwen, Cline, Amp, Antigravity, pi and omp. What is left is
+  where the harness itself drops what a hook returns — Kimi's post-tool events,
+  prime-agent's tool events, Roo until its hooks ship — and each is recorded in
+  the registry with the measurement behind it.
 - **Follow the work an agent handed off.** A subagent's run is its own session
   now, and where a harness records the edge — Grok's `summary.json`, Claude's
   sidechain files — recall can name the parent and the children. Cursor writes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,10 +25,14 @@ against the loader list.
 | Copilot CLI | `copilot.go` | `events.jsonl` per session under `~/.copilot/session-state` |
 | VS Code Copilot Chat | `copilot_chat.go` | `.jsonl` / `.json` under VS Code User `workspaceStorage/*/chatSessions` |
 | Cline | `cline.go` | task JSON under the VS Code extension's storage, both store generations |
-| Roo Code | `roo.go` | task JSON under `rooveterinaryinc.roo-cline` in VS Code globalStorage |
+| Roo Code | `roo.go` | task JSON under `rooveterinaryinc.roo-cline` in VS Code globalStorage, and the CLI's own store under `~/.vscode-mock/global-storage` |
 | Goose | `goose.go` | legacy JSONL sessions and the newer SQLite session store |
 | Kimi Code | `kimi.go` | per-agent `wire.jsonl` under `~/.kimi-code/sessions` |
 | OpenClaw | `openclaw.go` | append-only pi-format JSONL under `~/.openclaw/agents` |
+| omp (Oh My Pi) | `omp.go` | JSONL transcripts under `~/.omp/agent/sessions` and each profile beside it |
+| prime-agent (PrimeIntellect) | `prime.go` | JSONL transcripts under `~/.prime/agent/sessions` |
+| DeepSeek Harness | `deepseek.go` | zstd-compressed session JSONL under `~/.dsh/sessions` |
+| Zed | `zed.go` | threads in the SQLite store at `Zed/threads/threads.db` |
 | Hermes | `hermes.go`, `hermes_pg.go` | SQLite state per profile, or Postgres when `DEJA_HERMES_PG_DSN` is set |
 | deja notes | `notes.go` | `deja remember` entries in `notes.jsonl` |
 

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -99,6 +99,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -99,6 +99,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -72,6 +72,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -72,6 +72,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -53,7 +53,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -71,6 +71,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -34,7 +34,7 @@
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"The agent lost the context you had","description":"A crash, a cleared window or a restart takes the agent's context but not the transcript — how to get the work back and stop paying for it next time.","url":"https://vshulcz.github.io/deja-vu/guide/lost-context.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/lost-context.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Lost context","item":"https://vshulcz.github.io/deja-vu/guide/lost-context.html"}]}</script>
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What do I do when my coding agent loses context?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts it already wrote to disk with deja and a phrase you remember, or deja ctx for a digest of the best-matching session. Sixteen of twenty harnesses can also be reopened with deja resume."}},{"@type":"Question","name":"Is the context recoverable after a crash?","acceptedAnswer":{"@type":"Answer","text":"The transcript is, because agents write each turn to disk as it happens. What a crash destroys is the model's working set, not the file."}},{"@type":"Question","name":"How do I stop losing it?","acceptedAnswer":{"@type":"Answer","text":"deja install --auto wires recall at session start and on each prompt, so a fresh window opens already knowing the project's recent decisions."}}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What do I do when my coding agent loses context?","acceptedAnswer":{"@type":"Answer","text":"Search the transcripts it already wrote to disk with deja and a phrase you remember, or deja ctx for a digest of the best-matching session. Nineteen of twenty-three harnesses can also be reopened with deja resume."}},{"@type":"Question","name":"Is the context recoverable after a crash?","acceptedAnswer":{"@type":"Answer","text":"The transcript is, because agents write each turn to disk as it happens. What a crash destroys is the model's working set, not the file."}},{"@type":"Question","name":"How do I stop losing it?","acceptedAnswer":{"@type":"Answer","text":"deja install --auto wires recall at session start and on each prompt, so a fresh window opens already knowing the project's recent decisions."}}]}</script>
 </head>
 <body>
 <div class="glow"></div>
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html" aria-current="page">Lost context</a>
@@ -99,12 +100,12 @@
 <p>It happens mid-task, not between tasks: the window is cleared, the CLI is restarted, a session is resumed and comes back empty, the tab is closed by something that is not you. The agent is now confidently a stranger to work you did an hour ago.</p>
 
 <h2>The context is not gone, the pointer to it is</h2>
-<p>Almost every coding agent writes each turn to disk as it happens — <a href="where-sessions-are-stored.html">twenty formats, one per tool</a>. What a crash or a clear destroys is the model's working set, not the transcript. The file is still sitting under <code>~/.claude/projects</code>, <code>~/.codex/sessions</code>, <code>~/.qwen/projects</code> or wherever your agent keeps it, with the decision you now cannot recall.</p>
+<p>Almost every coding agent writes each turn to disk as it happens — <a href="where-sessions-are-stored.html">twenty-three formats, one per tool</a>. What a crash or a clear destroys is the model's working set, not the transcript. The file is still sitting under <code>~/.claude/projects</code>, <code>~/.codex/sessions</code>, <code>~/.qwen/projects</code> or wherever your agent keeps it, with the decision you now cannot recall.</p>
 
 <h2>Getting it back into the session you are in</h2>
 <pre>deja "the thing you were doing"</pre>
 <p>Search runs over every agent's history on the machine, so it does not matter which tool held the lost context — or whether that tool still exists. <code>deja ctx &lt;query&gt;</code> gives the single best-matching session as a digest rather than a wall of transcript, which is what you want to paste back into a fresh window.</p>
-<p>If the tool you lost supports it, <code>deja resume &lt;id&gt;</code> prints the exact command that reopens that conversation, in the directory it belongs to — sixteen of the twenty do.</p>
+<p>If the tool you lost supports it, <code>deja resume &lt;id&gt;</code> prints the exact command that reopens that conversation, in the directory it belongs to — nineteen of the twenty-three do.</p>
 
 <h2>Not losing it the next time</h2>
 <pre>deja install --auto</pre>

--- a/docs/guide/memory-for-amp.html
+++ b/docs/guide/memory-for-amp.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html" aria-current="page">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cline.html
+++ b/docs/guide/memory-for-cline.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html" aria-current="page">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-copilot-chat.html
+++ b/docs/guide/memory-for-copilot-chat.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html" aria-current="page">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-goose.html
+++ b/docs/guide/memory-for-goose.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-hermes.html
+++ b/docs/guide/memory-for-hermes.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Memory for Hermes: what its own memory does not cover — deja-vu</title>
-<meta name="description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
+<meta name="description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty-two agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Adding memory to Hermes">
-<meta property="og:description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
+<meta property="og:description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty-two agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -26,13 +26,13 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Adding memory to Hermes">
-<meta name="twitter:description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
+<meta name="twitter:description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty-two agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Adding memory to Hermes", "description": "Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.", "url": "https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Adding memory to Hermes", "description": "Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty-two agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.", "url": "https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Memory for Hermes", "item": "https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html"}]}</script>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does Hermes remember previous sessions?", "acceptedAnswer": {"@type": "Answer", "text": "Yes — its own. Hermes keeps sessions in a SQLite store per profile, searches them with FTS5 and summarises them for cross-session recall, and keeps MEMORY.md and USER.md. What it does not see is what you did in Claude Code, Codex, Cursor or any of the other agents on the same machine."}}, {"@type": "Question", "name": "How do I add deja to Hermes?", "acceptedAnswer": {"@type": "Answer", "text": "deja install hermes-auto writes the MCP server and a plugin under ~/.hermes/plugins/deja that answers pre_llm_call, appending matching history to the user message so the system prompt stays byte-identical and provider caching survives; it also enables the plugin and adds a /deja command. Or install only the skill: hermes skills install vshulcz/deja-vu/skills/deja-search."}}, {"@type": "Question", "name": "Can Hermes see what I did in Claude Code or Codex?", "acceptedAnswer": {"@type": "Answer", "text": "With deja, yes: the index covers the transcripts of twenty-three agents on the machine, Hermes included, and history from before deja was installed."}}]}</script>
 </head>
@@ -98,7 +98,7 @@
 <p>Hermes is one of the few agents that already has memory of its own: sessions live in a SQLite store per profile, an FTS5 index searches them and an LLM summarises them for cross-session recall, and <code>MEMORY.md</code> and <code>USER.md</code> carry what it has learned about the project and about you. This page is not about replacing any of that. It is about the question Hermes cannot answer: what you did in Claude Code, Codex, Cursor or opencode on the same machine, last week or last spring.</p>
 
 <h2>What Hermes already has</h2>
-<p>Its own sessions, searchable; its own notes, persistent; a skills system compatible with the <a href="https://agentskills.io">agentskills.io</a> standard. All of it is scoped to Hermes. The twenty-one other agents on the machine each keep their own log in their own format, and none of them are in Hermes's index.</p>
+<p>Its own sessions, searchable; its own notes, persistent; a skills system compatible with the <a href="https://agentskills.io">agentskills.io</a> standard. All of it is scoped to Hermes. The twenty-two other agents on the machine each keep their own log in their own format, and none of them are in Hermes's index.</p>
 
 <h2>Adding recall</h2>
 <pre>deja install hermes-auto</pre>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html" aria-current="page">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html" aria-current="page">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html" aria-current="page">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-prime.html
+++ b/docs/guide/memory-for-prime.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Memory for prime-agent: recall across Claude Code, Codex and the rest — deja-vu</title>
+<meta name="description" content="prime-agent has no hooks and an extension API; one file under ~/.prime/agent/extensions opens a session with what this project settled and recalls on every prompt after it.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to prime-agent">
+<meta property="og:description" content="prime-agent has no hooks and an extension API; one file under ~/.prime/agent/extensions opens a session with what this project settled and recalls on every prompt after it.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to prime-agent">
+<meta name="twitter:description" content="prime-agent has no hooks and an extension API; one file under ~/.prime/agent/extensions opens a session with what this project settled and recalls on every prompt after it.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Adding memory to prime-agent", "description": "prime-agent has no hooks and an extension API; one file under ~/.prime/agent/extensions opens a session with what this project settled and recalls on every prompt after it.", "url": "https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Memory for prime-agent", "item": "https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does prime-agent remember previous sessions?", "acceptedAnswer": {"@type": "Answer", "text": "It writes every session to disk under ~/.prime/agent/sessions and can list them, but a new session starts empty and reads none of them."}}, {"@type": "Question", "name": "How do I add memory to prime-agent?", "acceptedAnswer": {"@type": "Answer", "text": "deja install prime writes the deja MCP server into ~/.prime/agent/settings.json and an extension under ~/.prime/agent/extensions that hands the project digest to the first turn, recalls on each prompt, forgets what a compaction threw away, and adds a /deja command."}}, {"@type": "Question", "name": "Can prime-agent see what I did in Claude Code or Codex?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, once deja is installed: the index covers the transcripts of twenty-three agents on the machine, including sessions from before deja was installed."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="memory-for-copilot-chat.html">Memory for VS Code Copilot Chat</a>
+<a href="memory-for-openclaw.html">Memory for OpenClaw</a>
+<a href="memory-for-goose.html">Memory for Goose</a>
+<a href="memory-for-cline.html">Memory for Cline</a>
+<a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html" aria-current="page">Memory for prime-agent</a>
+<a href="memory-for-hermes.html">Memory for Hermes</a>
+</details>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to prime-agent</h1>
+<p class="pagelede">no hooks, an extension API — and one file is the whole install<span class="mins" data-mins></span></p>
+
+<p>prime-agent writes every session to <code>~/.prime/agent/sessions</code> as JSONL and can list them. A new session reads none of them, and none of the sessions the other agents on this machine wrote either — including the one where the same problem was already solved.</p>
+
+<h2>Adding recall</h2>
+<pre>deja install prime</pre>
+<p>That writes two things: the deja MCP server into <code>~/.prime/agent/settings.json</code>, so the model can ask for history itself, and an extension at <code>~/.prime/agent/extensions/deja.ts</code>, which is what makes recall arrive without being asked:</p>
+<ul>
+<li><b>The project digest</b> on the first turn — what this machine settled here — followed by recall on every prompt, both through <code>before_agent_start</code>.</li>
+<li><b>Forgetting on compaction</b>: when <code>session_compact</code> throws away the blocks the session was shown, the list that stops them repeating goes too, so recall can say them again.</li>
+<li><b>A <code>/deja</code> command</b> in the same session, for asking directly.</li>
+</ul>
+
+<h2>What is deliberately not wired</h2>
+<p>The repair beside a failed command, which Claude Code, Codex, Gemini and Qwen all get, is missing here for a measured reason: on prime-agent 0.9.1 the <code>tool_call</code> and <code>tool_result</code> events never fire, so a handler on them is a process spawned for nothing. It becomes work the day they do.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty-three of them, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in Claude Code answers a question asked here, including sessions from before any of this was installed. An injection is capped at 1,536 bytes per prompt — <a href="token-cost.html">what memory costs</a> has the measured comparison. Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="switching-agents.html">Switching between agents</a> · <a href="../registry/prime.html">The prime-agent session format</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-roo.html
+++ b/docs/guide/memory-for-roo.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html" aria-current="page">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html" aria-current="page">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -68,6 +68,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Where Claude Code, Codex and Cursor store session history — deja-vu</title>
-<meta name="description" content="Where each coding agent keeps its conversation history file, in twenty formats, and how to read them without the tool that wrote them.">
+<meta name="description" content="Where each coding agent keeps its conversation history file, in twenty-three formats, and how to read them without the tool that wrote them.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Where each coding agent stores its conversation history">
-<meta property="og:description" content="Where each coding agent keeps its conversation history file, in twenty formats, and how to read them without the tool that wrote them.">
+<meta property="og:description" content="Where each coding agent keeps its conversation history file, in twenty-three formats, and how to read them without the tool that wrote them.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -26,13 +26,13 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Where each coding agent stores its conversation history">
-<meta name="twitter:description" content="Where each coding agent keeps its conversation history file, in twenty formats, and how to read them without the tool that wrote them.">
+<meta name="twitter:description" content="Where each coding agent keeps its conversation history file, in twenty-three formats, and how to read them without the tool that wrote them.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Where each coding agent stores its conversation history","description":"Where each coding agent keeps its conversation history file, in twenty formats, and how to read them without the tool that wrote them.","url":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Where each coding agent stores its conversation history","description":"Where each coding agent keeps its conversation history file, in twenty-three formats, and how to read them without the tool that wrote them.","url":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Where history lives","item":"https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html"}]}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Where does Claude Code store its conversation history?","acceptedAnswer":{"@type":"Answer","text":"In JSONL files under ~/.claude/projects, one directory per project and one file per session. CLAUDE_CONFIG_DIR moves the whole tree."}},{"@type":"Question","name":"Where does Codex CLI keep its sessions?","acceptedAnswer":{"@type":"Answer","text":"Under ~/.codex: rollout JSONL files in sessions/, plus history.jsonl. CODEX_HOME moves both."}},{"@type":"Question","name":"Can I read those files myself?","acceptedAnswer":{"@type":"Answer","text":"Yes. Most are JSONL you can read with jq; opencode, Hermes and Zed use SQLite, and Zed compresses each thread body with zstd."}}]}</script>
 </head>
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">19</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-cline.html">Memory for Cline</a>
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>
@@ -94,7 +95,7 @@
 <article>
 
 <h1>Where each coding agent stores its conversation history</h1>
-<p class="pagelede">twenty agents, twenty formats, one table<span class="mins" data-mins></span></p>
+<p class="pagelede">twenty-three agents, twenty-three formats, one table<span class="mins" data-mins></span></p>
 
 <p>Every coding agent writes what you said and what it did to a file on your machine. The formats differ, the locations differ, and none of them is documented in one place — so here is that place, generated from the same registry deja's parsers are written against.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -475,6 +475,9 @@ footer a:hover{color:var(--ph-hi)}
     <span><a href="guide/memory-for-gemini.html">Gemini CLI</a></span>
     <span><a href="guide/memory-for-qwen.html">Qwen Code</a></span>
     <span><a href="guide/memory-for-roo.html">Roo Code</a></span>
+    <span><a href="guide/memory-for-prime.html">prime-agent</a></span>
+    <span><a href="guide/memory-for-amp.html">Amp</a></span>
+    <span><a href="guide/memory-for-copilot-chat.html">VS Code Copilot Chat</a></span>
     <span><a href="guide/memory-for-kimi.html">Kimi Code</a></span>
     <span><a href="guide/memory-for-dsh.html">DeepSeek Harness</a></span>
     <span><a href="guide/memory-for-grok.html">Grok Build</a></span>
@@ -649,9 +652,9 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;omp&nbsp;&nbsp;openclaw&nbsp;&nbsp;goose&nbsp;&nbsp;copilot&nbsp;&nbsp;copilot-chat&nbsp;&nbsp;deepseek&nbsp;&nbsp;zed&nbsp;&nbsp;hermes&nbsp;&nbsp;prime\n23 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;omp&nbsp;&nbsp;openclaw&nbsp;&nbsp;goose&nbsp;&nbsp;copilot&nbsp;&nbsp;copilot-chat&nbsp;&nbsp;deepseek&nbsp;&nbsp;zed&nbsp;&nbsp;hermes&nbsp;&nbsp;prime&nbsp;&nbsp;amp\n23 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
-    'version':'<p class="none">deja 0.19.3</p>',
+    'version':'<p class="none">deja 0.19.4</p>',
     'clear':''
   };
   COMMANDS['--help']=COMMANDS['help'];COMMANDS['--version']=COMMANDS['version'];

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 - [Getting started](https://vshulcz.github.io/deja-vu/guide/getting-started.html): install, wire an agent, and the first query
 - [Why agents forget](https://vshulcz.github.io/deja-vu/guide/forgetting.html): what ends with a session and what survives on disk
 - [Does my agent remember previous conversations](https://vshulcz.github.io/deja-vu/guide/does-my-agent-remember.html): what Claude Code, Codex and Cursor keep between sessions, and what they do not
-- [Where history lives](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html): the conversation history file each of the twenty agents writes, and its format
+- [Where history lives](https://vshulcz.github.io/deja-vu/guide/where-sessions-are-stored.html): the conversation history file each of the twenty-three agents writes, and its format
 - [Session files on disk](https://vshulcz.github.io/deja-vu/guide/session-files-on-disk.html): how to delete Claude Code sessions, how large ~/.claude/projects gets, what is inside a session file, and what deleting one costs
 - [CLI reference](https://vshulcz.github.io/deja-vu/guide/commands.html): every command and flag
 - [Agents & MCP](https://vshulcz.github.io/deja-vu/guide/agents.html): the deja MCP tool and its modes, and what each harness supports
@@ -40,6 +40,10 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 ## Per-harness setup
 
 - [Claude Code, Codex and the rest](https://vshulcz.github.io/deja-vu/guide/harnesses.html): the full support matrix
+- [Claude Code](https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html)
+- [Codex](https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html)
+- [Cursor](https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html)
+- [Copilot CLI](https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html)
 - [opencode](https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html)
 - [DeepSeek Harness](https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html)
 - [Kimi Code](https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html)
@@ -49,6 +53,7 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 - [Gemini CLI](https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html)
 - [Qwen Code](https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html)
 - [Roo Code](https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html)
+- [prime-agent (PrimeIntellect)](https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html)
 - [OpenClaw](https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html)
 - [Goose](https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html)
 - [Cline](https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html)
@@ -60,7 +65,7 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 
 - [Benchmarks](https://vshulcz.github.io/deja-vu/guide/benchmarks.html): 85.3% hit@1 on LongMemEval-S, 69.6% on LoCoMo, both harnesses in the repository
 - [How it compares](https://vshulcz.github.io/deja-vu/guide/compare.html): next to Mem0, Letta, memU, Memori, claude-mem and agentmemory
-- [Session format registry](https://vshulcz.github.io/deja-vu/registry/README.html): where each of the twenty agents stores its sessions, with fixtures
+- [Session format registry](https://vshulcz.github.io/deja-vu/registry/README.html): where each of the twenty-three agents stores its sessions, with fixtures
 - [Privacy](https://vshulcz.github.io/deja-vu/guide/privacy.html): what is read, what is redacted, what never leaves
 
 ## Optional

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -22,6 +22,7 @@ https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html
+https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -24,6 +24,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>

--- a/docs/zh/guide/does-my-agent-remember.html
+++ b/docs/zh/guide/does-my-agent-remember.html
@@ -86,7 +86,7 @@
 <tr><td>Kimi Code</td><td>否</td><td>是</td><td><code>~/.kimi-code/sessions/*/*/agents/main/wire.jsonl</code></td></tr>
 <tr><td>Qwen Code</td><td>否</td><td>是</td><td><code>~/.qwen/projects/*/chats/*.jsonl</code></td></tr>
 </table>
-<p><a href="../../registry/README.html">格式登记表</a>里有全部二十一个工具：各自的路径通配符，以及一条记录长什么样。</p>
+<p><a href="../../registry/README.html">格式登记表</a>里有全部二十三个工具：各自的路径通配符，以及一条记录长什么样。</p>
 
 <h2>「它不是给会话做了总结吗？」</h2>
 <p>压缩（compaction）是会话变长、窗口装不下时发生的事：早先的轮次被一段摘要替换掉，剩下的才放得进去。这段摘要只活在那个会话里，而且它是散文。</p>


### PR DESCRIPTION
Release prep for v0.19.4: the changelog section, the site version line, and the facts that had drifted while the harness passes landed.

- Changelog: the unreleased section becomes 0.19.4 and gains prime-agent, Roo, the two qwen fixes, the openclaw compaction forget, `files --json`, the codex manifest fix and the dsh version.
- Counts: several pages still said twenty agents or "sixteen of twenty resume". Nineteen of twenty-three resume; the store table, llms.txt, the Chinese README and the zh guide are on twenty-three.
- prime-agent had no per-agent guide; it has one now, and the home page and llms.txt were missing Amp, VS Code Copilot Chat, Claude Code, Codex, Cursor and Copilot CLI links.
- ARCHITECTURE: the store table was missing omp, prime-agent, DeepSeek Harness and Zed, and Roo's row now names the CLI store.
- ROADMAP: point-of-action is no longer "beyond codex and Claude" — it names what is left and why.

Manifests are left to `pinmanifests` after the tag, as in 0.19.3.