### PR TITLE
fix(install): the kept-snapshot line counts every file an -auto uninstall touched

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -27,6 +27,15 @@ type installResult struct {
 	// about, could not act on, and left as it found it. Empty in every ordinary
 	// case, so a printer can append it blind (#2218).
 	Note string
+	// also holds the other files an -auto target changed in the same run;
+	// the printer folds them into Note, the kept-snapshot line needs the paths.
+	also []string
+}
+
+// touched is every file this result changed: the one it is named for and the
+// ones that rode along in the note (#3171).
+func (r installResult) touched() []string {
+	return append([]string{r.Path}, r.also...)
 }
 
 func runInstall(dir string, args []string, uninstall bool) error {
@@ -204,7 +213,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 				pruneGuidanceDirs(cr.Path)
 			}
 		}
-		touchedPaths = append(touchedPaths, r.Path)
+		touchedPaths = append(touchedPaths, r.touched()...)
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path), r.Note})
 		} else {
@@ -805,6 +814,7 @@ func wroteAll(rs ...installResult) installResult {
 			continue
 		}
 		also = append(also, fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path)))
+		out.also = append(out.also, r.Path)
 	}
 	for _, line := range also {
 		if out.Note != "" {

--- a/cmd/deja/kept_snapshots_auto_test.go
+++ b/cmd/deja/kept_snapshots_auto_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An -auto target writes several configs; the kept-snapshot line after an
+// uninstall has to count every one of them, not only the file the folded
+// result is named for.
+func TestKeptSnapshotsCountEveryFileTheAutoTargetTouched(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "claude.json")
+	b := filepath.Join(dir, "settings.json")
+	for _, p := range []string{a + ".bak", b + ".bak"} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := wroteAll(installResult{Path: a, Action: "updated"}, installResult{Path: b, Action: "updated"})
+	line := keptSnapshotsLine(r.touched())
+	if !strings.Contains(line, "kept 2 snapshots") {
+		t.Fatalf("line = %q", line)
+	}
+}


### PR DESCRIPTION
An -auto target folds its writes into one result; only that result's `Path` reached `keptSnapshotsLine`, so `uninstall claude-auto` said `kept 1 snapshot` over two `.bak` files. The folded result now carries the other paths and `touched()` hands all of them over. `TestKeptSnapshotsCountEveryFileTheAutoTargetTouched` fails before with `r.touched undefined`; end to end on a hermetic HOME the line reads `kept 2 snapshots … ~/.claude.json.bak and 1 more`.

Closes #3171

## Review

Reviewer (cavecrew): checked whether `also` should carry results left "unchanged" (no — no new .bak is taken for them), whether `out = r` can drop a stale `also` (no caller nests wroteAll), other readers of touchedPaths (only keptSnapshotsLine, which dedups), the test before/after, and the doc-comment rule. Verdict: fix complete and correct, nothing to change.
