### PR TITLE
docs(site): every per-agent page is titled by the phrase people search

### DIFF
--- a/docs/guide/memory-for-amp.html
+++ b/docs/guide/memory-for-amp.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Amp: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>Amp memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Amp keeps every thread on the server and starts each one empty. A plugin file under ~/.config/amp/plugins puts this machine's own history in front of the model, and the MCP server lets it search the rest.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-amp.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-claude-code.html
+++ b/docs/guide/memory-for-claude-code.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Claude Code — deja-vu</title>
+<title>Claude Code memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Claude Code">
+<meta property="og:title" content="Claude Code memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Claude Code">
+<meta name="twitter:title" content="Claude Code memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Claude Code recall over every coding agent's sessions on this machine — the MCP server, the SessionStart hook and the plugin marketplace.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-cline.html
+++ b/docs/guide/memory-for-cline.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Cline: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>Cline memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Cline's hooks cannot carry context, so deja arrives as a plugin: a rule resolved when the session builds its instructions, a message builder that sees the prompt, and a /deja command.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-codex.html
+++ b/docs/guide/memory-for-codex.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Codex CLI — deja-vu</title>
+<title>Codex CLI memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Codex CLI">
+<meta property="og:title" content="Codex CLI memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Codex CLI">
+<meta name="twitter:title" content="Codex CLI memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Codex CLI recall over every coding agent's sessions on this machine — the MCP server, the hook it has to approve, and the plugin marketplace.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-continue.html
+++ b/docs/guide/memory-for-continue.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Continue: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>Continue memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Continue has no hook that fires yet, so deja arrives as an MCP server in its assistant config, a skill it names on every turn, and a /deja command.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-copilot-chat.html
+++ b/docs/guide/memory-for-copilot-chat.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to VS Code Copilot Chat — deja-vu</title>
+<title>VS Code Copilot Chat memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give VS Code Copilot Chat recall over every coding agent's sessions on the machine, the mcp.json shape VS Code actually reads, and the hook it does not have.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot-chat.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to VS Code Copilot Chat">
+<meta property="og:title" content="VS Code Copilot Chat memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give VS Code Copilot Chat recall over every coding agent's sessions on the machine, the mcp.json shape VS Code actually reads, and the hook it does not have.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot-chat.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to VS Code Copilot Chat">
+<meta name="twitter:title" content="VS Code Copilot Chat memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give VS Code Copilot Chat recall over every coding agent's sessions on the machine, the mcp.json shape VS Code actually reads, and the hook it does not have.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-copilot.html
+++ b/docs/guide/memory-for-copilot.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Copilot CLI — deja-vu</title>
+<title>Copilot CLI memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Copilot CLI">
+<meta property="og:title" content="Copilot CLI memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Copilot CLI">
+<meta name="twitter:title" content="Copilot CLI memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give GitHub Copilot CLI recall over every coding agent's sessions on this machine — where its events live, and the MCP entry it needs.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-cursor.html
+++ b/docs/guide/memory-for-cursor.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Cursor — deja-vu</title>
+<title>Cursor memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Cursor">
+<meta property="og:title" content="Cursor memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Cursor">
+<meta name="twitter:title" content="Cursor memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Cursor recall over every coding agent's sessions on this machine — where its SQLite chat store lives, and what deja install cursor-auto writes.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-dsh.html
+++ b/docs/guide/memory-for-dsh.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to DeepSeek Harness — deja-vu</title>
+<title>DeepSeek Harness memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to DeepSeek Harness">
+<meta property="og:title" content="DeepSeek Harness memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to DeepSeek Harness">
+<meta name="twitter:title" content="DeepSeek Harness memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give dsh recall over the sessions every coding agent on the machine already wrote — the plugin, the tools, and how it behaves beside the CLI install.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-gemini.html
+++ b/docs/guide/memory-for-gemini.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Gemini CLI — deja-vu</title>
+<title>Gemini CLI memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Gemini CLI">
+<meta property="og:title" content="Gemini CLI memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Gemini CLI">
+<meta name="twitter:title" content="Gemini CLI memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Gemini CLI recall over every coding agent's sessions on this machine — one extension install, and what the CLI install adds on top.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-goose.html
+++ b/docs/guide/memory-for-goose.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Goose: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>Goose memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Goose keeps sessions in a local database and reads .goosehints at start; nothing brings earlier sessions back. deja adds MCP recall, a session-start hook and a per-turn channel through the deja goose wrapper.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-grok.html
+++ b/docs/guide/memory-for-grok.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Grok Build — deja-vu</title>
+<title>Grok Build memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Grok Build">
+<meta property="og:title" content="Grok Build memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Grok Build">
+<meta name="twitter:title" content="Grok Build memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Grok Build recall over every coding agent's sessions on the machine — the hooks it reads, the marketplace plugin in review, and the name that is not it.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-hermes.html
+++ b/docs/guide/memory-for-hermes.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Hermes: what its own memory does not cover — deja-vu</title>
+<title>Hermes memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Hermes already searches its own sessions and keeps MEMORY.md. deja adds the other twenty-two agents on the machine: a plugin on pre_llm_call, the MCP tools, and a skill you can install straight from GitHub.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Kimi Code — deja-vu</title>
+<title>Kimi Code memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Kimi Code">
+<meta property="og:title" content="Kimi Code memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Kimi Code">
+<meta name="twitter:title" content="Kimi Code memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Kimi Code recall over every coding agent's sessions on the machine — the plugin, the hook that fires on each prompt, and the CLI path.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-openclaw.html
+++ b/docs/guide/memory-for-openclaw.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for OpenClaw: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>OpenClaw memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="OpenClaw keeps a session log per agent and can resume one; nothing reads earlier sessions back. deja indexes them with every other agent on the machine and puts recall in front of the model.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-opencode.html
+++ b/docs/guide/memory-for-opencode.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to opencode — deja-vu</title>
+<title>opencode memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give opencode recall over the sessions every coding agent on the machine already wrote — the plugin, the four moments it fires, and how it behaves beside the CLI install.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to opencode">
+<meta property="og:title" content="opencode memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give opencode recall over the sessions every coding agent on the machine already wrote — the plugin, the four moments it fires, and how it behaves beside the CLI install.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to opencode">
+<meta name="twitter:title" content="opencode memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give opencode recall over the sessions every coding agent on the machine already wrote — the plugin, the four moments it fires, and how it behaves beside the CLI install.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-pi.html
+++ b/docs/guide/memory-for-pi.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for pi and omp: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>pi and omp memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="pi and omp have no hooks; they have extension APIs. One file under the agent's extensions directory, auto-discovered, puts this machine's history in front of the model on every prompt.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-pi.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-prime.html
+++ b/docs/guide/memory-for-prime.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for prime-agent: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>prime-agent memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="prime-agent has no hooks and an extension API; one file under ~/.prime/agent/extensions opens a session with what this project settled and recalls on every prompt after it.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-qwen.html
+++ b/docs/guide/memory-for-qwen.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Qwen Code — deja-vu</title>
+<title>Qwen Code memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Qwen Code">
+<meta property="og:title" content="Qwen Code memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Qwen Code">
+<meta name="twitter:title" content="Qwen Code memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Qwen Code recall over every coding agent's sessions on this machine — the Gemini extension format, and Claude-format marketplaces.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/guide/memory-for-roo.html
+++ b/docs/guide/memory-for-roo.html
@@ -4,7 +4,7 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Memory for Roo Code: recall across Claude Code, Codex and the rest — deja-vu</title>
+<title>Roo Code memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="Roo Code has no lifecycle hooks yet, so deja arrives as an MCP server it may call, a skill that tells it when to, and a /deja command — plus the approval entry that keeps it from asking first.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html">
 <meta property="og:type" content="article">

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -4,11 +4,11 @@
 <script>document.documentElement.className=document.documentElement.className.replace("no-js","js")</script>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Adding memory to Zed's agent — deja-vu</title>
+<title>Zed memory: recall of past sessions, from every agent on the machine — deja-vu</title>
 <meta name="description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
 <link rel="canonical" href="https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html">
 <meta property="og:type" content="article">
-<meta property="og:title" content="Adding memory to Zed's agent">
+<meta property="og:title" content="Zed memory: recall of past sessions, from every agent on the machine">
 <meta property="og:description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
 <meta property="og:url" content="https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html">
 <meta property="og:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
@@ -25,7 +25,7 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="640">
 <meta property="og:image:alt" content="deja-vu — searchable local memory for coding agents">
-<meta name="twitter:title" content="Adding memory to Zed's agent">
+<meta name="twitter:title" content="Zed memory: recall of past sessions, from every agent on the machine">
 <meta name="twitter:description" content="How to give Zed's agent recall over every coding agent's sessions on the machine, why both install paths share one server id, and what Zed's API cannot do yet.">
 <meta name="twitter:image" content="https://vshulcz.github.io/deja-vu/assets/og.png">
 <meta name="twitter:image:alt" content="deja-vu — searchable local memory for coding agents">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -16,27 +16,27 @@
   <url><loc>https://vshulcz.github.io/deja-vu/guide/auditing-agents.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/find-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/parallel-sessions.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-opencode.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-dsh.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-kimi.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-zed.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-grok.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-gemini.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-qwen.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-roo.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-prime.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-continue.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html</loc><lastmod>2026-08-25</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-copilot-chat.html</loc><lastmod>2026-09-06</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-pi.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-claude-code.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-codex.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cursor.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-copilot.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-copilot-chat.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-openclaw.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-cline.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-pi.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-amp.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
-  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html</loc><lastmod>2026-09-02</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
+  <url><loc>https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html</loc><lastmod>2026-09-07</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/lost-context.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/context-window-full.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>
   <url><loc>https://vshulcz.github.io/deja-vu/guide/resume-a-session.html</loc><lastmod>2026-08-24</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>


### PR DESCRIPTION
One title shape on all twenty-one per-agent pages, the searched noun phrase first — "Claude Code memory: recall of past sessions, from every agent on the machine" — mirrored on og:title and twitter:title; H1s unchanged; sitemap lastmod moved for the pages.

Closes #3154
