### PR TITLE
docs(site): funes joins the day-zero table

### DIFF
--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -5,11 +5,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Day zero: what each memory tool knows the minute you install it — deja-vu</title>
-<meta name="description" content="Five memory tools on a machine with 19,195 coding-agent sessions already on disk, asked 100 questions only that history answers: build time, first answer, hit@1, install size.">
+<meta name="description" content="Six memory tools on a machine with 19,195 coding-agent sessions already on disk, asked 100 questions only that history answers: build time, first answer, hit@1, install size.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/day-zero.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="Day zero: what each memory tool knows the minute you install it">
-<meta property="og:description" content="Five memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
+<meta property="og:description" content="Six memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/day-zero.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -26,13 +26,13 @@
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
 <meta name="twitter:title" content="Day zero: what each memory tool knows the minute you install it">
-<meta name="twitter:description" content="Five memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
+<meta name="twitter:description" content="Six memory tools, one machine with 19,195 sessions already on disk, 100 questions only that history can answer.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
 <link rel="apple-touch-icon" href="../assets/icon.svg">
 <link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
 <link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
-<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Day zero","description":"Five memory tools installed on a machine with 19,195 coding-agent sessions already on disk, then asked 100 questions only that history can answer: build time, first answer, hit@1, install size.","url":"https://vshulcz.github.io/deja-vu/guide/day-zero.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Day zero","description":"Six memory tools installed on a machine with 19,195 coding-agent sessions already on disk, then asked 100 questions only that history can answer: build time, first answer, hit@1, install size.","url":"https://vshulcz.github.io/deja-vu/guide/day-zero.html","inLanguage":"en","author":{"@type":"Person","name":"vshulcz"},"publisher":{"@type":"Person","name":"vshulcz"},"mainEntityOfPage":{"@type":"WebPage","@id":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"},"isPartOf":{"@type":"WebSite","name":"deja-vu","url":"https://vshulcz.github.io/deja-vu/"}}</script>
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"deja-vu","item":"https://vshulcz.github.io/deja-vu/"},{"@type":"ListItem","position":2,"name":"Day zero","item":"https://vshulcz.github.io/deja-vu/guide/day-zero.html"}]}</script>
 <style>
 /* Full-width page: the matrix needs every pixel, so the sidebar folds into a top strip. */
@@ -127,7 +127,7 @@
 <h1>Day zero</h1>
 <p class="pagelede">what each memory tool knows the minute you install it<span class="mins" data-mins></span></p>
 <p>Every memory tool is measured warm: a store it has been filling for weeks, questions about what it captured. The minute after install is different. The machine already holds months of Claude Code, Codex and Cursor sessions, and the only question that matters that minute is whether a tool can answer from them at all, how long it takes to get there, and what it had to install to do it.</p>
-<p>This page runs that minute for five tools on one machine and one corpus. deja is the subject and I maintain it; the corpus, the drivers and the scoring rule are in the repository so the row you doubt can be re-run.</p>
+<p>This page runs that minute for six tools on one machine and one corpus. deja is the subject and I maintain it; the corpus, the drivers and the scoring rule are in the repository so the row you doubt can be re-run.</p>
 
 <h2>The setup</h2>
 <p>19,195 sessions from the LongMemEval-S cleaned set, written to disk in the real layouts — <code>~/.claude/projects/&lt;project&gt;/&lt;id&gt;.jsonl</code> and <code>~/.codex/sessions/&lt;date&gt;/rollout-&lt;id&gt;.jsonl</code> — before any tool is installed. 100 questions whose answer lives in exactly one of those sessions. A tool scores at rank <em>k</em> when the session holding the answer is the <em>k</em>-th result; hit@1 and hit@5 count ranks 0 and under 5, found@50 counts any rank in the first fifty. The control run points deja at an empty directory and scores 0/100, which is what a memory that only records forward sees on day zero.</p>
@@ -135,26 +135,27 @@
 
 <div class="cmpwrap">
 <table>
-<tr><th></th><th class="us">deja-vu</th><th>CASS</th><th>agentmemory</th><th>MemPalace</th><th>claude-mem</th></tr>
-<tr><td>Reads the history already on disk</td><td class="us y">✓ 23 agents, no capture step</td><td class="y">✓ 25+ agents</td><td class="y">✓ Claude Code JSONL import, ≤1000 files per call</td><td class="y">✓ <code>mine</code> per file tree</td><td class="n">— records from install on</td></tr>
-<tr><td>Install</td><td class="us y">18.6 MB binary</td><td>58.5 MB binary</td><td>689 MB npm + 28 MB engine</td><td>312 MB + 168 MB embedding model</td><td>npm + Claude Code plugin</td></tr>
-<tr><td>Runs in the background</td><td class="us y">nothing</td><td class="y">nothing</td><td>worker + engine, four ports</td><td>Chroma</td><td>worker</td></tr>
-<tr><td>Needs a model or key</td><td class="us y">no</td><td class="y">no</td><td>keyless mode: BM25 only</td><td>local embeddings</td><td>yes</td></tr>
-<tr><td>Build over 19,195 sessions</td><td class="us y">29 s</td><td>56 min</td><td>95 s</td><td>≈3 h</td><td class="n">—</td></tr>
-<tr><td>First answer after the build</td><td class="us y">24 ms</td><td>0.38 s</td><td>185 ms</td><td>4.5 s</td><td class="n">—</td></tr>
-<tr><td>Search latency, p50</td><td class="us y">155 ms</td><td>0.37 s</td><td>145 ms</td><td>2.6 s</td><td class="n">—</td></tr>
-<tr><td>hit@1 / 100</td><td class="us y">18</td><td>5 †</td><td>14</td><td>14</td><td class="n">0</td></tr>
-<tr><td>hit@5 / 100</td><td class="us y">35</td><td>8 †</td><td>34</td><td>20</td><td class="n">0</td></tr>
-<tr><td>found@50 / 100</td><td class="us y">67</td><td>16 †</td><td>65</td><td>46</td><td class="n">0</td></tr>
-<tr><td>Serves the agent by itself</td><td class="us y">✓ MCP, hooks at session start and before a tool runs</td><td>robot CLI, MCP</td><td class="y">✓ MCP, hooks</td><td class="y">✓ MCP, hooks</td><td class="y">✓ hooks</td></tr>
+<tr><th></th><th class="us">deja-vu</th><th>funes</th><th>CASS</th><th>agentmemory</th><th>MemPalace</th><th>claude-mem</th></tr>
+<tr><td>Reads the history already on disk</td><td class="us y">✓ 23 agents, no capture step</td><td class="y">✓ 4 agents</td><td class="y">✓ 25+ agents</td><td class="y">✓ Claude Code JSONL import, ≤1000 files per call</td><td class="y">✓ <code>mine</code> per file tree</td><td class="n">— records from install on</td></tr>
+<tr><td>Install</td><td class="us y">18.6 MB binary</td><td>binary + 1.1 GB of models on first recall</td><td>58.5 MB binary</td><td>689 MB npm + 28 MB engine</td><td>312 MB + 168 MB embedding model</td><td>npm + Claude Code plugin</td></tr>
+<tr><td>Runs in the background</td><td class="us y">nothing</td><td class="y">nothing</td><td class="y">nothing</td><td>worker + engine, four ports</td><td>Chroma</td><td>worker</td></tr>
+<tr><td>Needs a model or key</td><td class="us y">no</td><td>local embeddings + reranker</td><td class="y">no</td><td>keyless mode: BM25 only</td><td>local embeddings</td><td>yes</td></tr>
+<tr><td>Build over 19,195 sessions</td><td class="us y">29 s</td><td>2 h 3 min ‡</td><td>56 min</td><td>95 s</td><td>≈3 h</td><td class="n">—</td></tr>
+<tr><td>First answer after the build</td><td class="us y">24 ms</td><td>5.5 s (75 s with the models cold)</td><td>0.38 s</td><td>185 ms</td><td>4.5 s</td><td class="n">—</td></tr>
+<tr><td>Search latency, p50</td><td class="us y">155 ms</td><td>6.3 s</td><td>0.37 s</td><td>145 ms</td><td>2.6 s</td><td class="n">—</td></tr>
+<tr><td>hit@1 / 100</td><td class="us y">18</td><td>9 (19 with recency off)</td><td>5 †</td><td>14</td><td>14</td><td class="n">0</td></tr>
+<tr><td>hit@5 / 100</td><td class="us y">35</td><td>39 (46)</td><td>8 †</td><td>34</td><td>20</td><td class="n">0</td></tr>
+<tr><td>found@50 / 100</td><td class="us y">67</td><td>71 (71)</td><td>16 †</td><td>65</td><td>46</td><td class="n">0</td></tr>
+<tr><td>Serves the agent by itself</td><td class="us y">✓ MCP, hooks at session start and before a tool runs</td><td class="y">✓ MCP + per-turn hooks</td><td>robot CLI, MCP</td><td class="y">✓ MCP, hooks</td><td class="y">✓ MCP, hooks</td><td class="y">✓ hooks</td></tr>
 </table>
 </div>
 
 <p>† CASS is a keyword search: the question as typed returns nothing (a strict AND over every word, stop words included), so its row is the question with stop words removed — the only tool given anything but the question verbatim. The released 0.7.1 fails every query on this index with <code>Quill query fuel exhausted</code> (their #441, fixed on main after this was measured); the row is the main build. It also indexed both layouts as separate conversations, 38,394 in all.</p>
+<p>‡ funes 1.3.0 (Hugging Face, Rust, local bge-small embeddings and a bge-reranker), indexed with <code>funes index &lt;path&gt; --yes --no-thinking</code> on the same laptop: 308,580 chunks in 2 h 3 min. Its documented first run is a budgeted 60-second text pass, newest sessions first: after that minute it had 218 of the 19,195 sessions and answered 0 of 100. The accuracy row is with its defaults; the bracketed figures are <code>--half-life 0</code>, since the default 30-day recency weighting halves hit@1 on history this old. Measured September 7, 2026.</p>
 <p>Versions and dates: deja main at f2cebd6 with #3017, CASS 0.7.1 and main (38f0412, built from source), agentmemory @agentmemory/agentmemory 4.x from npm on Sep 2, MemPalace 0.9 line from uv on Sep 2, measured September 2–3, 2026 on an Apple Silicon laptop. The deja row is <code>go run ./scripts/day0bench -data longmemeval_s_cleaned.json -limit 100 -keep DIR</code>; the other rows are the drivers under <a href="https://github.com/vshulcz/deja-vu/tree/main/scripts/day0compare"><code>scripts/day0compare</code></a> run over <code>DIR</code>.</p>
 
 <h2>Reading the numbers</h2>
-<p>The absolute hit@1 is low for every tool because these are LongMemEval questions asked against nineteen thousand sessions rather than the fifty the benchmark ships per question, and a third of them are the kinds it is built to be hard on — preferences, multi-session aggregation. What separates the rows is not the ceiling. deja and agentmemory land within a point of each other on accuracy, both plain BM25 with no model; deja gets there in half a minute with nothing else running, agentmemory in a minute and a half with a worker and an engine up. MemPalace is a semantic store and pays for it twice here: an afternoon of mining with a model, and two and a half seconds a query, for fewer hits. CASS is the fastest indexer of the three that read history at all only if you count the release that cannot answer; the main build takes as long to index as MemPalace takes to mine a tenth of the pile, and it is a keyword tool that wants the question rewritten. claude-mem never gets there from this history; it starts recording at the first session after install.</p>
+<p>The absolute hit@1 is low for every tool because these are LongMemEval questions asked against nineteen thousand sessions rather than the fifty the benchmark ships per question, and a third of them are the kinds it is built to be hard on — preferences, multi-session aggregation. What separates the rows is not the ceiling. deja and agentmemory land within a point of each other on accuracy, both plain BM25 with no model; deja gets there in half a minute with nothing else running, agentmemory in a minute and a half with a worker and an engine up. funes is the one row that beats deja on ranking, once its recency weighting is switched off — a vector index plus a reranker finds the session at rank five for 46 questions against 35 — and it pays two hours of embedding on an Apple Silicon laptop and six seconds a query for it; with its defaults, on history older than a month, it finds half as many at rank one. After the one-minute first pass its documentation describes, it has one per cent of the sessions. MemPalace is a semantic store and pays for it twice here: an afternoon of mining with a model, and two and a half seconds a query, for fewer hits. CASS is the fastest indexer of the three that read history at all only if you count the release that cannot answer; the main build takes as long to index as MemPalace takes to mine a tenth of the pile, and it is a keyword tool that wants the question rewritten. claude-mem never gets there from this history; it starts recording at the first session after install.</p>
 <p>CASS and deja are the closest pair in intent — both index every agent's files, no model — and they split on what happens after the search: CASS is a search tool with a robot interface, deja hands the session to the agent on its own, at session start, before a file is edited, after a command fails. If you want a TUI over your history, CASS is the TUI. If you want the agent to already know, that is the part deja was built for.</p>
 
 <h2>What is not measured</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -464,7 +464,7 @@ footer a:hover{color:var(--ph-hi)}
         <a href="guide/privacy.html">Privacy</a> ·
         <a href="guide/benchmarks.html">Benchmarks</a> ·
         <a href="guide/compare.html">How it compares</a>
-<a href="guide/day-zero.html">Day zero: five memory tools, one machine with 19,195 sessions already on disk</a></p></div>
+<a href="guide/day-zero.html">Day zero: six memory tools, one machine with 19,195 sessions already on disk</a></p></div>
   </div>
   <p class="agents" style="margin-top:18px">
     <span><a href="guide/memory-for-claude-code.html">Claude Code</a></span>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -46,7 +46,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/privacy.html</loc><lastmod>2026-07-21</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/benchmarks.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/compare.html</loc><lastmod>2026-07-23</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/day-zero.html</loc><lastmod>2026-09-03</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/day-zero.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/README.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/aider.html</loc><lastmod>2026-07-27</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/registry/antigravity.html</loc><lastmod>2026-07-17</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>

--- a/scripts/day0compare/README.md
+++ b/scripts/day0compare/README.md
@@ -19,8 +19,12 @@ rule, so the numbers on the site's day-zero page can be reproduced end to end.
        CASS=/path/to/cass python3 scripts/day0compare/cass.py /tmp/day0
        AGENTMEMORY=/path/to/agentmemory python3 scripts/day0compare/agentmemory.py /tmp/day0
        MEMPALACE=mempalace python3 scripts/day0compare/mempalace.py /tmp/day0
+       FUNES=funes python3 scripts/day0compare/funes.py /tmp/day0 [--half-life 0]
 
-   agentmemory needs its worker running first (`agentmemory` with
+   funes indexes the Claude layout in full (`funes index <path> --yes`, about
+   two hours of local embedding for 19k sessions); its first recall downloads
+   ~1.1 GB of models, and the header shortens session ids, so the driver reads
+   the full id from the `→ get` line. agentmemory needs its worker running first (`agentmemory` with
    `HOME`/`AGENTMEMORY_DATA_DIR` set) and imports in batches of at most 1000
    files, its own cap; the driver builds the batches. MemPalace mines the
    Claude layout only — the sessions are the same files under both roots.

--- a/scripts/day0compare/funes.py
+++ b/scripts/day0compare/funes.py
@@ -1,0 +1,48 @@
+# Score Hugging Face funes over the day0bench corpus: `funes index` the Claude
+# layout (the same sessions sit under both roots), then run every question
+# through `funes recall` and look for the answer session's id in the result
+# headers, in rank order. Usage:
+#   FUNES=/path/to/funes python3 funes.py <keep-dir> [--half-life N]
+# The header line of a hit shortens the id to eight characters; the full one
+# is on the line under it:
+#   → get answer_355c48bb --from 0 --to 3 --memory …
+import json, os, re, subprocess, sys, time
+S = sys.argv[1]
+FUNES = os.environ.get('FUNES', 'funes')
+half = None
+if '--half-life' in sys.argv:
+    half = sys.argv[sys.argv.index('--half-life') + 1]
+home = os.path.join(S, 'home')
+env = dict(os.environ, HOME=home)
+corpus = os.path.join(home, '.claude', 'projects')
+memory = os.path.join(home, '.funes', 'memory')
+t0 = time.time()
+if not os.path.exists(memory):
+    r = subprocess.run([FUNES, 'index', corpus, '--harness', 'claude', '--yes', '--no-thinking'],
+                       capture_output=True, text=True, env=env)
+    print('index rc', r.returncode, (r.stdout + r.stderr)[-400:])
+build = time.time() - t0
+qs = json.load(open(os.path.join(S, 'questions.json')))
+hit1 = hit5 = found = 0; first = None; lat = []
+head = re.compile(r'^\s*→ get (\S+) --from', re.M)
+for q in qs:
+    args = [FUNES, 'recall', q['question'], '-k', '50', '--candidates', '50']
+    if half is not None:
+        args += ['--half-life', half]
+    t1 = time.time()
+    r = subprocess.run(args, capture_output=True, text=True, env=env)
+    dt = time.time() - t1; lat.append(dt)
+    if first is None: first = dt
+    want = set(q['answer_session_ids'])
+    order = []
+    for m in head.finditer(r.stdout):
+        sid = m.group(1)
+        if sid not in order: order.append(sid)
+    rank = next((k for k, sid in enumerate(order) if sid in want), None)
+    if rank is not None:
+        found += 1
+        if rank == 0: hit1 += 1
+        if rank < 5: hit5 += 1
+lat.sort()
+print(f'funes index {build:.0f}s first {first*1000:.0f}ms p50 {lat[len(lat)//2]*1000:.0f}ms '
+      f'hit@1 {hit1}/{len(qs)} hit@5 {hit5}/{len(qs)} found@50 {found}/{len(qs)} half-life {half or "default"}')


### PR DESCRIPTION
A funes column on the day-zero page, measured on the same 19,195-session corpus and rule as the other rows (the deja row was reproduced first), with both accuracy readings — defaults and recency off — and the minute-one result; scripts/day0compare/funes.py next to the other drivers; the page and the home link now count six tools.

Closes #3147
