### PR TITLE
fix(hook-prompt): stand down on the harness's own turns

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -170,6 +170,16 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// this prompt also earns a recall, so it is decided before the gates that
 	// silence the recall path.
 	nudge := failureNudge(dir, string(input.Prompt))
+	// Nobody asked. A harness delivers its own plumbing as the next user turn —
+	// a finished background task, a system reminder, a slash command's envelope
+	// — and the hook fires on it like a question. The terms are then the
+	// envelope's own field names plus an id that exists nowhere else, and what
+	// they match is another notification in another session: a block of noise
+	// injected as recalled history, under a line telling the user deja fires on
+	// noise (#3156). Same test the digest uses on transcript messages.
+	if digest.IsAgentArtifact(string(input.Prompt)) {
+		return emitNudgeOnly(stdout, plain, nudge)
+	}
 	terms := prompt.Terms(string(input.Prompt))
 	if !promptTermsWorthAsking(terms) {
 		return emitNudgeOnly(stdout, plain, nudge)

--- a/cmd/deja/hook_prompt_artifact_test.go
+++ b/cmd/deja/hook_prompt_artifact_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Nobody asked. A harness delivers its own plumbing as the next user turn — a
+// finished background task, a system reminder — and this hook fired on it like
+// a question. The terms were the envelope's field names plus a task id that
+// exists nowhere else, and what they matched was another notification in
+// another session: noise injected as recalled history, under a line telling the
+// user that deja fires on noise (#3156).
+func TestHookPromptStandsDownOnHarnessArtifacts(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+
+	// A past session holding a notification of its own — what the noisy prompt
+	// matched — and a real answer beside it, so silence here is a decision and
+	// not an empty store.
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "past.jsonl"), "past", []string{
+		`{"type":"user","sessionId":"past","timestamp":"` + ts +
+			`","message":{"role":"user","content":"<task-notification>\n<task-id>zx91qq4kb</task-id>\n<status>failed</status>\n</task-notification>"}}`,
+		`{"type":"assistant","sessionId":"past","timestamp":"` + ts +
+			`","message":{"role":"assistant","content":"the zibblex retry cap is four, we settled that"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	for _, artifact := range []string{
+		`<task-notification>\n<task-id>br50mykp6</task-id>\n<status>failed</status>\n</task-notification>`,
+		`<system-reminder>The task list is empty.</system-reminder>`,
+		`Summary: 1. Primary Request and Intent:\n   keep polishing the tool\n2. Key Technical Concepts:\n   - hooks`,
+	} {
+		var out bytes.Buffer
+		in := strings.NewReader(`{"prompt":"` + artifact + `","session_id":"asking"}`)
+		if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out.String(), "deja-recall") || strings.Contains(out.String(), "you have been here") {
+			t.Errorf("the hook recalled on a harness artifact:\nprompt: %s\ngot: %q", artifact, out.String())
+		}
+	}
+
+	// The control: a real question in the same session, against the same
+	// store, still gets its block.
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"what did we decide about the zibblex retry cap","session_id":"asking"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "retry cap is four") {
+		t.Fatalf("a real question went unanswered, so the silence above proves nothing:\n%q", out.String())
+	}
+}

--- a/internal/digest/compaction_summary_test.go
+++ b/internal/digest/compaction_summary_test.go
@@ -1,0 +1,34 @@
+package digest
+
+import "testing"
+
+// A compaction summary is the agent's own account of the session, written into
+// the transcript as the first user turn after a compaction. Taken as something
+// the user said, it becomes the session's title, and the "you have been here"
+// line then reads `"Summary: 1. Primary Request and Intent: - MOST R…"` — which
+// says nothing about the session and pushes the real question out (#3157).
+func TestCompactionSummariesAreArtifacts(t *testing.T) {
+	summary := "Summary: 1. Primary Request and Intent:\n" +
+		"   The user asked for the retry queue to stop double-acking.\n" +
+		"2. Key Technical Concepts:\n   - advisory locks\n"
+	if !IsAgentArtifact(summary) {
+		t.Error("a compaction summary was taken as something the user said")
+	}
+	resumed := "This session is being continued from a previous conversation that ran out of context. " +
+		"The summary below covers the earlier portion of the conversation."
+	if !IsAgentArtifact(resumed) {
+		t.Error("the resumption preamble was taken as something the user said")
+	}
+
+	// The control the issue names: an ordinary message that opens with the same
+	// word and carries none of the shape is still a title.
+	for _, real := range []string{
+		"Summary: the retry queue double-acks under two shards",
+		"Summary: I moved the lock into the outbox writer, tests are green",
+		"summary of what we decided about the shipping queue",
+	} {
+		if IsAgentArtifact(real) {
+			t.Errorf("a real message was discarded as an artifact: %q", real)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -567,6 +567,29 @@ var agentArtifactMarkers = []string{
 	`{"type":`,
 }
 
+// isCompactionSummary recognises the block a harness writes as the first user
+// turn after a context compaction. It is the agent's own summary of the session
+// so far, not something the user said, and as a session title it reads
+// "Summary: 1. Primary Request and Intent: - MOST R…" — which says nothing
+// about the session while pushing the real question out of the line (#3157).
+//
+// Two shapes, both anchored: the resumption preamble, and "Summary:" followed
+// by the numbered heading that always opens one. An ordinary message that
+// happens to begin "Summary:" carries neither and stays a title.
+func isCompactionSummary(trimmed string) bool {
+	if strings.HasPrefix(trimmed, "This session is being continued from a previous conversation") {
+		return true
+	}
+	if !strings.HasPrefix(trimmed, "Summary:") {
+		return false
+	}
+	head := trimmed
+	if len(head) > 400 {
+		head = head[:400]
+	}
+	return strings.Contains(head, "1. Primary Request and Intent")
+}
+
 func IsAgentArtifact(text string) bool {
 	for _, m := range agentArtifactMarkers {
 		if strings.Contains(text, m) {
@@ -577,6 +600,9 @@ func IsAgentArtifact(text string) bool {
 	// Harness preambles injected as user turns: <environment_context>,
 	// <user_instructions> and similar XML-wrapped plumbing.
 	if strings.HasPrefix(trimmed, "<") && strings.Contains(trimmed, "</") {
+		return true
+	}
+	if isCompactionSummary(trimmed) {
 		return true
 	}
 	// ls dumps recorded under a user role.

--- a/internal/search/opaque_id_test.go
+++ b/internal/search/opaque_id_test.go
@@ -1,0 +1,51 @@
+package search
+
+import "testing"
+
+// An id names one record and nothing else. Every rule in HasIdentifierTerm
+// reads it as a term of art — long, mixed letters and digits — so a prompt
+// carrying nothing but a task id cleared the bar that decides whether recall is
+// worth opening the store for, and what it then matched was another record
+// carrying an id of the same shape (#3156).
+//
+// The same test has to leave real vocabulary alone, which is most of what it
+// costs to get right: `sha256sum` and `x86_64` are words people search for.
+func TestOpaqueIDsAreNotIdentifiers(t *testing.T) {
+	ids := []string{
+		"br50mykp6",        // a Claude Code task id
+		"942cbc1e",         // a uuid's first group
+		"toolu_01A2b3C4d5", // a tool-call id behind its prefix
+		"01k9x2m4p7q",      // a ulid fragment
+		"7f3a9b2c1d4e",     // a hex digest fragment
+		"a1b2c3d4e5f6",     // and one with every pair split
+		"019f8c2a41b3",     // a uuidv7 prefix
+		"ses1a2b3c4d5",     // a session id with a word-like head
+		"deadbeef00ff11",   // hex that reads like a word at the start
+	}
+	for _, id := range ids {
+		if HasIdentifierTerm([]string{id}) {
+			t.Errorf("%q was taken as a term of art; it names one record", id)
+		}
+	}
+
+	words := []string{
+		"sha256sum", "iso8601", "x86_64", "utf8mb4", "base64", "oauth2",
+		"pgbouncer", "http2", "libssl1", "error404page", "postgres14",
+		"cve-2026-1234", "go1.22.4", "snake_case_name",
+	}
+	for _, w := range words {
+		if !HasIdentifierTerm([]string{w}) {
+			t.Errorf("%q stopped being an identifier; it is vocabulary, not an id", w)
+		}
+	}
+
+	// An id alongside a real word leaves the word doing the work, so the
+	// question still stands.
+	if !HasIdentifierTerm([]string{"br50mykp6", "pgbouncer"}) {
+		t.Error("an id next to a real term silenced the whole question")
+	}
+	// And a question that is only ids is not a question.
+	if HasIdentifierTerm([]string{"br50mykp6", "942cbc1e"}) {
+		t.Error("two ids read as a question")
+	}
+}

--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -1,6 +1,9 @@
 package search
 
-import "unicode/utf8"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // RecallWorthShowing is the one bar both the hook and the benchmark apply. It
 // lived in two places with two slightly different expressions, so the
@@ -112,6 +115,11 @@ func IdentifyingTerms(terms []string, known map[string]float64) []string {
 // something that reads like a term of art — long, or shaped like a symbol.
 func HasIdentifierTerm(terms []string) bool {
 	for _, t := range terms {
+		// An id names one record and nothing else, and every rule below reads
+		// it as a term of art.
+		if isOpaqueID(t) {
+			continue
+		}
 		// Letters, not bytes. Counting bytes read "omoda" as filler and every
 		// Cyrillic word of three letters as a term of art, because Cyrillic
 		// takes two bytes a letter. Measured on a real store: "напомни, что мы
@@ -132,6 +140,50 @@ func HasIdentifierTerm(terms []string) bool {
 		}
 	}
 	return false
+}
+
+// isOpaqueID reports a token that identifies one record somewhere and nothing
+// else: a task id, a tool-call id, a uuid fragment. It looks like a term of art
+// to every rule above — long, mixed letters and digits — and carries the
+// opposite: it exists in exactly one place, so a question holding nothing else
+// can only match another record that happens to carry an id of the same shape
+// (#3156).
+//
+// Three tests, all needed to keep real vocabulary out of it: long enough that a
+// word is unlikely, alphanumeric after an optional `prefix_` (so `x86_64` and
+// `go1.22` are never candidates), and switching between letters and digits at
+// least three times. `sha256sum` and `iso8601` switch once or twice and stay
+// identifiers; `br50mykp6` and `942cbc1e` switch three times and do not.
+func isOpaqueID(t string) bool {
+	if i := strings.IndexByte(t, '_'); i >= 0 {
+		// One leading prefix only: `toolu_01A2B3` is an id, `snake_case_name`
+		// is not a candidate at all.
+		if strings.IndexByte(t[i+1:], '_') >= 0 {
+			return false
+		}
+		t = t[i+1:]
+	}
+	if utf8.RuneCountInString(t) < 8 {
+		return false
+	}
+	runs, digit, first := 0, false, true
+	for _, r := range t {
+		switch {
+		case r >= '0' && r <= '9':
+			if first || !digit {
+				runs++
+			}
+			digit, first = true, false
+		case (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			if first || digit {
+				runs++
+			}
+			digit, first = false, false
+		default:
+			return false
+		}
+	}
+	return runs >= 4
 }
 
 // soleWorkingWord is the ordinary vocabulary a session is made of, long enough


### PR DESCRIPTION
Three related fixes, all on the path that produced the line in #3156.

**The hook fired on the harness's own turn.** `hook-prompt` never applied `digest.IsAgentArtifact` to the prompt itself, only to transcript messages when picking a title. It does now. On the issue's repro, against a seeded store:

```
before  deja-vu — you have been here: "the zibblex retry cap is four, we settled that"
        (3d ago · via: task-notification, task-id, br50mykp6)
after   (nothing)
control what did we decide about the zibblex retry cap → still recalled, same store
```

**A compaction summary was a session title.** `IsAgentArtifact` did not know the shape, so `"Summary: 1. Primary Request and Intent: - MOST R…"` became the quoted title whenever it was the best-matching user line — often, on a compacted session. Two anchored forms are recognised: the `This session is being continued…` preamble, and `Summary:` followed by the numbered heading that always opens one. A message that merely starts with "Summary:" is still a title.

**A bare id is not a term of art.** `br50mykp6` cleared `HasIdentifierTerm` on its length alone, so a prompt holding only an id was worth opening the store for. An id is now recognised by shape — eight or more characters, alphanumeric after an optional `prefix_`, and switching between letters and digits at least three times. That takes `br50mykp6`, `942cbc1e` and `toolu_01A2b3C4d5` out while leaving `sha256sum`, `iso8601`, `x86_64`, `oauth2` and `cve-2026-1234` in; the test carries both lists, and an id next to a real word still leaves the word doing the work.

Closes #3156, closes #3157.
