### PR TITLE
docs(codex): the plugin README names the hooks the bundle carries

### DIFF
--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -6,10 +6,12 @@ The plugin bundle Codex installs from this repository's marketplace:
 codex plugin marketplace add vshulcz/deja-vu && codex plugin add deja-vu@deja-vu
 ```
 
-It carries deja's MCP server and the `deja-history` skill.
+It carries deja's MCP server, the `deja-history` skill and three hooks:
+recall at session start and on each prompt, and what a compaction threw away
+served again once.
 
 [deja](https://github.com/vshulcz/deja-vu) indexes the session transcripts
-twenty-three coding agents already write to disk, including sessions from before it
+twenty-four coding agents already write to disk, including sessions from before it
 was installed, and answers from them locally: BM25 over the transcripts, no
 model and no embeddings, credentials redacted as the index is built.
 
@@ -25,9 +27,8 @@ or
 curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | sh
 ```
 
-`deja install codex` wires the same MCP server plus the session-start hook
-Codex reads from `hooks.json`, which the bundle cannot carry. Either path
-works, and having both does not wire anything twice.
+`deja install codex` writes the same MCP server and hooks into `~/.codex`
+from the CLI. Either path works, and having both does not wire anything twice.
 
 Details, the harness matrix and the benchmarks are in the
 [repository README](../README.md). Security policy: [SECURITY.md](../SECURITY.md).


### PR DESCRIPTION
The bundle has shipped hooks.json since #3132; the README still said it could not, and counted twenty-three agents. Wording of the three-hook line is open to change.

Closes #3174