### PR TITLE
fix(hook): a question under an attached_files block is still the question

### DIFF
--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -35,13 +35,14 @@ var userQueryTagRe = regexp.MustCompile(`(?i)</?user_query>`)
 // orphanCloseRe is the closing tag a nested block leaves behind: the block
 // regexp stops at the first closing tag of any listed name, so Cursor's
 // `<additional_data>…<attached_files>…</attached_files></additional_data>`
-// keeps its outer close. A closing tag on its own is nobody's words.
+// keeps its outer close. Only a closing tag standing on a line of its own
+// goes — "I removed the </attached_files> line" is a person's sentence.
 var orphanCloseRe = func() *regexp.Regexp {
 	alts := make([]string, 0, len(harnessBlockTags))
 	for _, t := range harnessBlockTags {
 		alts = append(alts, regexp.QuoteMeta(t))
 	}
-	return regexp.MustCompile(`(?i)</\s*(?:` + strings.Join(alts, "|") + `)\s*>`)
+	return regexp.MustCompile(`(?im)^[ \t]*</\s*(?:` + strings.Join(alts, "|") + `)\s*>[ \t]*$`)
 }()
 
 var harnessBlockRe = func() *regexp.Regexp {

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -22,7 +22,27 @@ var harnessBlockTags = []string{
 	"bash-input", "bash-stdout", "bash-stderr",
 	"environment_context", "user_instructions", "permissions instructions",
 	"skill-context", "meta", "hook_result", "hook_context", "deja-recall",
+	// Amp and Cursor put the attached file bodies ahead of the words: the
+	// question under them spent the term budget on `attached_files`, `file`,
+	// `path` and the file's opening and never reached the ranking.
+	"attached_files", "additional_data",
 }
+
+// userQueryTagRe is Cursor's wrapper around the words a person typed; the
+// tags go, the words stay.
+var userQueryTagRe = regexp.MustCompile(`(?i)</?user_query>`)
+
+// orphanCloseRe is the closing tag a nested block leaves behind: the block
+// regexp stops at the first closing tag of any listed name, so Cursor's
+// `<additional_data>…<attached_files>…</attached_files></additional_data>`
+// keeps its outer close. A closing tag on its own is nobody's words.
+var orphanCloseRe = func() *regexp.Regexp {
+	alts := make([]string, 0, len(harnessBlockTags))
+	for _, t := range harnessBlockTags {
+		alts = append(alts, regexp.QuoteMeta(t))
+	}
+	return regexp.MustCompile(`(?i)</\s*(?:` + strings.Join(alts, "|") + `)\s*>`)
+}()
 
 var harnessBlockRe = func() *regexp.Regexp {
 	alts := make([]string, 0, len(harnessBlockTags))
@@ -42,6 +62,8 @@ var harnessBlockRe = func() *regexp.Regexp {
 func StripHarnessBlocks(prompt string) string {
 	if strings.Contains(prompt, "<") {
 		prompt = harnessBlockRe.ReplaceAllString(prompt, "")
+		prompt = orphanCloseRe.ReplaceAllString(prompt, "")
+		prompt = userQueryTagRe.ReplaceAllString(prompt, "")
 	}
 	if strings.Contains(prompt, " says: ") {
 		prompt = stripHookStatusLines(prompt)

--- a/internal/digest/harness_blocks_test.go
+++ b/internal/digest/harness_blocks_test.go
@@ -22,6 +22,8 @@ func TestStripHarnessBlocksLeavesThePersonsWords(t *testing.T) {
 		// the file bodies go, the question stays (#3182).
 		"<attached_files>\n<file path=\"zebraquux/fetch.go\">package zebraquux\nfunc Fetch() {}\n</file>\n</attached_files>\nwhy does the zebraquux fetcher time out?":                                                                                         "why does the zebraquux fetcher time out?",
 		"<additional_data>\nBelow are some potentially helpful/relevant pieces of information\n<attached_files>\n<file_contents>x</file_contents>\n</attached_files>\n</additional_data>\n\n<user_query>why does the pager quokkabloom on scroll</user_query>": "why does the pager quokkabloom on scroll",
+		// A closing tag inside a sentence is the sentence's.
+		"I removed the </attached_files> line, is that right?": "I removed the </attached_files> line, is that right?",
 		// No tags at all: untouched.
 		"plain question about <T> generics": "plain question about <T> generics",
 	}

--- a/internal/digest/harness_blocks_test.go
+++ b/internal/digest/harness_blocks_test.go
@@ -18,6 +18,10 @@ func TestStripHarnessBlocksLeavesThePersonsWords(t *testing.T) {
 		"<bash-input>git status</bash-input>\n<bash-stdout>On branch main</bash-stdout>": "",
 		// A tag name that is only a prefix of a word in prose is not a tag.
 		"the <metadata> table has no meta column": "the <metadata> table has no meta column",
+		// Amp's attachment block ahead of the question, and Cursor's wrapper:
+		// the file bodies go, the question stays (#3182).
+		"<attached_files>\n<file path=\"zebraquux/fetch.go\">package zebraquux\nfunc Fetch() {}\n</file>\n</attached_files>\nwhy does the zebraquux fetcher time out?":                                                                                         "why does the zebraquux fetcher time out?",
+		"<additional_data>\nBelow are some potentially helpful/relevant pieces of information\n<attached_files>\n<file_contents>x</file_contents>\n</attached_files>\n</additional_data>\n\n<user_query>why does the pager quokkabloom on scroll</user_query>": "why does the pager quokkabloom on scroll",
 		// No tags at all: untouched.
 		"plain question about <T> generics": "plain question about <T> generics",
 	}


### PR DESCRIPTION
Two more envelopes for StripHarnessBlocks — `attached_files` and `additional_data` — plus the orphan closing tag a nested block leaves and Cursor's `user_query` wrapper unwrapped to its text. Before, the six-term budget went to `attached_files`, `file`, `path` and the file's opening and the question never reached the ranking. The two new cases in TestStripHarnessBlocksLeavesThePersonsWords fail before with the whole block returned.

Closes #3182

End to end on the Amp store the fan-out seeded (hermetic HOME, fresh session id): the attachment-then-question payload went from 0 B to the 798 B block; question-then-attachment stays 798 B and the attachment-only turn stays 0 B.

## Review

Reviewer (cavecrew): not refuted; the new cases fail before and the callers pass. One bug and one risk: the orphan-close strip took a closing tag out of a sentence ("I removed the </attached_files> line") — now only a closing tag standing on its own line goes, with that sentence as a test case; an unclosed `<attached_files>` mid-sentence swallows to the end of the text, which is the `|.*$` rule every tag in the list has had since #3164 (hosts truncate long blocks) and stays.
