### PR TITLE
fix: deja quoted its own hook line back as a session title

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -27,6 +27,20 @@ type installResult struct {
 	// about, could not act on, and left as it found it. Empty in every ordinary
 	// case, so a printer can append it blind (#2218).
 	Note string
+	// Also is every other config this target wrote, for the callers that need
+	// the paths rather than the sentence about them. An -auto target writes two
+	// files and folds them into one result, so the screen that names what was
+	// left behind saw one of them and reported "kept 1 snapshot" beside two
+	// .bak files (#3171).
+	Also []string
+}
+
+// paths is every config this result covers, the named one first.
+func (r installResult) paths() []string {
+	if r.Path == "" {
+		return r.Also
+	}
+	return append([]string{r.Path}, r.Also...)
 }
 
 func runInstall(dir string, args []string, uninstall bool) error {
@@ -204,7 +218,7 @@ func runInstall(dir string, args []string, uninstall bool) error {
 				pruneGuidanceDirs(cr.Path)
 			}
 		}
-		touchedPaths = append(touchedPaths, r.Path)
+		touchedPaths = append(touchedPaths, r.paths()...)
 		if banner {
 			done = append(done, lineItem{t, r.Action, shortHome(r.Path), r.Note})
 		} else {
@@ -815,12 +829,21 @@ func wroteAll(rs ...installResult) installResult {
 		}
 	}
 	var also []string
+	// Every other config this target touched, whether or not it changed: the
+	// snapshot beside an unchanged file is still one deja left behind, and the
+	// screen that names what stays behind needs the path, not the sentence.
+	var paths []string
 	for _, r := range rs {
-		if r.Path == "" || r.Action == "unchanged" || r.Path == out.Path {
+		if r.Path == "" || r.Path == out.Path {
+			continue
+		}
+		paths = append(paths, r.Path)
+		if r.Action == "unchanged" {
 			continue
 		}
 		also = append(also, fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path)))
 	}
+	out.Also = append(out.Also, paths...)
 	for _, line := range also {
 		if out.Note != "" {
 			out.Note += "; "

--- a/cmd/deja/kept_snapshots_test.go
+++ b/cmd/deja/kept_snapshots_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An -auto target writes two configs and folds them into one result, so the
+// screen whose whole job is naming what deja left behind saw one path and said
+// "kept 1 snapshot" beside two .bak files (#3171).
+func TestKeptSnapshotsCountsEveryConfigAnAutoTargetWrote(t *testing.T) {
+	dir := t.TempDir()
+	one := filepath.Join(dir, "a.json")
+	two := filepath.Join(dir, "b.json")
+	for _, p := range []string{one, two} {
+		if err := os.WriteFile(p+".bak", []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	r := wroteAll(
+		installResult{Path: one, Action: "updated"},
+		installResult{Path: two, Action: "updated"},
+	)
+	got := keptSnapshotsLine(r.paths())
+	if !strings.Contains(got, "kept 2 snapshots") {
+		t.Fatalf("the second config's snapshot went unmentioned:\n%s", got)
+	}
+
+	// A file the target read and did not change still has a snapshot beside it
+	// if an earlier run made one, and it is still deja's to name.
+	r = wroteAll(
+		installResult{Path: one, Action: "updated"},
+		installResult{Path: two, Action: "unchanged"},
+	)
+	if got := keptSnapshotsLine(r.paths()); !strings.Contains(got, "kept 2 snapshots") {
+		t.Fatalf("an unchanged config's snapshot went unmentioned:\n%s", got)
+	}
+	// …without claiming it was written: the note is about what changed.
+	if strings.Contains(r.Note, "unchanged") {
+		t.Errorf("the note reported an unchanged file as work: %q", r.Note)
+	}
+
+	// One target, one config: still one snapshot, not a duplicate.
+	r = wroteAll(installResult{Path: one, Action: "updated"})
+	if got := keptSnapshotsLine(r.paths()); !strings.Contains(got, "kept 1 snapshot ") {
+		t.Fatalf("a single-config target miscounted:\n%s", got)
+	}
+}
+
+// And the same through `deja uninstall claude-auto`, which is where it was
+// seen: the line is printed by runInstall out of what installTarget handed
+// back, so a unit test on the counter alone cannot hold the wiring (#3171).
+func TestUninstallNamesEverySnapshotItLeft(t *testing.T) {
+	home := hermeticEnv(t)
+	home = filepath.Join(home, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Two configs the reader already had, so both get a snapshot.
+	for _, p := range []string{
+		filepath.Join(home, ".claude.json"),
+		filepath.Join(home, ".claude", "settings.json"),
+	} {
+		if err := os.WriteFile(p, []byte(`{"mine":true}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := runInstall(index.DefaultDir(), []string{"claude-auto", "--no-index", "--no-guidance"}, false); err != nil {
+		t.Fatal(err)
+	}
+	// The line goes to stderr: it is a note about the reader's own files rather
+	// than part of what install reports doing.
+	out := captureStderr(t, func() {
+		if err := runInstall(index.DefaultDir(), []string{"claude-auto", "--no-index", "--no-guidance"}, true); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	baks := 0
+	for _, p := range []string{
+		filepath.Join(home, ".claude.json.bak"),
+		filepath.Join(home, ".claude", "settings.json.bak"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			baks++
+		}
+	}
+	if baks != 2 {
+		t.Skipf("this build left %d snapshots, not the two this is about", baks)
+	}
+	if !strings.Contains(out, "kept 2 snapshots") {
+		t.Fatalf("uninstall left 2 snapshots and named %s:\n%s",
+			map[bool]string{true: "one", false: "neither"}[strings.Contains(out, "kept 1 snapshot")], out)
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -396,6 +396,25 @@ func IsToolCallRecord(line string) bool {
 	return toolCallRecordRE.MatchString(line)
 }
 
+// hookEchoRE matches a host repeating what a hook returned. Claude Code writes
+// `UserPromptSubmit says: …`, `SessionStart:compact says: …` and
+// `⎿ SessionStart:startup says: …` into the transcript under the user role, so
+// deja's own status line comes back as something the person said and can be
+// quoted as the session's title (#3168).
+//
+// The event has to be one a harness actually fires, not merely a capitalised
+// word: "Vlad says: rebase first" opens a message the same way and is the
+// person's. Optional `:variant` for the spellings Claude Code uses —
+// SessionStart:startup, PreCompact:manual.
+var hookEchoRE = regexp.MustCompile(`^(?:⎿\s*)?(?:` + strings.Join([]string{
+	"SessionStart", "SessionEnd", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+	"PostToolUseFailure", "PreToolUseResult", "PreCompact", "SubagentStop", "Stop",
+	"Notification", "PreInvocation", "BeforeShellExecution", "AfterShellExecution",
+	"BeforeReadFile", "AfterFileEdit",
+}, "|") + `)(?::[A-Za-z]+)? says: `)
+
+func isHookEcho(t string) bool { return hookEchoRE.MatchString(t) }
+
 func noisyMessage(s string) bool {
 	t := strings.TrimSpace(s)
 	if t == "" {
@@ -413,6 +432,16 @@ func noisyMessage(s string) bool {
 	}
 	// Prose, so only where it opens the message.
 	if strings.HasPrefix(t, "Caveat:") {
+		return true
+	}
+	if isHookEcho(t) {
+		return true
+	}
+	// deja's own block, echoed back into the transcript under a user role by a
+	// host that records what a hook returned. It is in the artifact list and
+	// was not here, so a line out of deja's recall could still be picked as the
+	// session's title — recall quoting itself (#3168).
+	if strings.Contains(t, "<deja-recall>") {
 		return true
 	}
 	if strings.Contains(t, "tool_use") || strings.Contains(t, "tool_result") {
@@ -603,6 +632,11 @@ func IsAgentArtifact(text string) bool {
 		return true
 	}
 	if isCompactionSummary(trimmed) {
+		return true
+	}
+	// The host repeating a hook's own status line back into the transcript,
+	// and deja's block echoed with it (#3168).
+	if isHookEcho(trimmed) || strings.Contains(trimmed, "<deja-recall>") {
 		return true
 	}
 	// ls dumps recorded under a user role.

--- a/internal/digest/hook_echo_test.go
+++ b/internal/digest/hook_echo_test.go
@@ -1,0 +1,48 @@
+package digest
+
+import "testing"
+
+// Claude Code writes what a hook returned into the transcript under the user
+// role, so deja's own status line comes back as something the person said —
+// and gets quoted as the session's title. Seen in the status bar as
+// `you have been here: "UserPromptSubmit says: deja-vu — you have been h…"`,
+// which is recall quoting itself (#3168).
+func TestHookEchoesAreNotWhatThePersonSaid(t *testing.T) {
+	echoes := []string{
+		`UserPromptSubmit says: deja-vu — you have been here: "the retry cap" (today)`,
+		`SessionStart:compact says: deja recalled 3 prior sessions for this project`,
+		`⎿ SessionStart:startup says: deja: recalled 2 sessions`,
+		`PreToolUse says: deja: this command failed here before`,
+		`PreCompact:manual says: deja saved the session digest`,
+		"<deja-recall>\nRecalled history from prior sessions.\n</deja-recall>",
+		"the assistant answered, and the transcript kept\n<deja-recall>\nan echoed block\n</deja-recall>",
+	}
+	for _, e := range echoes {
+		if !IsPlumbing(e) {
+			t.Errorf("IsPlumbing missed a host echo: %q", e)
+		}
+		if !IsAgentArtifact(e) {
+			t.Errorf("IsAgentArtifact missed a host echo: %q", e)
+		}
+	}
+
+	// What a person actually wrote, including the shapes this could have eaten:
+	// a name in front of "says:", a quotation mid-sentence, and a message that
+	// merely talks about the hook.
+	mine := []string{
+		"Vlad says: rebase first, then push",
+		"the reviewer says: this needs a test",
+		"he says: no, and I think he is right",
+		"why does UserPromptSubmit fire on a task notification",
+		"SessionStart is the only event goose gives us at the top of a session",
+		"the hook says nothing when the index has no history for the command",
+	}
+	for _, m := range mine {
+		if IsPlumbing(m) {
+			t.Errorf("IsPlumbing discarded something the person wrote: %q", m)
+		}
+		if IsAgentArtifact(m) {
+			t.Errorf("IsAgentArtifact discarded something the person wrote: %q", m)
+		}
+	}
+}


### PR DESCRIPTION
Two separate reports, one file each.

**#3168 — deja quoting itself.** Claude Code writes what a hook returned into the transcript under the user role, so `UserPromptSubmit says: deja-vu — you have been here: …` is indexed as something the person wrote, and can be picked as a session's title. Both `IsPlumbing` and `IsAgentArtifact` now reject a line that opens with a hook event and `says:`, and any message carrying a `<deja-recall>` block.

The event has to be one a harness actually fires rather than any capitalised word, so `Vlad says: rebase first` stays the person's — that control is in the test, along with `the reviewer says: …` and a message that merely talks about `UserPromptSubmit`.

**#3171 — the second snapshot.** `wroteAll` folded an -auto target's writes into one result and only its `Path` reached `keptSnapshotsLine`, so the screen whose job is naming what deja leaves behind said "kept 1 snapshot" beside two `.bak` files. The result now carries every config it covered. End to end, same stand:

```
before  deja: kept 1 snapshot of configs you already had — ~/.claude.json.bak
after   deja: kept 2 snapshots of configs you already had — ~/.claude.json.bak and 1 more
disk    ~/.claude.json.bak  ~/.claude/settings.json.bak
```

A config the target read and did not change still gets counted — the snapshot beside it is deja's to name — without being reported as work in the note.

Closes #3168, closes #3171.
