### PR TITLE
feat(stats): count the replies that used a recall and did not say so

### DIFF
--- a/cmd/deja/stats.go
+++ b/cmd/deja/stats.go
@@ -377,6 +377,13 @@ func printStats(w io.Writer, r stats.Report) {
 	if r.AgentCredits > 0 {
 		fmt.Fprintf(w, "  Credited aloud   agents said \"déjà vu\" %d time%s (%d this week)\n", r.AgentCredits, pluralS(r.AgentCredits), r.WeekCredits)
 	}
+	if r.UsedNotCredited > 0 {
+		// The other half of the credit rate: a reply that names a recalled
+		// session and does not say the line. At most — a session about deja
+		// quotes ids in prose too (#3079).
+		fmt.Fprintf(w, "  Used, not said   at most %d repl%s named a recalled session without the line (%d this week)\n",
+			r.UsedNotCredited, map[bool]string{true: "y", false: "ies"}[r.UsedNotCredited == 1], r.WeekUsedNotCredited)
+	}
 	if r.HandoffsIn > 0 {
 		fmt.Fprintf(w, "  Handoffs         %d session%s started from a handoff\n", r.HandoffsIn, pluralS(r.HandoffsIn))
 	}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -269,6 +269,8 @@ the end returns an empty `messages` array and a `returned` count of zero.
   "handoffs_received": 0,
   "agent_credits": 1,
   "week_agent_credits": 0,
+  "used_not_credited": 4,
+  "week_used_not_credited": 1,
   "sidecar_size": 12345
 }
 ```
@@ -276,12 +278,20 @@ the end returns an empty `messages` array and a `returned` count of zero.
 `spans` and `span_files` count the replaced spans `deja restore` can hand back
 and the files they belong to. Both are omitted when the index holds none.
 
+`agent_credits` counts assistant turns that said the credit line. Beside it,
+`used_not_credited` counts turns that name a recalled session — `deja:<id>` —
+and do not say the line: memory that was used without being credited, as
+opposed to memory that was rightly ignored. It is an upper bound, because a
+session *about* deja quotes ids in prose; read the two together as the size of
+the question rather than as an answer.
+
 Inside `recall`, `raw_bytes` is the size of the source transcripts the served
 digests distilled and `since` is the oldest event still in the usage log; both
 are omitted when zero, so a store with no recall history yet shows neither.
 
 
-`week_recalls`, `week_bytes`, `week_injected` and `week_agent_credits` cover
+`week_recalls`, `week_bytes`, `week_injected`, `week_agent_credits` and
+`week_used_not_credited` cover
 seven calendar days back from now, at the same wall clock — not a fixed 168
 hours. Across a clock change that means the week runs an hour longer in autumn
 and an hour shorter in spring; and where a spring-forward removed the wall time

--- a/internal/stats/json_contract_test.go
+++ b/internal/stats/json_contract_test.go
@@ -47,6 +47,7 @@ func TestStatsJSONKeysMatchTheDocumentedContract(t *testing.T) {
 		"longest_session": true, "busiest_day": true, "recall": true,
 		"week_recalls": true, "week_bytes": true, "week_injected": true,
 		"handoffs_received": true, "agent_credits": true, "week_agent_credits": true,
+		"used_not_credited": true, "week_used_not_credited": true,
 		"sidecar_size": true, "spans": true, "span_files": true,
 		// HarnessStats / ProjectStats / MonthStats
 		"harness": true, "sessions": true, "messages": true, "project": true, "month": true,

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -3,6 +3,7 @@
 package stats
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -46,7 +47,12 @@ type Report struct {
 	HandoffsIn       int            `json:"handoffs_received"`
 	AgentCredits     int            `json:"agent_credits"`
 	WeekCredits      int            `json:"week_agent_credits"`
-	SidecarSize      int64          `json:"sidecar_size,omitempty"`
+	// UsedNotCredited is the other half of the 2% (#3079): a reply that names
+	// a recalled session and does not say the line. An upper bound — see
+	// UsedNotCredited.
+	UsedNotCredited     int   `json:"used_not_credited"`
+	WeekUsedNotCredited int   `json:"week_used_not_credited"`
+	SidecarSize         int64 `json:"sidecar_size,omitempty"`
 	// Spans and SpanFiles are what `deja restore` can hand back: the exact
 	// bytes an agent replaced, which no other tool keeps. Filled by the
 	// caller, not by Build — replaced spans are deliberately kept out of
@@ -235,6 +241,7 @@ func Build(ss []model.Session, now time.Time) Report {
 	}
 	out.RepeatQuestions = RepeatQuestions(ss)
 	out.AgentCredits, out.WeekCredits = AgentCredits(ss, now)
+	out.UsedNotCredited, out.WeekUsedNotCredited = UsedNotCredited(ss, now)
 	for _, s := range ss {
 		for _, msg := range s.Messages {
 			if msg.Role != "user" {
@@ -504,6 +511,40 @@ func CreditedAloud(text string) bool {
 		return true
 	}
 	return strings.Contains(text, "deja:") && strings.Contains(strings.ToLower(text), "déjà vu")
+}
+
+// dejaSessionRef matches a session id named the way a recall block names one.
+// Eight characters of hex is the shortest prefix deja itself prints, and the
+// bound keeps an ordinary "deja:" in prose from counting as a reference.
+var dejaSessionRef = regexp.MustCompile(`deja:[0-9a-zA-Z][0-9a-zA-Z_.-]{7,}`)
+
+// UsedNotCredited counts assistant turns that name a recalled session without
+// saying the credit line — the second of the two things folded into the 2% in
+// #3079: injections the model used and did not credit, as opposed to
+// injections it rightly ignored.
+//
+// An upper bound, deliberately. The id is the evidence: a reply carrying
+// `deja:<id>` had the recall block in front of it. But a session *about* deja
+// quotes ids in prose, and on the machine that develops deja those turns are
+// counted here too. Read it as "at most this many", and the gap between it and
+// AgentCredits as the size of the question rather than as an answer.
+func UsedNotCredited(ss []model.Session, now time.Time) (total, week int) {
+	weekCut := usage.WeekCut(now)
+	for _, s := range ss {
+		for _, msg := range s.Messages {
+			if msg.Role != "assistant" || CreditedAloud(msg.Text) {
+				continue
+			}
+			if !dejaSessionRef.MatchString(msg.Text) {
+				continue
+			}
+			total++
+			if !msg.Time.IsZero() && msg.Time.After(weekCut) {
+				week++
+			}
+		}
+	}
+	return total, week
 }
 
 // AgentCredits counts, over the whole corpus and over the last week, the

--- a/internal/stats/used_not_credited_test.go
+++ b/internal/stats/used_not_credited_test.go
@@ -1,0 +1,47 @@
+package stats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// `stats --impact` said memory was credited aloud 143 times out of 6,650 and
+// nothing else: the 2% folds together injections the model rightly ignored and
+// injections it used without saying so, and only the second is a problem worth
+// wording changes (#3079). This counts the second, from the id the reply
+// carries.
+func TestUsedNotCreditedCountsTheRepliesThatNameASessionAndSayNothing(t *testing.T) {
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-30 * 24 * time.Hour)
+	fresh := now.Add(-24 * time.Hour)
+	ss := []model.Session{{
+		Harness: "claude", ID: "s1",
+		Messages: []model.Message{
+			// Credited: counted by AgentCredits, not here.
+			{Role: "assistant", Text: "déjà vu: the retry budget (claude, Aug 2, deja:abc12345) — reusing it.", Time: fresh},
+			// Used and not said: the id is in the reply, the line is not.
+			{Role: "assistant", Text: "the budget stays at five, from deja:abc12345", Time: fresh},
+			{Role: "assistant", Text: "as in deja:99ff0011, one shard", Time: old},
+			// Nothing to do with a recall.
+			{Role: "assistant", Text: "running the tests now", Time: fresh},
+			// A person quoting an id is not the agent crediting itself.
+			{Role: "user", Text: "look at deja:abc12345", Time: fresh},
+			// "deja:" with nothing that looks like a session id is prose.
+			{Role: "assistant", Text: "the deja: prefix is what the block uses", Time: fresh},
+		},
+	}}
+
+	total, week := UsedNotCredited(ss, now)
+	if total != 2 {
+		t.Fatalf("total = %d, want the two replies that named a session without the line", total)
+	}
+	if week != 1 {
+		t.Fatalf("week = %d, want only the recent one", week)
+	}
+	// And the credited reply still counts as credited, in the other counter.
+	if credits, _ := AgentCredits(ss, now); credits != 1 {
+		t.Fatalf("credits = %d, want the one reply that said the line", credits)
+	}
+}


### PR DESCRIPTION
Step 1 of #3079 — the measurement, not the wording.

The 2.2% credit rate folds together two different things: injections the model rightly ignored, and injections it used without crediting. Only the second is worth changing wording over, and an instruction that makes a model credit memory it did not use is worse than the 2%.

`stats --impact` now prints, beside "Credited aloud":

    Used, not said   at most 4 replies named a recalled session without the line (1 this week)

The evidence is the id: a reply carrying `deja:<id>` had the block in front of it. It is an upper bound and says so — a session *about* deja quotes ids in prose, which on the machine that develops deja is a real share. Read the two counters together as the size of the question.

`used_not_credited` and `week_used_not_credited` join the stats JSON and are documented.

Step 2 — trying a conditional wording on real agents and comparing credit rate per harness — stays open on the issue; this is what tells us whether it is worth running.