### PR TITLE
feat(openclaw): index what a reset or a delete left behind

### DIFF
--- a/docs/registry/openclaw.html
+++ b/docs/registry/openclaw.html
@@ -57,10 +57,15 @@
 <p>back whole. Explicit deletes keep a compressed archive in</p>
 <p><code>session_transcript_archives</code>, which is not read. The fixture database is the</p>
 <p>output of <code>openclaw doctor --session-sqlite import</code> over the JSONL fixture.</p>
-<p>Skipped in the sessions directory: <code>sessions.json</code> (store metadata),</p>
-<p>compaction checkpoints (<code>&lt;id&gt;.checkpoint.&lt;uuid&gt;.jsonl</code>), archived</p>
-<p>transcripts (<code>.deleted</code>/<code>.reset</code>/<code>.bak</code> suffixes) and the</p>
-<p><code>session-sqlite-import-archive/</code> copies the migration leaves. Format verified</p>
+<p>Read in the sessions directory beside the live transcripts: what a reset or a</p>
+<p>delete left behind — <code>&lt;id&gt;.jsonl.reset.&lt;ts&gt;</code>, <code>&lt;id&gt;.jsonl.deleted.&lt;ts&gt;</code> and the</p>
+<p>compressed <code>&lt;id&gt;.jsonl.deleted.&lt;ts&gt;.zst</code> an explicit delete writes since the</p>
+<p>SQLite flip. That is the history someone asks for after losing it. An archive</p>
+<p>whose live file is back stands down, so a reset conversation is indexed once.</p>
+<p>Skipped: <code>sessions.json</code> (store metadata), compaction checkpoints</p>
+<p>(<code>&lt;id&gt;.checkpoint.&lt;uuid&gt;.jsonl</code>), <code>.bak</code> copies and the</p>
+<p><code>session-sqlite-import-archive/</code> copies the migration leaves — those sessions</p>
+<p>are in the SQLite store deja already reads. Format verified</p>
 <p>against a 2026.8.2 store and openclaw source</p>
 <p>(<code>src/config/sessions/session-accessor.sqlite-*.ts</code>, <code>paths.ts</code>).</p>
 <ul>

--- a/docs/registry/openclaw.md
+++ b/docs/registry/openclaw.md
@@ -21,10 +21,15 @@ back whole. Explicit deletes keep a compressed archive in
 `session_transcript_archives`, which is not read. The fixture database is the
 output of `openclaw doctor --session-sqlite import` over the JSONL fixture.
 
-Skipped in the sessions directory: `sessions.json` (store metadata),
-compaction checkpoints (`<id>.checkpoint.<uuid>.jsonl`), archived
-transcripts (`.deleted`/`.reset`/`.bak` suffixes) and the
-`session-sqlite-import-archive/` copies the migration leaves. Format verified
+Read in the sessions directory beside the live transcripts: what a reset or a
+delete left behind — `<id>.jsonl.reset.<ts>`, `<id>.jsonl.deleted.<ts>` and the
+compressed `<id>.jsonl.deleted.<ts>.zst` an explicit delete writes since the
+SQLite flip. That is the history someone asks for after losing it. An archive
+whose live file is back stands down, so a reset conversation is indexed once.
+Skipped: `sessions.json` (store metadata), compaction checkpoints
+(`<id>.checkpoint.<uuid>.jsonl`), `.bak` copies and the
+`session-sqlite-import-archive/` copies the migration leaves — those sessions
+are in the SQLite store deja already reads. Format verified
 against a 2026.8.2 store and openclaw source
 (`src/config/sessions/session-accessor.sqlite-*.ts`, `paths.ts`).
 

--- a/internal/sources/openclaw.go
+++ b/internal/sources/openclaw.go
@@ -121,7 +121,7 @@ func parseOpenClawArchive(path string) ([]model.Session, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer os.Remove(plain)
+		defer func() { _ = os.Remove(plain) }()
 		read = plain
 	}
 	ss, err := parsePiShaped(read, 0, "openclaw", openclawProject(path), true)
@@ -157,12 +157,12 @@ func zstdToTemp(path string) (string, error) {
 		return "", err
 	}
 	if _, err := f.Write(out.Bytes()); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+		_ = f.Close()
+		_ = os.Remove(f.Name())
 		return "", err
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
+		_ = os.Remove(f.Name())
 		return "", err
 	}
 	return f.Name(), nil

--- a/internal/sources/openclaw.go
+++ b/internal/sources/openclaw.go
@@ -1,8 +1,11 @@
 package sources
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,9 +18,12 @@ import (
 //
 //	${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/<agentId>/sessions/<sessionId>.jsonl
 //
-// sessions.json in the same directory is store metadata, compaction
-// checkpoints (<id>.checkpoint.<uuid>.jsonl) are context snapshots, and
-// archived transcripts carry .deleted/.reset/.bak suffixes — all skipped.
+// sessions.json in the same directory is store metadata and compaction
+// checkpoints (<id>.checkpoint.<uuid>.jsonl) are context snapshots; both are
+// skipped. What a reset or a delete leaves behind is not: OpenClaw renames the
+// transcript to <id>.jsonl.reset.<ts> or <id>.jsonl.deleted.<ts>, and since the
+// SQLite flip an explicit delete writes <id>.jsonl.deleted.<ts>.zst — which is
+// exactly the history someone asks deja for after losing it (#2997).
 // Verified against openclaw src/config/sessions/{paths,artifacts}.ts.
 
 // OpenClawStateDir is the OpenClaw state root.
@@ -32,10 +38,19 @@ func OpenClawRoot() string {
 
 var openclawCheckpointRE = regexp.MustCompile(`(?i)\.checkpoint\.[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$`)
 
+// openclawArchiveRE matches what a reset or a delete renames a transcript to.
+// The timestamp is whatever OpenClaw stamped it with, and the .zst is the
+// compressed form an explicit delete writes since the SQLite flip.
+var openclawArchiveRE = regexp.MustCompile(`\.jsonl\.(reset|deleted)\.[0-9]+(\.zst)?$`)
+
 // openclawTranscript reports whether p is a live transcript directly inside
 // an agent's sessions dir (agents/<id>/sessions/<file>.jsonl).
 func openclawTranscript(root, p string) bool {
-	if !strings.HasSuffix(p, ".jsonl") || openclawCheckpointRE.MatchString(p) {
+	archived := openclawArchiveRE.MatchString(p)
+	if !strings.HasSuffix(p, ".jsonl") && !archived {
+		return false
+	}
+	if openclawCheckpointRE.MatchString(p) {
 		return false
 	}
 	rel, err := filepath.Rel(root, p)
@@ -43,7 +58,27 @@ func openclawTranscript(root, p string) bool {
 		return false
 	}
 	parts := strings.Split(filepath.ToSlash(rel), "/")
-	return len(parts) == 3 && parts[1] == "sessions"
+	if len(parts) != 3 || parts[1] != "sessions" {
+		return false
+	}
+	// A reset writes the archive and starts a new transcript under the old
+	// name; taking both would index the same conversation twice. The live file
+	// is the one the agent is still writing to, so the archive stands down.
+	if archived {
+		if _, err := os.Stat(openclawArchiveLive(p)); err == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// openclawArchiveLive is the transcript an archive was renamed from.
+func openclawArchiveLive(p string) string {
+	at := strings.Index(p, ".jsonl.")
+	if at < 0 {
+		return p
+	}
+	return p[:at] + ".jsonl"
 }
 
 // OpenClawSessionFiles lists live transcript files for all agents.
@@ -69,7 +104,68 @@ func ParseOpenClawFile(path string) ([]model.Session, error) {
 
 // ParseOpenClawFileFromOffset parses an OpenClaw transcript from a byte offset.
 func ParseOpenClawFileFromOffset(path string, offset int64) ([]model.Session, error) {
+	if openclawArchiveRE.MatchString(path) {
+		return parseOpenClawArchive(path)
+	}
 	return parsePiShaped(path, offset, "openclaw", openclawProject(path), true)
+}
+
+// parseOpenClawArchive reads what a reset or a delete left behind. The file
+// never grows, so it is read whole rather than from an offset, and the session
+// keeps the id it had before the rename — that is the id the store, the key
+// mapping and anyone looking for it still use.
+func parseOpenClawArchive(path string) ([]model.Session, error) {
+	read := path
+	if strings.HasSuffix(path, ".zst") {
+		plain, err := zstdToTemp(path)
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(plain)
+		read = plain
+	}
+	ss, err := parsePiShaped(read, 0, "openclaw", openclawProject(path), true)
+	for i := range ss {
+		ss[i].Path = path
+		ss[i].ID = strings.TrimSuffix(filepath.Base(openclawArchiveLive(path)), ".jsonl")
+	}
+	return ss, err
+}
+
+// zstdToTemp decompresses a .zst archive into a temporary file and returns its
+// path. deja carries no Go dependencies, so the frames go through the same
+// `zstd` CLI the Zed and DeepSeek stores already need; the caller removes the
+// file. A scanner that reads from a path is what every transcript parser here
+// takes, and an archive is small enough that a temporary copy is cheaper than
+// teaching all of them to read a stream.
+func zstdToTemp(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("zstd", "-d", "-c", "-q")
+	cmd.Stdin = bytes.NewReader(raw)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("openclaw: zstd -d %s: %w: %s", filepath.Base(path), err,
+			strings.TrimSpace(errBuf.String()))
+	}
+	f, err := os.CreateTemp("", "deja-openclaw-*.jsonl")
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(out.Bytes()); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 // openclawProject attributes a session to its agent id; the header cwd, when

--- a/internal/sources/openclaw_archive_test.go
+++ b/internal/sources/openclaw_archive_test.go
@@ -1,0 +1,155 @@
+package sources
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func openclawArchiveBody(id, said string) string {
+	return `{"type":"session","id":"` + id + `","cwd":"/work/app","timestamp":"2026-08-02T10:00:00Z"}` + "\n" +
+		`{"type":"message","message":{"role":"user","content":[{"type":"text","text":"` + said + `"}]},"timestamp":"2026-08-02T10:01:00Z"}` + "\n"
+}
+
+// A reset or a delete renames the transcript rather than removing it, and that
+// file is exactly the history someone comes to deja for after losing it — the
+// old rule matched sessions/*.jsonl and let it fall out of the index (#2997).
+func TestOpenClawReadsWhatAResetLeftBehind(t *testing.T) {
+	root := t.TempDir()
+	sessions := filepath.Join(root, "main", "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	archive := filepath.Join(sessions, "aaaa1111.jsonl.reset.1788000000")
+	if err := os.WriteFile(archive, []byte(openclawArchiveBody("aaaa1111", "the reset queue keeps double-acking")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := OpenClawSessionFiles()
+	if len(files) != 1 || files[0] != archive {
+		t.Fatalf("the archived transcript is not offered to the index: %#v", files)
+	}
+	ss, err := ParseOpenClawFile(archive)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("archive parsed to %d sessions: %v", len(ss), err)
+	}
+	// The id it had before the rename: that is what the session key mapping and
+	// anyone looking for it still use.
+	if ss[0].ID != "aaaa1111" {
+		t.Fatalf("session id = %q, want the id from before the rename", ss[0].ID)
+	}
+	if ss[0].Path != archive {
+		t.Fatalf("session path = %q, want the archive it was read from", ss[0].Path)
+	}
+	if len(ss[0].Messages) == 0 || !strings.Contains(ss[0].Messages[0].Text, "double-acking") {
+		t.Fatalf("the archived turn did not come through: %#v", ss[0].Messages)
+	}
+}
+
+// Not every transcript carries a session header, and the file name is the only
+// place the id is then: the parser strips ".jsonl", which on an archive leaves
+// the rename stamp in the id someone would look it up by.
+func TestOpenClawArchiveKeepsTheIDFromBeforeTheRename(t *testing.T) {
+	root := t.TempDir()
+	sessions := filepath.Join(root, "main", "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	archive := filepath.Join(sessions, "eeee5555.jsonl.deleted.1788000002")
+	headerless := `{"type":"message","message":{"role":"user","content":[{"type":"text","text":"no header on this one"}]},"timestamp":"2026-08-02T10:01:00Z"}` + "\n"
+	if err := os.WriteFile(archive, []byte(headerless), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseOpenClawFile(archive)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("archive parsed to %d sessions: %v", len(ss), err)
+	}
+	if ss[0].ID != "eeee5555" {
+		t.Fatalf("session id = %q, want the id from before the rename", ss[0].ID)
+	}
+}
+
+// A reset starts a new transcript under the old name. Reading both would index
+// one conversation twice, so the live file wins.
+func TestOpenClawSkipsAnArchiveWhoseLiveFileIsBack(t *testing.T) {
+	root := t.TempDir()
+	sessions := filepath.Join(root, "main", "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	live := filepath.Join(sessions, "bbbb2222.jsonl")
+	if err := os.WriteFile(live, []byte(openclawArchiveBody("bbbb2222", "the live turn")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(live+".reset.1788000000", []byte(openclawArchiveBody("bbbb2222", "the archived turn")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := OpenClawSessionFiles()
+	if len(files) != 1 || files[0] != live {
+		t.Fatalf("want only the live transcript, got %#v", files)
+	}
+}
+
+// Since the SQLite flip an explicit delete writes the archive compressed. zstd
+// is already what the Zed and DeepSeek stores are read through.
+func TestOpenClawReadsACompressedDeletedTranscript(t *testing.T) {
+	if _, err := exec.LookPath("zstd"); err != nil {
+		t.Skip("zstd is not installed; the compressed archive path needs it")
+	}
+	root := t.TempDir()
+	sessions := filepath.Join(root, "main", "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	plain := filepath.Join(sessions, "cccc3333.jsonl.deleted.1788000001")
+	if err := os.WriteFile(plain, []byte(openclawArchiveBody("cccc3333", "we settled on one shard")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("zstd", "-q", "--rm", plain).CombinedOutput(); err != nil {
+		t.Fatalf("zstd: %v: %s", err, out)
+	}
+	archive := plain + ".zst"
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatal(err)
+	}
+	files := OpenClawSessionFiles()
+	if len(files) != 1 || files[0] != archive {
+		t.Fatalf("the compressed archive is not offered to the index: %#v", files)
+	}
+	ss, err := ParseOpenClawFile(archive)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("compressed archive parsed to %d sessions: %v", len(ss), err)
+	}
+	if ss[0].ID != "cccc3333" || !strings.Contains(ss[0].Messages[0].Text, "one shard") {
+		t.Fatalf("the deleted session did not come back: %#v", ss[0])
+	}
+	// The archive, not the temporary copy it was decompressed into: the path is
+	// what `deja show` prints and what the next index pass stats.
+	if ss[0].Path != archive {
+		t.Fatalf("session path = %q, want the archive itself", ss[0].Path)
+	}
+}
+
+// A compaction checkpoint is a context snapshot rather than a conversation, and
+// it stays out — the rule that lets archives in must not let those in with them.
+func TestOpenClawStillSkipsCheckpoints(t *testing.T) {
+	root := t.TempDir()
+	sessions := filepath.Join(root, "main", "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", root)
+	name := "dddd4444.checkpoint.aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee.jsonl"
+	if err := os.WriteFile(filepath.Join(sessions, name), []byte(openclawArchiveBody("dddd4444", "snapshot")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if files := OpenClawSessionFiles(); len(files) != 0 {
+		t.Fatalf("a checkpoint was offered to the index: %#v", files)
+	}
+}


### PR DESCRIPTION
Closes #2997.

`/new` and delete rename the transcript rather than removing it — `<id>.jsonl.reset.<ts>`, `<id>.jsonl.deleted.<ts>`, and since the SQLite flip `<id>.jsonl.deleted.<ts>.zst`. The matcher wanted `sessions/*.jsonl`, so the one history a user comes to deja for after losing it was the history deja did not have.

Those files are read now, keeping the id they had before the rename, so the session is the one the store and the key mapping name. The compressed form goes through the `zstd` CLI the Zed and DeepSeek stores already need. An archive whose live file is back stands down — a reset starts a new transcript under the old name, and reading both would index one conversation twice. Checkpoints and `.bak` copies stay out.

`session-sqlite-import-archive/` deliberately stays out too: those sessions are in the SQLite store deja already reads, so taking them would double every migrated session. Said in the registry page rather than left as an omission.

Six mutations, each red on its own test.