### PR TITLE
fix(hook): the prompt hook stands down on the host's own turns

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -166,11 +166,20 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if recallIsOff() {
 		return nil
 	}
+	// What the person typed, with the host's envelopes taken off: a task
+	// notification, a system reminder, a teammate message, deja's own block
+	// echoed back. A turn that is only the host talking to itself gets no
+	// recall at all — it once made this hook say "you have been here" about
+	// another notification, on the envelope's field names (#3156).
+	asked := digest.StripHarnessBlocks(string(input.Prompt))
+	if asked == "" {
+		return nil
+	}
 	// The failure the user just reported is worth capturing whether or not
 	// this prompt also earns a recall, so it is decided before the gates that
 	// silence the recall path.
-	nudge := failureNudge(dir, string(input.Prompt))
-	terms := prompt.Terms(string(input.Prompt))
+	nudge := failureNudge(dir, asked)
+	terms := prompt.Terms(asked)
 	if !promptTermsWorthAsking(terms) {
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
@@ -419,7 +428,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		// way of its own to tell "mm_status" from "decide", and the session
 		// that answers often says both — measured live, ten of the answers
 		// this hook newly returns open on the ordinary word.
-		digest, shown := search.AutoRecallDigestShowing(ss, digestBudget(confident), byIdentifying(terms, idfOf), string(input.Prompt))
+		digest, shown := search.AutoRecallDigestShowing(ss, digestBudget(confident), byIdentifying(terms, idfOf), asked)
 		if strings.TrimSpace(digest) == "" {
 			return emitNudgeOnly(stdout, plain, nudge)
 		}

--- a/cmd/deja/hook_prompt_artifact_test.go
+++ b/cmd/deja/hook_prompt_artifact_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A turn that is only the host's envelope — a task notification delivered as
+// a user prompt — gets nothing: no block, no "you have been here" line. Seen
+// live on 2026-09-08 with the envelope's field names as the identifying terms
+// (#3156). The same session, asked a real question, still gets its block.
+func TestHookPromptStandsDownOnTheHostsOwnTurn(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "notice.jsonl"), "notice", []string{
+		`{"type":"user","sessionId":"notice","timestamp":"` + old + `","message":{"role":"user","content":"<task-notification>\n<task-id>br50mykp6</task-id>\n<status>failed</status>\n</task-notification>"}}`,
+		`{"type":"assistant","sessionId":"notice","timestamp":"` + old + `","message":{"role":"assistant","content":"That is the earlier background task-id run; it failed on the task-notification path."}}`,
+		`{"type":"user","sessionId":"notice","timestamp":"` + old + `","message":{"role":"user","content":"the exporter_batch job drops rows at utc_midnight"}}`,
+		`{"type":"assistant","sessionId":"notice","timestamp":"` + old + `","message":{"role":"assistant","content":"utc_midnight rollover: the exporter_batch cursor was compared in local time."}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	ask := func(prompt string) string {
+		var out bytes.Buffer
+		in := `{"prompt":` + jsonString(prompt) + `,"session_id":"agent-9"}`
+		if err := runHookPrompt(index.DefaultDir(), strings.NewReader(in), &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+	if got := ask("<task-notification>\n<task-id>br50mykp6</task-id>\n<status>failed</status>\n<summary>Background command failed</summary>\n</task-notification>"); strings.TrimSpace(got) != "" {
+		t.Fatalf("the host's own turn got a block:\n%s", got)
+	}
+	// A person's words with the host's reminder appended still count as the
+	// person's words — and the reminder's words are not the query.
+	got := ask("exporter_batch dropping rows at utc_midnight again\n<system-reminder>\nCAVEMAN MODE ACTIVE\n</system-reminder>")
+	if !strings.Contains(got, "utc_midnight") {
+		t.Fatalf("a real question with a reminder appended got nothing:\n%s", got)
+	}
+	if strings.Contains(got, "CAVEMAN") {
+		t.Fatalf("the reminder's words reached the block:\n%s", got)
+	}
+}

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -9,12 +9,19 @@ import (
 // a user turn: what the host says to the model, recorded under the user's
 // role. A prompt is often a person's words with one of these appended; a
 // prompt that is only one of these is the host talking to itself.
+//
+// The list is what this machine's own transcripts hold under the user role
+// (counted on 2026-09-08): Claude Code's teammate-message ×656,
+// task-notification ×653, command-message ×108, bash-input/stdout/stderr
+// (the `!` shell), local-command-stdout; Copilot's skill-context; Kimi's
+// hook_result; opencode's meta; Codex's environment and instruction blocks.
 var harnessBlockTags = []string{
 	"task-notification", "system-reminder", "teammate-message",
 	"local-command-stdout", "local-command-stderr", "local-command-caveat",
 	"command-name", "command-message", "command-args",
+	"bash-input", "bash-stdout", "bash-stderr",
 	"environment_context", "user_instructions", "permissions instructions",
-	"hook_result", "hook_context", "deja-recall",
+	"skill-context", "meta", "hook_result", "hook_context", "deja-recall",
 }
 
 var harnessBlockRe = func() *regexp.Regexp {

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -1,0 +1,40 @@
+package digest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// harnessBlockTags are the envelopes a harness wraps around, or delivers as,
+// a user turn: what the host says to the model, recorded under the user's
+// role. A prompt is often a person's words with one of these appended; a
+// prompt that is only one of these is the host talking to itself.
+var harnessBlockTags = []string{
+	"task-notification", "system-reminder", "teammate-message",
+	"local-command-stdout", "local-command-stderr", "local-command-caveat",
+	"command-name", "command-message", "command-args",
+	"environment_context", "user_instructions", "permissions instructions",
+	"hook_result", "hook_context", "deja-recall",
+}
+
+var harnessBlockRe = func() *regexp.Regexp {
+	alts := make([]string, 0, len(harnessBlockTags))
+	for _, t := range harnessBlockTags {
+		alts = append(alts, regexp.QuoteMeta(t))
+	}
+	// A closed block, or an unclosed one that runs to the end of the text —
+	// hosts truncate long notifications and the tail is still not the user.
+	return regexp.MustCompile(`(?is)<(` + strings.Join(alts, "|") + `)(?:\s[^>]*)?>(?:.*?</\s*` + "(?:" + strings.Join(alts, "|") + `)\s*>|.*$)`)
+}()
+
+// StripHarnessBlocks returns what is left of a prompt once the harness's own
+// envelopes are removed: the person's words, or "" when the turn was the host
+// alone. A task notification delivered as a user turn once made the prompt
+// hook say "you have been here" about another notification, with the
+// envelope's field names as the identifying terms (#3156).
+func StripHarnessBlocks(prompt string) string {
+	if !strings.Contains(prompt, "<") {
+		return strings.TrimSpace(prompt)
+	}
+	return strings.TrimSpace(harnessBlockRe.ReplaceAllString(prompt, ""))
+}

--- a/internal/digest/harness_blocks_test.go
+++ b/internal/digest/harness_blocks_test.go
@@ -1,0 +1,25 @@
+package digest
+
+import "testing"
+
+func TestStripHarnessBlocksLeavesThePersonsWords(t *testing.T) {
+	cases := map[string]string{
+		// The host alone: nothing is left.
+		"<task-notification>\n<task-id>br50mykp6</task-id>\n<status>failed</status>\n</task-notification>": "",
+		"<system-reminder>\nCAVEMAN MODE ACTIVE\n</system-reminder>":                                       "",
+		// A person, with the host's reminder appended: the reminder goes, the words stay.
+		"why does the pool use the simple protocol?\n<system-reminder>\nthe file changed on disk\n</system-reminder>": "why does the pool use the simple protocol?",
+		// Attributes on the tag, and a block that is never closed.
+		`<teammate-message teammate_id="triage2" color="cyan">{"type":"idle"}</teammate-message> fix the flaky test`: "fix the flaky test",
+		"what did we decide about token refresh?\n<task-notification>\n<task-id>x</task-id>":                         "what did we decide about token refresh?",
+		// deja's own block echoed back is not the person either.
+		"<deja-recall>\nRecalled history…\n</deja-recall>\nand the second one?": "and the second one?",
+		// No tags at all: untouched.
+		"plain question about <T> generics": "plain question about <T> generics",
+	}
+	for in, want := range cases {
+		if got := StripHarnessBlocks(in); got != want {
+			t.Errorf("StripHarnessBlocks(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/digest/harness_blocks_test.go
+++ b/internal/digest/harness_blocks_test.go
@@ -14,6 +14,10 @@ func TestStripHarnessBlocksLeavesThePersonsWords(t *testing.T) {
 		"what did we decide about token refresh?\n<task-notification>\n<task-id>x</task-id>":                         "what did we decide about token refresh?",
 		// deja's own block echoed back is not the person either.
 		"<deja-recall>\nRecalled history…\n</deja-recall>\nand the second one?": "and the second one?",
+		// The `!` shell: what ran and what it printed is not a question.
+		"<bash-input>git status</bash-input>\n<bash-stdout>On branch main</bash-stdout>": "",
+		// A tag name that is only a prefix of a word in prose is not a tag.
+		"the <metadata> table has no meta column": "the <metadata> table has no meta column",
 		// No tags at all: untouched.
 		"plain question about <T> generics": "plain question about <T> generics",
 	}


### PR DESCRIPTION
The per-prompt hook now strips the host's envelopes from the prompt before anything reads it — task notifications, system reminders, teammate messages, local-command blocks, Codex's environment/instructions blocks, deja's own recall block echoed back — and a turn that is only an envelope gets no block and no status line. A person's words with a reminder appended keep their block, and the reminder's words no longer reach the query (they were becoming terms).

Fails before the fix: `TestHookPromptStandsDownOnTheHostsOwnTurn` — "the host's own turn got a block". Also `TestStripHarnessBlocksLeavesThePersonsWords` on the helper.

Closes #3156

## Review
Not refuted. Checked: the regex (no catastrophic backtracking; `meta` does not match `<metadata>`; the spaced tag name; case-insensitivity), every reader of input.Prompt now reads the stripped prompt, the early return skips nothing that used to run on a host-only turn (nudge, usage, cooldown), and both tests fail without the fix for the stated reason.