### PR TITLE
feat(recall): say when a session came back to the query after the excerpt

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1296,6 +1296,14 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 		for _, sn := range h.Snippets {
 			fmt.Fprintf(&hb, "- %s\n", recallListingLine(sn))
 		}
+		// After the excerpts, because it is about them. The excerpts are the
+		// passages that matched hardest, which in a session that changed its
+		// mind is the argument rather than the conclusion — recall answered
+		// "we are not on ClawHub yet" out of a session that later records the
+		// submission going through, and the caller acted on it (#2976).
+		if line := strings.TrimSpace(search.RevisitedLine(h)); line != "" {
+			fmt.Fprintf(&hb, "[%s]\n", line)
+		}
 		// Under the best hit only, and only when there is budget left: the
 		// excerpts say where the query words appear, which is not the same as
 		// what the session concluded. An agent had to open the session to learn

--- a/cmd/deja/mcp_revisited_test.go
+++ b/cmd/deja/mcp_revisited_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The MCP answer is what an agent acts on without opening the session, so the
+// note that the session reversed itself has to be there too — this is the
+// surface #2976 was reported from: recall said "we are not on ClawHub yet" out
+// of a session that later records the submission going through.
+func TestRecallSaysTheSessionCameBackToIt(t *testing.T) {
+	hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(role, text, at string) string {
+		b, err := json.Marshal(map[string]any{
+			"type": role, "sessionId": "flip", "cwd": "/proj", "timestamp": at,
+			"message": map[string]any{"role": role, "content": text},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b) + "\n"
+	}
+	body := line("user", "clawhub clawhub clawhub — checked, we are not listed", "2026-08-20T10:00:00Z") +
+		line("user", "clawhub clawhub, still nothing under our name", "2026-08-21T10:00:00Z") +
+		line("assistant", "clawhub clawhub, no listing", "2026-08-22T10:00:00Z") +
+		line("user", strings.Repeat("filler ", 200), "2026-08-24T10:00:00Z") +
+		line("assistant", "the clawhub listing is live, moderation passed", "2026-08-27T10:00:00Z")
+	if err := os.WriteFile(filepath.Join(store, "flip.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	answer, err := recallText(dir, "clawhub", "", 5, 8192)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(answer, "comes back to this later") {
+		t.Fatalf("the recall answer does not say the session revisits this:\n%s", answer)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -128,7 +128,10 @@ written against version 1:
 Stemmed search may also include `variants`; semantic search sets `semantic`.
 `superseded` (optional) carries the date of a newer same-project session whose
 matches overlap this hit — an earlier-attempt signal. `reused` (optional)
-counts recent agent recalls that served this session.
+counts recent agent recalls that served this session. `revisited` (optional) is
+the timestamp of a later message in *this* session that also matched, after the
+passages the excerpts came from: the session went on talking about the query,
+so what the excerpts say may be the half it later reversed.
 
 `--limit N` bounds the ranked result set to 1–100 hits, on the tiers that serve
 that cap (see [`hits` is not a fixed

--- a/internal/search/json_contract_test.go
+++ b/internal/search/json_contract_test.go
@@ -23,6 +23,7 @@ func TestSearchJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		// hit
 		"session": true, "count": true, "snippets": true, "score": true,
 		"tier_detail": true, "superseded": true, "reused": true, "moved": true,
+		"revisited": true,
 		"lifecycle": true, "lifecycle_note": true, "lifecycle_at": true,
 		// session
 		"id": true, "harness": true, "project": true, "path": true, "title": true,

--- a/internal/search/revisited_test.go
+++ b/internal/search/revisited_test.go
@@ -1,0 +1,102 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A session that says one thing and later says the opposite is served by the
+// passage that matched hardest, which is the argument rather than the
+// conclusion. Recall answered "we are not on ClawHub yet" out of a session
+// whose later half records the submission going through, and the reader acted
+// on the stale one (#2976).
+func TestAHitSaysWhenTheSessionCameBackToIt(t *testing.T) {
+	day := func(n int) time.Time { return time.Date(2026, 8, n, 9, 0, 0, 0, time.Local) }
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Started: day(20), Updated: day(27),
+		Messages: []model.Message{
+			// Three passages the ranking prefers — the excerpt budget is three,
+			// which is what leaves the session's last word out of the answer.
+			{Role: "user", Text: "clawhub clawhub clawhub — checked, we are not on clawhub", Time: day(20)},
+			{Role: "user", Text: "clawhub clawhub again, still not there", Time: day(21)},
+			{Role: "assistant", Text: "clawhub clawhub, nothing under our name", Time: day(22)},
+			{Role: "user", Text: strings.Repeat("filler ", 200), Time: day(24)},
+			// The later word on it, matching once.
+			{Role: "assistant", Text: "the clawhub listing is live now, moderation passed", Time: day(27)},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "clawhub"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hit, so nothing was measured")
+	}
+	h := hits[0]
+	if h.Revisited != "2026-08-27" {
+		t.Fatalf("Revisited = %q, want the date of the later mention", h.Revisited)
+	}
+	var out bytes.Buffer
+	Print(&out, hits, Options{Query: "clawhub", Width: 120})
+	if !strings.Contains(out.String(), "comes back to this later (2026-08-27)") {
+		t.Fatalf("the answer does not say the session revisits this:\n%s", out.String())
+	}
+}
+
+// And it stays quiet when the excerpts already carry the session's last word —
+// a note on every hit is a note nobody reads.
+func TestAHitIsQuietWhenTheExcerptsAreTheLastWord(t *testing.T) {
+	day := func(n int) time.Time { return time.Date(2026, 8, n, 9, 0, 0, 0, time.Local) }
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Started: day(20), Updated: day(21),
+		Messages: []model.Message{
+			{Role: "user", Text: "clawhub publish, first look", Time: day(20)},
+			{Role: "assistant", Text: "clawhub listing is live", Time: day(21)},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "clawhub"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hit, so nothing was measured")
+	}
+	if hits[0].Revisited != "" {
+		t.Fatalf("Revisited = %q on a session whose last mention is shown", hits[0].Revisited)
+	}
+	var out bytes.Buffer
+	Print(&out, hits, Options{Query: "clawhub", Width: 120})
+	if strings.Contains(out.String(), "comes back to this later") {
+		t.Fatalf("the note was printed anyway:\n%s", out.String())
+	}
+}
+
+// Only the messages that matched count as coming back to it: a session that
+// went on to talk about something else has not revisited the query.
+func TestLaterTalkAboutSomethingElseIsNotARevisit(t *testing.T) {
+	day := func(n int) time.Time { return time.Date(2026, 8, n, 9, 0, 0, 0, time.Local) }
+	s := model.Session{
+		Harness: "claude", Project: "p", ID: "s1",
+		Started: day(20), Updated: day(28),
+		Messages: []model.Message{
+			{Role: "user", Text: "clawhub publish, checked, we are not there", Time: day(20)},
+			{Role: "assistant", Text: "moved on to the winget manifest instead", Time: day(28)},
+		},
+	}
+	hits, err := Run([]model.Session{s}, Options{Query: "clawhub"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("no hit, so nothing was measured")
+	}
+	if hits[0].Revisited != "" {
+		t.Fatalf("Revisited = %q, but the later message is about something else", hits[0].Revisited)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -88,6 +88,13 @@ type Hit struct {
 	Superseded string `json:"superseded,omitempty"`
 	// Reused counts recent agent recalls that served this session.
 	Reused int `json:"reused,omitempty"`
+	// Revisited is the date this session last came back to the query, after the
+	// passages shown as excerpts. The excerpts are the strongest match rather
+	// than the last word, so a session that reversed itself served the half it
+	// argued hardest and nothing said the rest was there (#2976). A date rather
+	// than a time.Time for the same reason Superseded is one: an empty struct
+	// is not omitted from JSON, and the field is read by people.
+	Revisited string `json:"revisited,omitempty"`
 	// Lifecycle carries what was later recorded about this session: that its
 	// decision was rejected, superseded or has gone stale. A hit on a raw
 	// transcript used to arrive with no trace of that, so a decision someone
@@ -182,6 +189,11 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 		// window is how tightly the query's words meet in this message; 0 means
 		// they never do.
 		window int
+		// at is where in the session this was said: the excerpts are chosen by
+		// how well they match, so the strongest passage is often not the last
+		// word the session had on the subject.
+		at   int
+		when time.Time
 	}
 	snipCands := make([]snipCand, 0, 16)
 	df := make([]int, len(qtoks))
@@ -221,7 +233,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			doc.userCount = []int{0}
 		}
 		snipCands = snipCands[:0]
-		for _, m := range s.Messages {
+		for mi, m := range s.Messages {
 			if o.Role != "" && !roleMatches(m.Role, o.Role) {
 				continue
 			}
@@ -279,7 +291,7 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 				// first three showed wherever a word happened to appear early
 				// rather than the passage that carries the answer.
 				w := tokenWindow(windowText, windowToks)
-				snipCands = append(snipCands, snipCand{text: text, weight: c, window: w})
+				snipCands = append(snipCands, snipCand{text: text, weight: c, window: w, at: mi, when: m.Time})
 				if w > 0 && (doc.minWindow == 0 || w < doc.minWindow) {
 					doc.minWindow = w
 				}
@@ -320,8 +332,29 @@ func runScored(ss []model.Session, o Options) ([]Hit, error) {
 			}
 			return a.weight > b.weight
 		})
+		shown := -1
 		for i := 0; i < len(snipCands) && i < 3; i++ {
 			doc.hit.Snippets = append(doc.hit.Snippets, snippet(snipCands[i].text, o.Query, re))
+			if snipCands[i].at > shown {
+				shown = snipCands[i].at
+			}
+		}
+		// A session that says one thing and later says the opposite is served
+		// by the strongest passage, which is usually the first argument rather
+		// than the conclusion: recall answered "we are not on ClawHub yet" from
+		// a session that, further down, records the submission going through,
+		// and the reader acted on the stale half (#2976). The excerpts stay as
+		// they are — they are what matched — and the answer says the session
+		// comes back to this later.
+		doc.hit.Revisited = ""
+		var last time.Time
+		for _, c := range snipCands {
+			if c.at > shown && c.when.After(last) {
+				last = c.when
+			}
+		}
+		if !last.IsZero() {
+			doc.hit.Revisited = last.Local().Format("2006-01-02")
 		}
 		// The index hands ranking the records that matched, not the session, so
 		// doc.length measures the size of the match. Normalising by that told
@@ -960,6 +993,20 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	return boost
 }
 
+// RevisitedLine is the one line a hit gets when the session went on talking
+// about the query after the passages above it. Exported because the CLI and
+// the MCP tool build their answers separately and this has to read the same in
+// both — the reader acts on it either way.
+func RevisitedLine(h Hit) string { return revisitedLine(h) }
+
+func revisitedLine(h Hit) string {
+	if h.Revisited == "" {
+		return ""
+	}
+	return "  this session comes back to this later (" + h.Revisited +
+		") — what is above may be the half it reversed"
+}
+
 // lifecycleSummary words a hit's recorded state for a person. It says what
 // happened rather than naming the state: "superseded" is our vocabulary, not
 // the reader's.
@@ -1295,6 +1342,15 @@ func Print(w io.Writer, hits []Hit, o Options) {
 			// characters the terminal counts, so trimming the rendered string
 			// would cut a different number of visible runes on every line.
 			fmt.Fprintf(w, "  %s\n", highlight(SafeText(fitLine(sn, o.Width-2)), o.Query, o.Regex, color))
+		}
+		// After the excerpts, because it is about them: the session had more to
+		// say on this afterwards, and what is above may be the half it later
+		// reversed.
+		if line := revisitedLine(h); line != "" {
+			if color {
+				line = cDim + line + cReset
+			}
+			fmt.Fprintln(w, line)
 		}
 	}
 }


### PR DESCRIPTION
Closes #2976.

Excerpt choice is by match strength, and in a session that changed its mind the strongest passage is the argument, not the conclusion. The reported case: recall served "checked, we are not on ClawHub" out of a session whose later half records the submission going through, and the reader built a second submission on it.

The excerpts stay as they are — they are what matched. What is new is one line under them, on both surfaces, when the session went on matching the query after the last passage shown:

    this session comes back to this later (2026-08-27) — what is above may be the half it reversed

It fires on the session's own later *matching* messages, so a session that moved on to something else says nothing, and a session whose last mention is already in the excerpts says nothing either. `revisited` joins the JSON hit envelope and is documented.

This is the cheap half the issue asked for. The other half — spending one of the three excerpt slots on the session's latest matching passage — touches ranking and belongs with the #3007 work, where the snippet chosen inside a 5,000-match session is the same problem seen from the other side.

Four mutations, each red on its own test.