### PR TITLE
feat(install): say where the docs and the issue tracker are, once

### DIFF
--- a/cmd/deja/hook_built_note.go
+++ b/cmd/deja/hook_built_note.go
@@ -38,5 +38,11 @@ func builtNote(dir string) string {
 	} else {
 		line += " — what they decided now arrives before you re-ask"
 	}
+	// A marketplace install never runs `deja install`, so this notice is the
+	// first thing deja says to that person. It is also the only place left to
+	// say where the docs and the tracker are (#3030).
+	if where := whereToLook(dir); where != "" {
+		line += "\n" + where
+	}
 	return line
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -494,6 +494,11 @@ func printMemoryProofOf(dir, heading string, keep func(model.Session) bool, lead
 		fmt.Fprintln(os.Stderr, l)
 	}
 	fmt.Fprintln(os.Stderr, "ask your agent about any of these — it will remember.")
+	// Under the proof, because it is the moment the reader has just been shown
+	// something real and might want to know where the rest is (#3030).
+	if line := whereToLook(dir); line != "" {
+		fmt.Fprintln(os.Stderr, line)
+	}
 }
 
 // recurringErrorLine is the top row of `deja friction`, as one sentence, or ""

--- a/cmd/deja/where_to_look.go
+++ b/cmd/deja/where_to_look.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+)
+
+// whereToLookLine names the documentation and the issue tracker. Most installs
+// now arrive through a marketplace — `claude plugin install`, `npx skills add`,
+// the dsh store — so the person never opens the README, and the only lines deja
+// ever said to them were the install tail and the first-build notice. Neither
+// said where to read more or where to report something (#3030).
+//
+// Once per machine: it is a pointer, not news, and a line that repeats is a
+// line that gets skipped. The marker sits beside the index for the same reason
+// the built note's does — one machine, one index directory.
+const whereToLookLine = "docs: vshulcz.github.io/deja-vu · issues: github.com/vshulcz/deja-vu/issues"
+
+// whereToLook returns the line the first time it is asked for on this machine,
+// and "" afterwards. A store that has not been built yet is not the moment:
+// the line belongs under a proof that just showed real sessions.
+func whereToLook(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	marker := dir + ".wheretolook"
+	if _, err := os.Stat(marker); err == nil {
+		return ""
+	}
+	if err := os.WriteFile(marker, []byte("1"), 0o600); err != nil {
+		// Unwritable index directory: say it once here rather than every run.
+		return ""
+	}
+	return whereToLookLine
+}

--- a/cmd/deja/where_to_look_test.go
+++ b/cmd/deja/where_to_look_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Most installs arrive through a marketplace, so the README is never opened and
+// the install tail is the only thing deja ever says to that person. It said
+// nothing about where to read more or where to report something (#3030).
+func TestTheInstallProofSaysWhereToLook(t *testing.T) {
+	tmp := hermeticEnv(t)
+	seedProofSessions(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	out := captureStderr(t, func() { printInstallProof(dir) })
+	if !strings.Contains(out, "deja already knows this machine:") {
+		t.Fatalf("the proof did not print, so nothing was measured:\n%s", out)
+	}
+	if !strings.Contains(out, "docs: vshulcz.github.io/deja-vu") ||
+		!strings.Contains(out, "issues: github.com/vshulcz/deja-vu/issues") {
+		t.Fatalf("the proof does not say where the docs and the tracker are:\n%s", out)
+	}
+
+	// Once per machine: a pointer that repeats is a pointer nobody reads.
+	again := captureStderr(t, func() { printInstallProof(dir) })
+	if strings.Contains(again, "docs: vshulcz.github.io") {
+		t.Fatalf("the line came back on the second run:\n%s", again)
+	}
+	if !strings.Contains(again, "deja already knows this machine:") {
+		t.Fatalf("the proof itself stopped printing with it:\n%s", again)
+	}
+	_ = tmp
+}
+
+// The first-build notice is the only line a marketplace install sees at all, so
+// it carries the same pointer — and the two share the marker, so between them
+// it is said once.
+func TestTheFirstBuildNoticeCarriesItOnce(t *testing.T) {
+	hermeticEnv(t)
+	seedProofSessions(t)
+	dir := os.Getenv("DEJA_INDEX_DIR")
+	note := builtNote(dir)
+	if note == "" {
+		t.Fatal("no built note, so nothing was measured")
+	}
+	if !strings.Contains(note, "docs: vshulcz.github.io/deja-vu") {
+		t.Fatalf("the first-build notice does not say where to look:\n%s", note)
+	}
+	if out := captureStderr(t, func() { printInstallProof(dir) }); strings.Contains(out, "docs: vshulcz.github.io") {
+		t.Fatalf("the install said it again after the notice had:\n%s", out)
+	}
+}
+
+// seedProofSessions puts enough history in the store for the proof block to
+// have something real to print.
+func seedProofSessions(t *testing.T) {
+	t.Helper()
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	proj := filepath.Join(root, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"user","sessionId":"p1","cwd":"/work/app","timestamp":"2026-08-02T10:00:00Z","message":{"role":"user","content":"the retry queue keeps double-acking"}}` + "\n" +
+		`{"type":"assistant","sessionId":"p1","cwd":"/work/app","timestamp":"2026-08-02T10:01:00Z","message":{"role":"assistant","content":"one shard fixed it"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(proj, "p1.jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureRunStderr(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #3030.

    docs: vshulcz.github.io/deja-vu · issues: github.com/vshulcz/deja-vu/issues

Under the install proof, where the reader has just been shown real sessions, and on the first-build notice, which is the only line a marketplace install ever sees. The two share one marker beside the index, so between them it is said once per machine and never again. Not on the plain hook path — that text goes to the model.

Four mutations, each red on its own test.