### PR TITLE
fix(index): a store that would not open is not recorded as read by a rebuild

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -482,14 +482,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	}
 	reportPhase("reading sessions", total)
 	ss := sources.FilterSessions(filterTombstonedSet(loadProgress(harness, progress), dead))
-	// A store the loaders could not read is not recorded as read: with its
-	// size and mtime on file the next pass would call the index up to date
-	// and the store's history would stay missing until someone rebuilt by
-	// hand. Left out, the next pass parses it again — and skips it again,
-	// aloud, while it stays closed (#3176).
-	for p := range sources.DiagFailedPaths() {
-		delete(files, p)
-	}
+	forgetUnreadStores(files)
 	// Imported sessions are filtered too: excluding a project must also drop
 	// what a peer already pushed, not only what arrives next.
 	ss = append(ss, sources.FilterSessions(imported.sessions)...)
@@ -878,6 +871,19 @@ func markShared(sessions map[string]SessionMeta, key string) {
 	}
 }
 
+// forgetUnreadStores drops from the file table every path the loaders could
+// not read this pass. Recorded with its size and mtime, a store locked past
+// the sqlite timeout made the next pass call the index up to date, and its
+// history stayed missing until someone rebuilt by hand. Left out, the next
+// pass parses it again — and skips it again, aloud, while it stays closed
+// (#3176). Both rebuild paths, since a damaged index reaches the search one
+// directly.
+func forgetUnreadStores(files map[string]FileState) {
+	for p := range sources.DiagFailedPaths() {
+		delete(files, p)
+	}
+}
+
 func rebuildForSearch(dir string, o query.Options, scope string, files map[string]FileState, progress io.Writer) error {
 	beginPass()
 	tmp := dir + ".tmp"
@@ -896,6 +902,7 @@ func rebuildForSearch(dir string, o query.Options, scope string, files map[strin
 	}
 	reportPhase("reading sessions", total)
 	ss := sources.FilterSessions(filterTombstoned(loadProgress("", progress)))
+	forgetUnreadStores(files)
 	imported := importedSessions(dir)
 	ss = append(ss, imported.sessions...)
 	ss = filterTombstoned(ss)

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -482,6 +482,14 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	}
 	reportPhase("reading sessions", total)
 	ss := sources.FilterSessions(filterTombstonedSet(loadProgress(harness, progress), dead))
+	// A store the loaders could not read is not recorded as read: with its
+	// size and mtime on file the next pass would call the index up to date
+	// and the store's history would stay missing until someone rebuilt by
+	// hand. Left out, the next pass parses it again — and skips it again,
+	// aloud, while it stays closed (#3176).
+	for p := range sources.DiagFailedPaths() {
+		delete(files, p)
+	}
 	// Imported sessions are filtered too: excluding a project must also drop
 	// what a peer already pushed, not only what arrives next.
 	ss = append(ss, sources.FilterSessions(imported.sessions)...)

--- a/internal/index/locked_store_rebuild_test.go
+++ b/internal/index/locked_store_rebuild_test.go
@@ -1,0 +1,64 @@
+package index
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A sqlite store that cannot be read while a rebuild runs — locked by the
+// agent using it, or unreadable for the moment — must not be recorded as
+// read: the rebuild says so, doctor counts it, and the next pass reads it
+// again once it opens. It used to commit an empty index for the store in
+// silence and call it up to date until the next --rebuild.
+func TestRebuildRetriesAStoreItCouldNotRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("needs a file the owner cannot read")
+	}
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "index")
+	db := os.Getenv("DEJA_OPENCODE_DB")
+	runStoreSQL(t, db, `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/w','2026-01-02T03:00:00Z','2026-01-03T03:00:00Z');
+insert into message values('m1','s1',1767409200000,'{"role":"user"}');
+insert into part values('p1','m1','{"type":"text","text":"why does the lockedneedle pager stall"}');`)
+	if err := os.Chmod(db, 0); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := Ensure(dir, "", true, &out); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if h := IngestHealth(dir)["opencode"]; h.FailedFiles != 1 {
+		t.Errorf("the unreadable store was not counted: %+v\n%s", h, out.String())
+	}
+	if !strings.Contains(out.String(), "could not be read") {
+		t.Errorf("the rebuild said nothing about the store it could not read:\n%s", out.String())
+	}
+	// The file itself is untouched — same size, same mtime — only readable
+	// again, which is what the end of a lock looks like.
+	if err := os.Chmod(db, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Ensure(dir, "", false, &out); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	hits, err := Search(dir, query.Options{Query: "lockedneedle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("the store was not read again once it opened: %d hits\n%s", len(hits), out.String())
+	}
+}

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -124,7 +124,8 @@ func fileExists(p string) bool {
 func LoadCursor() []model.Session {
 	var ss []model.Session
 	for _, db := range CursorDBs() {
-		got, _ := ParseCursorDB(db)
+		got, err := ParseCursorDB(db)
+		diagFileError(db, err)
 		ss = append(ss, got...)
 	}
 	ss = append(ss, parseFiles(CursorTranscripts(), ParseCursorTranscript)...)

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -38,7 +38,11 @@ func OpencodeDB() string {
 }
 
 func LoadOpencode() []model.Session {
-	ss, _ := ParseOpencodeDBWhere(OpencodeDB(), "", 0)
+	// A store that would not open — locked past the timeout by the agent
+	// using it, or unreadable — is reported like a transcript that would not
+	// parse, so the pass says so and does not record the store as read.
+	ss, err := ParseOpencodeDBWhere(OpencodeDB(), "", 0)
+	diagFileError(OpencodeDB(), err)
 	return ss
 }
 


### PR DESCRIPTION
The incremental path already keeps the old file state when a parser fails ("skipping … this pass") — the rebuild path did not, because `LoadOpencode` and `LoadCursor` dropped the parser's error. The loaders now report it through the same side channel a transcript that would not parse uses, the rebuild narrates it (`opencode: nothing indexed — 1 path could not be read`) and leaves the store out of the file table, so the next `deja index` reads it again once it opens — without the file having to change.

`TestRebuildRetriesAStoreItCouldNotRead` fails before on all three counts: `FailedFiles:0`, nothing said, `0 hits` after the store opens. End to end with the binary: rebuild on an unreadable store prints the two lines above; the next pass reports `changed_files=1 … sessions=1` and the search hits.

Closes #3176

## Review

Reviewer (cavecrew): not refuted — test fails before on all three counts and passes with -race; setStoreLastUpdated and wholeStoresThisPass handle a missing files[db]. Three risks: (1) rebuildForSearch reaches writeSessionsWithSync by its own path without the pruning — now shares `forgetUnreadStores`; (2) a transcript that would not parse is also left out of the table by a rebuild, so the next incremental pass re-parses it once and says "skipping … this pass" — the behaviour the incremental path already has for the same file, kept on purpose; (3) chmod 0 as the unreadable store — the test skips on Windows and as root.
