### PR TITLE
perf(copilot-chat): ask VS Code for the session directories instead of walking its User folder

### DIFF
--- a/internal/sources/copilot_chat.go
+++ b/internal/sources/copilot_chat.go
@@ -69,9 +69,75 @@ func CopilotChatRoots() []string {
 func CopilotChatSessionFiles() []string {
 	var files []string
 	for _, root := range CopilotChatRoots() {
-		files = append(files, walkFiles(root, copilotChatFile)...)
+		dirs := copilotChatStoreDirs(root)
+		if dirs == nil {
+			// A root laid out in none of the shapes below: walk it, as this
+			// always did. Costs what it costs, and finds what is there.
+			files = append(files, walkFiles(root, copilotChatFile)...)
+			continue
+		}
+		for _, dir := range dirs {
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				continue
+			}
+			for _, e := range entries {
+				p := filepath.Join(dir, e.Name())
+				if e.Type().IsRegular() && copilotChatFile(p) {
+					files = append(files, p)
+				}
+			}
+		}
 	}
 	return copilotChatDropJSONSiblings(files)
+}
+
+// copilotChatStoreDirs names the directories transcripts live in, instead of
+// walking the User folder to find them. It returns nil when the root has none
+// of VS Code's own top-level directories, which is the signal to walk instead.
+//
+// The root belongs to the editor, and almost none of it is ours: extension
+// caches, the editor's history, per-workspace state. Measured on a working
+// machine, the walk read 2,643 workspace directories to reach 28 that hold
+// chat sessions — 72 ms of the 95 ms every search spends discovering the stores
+// of all twenty-five harnesses, and by a wide margin the largest single term in
+// it. Asking for `<hash>/chatSessions` directly turns each of those workspace
+// directories from a directory read into one failed open (#3167).
+func copilotChatStoreDirs(root string) []string {
+	sessionDirs := func(base string) []string {
+		var out []string
+		out = append(out, filepath.Join(base, "globalStorage", "emptyWindowChatSessions"))
+		entries, err := os.ReadDir(filepath.Join(base, "workspaceStorage"))
+		if err != nil {
+			return out
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				out = append(out, filepath.Join(base, "workspaceStorage", e.Name(), "chatSessions"))
+			}
+		}
+		return out
+	}
+	known := false
+	for _, name := range []string{"workspaceStorage", "globalStorage", "profiles"} {
+		if fi, err := os.Stat(filepath.Join(root, name)); err == nil && fi.IsDir() {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return nil
+	}
+	dirs := sessionDirs(root)
+	// A named profile keeps its own copy of both, one level down.
+	if profiles, err := os.ReadDir(filepath.Join(root, "profiles")); err == nil {
+		for _, e := range profiles {
+			if e.IsDir() {
+				dirs = append(dirs, sessionDirs(filepath.Join(root, "profiles", e.Name()))...)
+			}
+		}
+	}
+	return dirs
 }
 
 func LoadCopilotChat() []model.Session {

--- a/internal/sources/copilot_chat_dirs_test.go
+++ b/internal/sources/copilot_chat_dirs_test.go
@@ -1,0 +1,82 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Discovery no longer walks the editor's User folder; it asks for the
+// directories VS Code puts transcripts in. That is faster by 65x on a real
+// machine and it is also narrower, so every layout it has to cover is named
+// here — a shape this forgets is a store that silently stops being read.
+func TestCopilotChatFindsEveryLayoutWithoutWalking(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_COPILOT_CHAT_ROOTS", root)
+
+	write := func(parts ...string) string {
+		p := filepath.Join(append([]string{root}, parts...)...)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(`{"kind":0}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	want := []string{
+		// A workspace's own sessions.
+		write("workspaceStorage", "abc123", "chatSessions", "s1.jsonl"),
+		// A window opened on no folder.
+		write("globalStorage", "emptyWindowChatSessions", "s2.jsonl"),
+		// And the same two again inside a named profile, which keeps its own
+		// copy of both one level further down.
+		write("profiles", "-1a2b3c", "workspaceStorage", "def456", "chatSessions", "s3.jsonl"),
+		write("profiles", "-1a2b3c", "globalStorage", "emptyWindowChatSessions", "s4.jsonl"),
+	}
+
+	// Things that live in the same tree and are not transcripts. The walk this
+	// replaces read all of them.
+	write("History", "1a2b3c", "entries.json")
+	write("workspaceStorage", "abc123", "state.vscdb")
+	write("globalStorage", "some.extension", "cache.json")
+	write("workspaceStorage", "abc123", "chatSessions", "notes.txt")
+
+	got := CopilotChatSessionFiles()
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("discovery found\n%s\nwant\n%s", strings.Join(got, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// A root in none of those shapes still gets walked, so a layout nobody has seen
+// is slow rather than invisible.
+func TestCopilotChatWalksARootItDoesNotRecognise(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_COPILOT_CHAT_ROOTS", root)
+	odd := filepath.Join(root, "somewhere", "else", "deeper", "chatSessions")
+	if err := os.MkdirAll(odd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(odd, "s1.jsonl")
+	if err := os.WriteFile(p, []byte(`{"kind":0}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := CopilotChatSessionFiles()
+	if len(got) != 1 || got[0] != p {
+		t.Fatalf("an unrecognised layout was not walked: %v", got)
+	}
+
+	// And once the root looks like VS Code's, the targeted read is used — which
+	// is the trade this makes, and the reason the shapes above are pinned.
+	if err := os.MkdirAll(filepath.Join(root, "workspaceStorage"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := CopilotChatSessionFiles(); len(got) != 0 {
+		t.Fatalf("a recognised root still walked the whole tree: %v", got)
+	}
+}


### PR DESCRIPTION
The Copilot Chat store lives inside VS Code's User folder, and discovery walked all of it. On this machine that is 2,643 workspace directories read to reach the 28 that hold chat sessions:

```
                   before    after
walk copilot-chat  72.3ms    1.1ms     42 files either way
trace walk stores  95.1ms   26.6ms     all twenty-five harnesses
```

It now asks for the directories VS Code actually uses — `workspaceStorage/<hash>/chatSessions`, `globalStorage/emptyWindowChatSessions`, and both again under each named profile — so a workspace directory costs one failed open instead of a directory read. A root in none of those shapes still gets walked, so an unknown layout is slow rather than invisible; the test names every shape and the fallback, and each of the five is a mutation that turns it red.

Found while measuring #3021. Closes #3167.
