### PR TITLE
fix(release): keep the plugins' deja dependency on the release

### DIFF
--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -50,7 +50,7 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.2"
+    "@vshulcz/deja-vu": "^0.19.4"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.0"
+    "@vshulcz/deja-vu": "^0.19.4"
   },
   "peerDependencies": {
     "openclaw": ">=2026.7.1"

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": ">=1.0.0",
-    "@vshulcz/deja-vu": "^0.18.0"
+    "@vshulcz/deja-vu": "^0.19.4"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.0"
+    "@vshulcz/deja-vu": "^0.19.4"
   },
   "pi": {
     "extensions": ["./index.ts"],

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.2"
+    "@vshulcz/deja-vu": "^0.19.4"
   }
 }

--- a/scripts/pinmanifests/main.go
+++ b/scripts/pinmanifests/main.go
@@ -69,6 +69,11 @@ const (
 	assetBase  = "https://github.com/vshulcz/deja-vu/releases/download"
 )
 
+// npmHarnessPackages are the plugins published to npm that install the deja
+// binary package as a dependency. Their own version is set at publish time;
+// what is pinned here is which deja they ask for.
+var npmHarnessPackages = []string{"dsh", "opencode", "openclaw", "pi"}
+
 type pins struct {
 	version string
 	amd64   string
@@ -137,8 +142,12 @@ func parse(version, checksums string) (pins, error) {
 	return p, nil
 }
 
-func write(root string, p pins) error {
-	for path, render := range map[string]func(pins) ([]byte, error){
+// targets is the whole pinned set, in one place. The writer and the check used
+// to carry their own copy of this list, so a target added to one and not the
+// other was pinned at release time and never verified again — or verified and
+// never written.
+func targets() map[string]func(pins) ([]byte, error) {
+	t := map[string]func(pins) ([]byte, error){
 		scoopPath:         renderScoop,
 		versionPath:       renderVersion,
 		localePath:        renderLocale,
@@ -151,7 +160,25 @@ func write(root string, p pins) error {
 		kimiPacked:        renderPluginVersion(kimiPacked),
 		kimiConst:         renderGoVersionConst(kimiConst, "kimiPluginVersion"),
 		agentPlugin:       renderPluginVersion(agentPlugin),
-	} {
+	}
+	// The harness packages depend on the deja binary package. The pin is a
+	// caret on a 0.x version, which npm reads as "this minor and no further",
+	// so a plugin left behind installs a binary from an older release for the
+	// one user who has no deja on PATH — the user who installed the plugin to
+	// get one (#2993).
+	for _, dir := range npmHarnessPackages {
+		path := filepath.Join("extensions", dir, "package.json")
+		t[path] = renderNpmDejaDep(path)
+	}
+	// The root manifest mirrors the dsh plugin — DSH installs a plugin from a
+	// repository root — and a test pins the two to agree, so it carries the
+	// same dependency and moves with it.
+	t["package.json"] = renderNpmDejaDep("package.json")
+	return t
+}
+
+func write(root string, p pins) error {
+	for path, render := range targets() {
 		body, err := render(p)
 		if err != nil {
 			return err
@@ -259,6 +286,23 @@ func renderGoVersionConst(path, name string) func(pins) ([]byte, error) {
 	}
 }
 
+// renderNpmDejaDep pins a harness package's dependency on the deja binary
+// package. Only that one line: these manifests carry keywords, engines and a
+// description no release derives.
+func renderNpmDejaDep(path string) func(pins) ([]byte, error) {
+	re := regexp.MustCompile(`("@vshulcz/deja-vu":\s*)"[^"]*"`)
+	return func(p pins) ([]byte, error) {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if !re.Match(b) {
+			return nil, fmt.Errorf("%s does not depend on @vshulcz/deja-vu", path)
+		}
+		return re.ReplaceAll(b, []byte(`${1}"^`+p.version+`"`)), nil
+	}
+}
+
 func renderPluginVersion(path string) func(pins) ([]byte, error) {
 	return func(p pins) ([]byte, error) {
 		b, err := os.ReadFile(path)
@@ -331,20 +375,7 @@ func runCheck(root string) error {
 	if err != nil {
 		return err
 	}
-	for path, render := range map[string]func(pins) ([]byte, error){
-		scoopPath:         renderScoop,
-		versionPath:       renderVersion,
-		localePath:        renderLocale,
-		installer:         renderInstaller,
-		codexPlugin:       renderPluginVersion(codexPlugin),
-		claudePlugin:      renderPluginVersion(claudePlugin),
-		claudeAgentPlugin: renderPluginVersion(claudeAgentPlugin),
-		geminiExtension:   renderPluginVersion(geminiExtension),
-		kimiPlugin:        renderPluginVersion(kimiPlugin),
-		kimiPacked:        renderPluginVersion(kimiPacked),
-		kimiConst:         renderGoVersionConst(kimiConst, "kimiPluginVersion"),
-		agentPlugin:       renderPluginVersion(agentPlugin),
-	} {
+	for path, render := range targets() {
 		want, err := render(p)
 		if err != nil {
 			return err

--- a/scripts/pinmanifests/npm_dep_test.go
+++ b/scripts/pinmanifests/npm_dep_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The harness plugins install the deja binary package when there is no deja on
+// PATH, and the pin is a caret on a 0.x version — which npm reads as "this
+// minor and no further". opencode-deja asked for ^0.18.0 through two releases,
+// so the one user who needed the fallback got a binary from two releases back
+// and nothing said so (#2993).
+func TestNpmDepIsPinnedToTheRelease(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package.json")
+	before := `{
+  "name": "opencode-deja",
+  "version": "0.18.0",
+  "keywords": ["memory"],
+  "dependencies": {
+    "@opencode-ai/plugin": ">=1.0.0",
+    "@vshulcz/deja-vu": "^0.18.0"
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := renderNpmDejaDep(path)(pins{version: "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `"@vshulcz/deja-vu": "^1.2.3"`) {
+		t.Fatalf("the dependency was not pinned to the release:\n%s", got)
+	}
+	// Only that line: these manifests carry keywords, engines and a description
+	// no release derives, and the package's own version is set at publish time
+	// from its own line.
+	if !strings.Contains(got, `"@opencode-ai/plugin": ">=1.0.0"`) || !strings.Contains(got, `"version": "0.18.0"`) {
+		t.Fatalf("something other than the deja dependency moved:\n%s", got)
+	}
+}
+
+// A package that stopped depending on deja is a change worth stopping for: the
+// silent alternative is a pin that quietly covers nothing.
+func TestNpmDepRefusesAManifestWithoutIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package.json")
+	if err := os.WriteFile(path, []byte(`{"name":"x","dependencies":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := renderNpmDejaDep(path)(pins{version: "1.2.3"}); err == nil {
+		t.Fatal("a manifest with no deja dependency was accepted")
+	}
+}
+
+// The writer and the check read one list. They used to carry a copy each, so a
+// target added to one and not the other was either pinned and never verified or
+// verified and never pinned.
+func TestEveryHarnessPackageIsATarget(t *testing.T) {
+	got := targets()
+	// Named here rather than read from the list under test: a list that lost an
+	// entry would otherwise check nothing and pass.
+	for _, name := range []string{"dsh", "opencode", "openclaw", "pi"} {
+		path := filepath.Join("extensions", name, "package.json")
+		if _, ok := got[path]; !ok {
+			t.Fatalf("%s is not pinned", path)
+		}
+		if _, err := os.Stat(filepath.Join("..", "..", path)); err != nil {
+			t.Fatalf("%s is pinned but not in the repository: %v", path, err)
+		}
+	}
+	// And the manifests that were already covered stay covered.
+	for _, path := range []string{scoopPath, installer, codexPlugin, kimiConst, agentPlugin} {
+		if _, ok := got[path]; !ok {
+			t.Fatalf("%s dropped out of the pinned set", path)
+		}
+	}
+}

--- a/scripts/release-npm.mjs
+++ b/scripts/release-npm.mjs
@@ -69,36 +69,41 @@ main.optionalDependencies = Object.fromEntries(
 fs.writeFileSync(mainPkgPath, JSON.stringify(main, null, 2));
 run("npm", ["publish", "--access", "public"], mainDir);
 
-// The harness packages ride the same version. Two of them were versioned
-// independently before this, so a release whose version is behind what npm
-// already has would move the `latest` tag backwards: skip those and say so,
-// and the lines converge on their own as soon as deja passes them.
+// The harness packages ride the same version where they can. Two of them were
+// versioned independently before this, and publishing them at a release behind
+// what npm already has would move the `latest` tag backwards, which cannot be
+// undone. Those get the next patch of their own line rather than being skipped:
+// skipping left dsh-deja on npm asking for a deja two releases old, and its
+// version line is ahead of deja's, so "they converge on their own" never came
+// (#2993).
 const extensions = ["opencode", "dsh", "openclaw", "pi"];
 const published = [];
 for (const name of extensions) {
   const dir = path.join("extensions", name);
   const pkg = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), "utf8"));
   const live = npmLatest(pkg.name);
-  if (live && compareVersions(version, live) <= 0) {
-    console.log(`skipping ${pkg.name}: npm has ${live}, this release is ${version}`);
-    continue;
+  const publishAs = live && compareVersions(version, live) <= 0 ? nextPatch(live) : version;
+  if (publishAs !== version) {
+    console.log(`${pkg.name}: npm has ${live}, this release is ${version} — publishing ${publishAs}`);
   }
   const out = path.join(work, name);
   fs.cpSync(dir, out, { recursive: true });
   const outPkgPath = path.join(out, "package.json");
   const outPkg = JSON.parse(fs.readFileSync(outPkgPath, "utf8"));
-  outPkg.version = version;
+  outPkg.version = publishAs;
+  // The dependency names this release either way: what the plugin installs
+  // when there is no deja on PATH has to be the binary this release built.
   if (outPkg.dependencies?.["@vshulcz/deja-vu"]) {
     outPkg.dependencies["@vshulcz/deja-vu"] = `^${version}`;
   }
   fs.writeFileSync(outPkgPath, JSON.stringify(outPkg, null, 2) + "\n");
   run("npm", ["publish", "--access", "public"], out);
-  published.push(outPkg.name);
+  published.push(`${outPkg.name}@${publishAs}`);
 }
 
 console.log(
   `published ${platforms.length} platform packages + @vshulcz/deja-vu@${version}` +
-    (published.length ? ` + ${published.join(", ")}@${version}` : ""),
+    (published.length ? ` + ${published.join(", ")}` : ""),
 );
 
 // npmLatest is the version npm serves as `latest`, or "" when the package has
@@ -109,6 +114,17 @@ function npmLatest(name) {
   } catch {
     return "";
   }
+}
+
+// nextPatch is the next version on a package's own line. A harness package
+// whose version has run ahead of deja's is published here rather than skipped,
+// and this is the smallest version npm accepts from it.
+function nextPatch(v) {
+  const parts = v.split(".").map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isInteger(n))) {
+    throw new Error(`not a plain version: ${v}`);
+  }
+  return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
 }
 
 // compareVersions orders two plain x.y.z versions. Releases here are always

--- a/scripts/release_npm_test.mjs
+++ b/scripts/release_npm_test.mjs
@@ -19,6 +19,7 @@ function extract(name) {
 }
 
 const compareVersions = extract("compareVersions");
+const nextPatch = extract("nextPatch");
 
 test("plain versions order by number, not by string", () => {
   assert.equal(compareVersions("0.18.0", "0.20.3"), -1);
@@ -36,12 +37,18 @@ test("anything that is not a plain x.y.z stops the release", () => {
 test("the extension packages are published from the release version", () => {
   // The dependency has to move with it: a plugin pinned to an older deja is a
   // plugin that ships the wrong binary as its fallback.
-  assert.match(source, /outPkg\.version = version/);
+  assert.match(source, /outPkg\.version = publishAs/);
   assert.match(source, /outPkg\.dependencies\["@vshulcz\/deja-vu"\] = `\^\$\{version\}`/);
   assert.match(source, /const extensions = \["opencode", "dsh", "openclaw", "pi"\]/);
 });
 
-test("a release behind npm skips instead of moving latest backwards", () => {
-  assert.match(source, /compareVersions\(version, live\) <= 0/);
-  assert.match(source, /skipping \$\{pkg\.name\}/);
+test("a package whose line runs ahead is published, not skipped", () => {
+  // dsh-deja sat on npm at 0.20.5 asking for deja ^0.19.2 while deja shipped
+  // 0.19.4: skipping it meant the pin was never refreshed, and its version line
+  // is ahead, so nothing was going to catch up (#2993).
+  assert.equal(nextPatch("0.20.5"), "0.20.6");
+  assert.throws(() => nextPatch("0.21.0-rc.1"), /not a plain version/);
+  assert.match(source, /const publishAs = live && compareVersions\(version, live\) <= 0 \? nextPatch\(live\) : version/);
+  assert.match(source, /outPkg\.version = publishAs/);
+  assert.doesNotMatch(source, /continue;\n\s*\}\n\s*const out = path\.join\(work, name\)/);
 });


### PR DESCRIPTION
Closes #2993.

The pin is a caret on a 0.x version, so `^0.18.0` resolves to 0.18.0 and never further. `opencode-deja` carried that through two releases; `dsh-deja` carried `^0.19.2` and could not be fixed by publishing, because its own version line (0.20.5) is ahead of deja's and the release script skipped it to avoid moving `latest` backwards. The user this bites is the one with no deja on PATH — the one who installed the plugin to get one.

Two halves, both of which the issue asked for:

- The pin is now part of `pinmanifests`, so `-check` — which CI runs — fails when a plugin's dependency lags the newest release. The writer and the check now read one target list instead of a copy each; they had drifted apart by construction. The root manifest is in the set too, since a test pins it to mirror the dsh plugin.
- A package whose version line runs ahead of deja's is published at the next patch of its own line rather than skipped, and its dependency names the release either way. `latest` still never moves backwards.

Pins updated to 0.19.4 by running the tool.