### PR TITLE
probe: Windows-only failures in deja_once and files --json (not for merge)

### DIFF
--- a/cmd/deja/files_json_rows_test.go
+++ b/cmd/deja/files_json_rows_test.go
@@ -82,6 +82,21 @@ func TestFilesJSONCarriesTheRankedRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if st, err := captureRun(t, "stats"); err == nil {
+		t.Logf("PROBE stats:\n%s", st)
+	} else {
+		t.Logf("PROBE stats error: %v", err)
+	}
+	if sr, err := captureRun(t, "search", "--json", "singbox"); err == nil {
+		t.Logf("PROBE search --json singbox: %s", sr)
+	} else {
+		t.Logf("PROBE search error: %v", err)
+	}
+	if ls, err := os.ReadDir(proj); err == nil {
+		for _, e := range ls {
+			t.Logf("PROBE fixture file %s", e.Name())
+		}
+	}
 	out, err := captureRun(t, "files", "--json", "singbox")
 	if err != nil {
 		t.Fatalf("files --json: %v\n%s", err, out)

--- a/cmd/deja/hook_context_once_test.go
+++ b/cmd/deja/hook_context_once_test.go
@@ -61,7 +61,14 @@ func TestDejaOnceKeepsTheDigestToTheFirstTurn(t *testing.T) {
 		return captureStdout(t, func() { _ = runHookContext(index.DefaultDir(), true) })
 	}
 
-	if first := ask("once-1", true); strings.TrimSpace(first) == "" {
+	first := ask("once-1", true)
+	if seen, err := os.ReadFile(index.DefaultDir() + ".hookseen"); err != nil {
+		t.Logf("PROBE hookseen after first call: read error %v (dir=%q)", err, index.DefaultDir())
+	} else {
+		t.Logf("PROBE hookseen after first call:\n%s", seen)
+	}
+	t.Logf("PROBE first output %d bytes", len(first))
+	if strings.TrimSpace(first) == "" {
 		t.Fatal("the session opened with nothing, so there is no repeat to test")
 	}
 	if again := ask("once-1", true); strings.TrimSpace(again) != "" {


### PR DESCRIPTION
Diagnostics only, to read the Windows runner's view of #3137 and #3138: the .hookseen file after the first once-call, and stats / search / fixture listing before files --json. Will be closed unmerged.