### PR TITLE
feat(continue): wire Continue — MCP server, skill and slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ harness supports, aider's read-only context file, and the Windows `cmd /c deja m
 <details>
 <summary>What gets written into each agent's own guidance file</summary>
 
-Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, opencode, Gemini CLI, Antigravity, Qwen, Kimi Code, pi, Copilot, VS Code Copilot Chat, Cursor, Goose, OpenClaw, Hermes, Roo Code, omp, Amp, prime-agent, DeepSeek Harness and Zed each get it in their own guidance file (or under the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Grok Build gets the shared skill in `~/.agents/skills`, which is what it reads; the `~/.grok/GROK.md` written beside it is for the unrelated community CLI that shares that directory. Cursor has no user-level instructions file, so it gets a skill at `~/.cursor/skills/` instead, read only when something looks relevant rather than every session.
+Install also writes user-level guidance for the harnesses it detects: Claude Code, Codex, opencode, Gemini CLI, Antigravity, Qwen, Kimi Code, pi, Copilot, VS Code Copilot Chat, Cursor, Goose, OpenClaw, Hermes, Roo Code, omp, Amp, prime-agent, DeepSeek Harness, Continue and Zed each get it in their own guidance file (or under the configured `XDG_CONFIG_HOME`). Re-run rewrites deja's skill or marked block without changing surrounding user content. Use `deja install --all --no-guidance` to opt out; Grok Build gets the shared skill in `~/.agents/skills`, which is what it reads; the `~/.grok/GROK.md` written beside it is for the unrelated community CLI that shares that directory. Cursor has no user-level instructions file, so it gets a skill at `~/.cursor/skills/` instead, read only when something looks relevant rather than every session.
 
 </details>
 
@@ -265,7 +265,7 @@ aider &middot; Amp &middot; Antigravity &middot; Claude Code &middot; Cline &mid
 | omp (Oh My Pi) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | OpenClaw | ✅ | ✅ | ✅ | ✅ | ✅ | paste | — |
 | opencode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | sqlite3 |
-| Continue | — | ✕ | — | — | ✕ | paste | — |
+| Continue | ✅ | ⚠ | ✅ | ✅ | — | paste | — |
 | pi | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | prime-agent (PrimeIntellect) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
 | Qwen Code | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |

--- a/cmd/deja/capability_drift_test.go
+++ b/cmd/deja/capability_drift_test.go
@@ -142,6 +142,10 @@ func TestCapabilityRegistryMatchesCode(t *testing.T) {
 		case "goose":
 			// Goose declares commands in config.yaml, not a commands directory.
 			gotCommand = strings.Contains(gooseRecipe("/bin/deja"), "title: deja")
+		case "continue":
+			// Continue declares its slash commands in the assistant config, as
+			// `prompts:`, so the artifact to read is the config deja writes.
+			gotCommand = strings.Contains(continueInstalledConfig(t, "/bin/deja"), "- name: deja")
 		case "antigravity", "openclaw", "codex", "qwen", "kimi", "copilot", "grok", "zed":
 			// These make a skill invocable by name, so the skill deja installs
 			// is the command and a second file would only add another entry.

--- a/cmd/deja/continue_yaml_probe_test.go
+++ b/cmd/deja/continue_yaml_probe_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A probe on the two string helpers, so a failure says which one moved the
+// text rather than only that the file came out wrong.
+func TestContinueYAMLHelpers(t *testing.T) {
+	doc := "name: mine\nmcpServers:\n  - name: sqlite\n    command: uvx\nrules:\n  - be brief\n"
+	got := appendYAMLListItem(doc, "mcpServers", "  - name: deja\n    command: /bin/deja\n")
+	want := "name: mine\nmcpServers:\n  - name: sqlite\n    command: uvx\n  - name: deja\n    command: /bin/deja\nrules:\n  - be brief\n"
+	if got != want {
+		t.Fatalf("append put the item in the wrong place:\n--- got ---\n%s--- want ---\n%s", got, want)
+	}
+	back := removeContinueItem(got, "mcpServers", "deja")
+	if back != doc {
+		t.Fatalf("remove did not put the file back:\n--- got ---\n%q\n--- want ---\n%q", back, doc)
+	}
+	// A file with no such key gets one.
+	fresh := appendYAMLListItem("name: mine\n", "prompts", "  - name: deja\n")
+	if fresh != "name: mine\nprompts:\n  - name: deja\n" {
+		t.Fatalf("append did not write the missing key:\n%q", fresh)
+	}
+	// And the key at the end of the file, with no line after it.
+	tail := appendYAMLListItem("name: mine\nprompts:\n  - name: other\n", "prompts", "  - name: deja\n")
+	if !strings.HasSuffix(tail, "  - name: other\n  - name: deja\n") {
+		t.Fatalf("append at the end of the file:\n%q", tail)
+	}
+}

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1250,6 +1250,7 @@ func doctorMCPConfigs() []doctorMCPConfig {
 		{"vscode", doctorVSCodeMCPPath(), doctorJSONWired("servers"), doctorJSONDejaKeys("servers")},
 		{"hermes", filepath.Join(sources.HermesHome(), "config.yaml"), doctorHermesWired, nil},
 		{"goose", filepath.Join(gooseConfigDir(), "config.yaml"), doctorGooseWired, nil},
+		{"continue", continueConfigPath(), doctorContinueWired, nil},
 		{"zed", sources.ZedSettingsPath(), doctorZedWired, nil},
 	}
 }

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -141,6 +141,17 @@ func doctorHermesWired(path string) bool {
 	return yamlHasChildKey(path, "mcp_servers:", "deja:")
 }
 
+// Continue keys its servers by a name field inside a list item rather than by a
+// key, so the child-key check above has nothing to look for: the row asks
+// whether an item under mcpServers names deja.
+func doctorContinueWired(path string) bool {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return removeContinueItem(string(b), "mcpServers", "deja") != string(b)
+}
+
 // yamlHasChildKey reports whether a key sits directly under a top-level parent.
 //
 // The indent is whatever the reader wrote the block at, and asking for exactly

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -95,6 +95,11 @@ func guidancePath(harness string) string {
 		// guidance missing on a machine where the skill was installed and
 		// working.
 		return filepath.Join(antigravityConfigHome(), "plugins", antigravityPluginName, "skills", "deja-history", "SKILL.md")
+	case "continue":
+		// Continue reads skills from its global folder, and what lands there is
+		// named in the `Skills` tool's own description — in front of the model
+		// on every turn, which is what makes recall arrive unasked (#3062).
+		return continueSkillPath()
 	case "copilot":
 		return filepath.Join(homeDir(), ".copilot", "skills", "deja-history", "SKILL.md")
 	case "pi":
@@ -651,7 +656,7 @@ func guidanceOwnsWholeFile(harness string) bool {
 		return true
 	}
 	switch harness {
-	case "claude-code", "claude", "antigravity", "copilot", "pi", "opencode", "hermes", "vscode":
+	case "claude-code", "claude", "antigravity", "copilot", "pi", "opencode", "hermes", "vscode", "continue":
 		return true
 	}
 	return false

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -726,6 +726,8 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 			return installResult{}, err
 		}
 		return installClineAuto(exe, uninstall)
+	case "continue":
+		return installContinue(exe, uninstall)
 	case "copilot":
 		return installCopilotMCP(exe, uninstall)
 	case "vscode", "copilot-chat":
@@ -3641,6 +3643,10 @@ func installTargetNames() []string {
 		"cline", "cline-auto",
 		"goose", "goose-auto",
 		"grok", "grok-auto", "copilot", "roo", "aider",
+		// Continue keeps the server and the slash command in one assistant
+		// config, and its skill in the folder beside it; there is no hook to
+		// wire, so there is nothing an -auto target would add (#3062).
+		"continue",
 		// VS Code Copilot Chat takes MCP servers and nothing else an outside CLI
 		// can reach — no hook, no plugin — so there is no -auto pair.
 		"vscode",

--- a/cmd/deja/install_continue.go
+++ b/cmd/deja/install_continue.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Continue keeps one assistant config, and both surfaces deja can reach live in
+// it: `mcpServers:` is where the tool comes from, and `prompts:` is where a
+// slash command does. Both are sequences of mappings rather than the keyed
+// objects most harnesses use, so the writer appends an item and finds ours
+// again by its name.
+//
+// Measured on @continuedev/cli 1.5.47 against a recording endpoint: with the
+// server in this file, `deja` is in the tool list of every request, and a
+// scripted call came back with the seeded decision in the bytes Continue sent
+// next. Continue's hooks system — Claude-shaped, Claude's own event set — is in the
+// bundle and loads a config from ~/.continue/settings.json, but nothing fires
+// it in that release: hooks written for every event produced no process and no
+// additionalContext, while the same run's tool call went through. It becomes
+// work the day a release fires them (#3062).
+func continueConfigPath() string {
+	return filepath.Join(sources.ContinueRoot(), "config.yaml")
+}
+
+// continueSkillPath is where Continue reads skills from: the global folder's
+// skills directory. What lands there is named in the `Skills` tool's own
+// description, so it is in front of the model on every turn — which is what
+// makes recall arrive without being asked for.
+func continueSkillPath() string {
+	return filepath.Join(sources.ContinueRoot(), "skills", "deja-history", "SKILL.md")
+}
+
+const continuePromptBody = "Search this machine's past AI coding sessions with the deja tool " +
+	"(mode: recall) and answer from what it returns. The query is everything after the command; " +
+	"an exact error, a function name or a path is the strongest one."
+
+func installContinue(exe string, uninstall bool) (installResult, error) {
+	path := continueConfigPath()
+	old, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return installResult{}, err
+	}
+	body, crlf := normaliseNewlines(string(old))
+	next := removeContinueItem(body, "mcpServers", "deja")
+	next = removeContinueItem(next, "prompts", "deja")
+	next = dropEmptyYAMLKey(next, "mcpServers:")
+	next = dropEmptyYAMLKey(next, "prompts:")
+
+	if !uninstall {
+		cmd, args := mcpCommandArgs(exe)
+		var server strings.Builder
+		fmt.Fprintf(&server, "  - name: deja\n    command: %s\n    args:\n", yamlQuote(cmd))
+		for _, a := range args {
+			fmt.Fprintf(&server, "      - %s\n", yamlQuote(a))
+		}
+		var prompt strings.Builder
+		fmt.Fprintf(&prompt, "  - name: deja\n    description: Search this machine's past coding sessions\n")
+		fmt.Fprintf(&prompt, "    prompt: %s\n", yamlQuote(continuePromptBody))
+
+		for _, add := range []struct{ key, item string }{
+			{"mcpServers", server.String()},
+			{"prompts", prompt.String()},
+		} {
+			// An inline value — `prompts: []` — is not a block, and appending
+			// under it would leave the key twice, of which a parser takes one.
+			// The goose writer refuses the same shape for the same reason.
+			if v := inlineYAMLValue(next, add.key+":"); v != "" {
+				return installResult{}, fmt.Errorf("%s: %s: %s is on one line, and deja edits the block form — move it to a block and run this again", shortHome(path), add.key, v)
+			}
+			next = appendYAMLListItem(next, add.key, add.item)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return installResult{}, err
+	}
+	next = keepTrailingNewline(string(old), next)
+	if crlf {
+		next = strings.ReplaceAll(next, "\n", "\r\n")
+	}
+	a, err := writeIfChanged(path, old, []byte(next))
+	return installResult{Path: path, Action: a}, err
+}
+
+// appendYAMLListItem puts item at the end of key's block, or writes the key
+// with it when the file has none.
+func appendYAMLListItem(text, key, item string) string {
+	head := "\n" + key + ":\n"
+	at := strings.Index("\n"+text, head)
+	if at < 0 {
+		if text != "" && !strings.HasSuffix(text, "\n") {
+			text += "\n"
+		}
+		return text + key + ":\n" + item
+	}
+	start := at + len(head) - 1
+	end := yamlBlockEnd(text, start)
+	return text[:end] + item + text[end:]
+}
+
+// yamlBlockEnd is where the indented block that starts at from ends: the first
+// line after it that is neither indented nor blank.
+func yamlBlockEnd(text string, from int) int {
+	i := from
+	for i < len(text) {
+		nl := strings.IndexByte(text[i:], '\n')
+		line := text[i:]
+		if nl >= 0 {
+			line = text[i : i+nl]
+		}
+		if strings.TrimSpace(line) != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			return i
+		}
+		if nl < 0 {
+			return len(text)
+		}
+		i += nl + 1
+	}
+	return len(text)
+}
+
+// removeContinueItem drops the list item under key whose mapping opens with the
+// given name. Ours is found by the name rather than by a marker comment,
+// because that is the field Continue itself keys these lists by.
+func removeContinueItem(text, key, name string) string {
+	head := "\n" + key + ":\n"
+	at := strings.Index("\n"+text, head)
+	if at < 0 {
+		return text
+	}
+	start := at + len(head) - 1
+	end := yamlBlockEnd(text, start)
+	block := text[start:end]
+	lines := strings.Split(block, "\n")
+	var kept []string
+	dropping := false
+	dash := ""
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		isItem := strings.HasPrefix(trimmed, "- ")
+		if dropping {
+			// The item runs until the next item at the same indent, until
+			// something less indented, or until the block ends. A blank line
+			// is the end of it too — deja writes none inside its own item, and
+			// treating one as part of it swallowed the newline the next key
+			// needed.
+			switch {
+			case trimmed == "":
+				dropping = false
+			case isItem && yamlIndentOf(line) <= len(dash):
+				dropping = false
+			case yamlIndentOf(line) <= len(dash):
+				dropping = false
+			default:
+				continue
+			}
+		}
+		if isItem && strings.HasPrefix(trimmed, "- name: ") &&
+			strings.TrimSpace(strings.TrimPrefix(trimmed, "- name:")) == name {
+			dropping = true
+			dash = strings.Repeat(" ", yamlIndentOf(line))
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return text[:start] + strings.Join(kept, "\n") + text[end:]
+}
+
+func yamlIndentOf(line string) int {
+	return len(line) - len(strings.TrimLeft(line, " \t"))
+}

--- a/cmd/deja/install_continue_test.go
+++ b/cmd/deja/install_continue_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// continueInstalledConfig runs the installer against an empty home and returns
+// the config it wrote — the artifact, not a description of it.
+func continueInstalledConfig(t *testing.T, exe string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CONTINUE_ROOT", filepath.Join(home, ".continue"))
+	t.Setenv("CONTINUE_GLOBAL_DIR", "")
+	if _, err := installContinue(exe, false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, ".continue", "config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// Continue keeps the MCP server and the slash command in the same assistant
+// config, both as sequences of mappings rather than the keyed objects every
+// other harness uses. Measured on @continuedev/cli 1.5.47: with this entry the
+// `deja` tool is in the tool list of every request (#3062).
+func TestInstallContinueWritesTheServerAndTheCommand(t *testing.T) {
+	got := continueInstalledConfig(t, "/usr/local/bin/deja")
+	for _, want := range []string{
+		"mcpServers:",
+		"  - name: deja",
+		"command: \"/usr/local/bin/deja\"",
+		"      - \"mcp\"",
+		"prompts:",
+		"description: Search this machine's past coding sessions",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("the config does not carry %q:\n%s", want, got)
+		}
+	}
+	// Two items, one under each key — not one key with both.
+	if n := strings.Count(got, "- name: deja"); n != 2 {
+		t.Fatalf("deja is named %d times, want once under each key:\n%s", n, got)
+	}
+}
+
+// The config is the reader's own file: whatever else is in it survives, and a
+// second install neither doubles the entry nor moves anything.
+func TestInstallContinueKeepsTheRestOfTheConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, ".continue")
+	t.Setenv("DEJA_CONTINUE_ROOT", root)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "config.yaml")
+	before := `name: mine
+version: 0.0.1
+models:
+  - name: sonnet
+    provider: anthropic
+    model: claude-sonnet-4
+mcpServers:
+  - name: sqlite
+    command: uvx
+    args:
+      - mcp-server-sqlite
+rules:
+  - be brief
+`
+	if err := os.WriteFile(path, []byte(before), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installContinue("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFileString(t, path)
+	for _, want := range []string{"name: mine", "- name: sonnet", "- name: sqlite", "- mcp-server-sqlite", "rules:", "  - be brief"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("the reader's own config lost %q:\n%s", want, got)
+		}
+	}
+	// deja's server joins the list rather than replacing it.
+	if strings.Index(got, "- name: sqlite") > strings.Index(got, "- name: deja") {
+		t.Fatalf("deja was inserted ahead of the reader's own server:\n%s", got)
+	}
+
+	if _, err := installContinue("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	twice := readFileString(t, path)
+	if strings.Count(twice, `command: "/bin/deja"`) != 1 {
+		t.Fatalf("a second install doubled the entry:\n%s", twice)
+	}
+
+	// And the way out leaves the file as it was found.
+	if _, err := installContinue("/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	after := readFileString(t, path)
+	if strings.Contains(after, "deja") {
+		t.Fatalf("uninstall left deja behind:\n%s", after)
+	}
+	if !strings.Contains(after, "- name: sqlite") || !strings.Contains(after, "  - be brief") {
+		t.Fatalf("uninstall took something that was not deja's:\n%s", after)
+	}
+}
+
+// A binary path moves; the entry has to move with it rather than doubling.
+func TestInstallContinueAdoptsAMovedBinary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_CONTINUE_ROOT", filepath.Join(home, ".continue"))
+	if _, err := installContinue("/old/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installContinue("/new/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	got := readFileString(t, filepath.Join(home, ".continue", "config.yaml"))
+	if strings.Contains(got, "/old/deja") {
+		t.Fatalf("the old path is still there:\n%s", got)
+	}
+	if strings.Count(got, `command: "/new/deja"`) != 1 {
+		t.Fatalf("the moved binary is not named once:\n%s", got)
+	}
+}
+
+// An inline list is not a block, and appending under it would leave the key
+// twice — of which a parser takes one, silently dropping the reader's servers.
+// The goose writer refuses the same shape for the same reason.
+func TestInstallContinueRefusesAnInlineList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, ".continue")
+	t.Setenv("DEJA_CONTINUE_ROOT", root)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(path, []byte("name: mine\nmcpServers: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installContinue("/bin/deja", false); err == nil {
+		t.Fatal("an inline list was edited anyway")
+	}
+	if got := readFileString(t, path); !strings.Contains(got, "mcpServers: []") {
+		t.Fatalf("the refused file was changed:\n%s", got)
+	}
+}
+
+// Continue reads skills from its own global folder and names each one in the
+// Skills tool's description — that is the surface that makes recall arrive
+// without being asked for, so the file has to land there and nowhere else.
+func TestContinueSkillLandsWhereContinueReadsIt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	root := filepath.Join(home, ".continue")
+	t.Setenv("DEJA_CONTINUE_ROOT", root)
+	want := filepath.Join(root, "skills", "deja-history", "SKILL.md")
+	if got := guidancePath("continue"); got != want {
+		t.Fatalf("guidance path = %q, want %q", got, want)
+	}
+	if _, err := installGuidance("continue", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("the skill was not written where Continue reads: %v", err)
+	}
+	for _, line := range []string{"name: deja-history", "description:"} {
+		if !strings.Contains(string(b), line) {
+			t.Fatalf("the skill has no %q, so Continue lists nothing:\n%s", line, b)
+		}
+	}
+}

--- a/cmd/deja/readme_guidance_claims_test.go
+++ b/cmd/deja/readme_guidance_claims_test.go
@@ -33,6 +33,7 @@ var readmeGuidanceNames = map[string]string{
 	"prime":       "prime-agent",
 	"deepseek":    "DeepSeek Harness",
 	"zed":         "Zed",
+	"continue":    "Continue",
 	"vscode":      "VS Code Copilot Chat",
 	// Grok is named in its own sentence in the same paragraph, because the
 	// home copy only applies when a project has no .grok/GROK.md.

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -329,6 +329,11 @@
       "path": "<tmp>/home/.config/goose/config.yaml"
     },
     {
+      "name": "continue",
+      "state": "config-missing",
+      "path": "<tmp>/home/.continue/config.yaml"
+    },
+    {
       "name": "zed",
       "state": "config-missing",
       "path": "<tmp>/home/.config/zed/settings.json"

--- a/docs/guide/after-compaction.html
+++ b/docs/guide/after-compaction.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/agents.html
+++ b/docs/guide/agents.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/auditing-agents.html
+++ b/docs/guide/auditing-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/benchmarks.html
+++ b/docs/guide/benchmarks.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/compare.html
+++ b/docs/guide/compare.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -100,6 +100,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/context-window-full.html
+++ b/docs/guide/context-window-full.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/day-zero.html
+++ b/docs/guide/day-zero.html
@@ -81,7 +81,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -100,6 +100,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/does-my-agent-remember.html
+++ b/docs/guide/does-my-agent-remember.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -73,6 +73,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/export-conversations.html
+++ b/docs/guide/export-conversations.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/find-a-session.html
+++ b/docs/guide/find-a-session.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/forgetting.html
+++ b/docs/guide/forgetting.html
@@ -54,7 +54,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -73,6 +73,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/getting-started.html
+++ b/docs/guide/getting-started.html
@@ -53,7 +53,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -72,6 +72,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/harnesses.html
+++ b/docs/guide/harnesses.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>
@@ -117,7 +118,7 @@
 <tr><td><a href="../registry/omp.html">omp (Oh My Pi)</a></td><td><code>${DEJA_OMP_ROOT:-~/.omp/agent/sessions}/**/*.jsonl</code><br><code>~/.omp/profiles/*/agent/sessions/**/*.jsonl</code><br><code>${XDG_DATA_HOME}/omp/sessions/**/*.jsonl</code><br><code>${XDG_DATA_HOME}/omp/profiles/*/sessions/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td><a href="../registry/openclaw.html">OpenClaw</a></td><td><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/agent/openclaw-agent.sqlite</code><br><code>${OPENCLAW_STATE_DIR:-~/.openclaw}/agents/*/sessions/*.jsonl</code><br><code>${DEJA_OPENCLAW_ROOT}/*/agent/openclaw-agent.sqlite</code><br><code>${DEJA_OPENCLAW_ROOT}/*/sessions/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>paste</td><td>—</td></tr>
 <tr><td><a href="../registry/opencode.html">opencode</a></td><td><code>~/.local/share/opencode/opencode.db</code><br><code>${XDG_DATA_HOME}/opencode/opencode.db</code><br><code>${DEJA_OPENCODE_DB}</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>sqlite3</td></tr>
-<tr><td><a href="../registry/continue.html">Continue</a></td><td><code>${CONTINUE_GLOBAL_DIR:-~/.continue}/sessions/*.json</code><br><code>${DEJA_CONTINUE_ROOT}/sessions/*.json</code></td><td>—</td><td>✕</td><td>—</td><td>—</td><td>✕</td><td>paste</td><td>—</td></tr>
+<tr><td><a href="../registry/continue.html">Continue</a></td><td><code>${CONTINUE_GLOBAL_DIR:-~/.continue}/sessions/*.json</code><br><code>${DEJA_CONTINUE_ROOT}/sessions/*.json</code></td><td>✅</td><td>⚠</td><td>✅</td><td>✅</td><td>—</td><td>paste</td><td>—</td></tr>
 <tr><td><a href="../registry/pi.html">pi</a></td><td><code>${DEJA_PI_ROOT:-~/.pi/agent/sessions}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td><a href="../registry/prime.html">prime-agent (PrimeIntellect)</a></td><td><code>${DEJA_PRIME_ROOT:-~/.prime/agent/sessions}/**/*.jsonl</code><br><code>${PRIME_AGENT_SESSION_DIR}/**/*.jsonl</code><br><code>${PRIME_AGENT_CODING_AGENT_SESSION_DIR}/**/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
 <tr><td><a href="../registry/qwen.html">Qwen Code</a></td><td><code>${DEJA_QWEN_ROOT:-~/.qwen}/projects/*/chats/*.jsonl</code></td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>✅</td><td>—</td></tr>
@@ -131,7 +132,7 @@
 <li>aider <code>command</code> — the slash command set is built in; adding custom commands is an open feature request upstream, not something a third party can wire today (https://github.com/Aider-AI/aider/issues/894)</li>
 <li>Copilot CLI <code>auto</code> — Copilot runs the hooks but drops their context, so recall there is MCP plus the skill</li>
 <li>VS Code Copilot Chat <code>auto</code> — VS Code Copilot Chat has no session-start or per-prompt hook, so there is nothing to install</li>
-<li>Continue <code>auto</code> — Continue has no session-start, per-prompt or tool hook — there is no event deja could answer</li>
+<li>Continue <code>auto</code> — Continue&#39;s CLI carries a Claude-shaped hooks system — Claude&#39;s own event set, additionalContext, settings read from ~/.continue/settings.json — and nothing fires it in the published release: measured on @continuedev/cli 1.5.47, hooks written for every event loaded (&#34;Hooks loaded: 8 handler(s)&#34; in its own log) and no handler ran, while the same run&#39;s tool call went through. Becomes work the day a release fires them (https://github.com/continuedev/continue/tree/main/extensions/cli/src/hooks)</li>
 <li>Roo Code <code>auto</code> — Roo&#39;s hooks are in flight upstream, not shipped: PR #10785 implements a Claude Code-style hooks system, #11128 is Hooks beta and #11663 Hooks phase 1, all still open, and no release names lifecycle hooks. A user&#39;s bug report about PreToolUse coverage (#10834) shows they work on a branch build. Becomes work the day one of those merges (https://github.com/RooCodeInc/Roo-Code/pull/10785)</li>
 <li>Zed <code>auto</code> — Zed&#39;s agent exposes no lifecycle hook: nothing runs before a prompt is sent, and the extension API covers language servers, slash commands, context servers and debuggers only, so there is no point at which recall could be injected. Becomes work the day Zed ships one (no hook API in Zed 1.16.1 or extension API 0.7)</li>
 </ul><!-- matrix:end -->

--- a/docs/guide/lost-context.html
+++ b/docs/guide/lost-context.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html" aria-current="page">Lost context</a>

--- a/docs/guide/memory-for-amp.html
+++ b/docs/guide/memory-for-amp.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html" aria-current="page">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cline.html
+++ b/docs/guide/memory-for-cline.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-continue.html
+++ b/docs/guide/memory-for-continue.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+<script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Memory for Continue: recall across Claude Code, Codex and the rest — deja-vu</title>
+<meta name="description" content="Continue has no hook that fires yet, so deja arrives as an MCP server in its assistant config, a skill it names on every turn, and a /deja command.">
+<link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Adding memory to Continue">
+<meta property="og:description" content="Continue has no hook that fires yet, so deja arrives as an MCP server in its assistant config, a skill it names on every turn, and a /deja command.">
+<meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html">
+<meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="icon" type="image/svg+xml" sizes="16x16" href="../assets/favicon.svg">
+<link rel="icon" type="image/svg+xml" sizes="any" href="../assets/icon.svg">
+<link rel="stylesheet" href="../assets/site.css">
+
+<meta name="author" content="vshulcz">
+<meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1">
+<meta name="theme-color" content="#0d0b16">
+<meta name="color-scheme" content="dark light">
+<meta property="og:site_name" content="deja-vu">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="640">
+<meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
+<meta name="twitter:title" content="Adding memory to Continue">
+<meta name="twitter:description" content="Continue has no hook that fires yet, so deja arrives as an MCP server in its assistant config, a skill it names on every turn, and a /deja command.">
+<meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
+<meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">
+<link rel="apple-touch-icon" href="../assets/icon.svg">
+<link rel="sitemap" type="application/xml" href="https://vshulcz.github.io/deja-vu/sitemap.xml">
+<link rel="describedby" type="text/markdown" href="https://vshulcz.github.io/deja-vu/llms.txt">
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "TechArticle", "headline": "Adding memory to Continue", "description": "Continue has no hook that fires yet, so deja arrives as an MCP server in its assistant config, a skill it names on every turn, and a /deja command.", "url": "https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html", "inLanguage": "en", "author": {"@type": "Person", "name": "vshulcz"}, "publisher": {"@type": "Person", "name": "vshulcz"}, "mainEntityOfPage": {"@type": "WebPage", "@id": "https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html"}, "isPartOf": {"@type": "WebSite", "name": "deja-vu", "url": "https://vshulcz.github.io/deja-vu/"}}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "deja-vu", "item": "https://vshulcz.github.io/deja-vu/"}, {"@type": "ListItem", "position": 2, "name": "Memory for Continue", "item": "https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [{"@type": "Question", "name": "Does Continue remember previous sessions?", "acceptedAnswer": {"@type": "Answer", "text": "It writes every session to ~/.continue/sessions and can reopen the last one, but a new session reads none of the others."}}, {"@type": "Question", "name": "How do I add memory to Continue?", "acceptedAnswer": {"@type": "Answer", "text": "deja install continue adds the deja MCP server and a /deja command to ~/.continue/config.yaml and writes a skill into ~/.continue/skills, which Continue names in its Skills tool on every turn."}}, {"@type": "Question", "name": "Can Continue see what I did in Claude Code or Codex?", "acceptedAnswer": {"@type": "Answer", "text": "Yes, once deja is installed: the index covers the transcripts of twenty-four agents on the machine, including sessions from before deja was installed."}}]}</script>
+</head>
+<body>
+<div class="glow"></div>
+<nav><a class="brand" href="../"><img src="../assets/icon.svg" alt="" width="22" height="22">deja-vu</a><span class="spacer"></span><a class="lnk" href="../">Home</a><a class="lnk" href="getting-started.html">Docs</a><a class="lnk" href="https://github.com/vshulcz/deja-vu">GitHub</a></nav>
+<div class="wrap"><div class="doc">
+<aside><a href="../">← deja-vu</a><div class="grp">Guide</div>
+<a href="getting-started.html">Getting started</a>
+<a href="forgetting.html">Why agents forget</a>
+<a href="does-my-agent-remember.html">Does my agent remember?</a>
+<a href="where-sessions-are-stored.html">Where history lives</a>
+<a href="session-files-on-disk.html">Session files on disk</a>
+<a href="find-a-session.html">Finding a session</a>
+<a href="after-compaction.html">After compaction</a>
+<a href="repeated-mistakes.html">Repeated mistakes</a>
+<a href="switching-agents.html">Switching agents</a>
+<a href="parallel-sessions.html">Parallel sessions</a>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
+<a href="memory-for-opencode.html">Memory for opencode</a>
+<a href="memory-for-dsh.html">Memory for dsh</a>
+<a href="memory-for-kimi.html">Memory for Kimi Code</a>
+<a href="memory-for-zed.html">Memory for Zed</a>
+<a href="memory-for-grok.html">Memory for Grok Build</a>
+<a href="memory-for-gemini.html">Memory for Gemini CLI</a>
+<a href="memory-for-qwen.html">Memory for Qwen Code</a>
+<a href="memory-for-claude-code.html">Memory for Claude Code</a>
+<a href="memory-for-codex.html">Memory for Codex</a>
+<a href="memory-for-cursor.html">Memory for Cursor</a>
+<a href="memory-for-copilot.html">Memory for Copilot CLI</a>
+<a href="memory-for-copilot-chat.html">Memory for VS Code Copilot Chat</a>
+<a href="memory-for-openclaw.html">Memory for OpenClaw</a>
+<a href="memory-for-goose.html">Memory for Goose</a>
+<a href="memory-for-cline.html">Memory for Cline</a>
+<a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
+<a href="memory-for-roo.html">Memory for Roo Code</a>
+<a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html" aria-current="page">Memory for Continue</a>
+<a href="memory-for-hermes.html">Memory for Hermes</a>
+</details>
+<a href="lost-context.html">Lost context</a>
+<a href="context-window-full.html">Context window full</a>
+<a href="resume-a-session.html">Resuming a session</a>
+<a href="export-conversations.html">Exporting sessions</a>
+<a href="sync-across-machines.html">Across machines</a>
+<a href="token-cost.html">What memory costs</a>
+<a href="rules-files.html">When CLAUDE.md grows</a>
+<a href="auditing-agents.html">Auditing an agent</a>
+<a href="agents.html">Agents &amp; MCP</a>
+<a href="search.html">Search</a>
+<a href="commands.html">CLI reference</a>
+<a href="harnesses.html">Harnesses</a>
+<a href="privacy.html">Privacy</a>
+<a href="benchmarks.html">Benchmarks</a>
+<a href="compare.html">Compare</a>
+<a href="day-zero.html">Day zero</a>
+<div class="grp">Reference</div>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+<a href="https://github.com/vshulcz/deja-vu/blob/main/docs/SECURITY-MODEL.md">Security model</a>
+<a href="../registry/README.html">Format registry</a><a class="sidecat" href="../"><img src="../assets/icon-live.svg" width="46" height="46" alt=""><span>it remembers, so you do not have to</span></a></aside>
+<article>
+
+<h1>Adding memory to Continue</h1>
+<p class="pagelede">no hook fires yet, so recall is a tool it reaches for — and is told about<span class="mins" data-mins></span></p>
+
+<p>Continue writes every session to <code>~/.continue/sessions</code> — one JSON document each, in VS Code, JetBrains and the <code>cn</code> CLI alike. A new session reads none of them, and none of the sessions the other agents on this machine wrote either, including the one where the problem was already solved.</p>
+
+<h2>Adding recall</h2>
+<pre>deja install continue</pre>
+<p>Three things, in the two places Continue reads:</p>
+<ul>
+<li><b>The MCP server</b>, as an item under <code>mcpServers:</code> in <code>~/.continue/config.yaml</code>. Continue keys that list by <code>name</code> rather than by a key, so deja's entry is found again by its own name, and everything else in the file is left where it was. The CLI's header lists it under <code>MCP Servers</code>.</li>
+<li><b>The <code>deja-history</code> skill</b> in <code>~/.continue/skills</code>. Continue names every skill it finds in the <code>Skills</code> tool's own description, so the reason to look at history is in front of the model on every turn rather than only when someone asks.</li>
+<li><b>A <code>/deja</code> command</b>, as a <code>prompts:</code> entry in the same config.</li>
+</ul>
+
+<h2>Why there is no session-start injection yet</h2>
+<p>Continue's CLI carries a hooks system shaped exactly like Claude Code's — the same event names, the same <code>additionalContext</code>, settings read from <code>~/.continue/settings.json</code> — and in the published release nothing fires it. Measured on <code>@continuedev/cli</code> 1.5.47 against a recording endpoint: hooks written for every event were loaded (its own log says <code>Hooks loaded: 8 handler(s) across 8 event type(s)</code>) and not one handler ran, while the same run's tool call went through. The day a release fires them, deja's Claude-shaped wiring works here unchanged.</p>
+
+<h2>What it costs</h2>
+<p>From the recorded requests on that version: deja's tool schema is 3,112 bytes of the 10 KB of tools Continue sends with every request, the skill adds 700 bytes to the <code>Skills</code> tool's description, and a recall that answers adds 1,384 bytes to the turn that asked for it. A recall with no answer adds nothing.</p>
+
+<h2>The part that is not about this harness</h2>
+<p>The index covers every agent's transcripts on the machine — twenty-four of them, <a href="where-sessions-are-stored.html">each in its own format</a> — so a fix found in Claude Code answers a question asked in Continue, including sessions from before any of this was installed. Nothing here writes memories, so there is nothing to hallucinate into your history; indexing and search are local, and credentials are stripped as the index is built (<a href="privacy.html">privacy</a>).</p>
+
+<p><a href="getting-started.html">Getting started</a> · <a href="switching-agents.html">Switching between agents</a> · <a href="../registry/continue.html">The Continue session format</a></p>
+</article>
+</div>
+<footer>deja-vu is MIT-licensed and fully local. <a href="https://github.com/vshulcz/deja-vu">Source on GitHub</a> · <a href="../">Home</a></footer>
+</div>
+<script>
+const io=new IntersectionObserver(es=>es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}}),{threshold:.1});
+document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+<script src="../assets/guide.js" defer></script>
+</body>
+</html>

--- a/docs/guide/memory-for-copilot-chat.html
+++ b/docs/guide/memory-for-copilot-chat.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html" aria-current="page">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-goose.html
+++ b/docs/guide/memory-for-goose.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html" aria-current="page">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html" aria-current="page">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html" aria-current="page">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-prime.html
+++ b/docs/guide/memory-for-prime.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html" aria-current="page">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-roo.html
+++ b/docs/guide/memory-for-roo.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html" aria-current="page">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold" open><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold" open><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/parallel-sessions.html
+++ b/docs/guide/parallel-sessions.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html" aria-current="page">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/privacy.html
+++ b/docs/guide/privacy.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/repeated-mistakes.html
+++ b/docs/guide/repeated-mistakes.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html" aria-current="page">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/resume-a-session.html
+++ b/docs/guide/resume-a-session.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/rules-files.html
+++ b/docs/guide/rules-files.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/search.html
+++ b/docs/guide/search.html
@@ -50,7 +50,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -69,6 +69,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/session-files-on-disk.html
+++ b/docs/guide/session-files-on-disk.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/switching-agents.html
+++ b/docs/guide/switching-agents.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html" aria-current="page">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/sync-across-machines.html
+++ b/docs/guide/sync-across-machines.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/token-cost.html
+++ b/docs/guide/token-cost.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/guide/where-sessions-are-stored.html
+++ b/docs/guide/where-sessions-are-stored.html
@@ -51,7 +51,7 @@
 <a href="repeated-mistakes.html">Repeated mistakes</a>
 <a href="switching-agents.html">Switching agents</a>
 <a href="parallel-sessions.html">Parallel sessions</a>
-<details class="grpfold"><summary>Per-agent guides <span class="n">20</span></summary>
+<details class="grpfold"><summary>Per-agent guides <span class="n">21</span></summary>
 <a href="memory-for-opencode.html">Memory for opencode</a>
 <a href="memory-for-dsh.html">Memory for dsh</a>
 <a href="memory-for-kimi.html">Memory for Kimi Code</a>
@@ -70,6 +70,7 @@
 <a href="memory-for-pi.html">Memory for pi and omp</a><a href="memory-for-amp.html">Memory for Amp</a>
 <a href="memory-for-roo.html">Memory for Roo Code</a>
 <a href="memory-for-prime.html">Memory for prime-agent</a>
+<a href="memory-for-continue.html">Memory for Continue</a>
 <a href="memory-for-hermes.html">Memory for Hermes</a>
 </details>
 <a href="lost-context.html">Lost context</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -476,6 +476,7 @@ footer a:hover{color:var(--ph-hi)}
     <span><a href="guide/memory-for-qwen.html">Qwen Code</a></span>
     <span><a href="guide/memory-for-roo.html">Roo Code</a></span>
     <span><a href="guide/memory-for-prime.html">prime-agent</a></span>
+    <span><a href="guide/memory-for-continue.html">Continue</a></span>
     <span><a href="guide/memory-for-amp.html">Amp</a></span>
     <span><a href="guide/memory-for-copilot-chat.html">VS Code Copilot Chat</a></span>
     <span><a href="guide/memory-for-kimi.html">Kimi Code</a></span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -54,6 +54,7 @@ Install is one command (`curl -fsSL https://raw.githubusercontent.com/vshulcz/de
 - [Qwen Code](https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html)
 - [Roo Code](https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html)
 - [prime-agent (PrimeIntellect)](https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html)
+- [Continue](https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html)
 - [OpenClaw](https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html)
 - [Goose](https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html)
 - [Cline](https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html)

--- a/docs/registry/continue.html
+++ b/docs/registry/continue.html
@@ -61,20 +61,44 @@
 <p><code>ChatHistoryItem</code>, <code>ChatMessage</code>) and <code>core/util/paths.ts</code>; a live-store</p>
 <p>validation is still welcome.</p>
 <ul>
-<li><strong>MCP</strong>: not wired yet. Continue reads MCP servers from</li>
+<li><strong>MCP</strong>: <code>deja install continue</code> adds the server to <code>mcpServers:</code> in</li>
 </ul>
-<p><code>~/.continue/config.yaml</code> under <code>mcpServers:</code>, which deja does not write.</p>
+<p><code>~/.continue/config.yaml</code> — a list of mappings, not the keyed object other</p>
+<p>harnesses use, so the entry is found again by its <code>name</code>. Verified on</p>
+<p>@continuedev/cli 1.5.47 against a recording endpoint: the <code>deja</code> tool is in</p>
+<p>the tool list of every request, and a call came back with the seeded decision</p>
+<p>in the bytes Continue sent next. The TUI header lists it under <code>MCP Servers</code>.</p>
 <ul>
-<li><strong>Auto-recall</strong>: none — Continue has no session-start, per-prompt or tool</li>
+<li><strong>Skill</strong>: the same install writes <code>~/.continue/skills/deja-history/SKILL.md</code>.</li>
 </ul>
-<p>hook, so there is no event to answer.</p>
+<p>Continue reads skills from its global folder and from <code>&lt;workspace&gt;/.claude/skills</code>,</p>
+<p>and names each one in the <code>Skills</code> tool&#39;s own description — so it is in front</p>
+<p>of the model on every turn, which is what makes recall arrive unasked.</p>
 <ul>
-<li><strong>Resume</strong>: from Continue&#39;s history view in the editor; nothing takes a</li>
+<li><strong>Command</strong>: <code>prompts:</code> in the same config carries <code>/deja</code>. Continue expands</li>
 </ul>
-<p>session id from a shell.</p>
+<p>slash commands in its TUI; in <code>-p</code> headless mode the text goes through</p>
+<p>verbatim, so the entry is written but its expansion is unverified here.</p>
+<ul>
+<li><strong>Auto-recall</strong>: none yet. The CLI carries a Claude-shaped hooks system —</li>
+</ul>
+<p>Claude&#39;s own event set, <code>additionalContext</code>, settings read from</p>
+<p><code>~/.continue/settings.json</code> — and nothing fires it in 1.5.47: hooks written</p>
+<p>for every event loaded (its own log says &#34;Hooks loaded: 8 handler(s) across 8</p>
+<p>event type(s)&#34;) and no handler ran, while the same run&#39;s tool call went</p>
+<p>through. It becomes work the day a release fires them.</p>
+<ul>
+<li><strong>Resume</strong>: <code>cn --resume</code> reopens the last session and <code>--fork &lt;id&gt;</code> branches</li>
+</ul>
+<p>from one, but nothing takes the id of an arbitrary session; the editor</p>
+<p>reopens one from its history view.</p>
 <ul>
 <li><strong>Handoff</strong>: paste.</li>
 </ul>
+<p>Costs on that version, measured from the recorded requests: deja&#39;s tool schema</p>
+<p>is 3,112 bytes of the 10 KB tool block in every request, the skill adds 700</p>
+<p>bytes to the <code>Skills</code> tool&#39;s description, and a recall that answers adds 1,384</p>
+<p>bytes to the turn that asked.</p>
 <p><strong>Last verified:</strong> 2026-09-07</p>
 
 <hr>

--- a/docs/registry/continue.md
+++ b/docs/registry/continue.md
@@ -25,12 +25,33 @@ Shape verified against Continue's own types (`core/index.d.ts`: `Session`,
 `ChatHistoryItem`, `ChatMessage`) and `core/util/paths.ts`; a live-store
 validation is still welcome.
 
-- **MCP**: not wired yet. Continue reads MCP servers from
-  `~/.continue/config.yaml` under `mcpServers:`, which deja does not write.
-- **Auto-recall**: none — Continue has no session-start, per-prompt or tool
-  hook, so there is no event to answer.
-- **Resume**: from Continue's history view in the editor; nothing takes a
-  session id from a shell.
+- **MCP**: `deja install continue` adds the server to `mcpServers:` in
+  `~/.continue/config.yaml` — a list of mappings, not the keyed object other
+  harnesses use, so the entry is found again by its `name`. Verified on
+  @continuedev/cli 1.5.47 against a recording endpoint: the `deja` tool is in
+  the tool list of every request, and a call came back with the seeded decision
+  in the bytes Continue sent next. The TUI header lists it under `MCP Servers`.
+- **Skill**: the same install writes `~/.continue/skills/deja-history/SKILL.md`.
+  Continue reads skills from its global folder and from `<workspace>/.claude/skills`,
+  and names each one in the `Skills` tool's own description — so it is in front
+  of the model on every turn, which is what makes recall arrive unasked.
+- **Command**: `prompts:` in the same config carries `/deja`. Continue expands
+  slash commands in its TUI; in `-p` headless mode the text goes through
+  verbatim, so the entry is written but its expansion is unverified here.
+- **Auto-recall**: none yet. The CLI carries a Claude-shaped hooks system —
+  Claude's own event set, `additionalContext`, settings read from
+  `~/.continue/settings.json` — and nothing fires it in 1.5.47: hooks written
+  for every event loaded (its own log says "Hooks loaded: 8 handler(s) across 8
+  event type(s)") and no handler ran, while the same run's tool call went
+  through. It becomes work the day a release fires them.
+- **Resume**: `cn --resume` reopens the last session and `--fork <id>` branches
+  from one, but nothing takes the id of an arbitrary session; the editor
+  reopens one from its history view.
 - **Handoff**: paste.
+
+Costs on that version, measured from the recorded requests: deja's tool schema
+is 3,112 bytes of the 10 KB tool block in every request, the skill adds 700
+bytes to the `Skills` tool's description, and a recall that answers adds 1,384
+bytes to the turn that asked.
 
 **Last verified:** 2026-09-07

--- a/docs/registry/registry.json
+++ b/docs/registry/registry.json
@@ -515,34 +515,23 @@
       "last_verified": "2026-09-07",
       "display_name": "Continue",
       "capabilities": {
-        "mcp": false,
+        "mcp": true,
         "auto": false,
-        "skill": false,
-        "command": false,
+        "skill": true,
+        "command": true,
         "resume": false,
         "handoff": "paste",
         "prereq": ""
       },
       "gaps": {
-        "mcp": {
-          "state": "todo",
-          "why": "Continue reads MCP servers from ~/.continue/config.yaml under mcpServers:; deja does not write that file yet"
-        },
         "auto": {
-          "state": "impossible",
-          "why": "Continue has no session-start, per-prompt or tool hook — there is no event deja could answer"
-        },
-        "skill": {
-          "state": "todo",
-          "why": "Continue reads rules from ~/.continue/rules; deja writes no guidance there yet"
-        },
-        "command": {
-          "state": "todo",
-          "why": "Continue has slash commands in config.yaml rather than a command file, and deja writes none yet"
+          "state": "blocked",
+          "why": "Continue's CLI carries a Claude-shaped hooks system — Claude's own event set, additionalContext, settings read from ~/.continue/settings.json — and nothing fires it in the published release: measured on @continuedev/cli 1.5.47, hooks written for every event loaded (\"Hooks loaded: 8 handler(s)\" in its own log) and no handler ran, while the same run's tool call went through. Becomes work the day a release fires them",
+          "source": "https://github.com/continuedev/continue/tree/main/extensions/cli/src/hooks"
         },
         "resume": {
-          "state": "impossible",
-          "why": "Continue reopens a session from its history view in the editor; nothing takes a session id from a shell"
+          "state": "todo",
+          "why": "The CLI has --resume for the last session and --fork <sessionId>, but nothing that takes the id of an arbitrary session; the editor reopens one from its history view"
         }
       }
     },

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -23,6 +23,7 @@ https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html
+https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html
 https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -25,6 +25,7 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
The harness pass for Continue, on a stand: `@continuedev/cli` 1.5.47 in an isolated home, a recording endpoint standing in for the model, a seeded store whose answer exists nowhere else.

**What is wired.** `deja install continue` writes three things into the two places Continue reads:

- the MCP server as an item under `mcpServers:` in `~/.continue/config.yaml` — a list keyed by `name`, not the object other harnesses use, so the entry is found again by its own name and the rest of the file is left alone;
- the `deja-history` skill in `~/.continue/skills`, which Continue names in the `Skills` tool's own description — in front of the model on every turn;
- `/deja` as a `prompts:` entry in the same config.

**Read out of the bytes, not inferred.** With the server in place the request carries a `deja` tool and the skill's description; a scripted call came back with the seeded decision — the invented `FROBNAX_SHARD=single` — in the request Continue sent next. The CLI's own header lists `MCP Servers: - deja`, which is where a person sees it.

**Cost**, from the same recordings: the tool schema is 3,112 bytes of the 10 KB tool block in every request, the skill adds 700 bytes to the `Skills` tool, and a recall that answers adds 1,384 bytes to the turn that asked. Silence adds nothing.

**The negative result.** Continue's CLI carries a hooks system shaped exactly like Claude Code's — same event names, same `additionalContext`, settings read from `~/.continue/settings.json` — and nothing fires it in 1.5.47. Hooks written for every event loaded (its own log: `Hooks loaded: 8 handler(s) across 8 event type(s)`) and not one handler ran, while the same run's tool call went through. Recorded as a blocked gap with the upstream link; the day a release fires them, deja's Claude-shaped wiring works here unchanged.

Unproven and said so: the slash command. `-p` mode passes `/deja …` through as text, and I could not submit a line to the ink TUI through a pty — the text lands in the input box and Enter does not send it. The entry is written the way Continue's reference documents `prompts:`.

Six mutations, each red on its own test. Registry, matrix, doctor rows, the guide page and the counts move with it.