### PR TITLE
test(files): seed the ranked-rows fixture as JSON, not as pasted text

### DIFF
--- a/cmd/deja/files_json_rows_test.go
+++ b/cmd/deja/files_json_rows_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -35,23 +36,43 @@ func TestFilesJSONCarriesTheRankedRows(t *testing.T) {
 	if err := os.MkdirAll(proj, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	// Marshalled rather than pasted together: a Windows path inside a JSON
+	// string is full of backslash escapes — `repo\render.go` carries a \r — so
+	// a hand-built line parses as nothing there and the store comes up empty.
+	rec := func(sid, role string, content any, at string) []byte {
+		b, err := json.Marshal(map[string]any{
+			"type": role, "sessionId": sid, "cwd": repo, "timestamp": at,
+			"message": map[string]any{"role": role, "content": content},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return append(b, '\n')
+	}
+	edit := func(path string) []any {
+		return []any{map[string]any{"type": "tool_use", "name": "Edit",
+			"input": map[string]any{"file_path": path, "old_string": "a", "new_string": "b"}}}
+	}
 	// Three sessions on the topic. render.go is touched in all three, routes.go
 	// in one, so the ranking has something to order and `sessions` differs
 	// between the two rows.
 	for i, sid := range []string{"s1", "s2", "s3"} {
-		body := `{"type":"user","sessionId":"` + sid + `","cwd":"` + repo + `","timestamp":"2026-10-0` +
-			string(rune('1'+i)) + `T09:00:00Z","message":{"role":"user","content":"the singbox renderer keeps dropping routes"}}
-{"type":"assistant","sessionId":"` + sid + `","cwd":"` + repo + `","timestamp":"2026-10-0` +
-			string(rune('1'+i)) + `T09:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
-			render + `","old_string":"a","new_string":"b"}}]}}
-`
+		day := string(rune('1' + i))
+		body := rec(sid, "user", "the singbox renderer keeps dropping routes", "2026-10-0"+day+"T09:00:00Z")
+		body = append(body, rec(sid, "assistant", edit(render), "2026-10-0"+day+"T09:01:00Z")...)
 		if sid == "s1" {
-			body += `{"type":"assistant","sessionId":"s1","cwd":"` + repo + `","timestamp":"2026-10-01T09:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` +
-				routes + `","old_string":"c","new_string":"d"}}]}}
-`
+			body = append(body, rec(sid, "assistant", edit(routes), "2026-10-01T09:02:00Z")...)
 		}
-		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(body), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), body, 0o600); err != nil {
 			t.Fatal(err)
+		}
+		// A seed the parser cannot read indexes as nothing, and the assertions
+		// below then fail for a reason that has nothing to do with ranking —
+		// which is how this test went red on Windows and nowhere else.
+		for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+			if !json.Valid([]byte(line)) {
+				t.Fatalf("the seeded transcript is not JSON: %s", line)
+			}
 		}
 	}
 	t.Setenv("DEJA_CLAUDE_ROOT", claude)

--- a/cmd/deja/hook_context_once_test.go
+++ b/cmd/deja/hook_context_once_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,14 +32,32 @@ func TestDejaOnceKeepsTheDigestToTheFirstTurn(t *testing.T) {
 	}
 	t.Chdir(cwd)
 
+	// Marshalled rather than pasted: a Windows temp path inside a JSON string
+	// is a run of backslash escapes, the payload decodes to nothing, and the
+	// hook then has no session id to hold the digest against — which reads as
+	// the once rule failing when it never ran.
+	payload := func(fields map[string]any) string {
+		t.Helper()
+		b, err := json.Marshal(fields)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The hook reads this back; a payload it cannot decode has no session
+		// id, and every assertion below would fail for that instead.
+		var back map[string]any
+		if err := json.Unmarshal(b, &back); err != nil || back["cwd"] != cwd {
+			t.Fatalf("the payload does not survive a decode: %v\n%s", err, b)
+		}
+		return string(b)
+	}
+
 	ask := func(sid string, once bool) string {
 		t.Helper()
-		payload := `{"session_id":"` + sid + `","cwd":"` + cwd + `","source":"startup"`
+		fields := map[string]any{"session_id": sid, "cwd": cwd, "source": "startup"}
 		if once {
-			payload += `,"deja_once":true`
+			fields["deja_once"] = true
 		}
-		payload += `}`
-		withHookStdin(t, payload)
+		withHookStdin(t, payload(fields))
 		return captureStdout(t, func() { _ = runHookContext(index.DefaultDir(), true) })
 	}
 
@@ -65,8 +84,10 @@ func TestDejaOnceKeepsTheDigestToTheFirstTurn(t *testing.T) {
 	// every message of the session.
 	fromFlag := func(sid string) string {
 		t.Helper()
-		withHookStdin(t, `{"hook_event_name":"UserPromptSubmit","session_id":"`+sid+
-			`","cwd":"`+cwd+`","prompt":[{"type":"text","text":"anything"}]}`)
+		withHookStdin(t, payload(map[string]any{
+			"hook_event_name": "UserPromptSubmit", "session_id": sid, "cwd": cwd,
+			"prompt": []any{map[string]any{"type": "text", "text": "anything"}},
+		}))
 		return captureStdout(t, func() { _ = runHookContextMode(index.DefaultDir(), true, true) })
 	}
 	if first := fromFlag("flag-1"); strings.TrimSpace(first) == "" {


### PR DESCRIPTION
main has been red on windows-latest since #3124: `TestFilesJSONCarriesTheRankedRows` builds its transcript by pasting paths into JSON, and a Windows path is full of backslash escapes (`repo\render.go` carries a \r), so every seeded line failed to parse and the store indexed nothing.

The PR checks never saw it — the windows leg is skipped on an unlabelled pull request and runs on every push to main, so it only went red after the merge. This PR carries the `windows` label, so the leg runs here.

The records are marshalled now, and the test asserts its own seed is valid JSON, so the next hand-built fixture fails everywhere rather than on one runner.