### PR TITLE
docs(bench): say that the context union row is a floor

### DIFF
--- a/cmd/deja/bench_context.go
+++ b/cmd/deja/bench_context.go
@@ -268,4 +268,9 @@ func printContextReport(w io.Writer, report contextReport) {
 		span := fmt.Sprintf("%.0f-%.0f", r.P10Tokens, r.P90Tokens)
 		fmt.Fprintf(w, "%-13s %-14.0f %-13s %-16.2f %.0f\n", name, r.MedianTokens, span, r.MedianCoverage, r.NegativeMedian)
 	}
+	// deja-recall is the union of the two surfaces below it, and each of them
+	// reaches the chain's facts on its own — so its coverage cannot fall until
+	// both are broken. Read the two halves for a regression; the union is a
+	// floor (#2931).
+	fmt.Fprintln(w, "deja-recall is the union of the two rows under it: its coverage only falls when both do — read those.")
 }

--- a/cmd/deja/bench_context_report_test.go
+++ b/cmd/deja/bench_context_report_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The union arm cannot fall until both surfaces under it do — each carries the
+// chain's facts alone, which is how four PR bodies came to cite "coverage 1.00
+// unchanged" as evidence about a digest that was emitting nothing (#2931). The
+// report says which rows to read instead.
+func TestTheContextReportSaysTheUnionRowIsAFloor(t *testing.T) {
+	report := contextReport{
+		Chains: 3, Negatives: 1,
+		Arms: map[string]contextArmReport{
+			"deja-recall": {MedianTokens: 563, MedianCoverage: 1},
+			"deja-digest": {MedianTokens: 294, MedianCoverage: 1},
+			"deja-block":  {MedianTokens: 269, MedianCoverage: 0.67},
+		},
+	}
+	var out bytes.Buffer
+	printContextReport(&out, report)
+	got := out.String()
+	for _, arm := range []string{"deja-recall", "deja-digest", "deja-block"} {
+		if !strings.Contains(got, arm) {
+			t.Fatalf("the %s row is missing:\n%s", arm, got)
+		}
+	}
+	if !strings.Contains(got, "union of the two rows under it") {
+		t.Fatalf("the report does not say the union row is a floor:\n%s", got)
+	}
+}


### PR DESCRIPTION
Follow-on to #2931, which is about the coverage column that could not go red.

The split into `deja-digest` and `deja-block` has landed, and it works — verified by the issue's own method, deleting half the arm and re-running:

    build                    deja-recall        deja-digest      deja-block
    main today               563 tok / 1.00     294 / 1.00       269 / 0.67
    PrintContext removed     269 / 0.67         0 / 0.00         269 / 0.67
    BuildAutoRecall removed  294 / 1.00         294 / 1.00       0 / 0.00

So a regression in either surface is now attributable, and `deja-block` sitting at 0.67 shows the column is not saturated. What has not changed is the union row: `deja-recall` still reads 1.00 with the block gone, because each surface reaches the facts alone. That is what the four PR bodies cited.

This adds one line under the table saying so, so nobody reads the union row as the signal again. Making the union able to move — direction 2 in the issue, a harder corpus — is not this.