### PR TITLE
feat(install): say where deja lives, once, after the proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- After the install proof, once per index, deja says where it lives — one line with the repository address; a package or plugin install that printed no proof gets the same line in its first week note, and never again. (#3159)
+
 ## [0.19.4] - 2026-09-07
 
 The release where every agent on the machine gets the same memory. Amp,

--- a/cmd/deja/hook_week_note.go
+++ b/cmd/deja/hook_week_note.go
@@ -51,5 +51,11 @@ func weekNoteAt(dir string, now time.Time) string {
 	if dv := usage.DejaVuWeek(dir); dv > 0 {
 		line += fmt.Sprintf(", %d déjà vu", dv)
 	}
-	return line + " — deja stats --card"
+	line += " — deja stats --card"
+	// The first week note carries the one sentence deja says about itself, when
+	// the install never printed it (a plugin or package install has no proof).
+	if star := starLine(dir); star != "" {
+		line += " · " + star
+	}
+	return line
 }

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -397,6 +397,9 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 // value is visible before the first agent session ever runs.
 func printInstallProof(dir string) {
 	printMemoryProofOf(dir, "deja already knows this machine:", nil, installLead(dir))
+	if line := starLine(dir); line != "" {
+		fmt.Fprintln(os.Stderr, line)
+	}
 }
 
 // printMemoryProofOf is the proof narrowed to the rows a caller can honestly

--- a/cmd/deja/star_line.go
+++ b/cmd/deja/star_line.go
@@ -1,0 +1,25 @@
+package main
+
+import "os"
+
+// starLine is the one sentence deja says about itself, once per index: after
+// the install proof, or in the first week note if the install never printed
+// it. deja has no telemetry and no account, so a star is the only signal that
+// reaches the project from a machine that uses it — and the install proof is
+// the moment the reader has just been shown something real. Once, because the
+// second time it is a nag, and a nag costs more than a star is worth.
+const starText = "deja is one person's project — a star on GitHub helps it get found: https://github.com/vshulcz/deja-vu"
+
+// starLine returns the sentence the first time it is asked for a given index
+// and "" after that. The marker sits beside the index like .builtnote and
+// .weeknote, so a rebuild does not repeat it and a second machine gets its own.
+func starLine(dir string) string {
+	p := dir + ".starnote"
+	if _, err := os.Stat(p); err == nil {
+		return ""
+	}
+	if err := os.WriteFile(p, []byte("1\n"), 0o600); err != nil {
+		return ""
+	}
+	return starText
+}

--- a/cmd/deja/star_line.go
+++ b/cmd/deja/star_line.go
@@ -2,7 +2,7 @@ package main
 
 import "os"
 
-// starLine is the one sentence deja says about itself, once per index: after
+// starText is the one sentence deja says about itself, once per index: after
 // the install proof, or in the first week note if the install never printed
 // it. deja has no telemetry and no account, so a star is the only signal that
 // reaches the project from a machine that uses it — and the install proof is

--- a/cmd/deja/star_line_test.go
+++ b/cmd/deja/star_line_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// One sentence, once per index: the install proof says it, and after that
+// neither the proof nor the week note repeats it.
+func TestStarLineIsSaidOncePerIndex(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := starLine(dir); !strings.Contains(got, "github.com/vshulcz/deja-vu") {
+		t.Fatalf("first call = %q", got)
+	}
+	if again := starLine(dir); again != "" {
+		t.Fatalf("said twice: %q", again)
+	}
+	// The week note after an install that already said it stays as it was.
+	usage.RecordResult(dir, usage.KindHook, 900, 2, false)
+	now := time.Now()
+	_ = weekNoteAt(dir, now)
+	if got := weekNoteAt(dir, now.Add(8*24*time.Hour)); strings.Contains(got, "github.com") {
+		t.Fatalf("week note repeated the star line: %q", got)
+	}
+}
+
+// A package install has no proof, so the first week note is where the
+// sentence lands — and only the first.
+func TestWeekNoteCarriesTheStarLineWhenTheInstallDidNot(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	usage.RecordResult(dir, usage.KindHook, 900, 2, false)
+	now := time.Now()
+	_ = weekNoteAt(dir, now)
+	got := weekNoteAt(dir, now.Add(8*24*time.Hour))
+	if !strings.HasPrefix(got, "deja this week: 1 recall") || !strings.Contains(got, "github.com/vshulcz/deja-vu") {
+		t.Fatalf("first week note = %q", got)
+	}
+	usage.RecordResult(dir, usage.KindHook, 900, 2, false)
+	if again := weekNoteAt(dir, now.Add(16*24*time.Hour)); strings.Contains(again, "github.com") {
+		t.Fatalf("second week note repeated it: %q", again)
+	}
+}


### PR DESCRIPTION
One sentence with the repository address after the install proof, once per index (marker .starnote beside the index, like .builtnote); a package or plugin install with no proof gets it in the first week note instead, and neither surface repeats it. Tests: TestStarLineIsSaidOncePerIndex, TestWeekNoteCarriesTheStarLineWhenTheInstallDidNot.

The wording is in one constant, starText, if you want it different.

Closes #3159
