### PR TITLE
fix(pi): the package reads the session id where pi keeps it

### DIFF
--- a/extensions/pi/lib.mjs
+++ b/extensions/pi/lib.mjs
@@ -40,8 +40,16 @@ export function argv(cmd, flags, text) {
 }
 
 // sessionKey is what per-prompt recall dedups on: a hit shown once in a
-// session is not shown again. Without one it repeats itself every message.
-// Same order as the extension `deja install pi-auto` writes.
+// session is not shown again. Without one it repeats itself every message —
+// which it did, because pi keeps the id on ctx.sessionManager and nowhere the
+// event or ctx.session shapes below look (#3179). The manager first, the same
+// order as the extension `deja install pi-auto` writes; the rest for hosts
+// that put an id on the event.
 export function sessionKey(event, ctx) {
+  try {
+    const m = ctx && ctx.sessionManager
+    const id = m && (typeof m.getSessionId === "function" ? m.getSessionId() : m.sessionId)
+    if (id) return String(id)
+  } catch {}
   return (event && (event.sessionId || event.session_id)) || (ctx && ctx.session && ctx.session.id) || ""
 }

--- a/extensions/pi/test/pure.test.mjs
+++ b/extensions/pi/test/pure.test.mjs
@@ -17,7 +17,11 @@ test("a query that starts with a dash gets the flag terminator", () => {
   assert.deepEqual(argv("search", [], "pgbouncer"), ["search", "pgbouncer"])
 })
 
-test("the session key comes from the event first, then the context", () => {
+test("the session key is what pi keeps on the session manager", () => {
+  // pi 0.73 / omp 18: the event carries prompt and images only, the context a
+  // sessionManager — the shapes the installer's extension reads (#3179).
+  assert.equal(sessionKey({ prompt: "why" }, { sessionManager: { getSessionId: () => "s1" } }), "s1")
+  assert.equal(sessionKey({ prompt: "why" }, { sessionManager: { sessionId: "s2" } }), "s2")
   assert.equal(sessionKey({ sessionId: "e1" }, { session: { id: "c1" } }), "e1")
   assert.equal(sessionKey({}, { session: { id: "c1" } }), "c1")
   assert.equal(sessionKey({}, {}), "")


### PR DESCRIPTION
sessionKey looked at event.sessionId / event.session_id / ctx.session.id, none of which pi 0.73 or omp 18 provide; the id lives on ctx.sessionManager, which the installer's extension already reads. The manager comes first now, the old fields stay as fallbacks. The test pins pi's real shape and fails before with `''` for both manager forms.

Closes #3179

## Review

Reviewer (cavecrew): not refuted. Checked pi 0.73 / omp 18 shapes in the unpacked package (BeforeAgentStartEvent has type/prompt/images only; HookContext carries sessionManager with getSessionId()), the installer's extension reads the same thing, index.ts passes the key to hook-prompt, session_start sends no id and needs none; the test fails before with "" for both manager forms. Two nits, no change: the typeof check is stricter than the installer's truthiness check, and the fallback order (manager, then event, then ctx.session) is stated here rather than in the commit line.
