### PR TITLE
fix(install): the star line is an aside — a glyph, a blank line, softer words

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -397,8 +397,11 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 // value is visible before the first agent session ever runs.
 func printInstallProof(dir string) {
 	printMemoryProofOf(dir, "deja already knows this machine:", nil, installLead(dir))
+	// A blank line and a glyph set it apart from the proof: an aside, not a
+	// step of the install, and the last thing on the screen rather than the
+	// first.
 	if line := starLine(dir); line != "" {
-		fmt.Fprintln(os.Stderr, line)
+		fmt.Fprintln(os.Stderr, "\n  ★ "+line)
 	}
 }
 

--- a/cmd/deja/star_line.go
+++ b/cmd/deja/star_line.go
@@ -8,7 +8,7 @@ import "os"
 // reaches the project from a machine that uses it — and the install proof is
 // the moment the reader has just been shown something real. Once, because the
 // second time it is a nag, and a nag costs more than a star is worth.
-const starText = "deja is one person's project — a star on GitHub helps it get found: https://github.com/vshulcz/deja-vu"
+const starText = "if deja earns its keep, a star on GitHub helps the next person find it — github.com/vshulcz/deja-vu"
 
 // starLine returns the sentence the first time it is asked for a given index
 // and "" after that. The marker sits beside the index like .builtnote and


### PR DESCRIPTION
The sentence after the proof now reads "if deja earns its keep, a star on GitHub helps the next person find it — github.com/vshulcz/deja-vu", set apart by a blank line and a ★, so it is an aside rather than a step; the week note carries the same words. Follow-on from #3159.
