### PR TITLE
fix(digest): what the host writes under the user role is not the person's line

### DIFF
--- a/cmd/deja/hook_prompt_summary_title_test.go
+++ b/cmd/deja/hook_prompt_summary_title_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A session that opens with a compaction summary is titled by the person's
+// first real line, not by "Summary: 1. Primary Request and Intent: …" — the
+// line the status bar quoted on 2026-09-08 (#3157).
+func TestOpenerSkipsTheCompactionSummaryAsATitle(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "compact.jsonl"), "compact", []string{
+		`{"type":"user","sessionId":"compact","timestamp":"` + old + `","message":{"role":"user","content":"Summary:\n1. Primary Request and Intent:\n   - MOST RECENT: fix the exporter_batch rows dropped at utc_midnight\n2. Key Technical Concepts:\n   - exporter_batch cursor"}}`,
+		`{"type":"assistant","sessionId":"compact","timestamp":"` + old + `","message":{"role":"assistant","content":"Continuing from the summary."}}`,
+		`{"type":"user","sessionId":"compact","timestamp":"` + old + `","message":{"role":"user","content":"the exporter_batch job drops rows at utc_midnight"}}`,
+		`{"type":"assistant","sessionId":"compact","timestamp":"` + old + `","message":{"role":"assistant","content":"utc_midnight rollover: the exporter_batch cursor was compared in local time."}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	var out bytes.Buffer
+	in := `{"prompt":"exporter_batch dropping rows at utc_midnight again","session_id":"agent-7"}`
+	if err := runHookPrompt(index.DefaultDir(), strings.NewReader(in), &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Primary Request") {
+		t.Fatalf("the compaction summary became a title:\n%s", got)
+	}
+	if !strings.Contains(got, "déjà vu: the exporter_batch job drops rows at utc_midnight") {
+		t.Fatalf("the person's line was not the title:\n%s", got)
+	}
+}

--- a/internal/digest/compaction_summary_test.go
+++ b/internal/digest/compaction_summary_test.go
@@ -24,9 +24,9 @@ func TestCompactionSummaryIsNotAPersonsLine(t *testing.T) {
 	}
 }
 
-// What Claude Code writes into the transcript when a hook returns a status
-// line is the hook's, not the person's — and deja's own block coming back
-// is plumbing for titles too (#3168).
+// A hook's status bar pasted on its own is the hook's, not the person's — and
+// deja's own block coming back is plumbing for titles too (#3168). Pasted
+// above a question, the bar comes off and the question stays.
 func TestHookStatusLinesAreTheHosts(t *testing.T) {
 	yes := []string{
 		"UserPromptSubmit says: deja-vu — you have been here: \"what did we decide\" (today · via: x)",
@@ -49,5 +49,12 @@ func TestHookStatusLinesAreTheHosts(t *testing.T) {
 		if IsHookStatusLine(s) {
 			t.Errorf("a person's line taken for a hook status: %q", s)
 		}
+	}
+	pasted := "UserPromptSubmit says: deja-vu — you have been here: \"Summary: 1. Primary Request and Intent: - MOST R…\" (Aug 11 · via: task-notification, task-id, br50mykp6)\nчто за ошибка в нашем диалоге? потенциальный баг в deja?"
+	if IsHookStatusLine(pasted) || IsAgentArtifact(pasted) {
+		t.Errorf("a question under a pasted status bar taken for the host's")
+	}
+	if got := StripHarnessBlocks(pasted); got != "что за ошибка в нашем диалоге? потенциальный баг в deja?" {
+		t.Errorf("the bar did not come off the question: %q", got)
 	}
 }

--- a/internal/digest/compaction_summary_test.go
+++ b/internal/digest/compaction_summary_test.go
@@ -1,0 +1,24 @@
+package digest
+
+import "testing"
+
+func TestCompactionSummaryIsNotAPersonsLine(t *testing.T) {
+	yes := []string{
+		"Summary:\n1. Primary Request and Intent:\n   - MOST RECENT (active task): 'ты сам отревьювь строго'",
+		"This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion.",
+	}
+	no := []string{
+		"Summary: the migration locked the table, we rolled it back",
+		"what did we decide about the primary request timeout?",
+	}
+	for _, s := range yes {
+		if !IsCompactionSummary(s) || !IsAgentArtifact(s) || !IsPlumbing(s) {
+			t.Errorf("not recognised as a compaction summary: %q", s[:40])
+		}
+	}
+	for _, s := range no {
+		if IsCompactionSummary(s) {
+			t.Errorf("a person's line taken for a compaction summary: %q", s)
+		}
+	}
+}

--- a/internal/digest/compaction_summary_test.go
+++ b/internal/digest/compaction_summary_test.go
@@ -9,6 +9,7 @@ func TestCompactionSummaryIsNotAPersonsLine(t *testing.T) {
 	}
 	no := []string{
 		"Summary: the migration locked the table, we rolled it back",
+		"Summary: what is the Primary Request and Intent here, in one line?",
 		"what did we decide about the primary request timeout?",
 	}
 	for _, s := range yes {
@@ -35,6 +36,8 @@ func TestHookStatusLinesAreTheHosts(t *testing.T) {
 	}
 	no := []string{
 		"the changelog says: nothing about hooks, so where is it documented?",
+		"Vlad says: ship it without the retry",
+		"Codex says: the lock is held by the daemon, is that right?",
 		"Says who? the test passes locally",
 	}
 	for _, s := range yes {

--- a/internal/digest/compaction_summary_test.go
+++ b/internal/digest/compaction_summary_test.go
@@ -22,3 +22,29 @@ func TestCompactionSummaryIsNotAPersonsLine(t *testing.T) {
 		}
 	}
 }
+
+// What Claude Code writes into the transcript when a hook returns a status
+// line is the hook's, not the person's — and deja's own block coming back
+// is plumbing for titles too (#3168).
+func TestHookStatusLinesAreTheHosts(t *testing.T) {
+	yes := []string{
+		"UserPromptSubmit says: deja-vu — you have been here: \"what did we decide\" (today · via: x)",
+		"SessionStart:compact says: deja recalled 3 prior sessions touching doctor.go",
+		"⎿ SessionStart:startup says: deja: recalled 3 prior sessions from this project",
+		"<deja-recall>\nRecalled history from prior sessions.\n- **app** `x`\n</deja-recall>",
+	}
+	no := []string{
+		"the changelog says: nothing about hooks, so where is it documented?",
+		"Says who? the test passes locally",
+	}
+	for _, s := range yes {
+		if !IsPlumbing(s) || !IsAgentArtifact(s) {
+			t.Errorf("the host's line taken for a person's: %q", s[:40])
+		}
+	}
+	for _, s := range no {
+		if IsHookStatusLine(s) {
+			t.Errorf("a person's line taken for a hook status: %q", s)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -645,10 +645,12 @@ func IsCompactionSummary(t string) bool {
 // deja-vu — you have been h…'" (#3168).
 var hookStatusLineRE = regexp.MustCompile(`^(?:⎿\s*)?(?:SessionStart|SessionEnd|UserPromptSubmit|PreToolUse|PostToolUse|PostToolUseFailure|PreCompact|Stop|SubagentStart|SubagentStop|Notification|PermissionRequest|Setup)(?::[a-z]+)? says: `)
 
-// IsHookStatusLine reports whether a message is a hook's status line recorded
-// by the host, not something the person typed.
+// IsHookStatusLine reports whether a message is nothing but a hook's status
+// line — the bar pasted on its own, no question under it. With a question
+// under it the message is the person's; StripHarnessBlocks takes the bar off.
 func IsHookStatusLine(t string) bool {
-	return hookStatusLineRE.MatchString(strings.TrimSpace(t))
+	t = strings.TrimSpace(t)
+	return hookStatusLineRE.MatchString(t) && strings.TrimSpace(stripHookStatusLines(t)) == ""
 }
 
 // cleanSession drops agent artifacts and exact repeats so the digest carries

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -406,13 +406,13 @@ func noisyMessage(s string) bool {
 	// <teammate-message ...>" — slipped past the prefix check and reached the
 	// session-start block, where truncated inter-agent JSON was among the first
 	// things an agent read. Nobody writes these tags in prose.
-	for _, p := range []string{"<local-command", "<command-", "<task-notification", "<teammate-message", "<bash-", "<system-reminder"} {
+	for _, p := range []string{"<local-command", "<command-", "<task-notification", "<teammate-message", "<bash-", "<system-reminder", "<deja-recall"} {
 		if strings.Contains(t, p) {
 			return true
 		}
 	}
 	// Prose, so only where it opens the message.
-	if strings.HasPrefix(t, "Caveat:") || IsCompactionSummary(t) {
+	if strings.HasPrefix(t, "Caveat:") || IsCompactionSummary(t) || IsHookStatusLine(t) {
 		return true
 	}
 	if strings.Contains(t, "tool_use") || strings.Contains(t, "tool_result") {
@@ -574,7 +574,7 @@ func IsAgentArtifact(text string) bool {
 		}
 	}
 	trimmed := strings.TrimSpace(text)
-	if IsCompactionSummary(trimmed) {
+	if IsCompactionSummary(trimmed) || IsHookStatusLine(trimmed) {
 		return true
 	}
 	// Harness preambles injected as user turns: <environment_context>,
@@ -630,6 +630,20 @@ func IsCompactionSummary(t string) bool {
 		head = head[:300]
 	}
 	return strings.HasPrefix(t, "Summary:") && strings.Contains(head, "Primary Request and Intent")
+}
+
+// hookStatusLineRE is the shape Claude Code uses to record what a hook said
+// in its systemMessage: `UserPromptSubmit says: …`, `SessionStart:compact
+// says: …`, sometimes behind the tree glyph. The line is deja's own status
+// bar coming back through the transcript under the user role, and it was
+// quoted as a session title: "you have been here: 'UserPromptSubmit says:
+// deja-vu — you have been h…'" (#3168).
+var hookStatusLineRE = regexp.MustCompile(`^(?:⎿\s*)?[A-Z][A-Za-z]*(?::[a-z]+)? says: `)
+
+// IsHookStatusLine reports whether a message is a hook's status line recorded
+// by the host, not something the person typed.
+func IsHookStatusLine(t string) bool {
+	return hookStatusLineRE.MatchString(strings.TrimSpace(t))
 }
 
 // cleanSession drops agent artifacts and exact repeats so the digest carries

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -612,6 +612,10 @@ func IsAgentArtifact(text string) bool {
 	return false
 }
 
+// compactionOutlineRE is the numbered outline the summary opens with; a person
+// asking "Summary: what is the Primary Request and Intent here?" has no "1.".
+var compactionOutlineRE = regexp.MustCompile(`(?m)^\s*1\.\s*Primary Request and Intent`)
+
 // IsCompactionSummary reports whether a message is the block a harness writes
 // as the first user turn after a compaction — Claude Code's "Summary: 1.
 // Primary Request and Intent: …" and the "This session is being continued
@@ -620,10 +624,6 @@ func IsAgentArtifact(text string) bool {
 // session "Summary: 1. Primary Request and Intent: - MOST R…" and told the
 // reader nothing (#3157). Judged on the opening, since a person can write
 // "Summary:" and go on to say something.
-// compactionOutlineRE is the numbered outline the summary opens with; a person
-// asking "Summary: what is the Primary Request and Intent here?" has no "1.".
-var compactionOutlineRE = regexp.MustCompile(`(?m)^\s*1\.\s*Primary Request and Intent`)
-
 func IsCompactionSummary(t string) bool {
 	t = strings.TrimSpace(t)
 	if strings.HasPrefix(t, "This session is being continued from a previous conversation") {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -620,6 +620,10 @@ func IsAgentArtifact(text string) bool {
 // session "Summary: 1. Primary Request and Intent: - MOST R…" and told the
 // reader nothing (#3157). Judged on the opening, since a person can write
 // "Summary:" and go on to say something.
+// compactionOutlineRE is the numbered outline the summary opens with; a person
+// asking "Summary: what is the Primary Request and Intent here?" has no "1.".
+var compactionOutlineRE = regexp.MustCompile(`(?m)^\s*1\.\s*Primary Request and Intent`)
+
 func IsCompactionSummary(t string) bool {
 	t = strings.TrimSpace(t)
 	if strings.HasPrefix(t, "This session is being continued from a previous conversation") {
@@ -629,16 +633,17 @@ func IsCompactionSummary(t string) bool {
 	if len(head) > 300 {
 		head = head[:300]
 	}
-	return strings.HasPrefix(t, "Summary:") && strings.Contains(head, "Primary Request and Intent")
+	return strings.HasPrefix(t, "Summary:") && compactionOutlineRE.MatchString(head)
 }
 
 // hookStatusLineRE is the shape Claude Code uses to record what a hook said
 // in its systemMessage: `UserPromptSubmit says: …`, `SessionStart:compact
-// says: …`, sometimes behind the tree glyph. The line is deja's own status
+// says: …`, sometimes behind the tree glyph. Only the host's event names
+// count — "Vlad says: no" is a person. The line is deja's own status
 // bar coming back through the transcript under the user role, and it was
 // quoted as a session title: "you have been here: 'UserPromptSubmit says:
 // deja-vu — you have been h…'" (#3168).
-var hookStatusLineRE = regexp.MustCompile(`^(?:⎿\s*)?[A-Z][A-Za-z]*(?::[a-z]+)? says: `)
+var hookStatusLineRE = regexp.MustCompile(`^(?:⎿\s*)?(?:SessionStart|SessionEnd|UserPromptSubmit|PreToolUse|PostToolUse|PostToolUseFailure|PreCompact|Stop|SubagentStart|SubagentStop|Notification|PermissionRequest|Setup)(?::[a-z]+)? says: `)
 
 // IsHookStatusLine reports whether a message is a hook's status line recorded
 // by the host, not something the person typed.

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -412,7 +412,7 @@ func noisyMessage(s string) bool {
 		}
 	}
 	// Prose, so only where it opens the message.
-	if strings.HasPrefix(t, "Caveat:") {
+	if strings.HasPrefix(t, "Caveat:") || IsCompactionSummary(t) {
 		return true
 	}
 	if strings.Contains(t, "tool_use") || strings.Contains(t, "tool_result") {
@@ -574,6 +574,9 @@ func IsAgentArtifact(text string) bool {
 		}
 	}
 	trimmed := strings.TrimSpace(text)
+	if IsCompactionSummary(trimmed) {
+		return true
+	}
 	// Harness preambles injected as user turns: <environment_context>,
 	// <user_instructions> and similar XML-wrapped plumbing.
 	if strings.HasPrefix(trimmed, "<") && strings.Contains(trimmed, "</") {
@@ -607,6 +610,26 @@ func IsAgentArtifact(text string) bool {
 		}
 	}
 	return false
+}
+
+// IsCompactionSummary reports whether a message is the block a harness writes
+// as the first user turn after a compaction — Claude Code's "Summary: 1.
+// Primary Request and Intent: …" and the "This session is being continued
+// from a previous conversation" preamble in front of it. The model wrote it
+// and the host filed it under the user's role, so as a title it named a
+// session "Summary: 1. Primary Request and Intent: - MOST R…" and told the
+// reader nothing (#3157). Judged on the opening, since a person can write
+// "Summary:" and go on to say something.
+func IsCompactionSummary(t string) bool {
+	t = strings.TrimSpace(t)
+	if strings.HasPrefix(t, "This session is being continued from a previous conversation") {
+		return true
+	}
+	head := t
+	if len(head) > 300 {
+		head = head[:300]
+	}
+	return strings.HasPrefix(t, "Summary:") && strings.Contains(head, "Primary Request and Intent")
 }
 
 // cleanSession drops agent artifacts and exact repeats so the digest carries

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -40,8 +40,27 @@ var harnessBlockRe = func() *regexp.Regexp {
 // hook say "you have been here" about another notification, with the
 // envelope's field names as the identifying terms (#3156).
 func StripHarnessBlocks(prompt string) string {
-	if !strings.Contains(prompt, "<") {
-		return strings.TrimSpace(prompt)
+	if strings.Contains(prompt, "<") {
+		prompt = harnessBlockRe.ReplaceAllString(prompt, "")
 	}
-	return strings.TrimSpace(harnessBlockRe.ReplaceAllString(prompt, ""))
+	if strings.Contains(prompt, " says: ") {
+		prompt = stripHookStatusLines(prompt)
+	}
+	return strings.TrimSpace(prompt)
+}
+
+// stripHookStatusLines drops the lines that are a hook's status bar pasted
+// into the turn — `UserPromptSubmit says: deja-vu — you have been here: …`
+// above the question a person went on to ask about it (#3168). The question
+// stays; the bar is neither a title nor terms.
+func stripHookStatusLines(text string) string {
+	lines := strings.Split(text, "\n")
+	kept := lines[:0]
+	for _, l := range lines {
+		if hookStatusLineRE.MatchString(strings.TrimSpace(l)) {
+			continue
+		}
+		kept = append(kept, l)
+	}
+	return strings.Join(kept, "\n")
 }

--- a/internal/search/asked_before.go
+++ b/internal/search/asked_before.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -45,7 +46,16 @@ func AskedBefore(s model.Session, terms []string) string {
 		if m.Role != "user" {
 			continue
 		}
-		past := prompt.Terms(m.Text)
+		// The host's own turns and the model's compaction summary sit under the
+		// user role too; two task notifications share every word and are not
+		// a question asked twice. A person's question with a reminder appended
+		// is still the question, so the envelope comes off rather than the
+		// message being skipped.
+		text := digest.StripHarnessBlocks(m.Text)
+		if text == "" || digest.IsCompactionSummary(text) {
+			continue
+		}
+		past := prompt.Terms(text)
 		if len(past) < askedAgainMinTerms {
 			continue
 		}
@@ -63,7 +73,7 @@ func AskedBefore(s model.Session, terms []string) string {
 			continue
 		}
 		if shared > bestShared {
-			best, bestShared = strings.TrimSpace(firstSentence(m.Text)), shared
+			best, bestShared = strings.TrimSpace(firstSentence(text)), shared
 		}
 	}
 	return best

--- a/internal/search/asked_before_test.go
+++ b/internal/search/asked_before_test.go
@@ -1,9 +1,11 @@
 package search
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 )
 
 func askedSession(texts ...string) model.Session {
@@ -59,5 +61,26 @@ func TestAskedBeforeIgnoresTheAgentsOwnWords(t *testing.T) {
 	}}
 	if got := AskedBefore(s, []string{"scheduler", "retrying", "pgbouncer"}); got != "" {
 		t.Errorf("the agent's own restatement counted as a repeat: %q", got)
+	}
+}
+
+// Two task notifications share every word; that is the host repeating itself,
+// not a question asked twice. A person's question with a reminder appended is
+// still the question, and the quote is the question alone (#3156, #3157).
+func TestAskedBeforeSkipsTheHostsOwnLines(t *testing.T) {
+	s := model.Session{Messages: []model.Message{
+		{Role: "user", Text: "<task-notification>\n<task-id>br50mykp6</task-id>\n<status>failed</status>\n<summary>Background command failed with exit code 2</summary>\n</task-notification>"},
+		{Role: "user", Text: "Summary:\n1. Primary Request and Intent:\n   - fix the exporter_batch rows dropped at utc_midnight"},
+	}}
+	if got := AskedBefore(s, prompt.Terms("<task-notification>\n<task-id>x</task-id>\n<status>failed</status>\n<summary>Background command failed with exit code 2</summary>\n</task-notification>")); got != "" {
+		t.Fatalf("a notification was asked before: %q", got)
+	}
+	if got := AskedBefore(s, prompt.Terms("fix the exporter_batch rows dropped at utc_midnight")); got != "" {
+		t.Fatalf("a compaction summary was asked before: %q", got)
+	}
+	s.Messages = append(s.Messages, model.Message{Role: "user", Text: "why does exporter_batch drop rows at utc_midnight?\n<system-reminder>\nthe file changed on disk\n</system-reminder>"})
+	got := AskedBefore(s, prompt.Terms("why does exporter_batch drop rows at utc_midnight"))
+	if !strings.HasPrefix(got, "why does exporter_batch") || strings.Contains(got, "system-reminder") {
+		t.Fatalf("the person's question with a reminder appended: %q", got)
 	}
 }

--- a/internal/search/matched_user_line_pasted_test.go
+++ b/internal/search/matched_user_line_pasted_test.go
@@ -1,0 +1,20 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A person who pastes a hook's status bar and asks about it gets the
+// question as the title, not the bar (#3168).
+func TestMatchedUserLineSkipsThePastedStatusBar(t *testing.T) {
+	s := model.Session{Messages: []model.Message{{
+		Role: "user",
+		Text: "UserPromptSubmit says: deja-vu — you have been here: \"Summary: 1. Primary Request…\" (Aug 11 · via: task-notification)\nwhy does the prompt hook quote a task notification as a title?",
+	}}}
+	got := MatchedUserLine(s, []string{"prompt", "hook", "notification"})
+	if got != "why does the prompt hook quote a task notification as a title?" {
+		t.Fatalf("title = %q", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -968,7 +968,7 @@ func MatchedUserLine(s model.Session, terms []string) string {
 		if m.Role != "user" || noiseMessage(m.Text) {
 			continue
 		}
-		line, hits := densestLine(m.Text, terms)
+		line, hits := densestLine(digest.StripHarnessBlocks(m.Text), terms)
 		if hits > bestHits {
 			best, bestHits = strings.TrimSpace(line), hits
 		}


### PR DESCRIPTION
Three lines the host writes under the user role stop counting as the person's: the compaction summary Claude Code writes after /compact ("Summary: 1. Primary Request and Intent…"), the hook status lines it records ("UserPromptSubmit says: …", "SessionStart:compact says: …"), and deja's own recall block echoed back. They are artifacts for titles and the digest, and `AskedBefore` strips the host's envelopes from past turns before comparing, so two task notifications no longer read as a question asked twice. One classification, three surfaces.

Fail before the fix: `TestOpenerSkipsTheCompactionSummaryAsATitle` ("the compaction summary became a title"), `TestAskedBeforeSkipsTheHostsOwnLines` ("a notification was asked before"), `TestHookStatusLinesAreTheHosts`.

Closes #3157
Closes #3168


## Review

Reviewer: hookStatusLineRE matched "User says:", "Codex says:" (any capitalised word); IsCompactionSummary matched a person asking "Summary: what is the Primary Request and Intent here?". Both tightened — the status line now needs one of the host's event names, the summary needs the numbered "1. Primary Request and Intent" outline — with the two counter-cases in TestCompactionSummaryIsNotAPersonsLine and TestHookStatusLinesAreTheHosts. The rest not refuted: three new tests fail without the fix; firstSentence runs on the stripped text after the empty check.

Second pass: the "UserPromptSubmit says:" lines in the index were the person's own paste with a question under it (Claude Code does not record a hook's status under the user role), so a whole-message test lost the question. The bar now comes off in StripHarnessBlocks and MatchedUserLine reads the stripped text; TestMatchedUserLineSkipsThePastedStatusBar gives `title = ""` before the change.
