### PR TITLE
fix(install): gemini-auto names the extension it writes and the switch it leaves on

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -680,10 +680,18 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		// grok-auto pairs them the same way.
 		// Same file, same reason as qwen-auto: whichever half may refuse goes
 		// first (#2745).
-		if _, err := installGeminiAuto(exe, uninstall); err != nil {
+		ext, err := installGeminiAuto(exe, uninstall)
+		if err != nil {
 			return installResult{}, err
 		}
-		return installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
+		mcp, err := installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		// Both writes in one result, like every other -auto target: the
+		// extension's path and its note about hooksConfig reached nobody
+		// while the first result was dropped (#3185).
+		return wroteAll(mcp, ext), nil
 	case "antigravity":
 		return installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall)
 	case "antigravity-auto":
@@ -828,7 +836,13 @@ func wroteAll(rs ...installResult) installResult {
 		if r.Path == "" || r.Action == "unchanged" || r.Path == out.Path {
 			continue
 		}
-		also = append(also, fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path)))
+		line := fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path))
+		// The other write's own note rides with its line: gemini's extension
+		// says what switch it left on, and that was lost with the result.
+		if r.Note != "" {
+			line += " — " + r.Note
+		}
+		also = append(also, line)
 		out.also = append(out.also, r.Path)
 	}
 	for _, line := range also {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -673,13 +673,12 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "gemini":
 		return installMCPJSON(filepath.Join(sources.GeminiHome(), "settings.json"), exe, uninstall)
 	case "gemini-auto":
-		// MCP first, then the hooks extension. `--auto` maps gemini to this
-		// target alone, so installing only the extension left the harness
-		// without the tools: its own `gemini mcp list` said "No MCP servers
+		// The hooks extension, then MCP. `--auto` maps gemini to this target
+		// alone, so installing only the extension left the harness without
+		// the tools: its own `gemini mcp list` said "No MCP servers
 		// configured" on a machine that had just run `deja install --auto`.
-		// grok-auto pairs them the same way.
-		// Same file, same reason as qwen-auto: whichever half may refuse goes
-		// first (#2745).
+		// grok-auto pairs them the same way. The extension goes first for the
+		// reason qwen-auto has: whichever half may refuse goes first (#2745).
 		ext, err := installGeminiAuto(exe, uninstall)
 		if err != nil {
 			return installResult{}, err
@@ -691,7 +690,7 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		// Both writes in one result, like every other -auto target: the
 		// extension's path and its note about hooksConfig reached nobody
 		// while the first result was dropped (#3185).
-		return wroteAll(mcp, ext), nil
+		return wroteAll(ext, mcp), nil
 	case "antigravity":
 		return installMCPJSON(filepath.Join(antigravityConfigHome(), "mcp_config.json"), exe, uninstall)
 	case "antigravity-auto":

--- a/cmd/deja/install_gemini_auto_result_test.go
+++ b/cmd/deja/install_gemini_auto_result_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The gemini-auto target writes two things — the MCP entry and the hooks
+// extension — and its result has to say so, the way every other -auto target
+// folds its writes: an uninstall that removed the extension and left
+// hooksConfig on said neither (#3185).
+func TestGeminiAutoResultNamesTheExtension(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.GeminiHome(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"theme":"GitHub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	in, err := installTarget("gemini-auto", "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(in.Path+" "+in.Note, "extensions") {
+		t.Errorf("install did not name the extension: path=%q note=%q", in.Path, in.Note)
+	}
+	out, err := installTarget("gemini-auto", "/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Path+" "+out.Note, "extensions") || !strings.Contains(out.Note, "hooksConfig") {
+		t.Errorf("uninstall did not name the extension or the switch it left on: path=%q note=%q", out.Path, out.Note)
+	}
+}


### PR DESCRIPTION
installTarget dropped installGeminiAuto's result, so the CLI never named ~/.gemini/extensions/deja and the hooksConfig note from #2487 reached only a unit test. The two writes fold with wroteAll like every other -auto target, and wroteAll now carries a folded write's note (`also removed ~/.gemini/extensions/deja — left hooksConfig.enabled on …`). TestGeminiAutoResultNamesTheExtension fails before with an empty note on both install and uninstall.

Closes #3185

## Review

Reviewer (cavecrew): test fails before and passes after; the note carry and its " — " separator are fine for the blind-append printer. Refuted on one point: the writes were folded as (mcp, ext) while they run ext then mcp, and the comment above still said "MCP first" — both now follow the execution order, so with both changed the line is named for the extension and settings.json rides along.
