### PR TITLE
fix(sources): an opencode store that would not open says so on its row

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3058,7 +3058,7 @@ func printSources(dir string) {
 	if fi, err := os.Stat(sources.OpencodeDB()); err == nil {
 		size = fi.Size()
 	}
-	s, m, _ := sources.OpencodeCounts()
+	s, m, countErr := sources.OpencodeCounts()
 	// The counts come out of sqlite, which knows nothing about the exclude
 	// list, so with a pattern in force this row kept reporting sessions that
 	// are not indexed, not searchable and not exported while every other row
@@ -3090,6 +3090,18 @@ func printSources(dir string) {
 	}
 	if opencodeExcluded > 0 {
 		note += fmt.Sprintf("\texcluded-sessions=%d", opencodeExcluded)
+	}
+	// A store sqlite could not open — locked past the timeout, or a file the
+	// reader may not open — looked like one nobody had used, the shape #1000
+	// fixed for the file stores (#3190).
+	if countErr != nil {
+		reason := "sqlite3: " + countErr.Error()
+		if f, err := os.Open(sources.OpencodeDB()); err != nil {
+			reason = err.Error()
+		} else {
+			f.Close()
+		}
+		note = "\t(cannot be read — " + reason + ")" + note
 	}
 	fmt.Printf("opencode\t%s\tsessions=%d messages=%d size=%s redacted=%d%s\n", sources.OpencodeDB(), s, m, humanBytes(size), redactions[sources.OpencodeDB()], note)
 }

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3094,8 +3094,11 @@ func printSources(dir string) {
 	// A store sqlite could not open — locked past the timeout, or a file the
 	// reader may not open — looked like one nobody had used, the shape #1000
 	// fixed for the file stores (#3190).
-	if countErr != nil {
+	if countErr != nil && sources.SQLite3Available() {
 		reason := "sqlite3: " + countErr.Error()
+		if line := sources.ExitStderrLine(countErr); line != "" {
+			reason = "sqlite3: " + line
+		}
 		if f, err := os.Open(sources.OpencodeDB()); err != nil {
 			reason = err.Error()
 		} else {

--- a/cmd/deja/sources_corrupt_store_test.go
+++ b/cmd/deja/sources_corrupt_store_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The reason on the row is what sqlite3 said, not its exit code (#3190).
+func TestSourcesNamesSqlitesReasonForAStoreThatIsNotADatabase(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	if err := os.WriteFile(db, []byte("garbage, not a database, sixty-four bytes of nothing useful....."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, "opencode\t") {
+			if !strings.Contains(l, "cannot be read — sqlite3: ") || !strings.Contains(l, "not a database") {
+				t.Fatalf("row does not carry sqlite's reason: %s", l)
+			}
+			return
+		}
+	}
+	t.Fatalf("no opencode row in:\n%s", out)
+}

--- a/cmd/deja/sources_unreadable_store_test.go
+++ b/cmd/deja/sources_unreadable_store_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// An opencode store that would not open read as a store nobody had used —
+// `sessions=0 messages=0` with no note — while every file-store row says
+// "cannot be read" for the same thing (#1000, #3190).
+func TestSourcesSaysAnOpencodeStoreCouldNotBeRead(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("needs a file the owner cannot read")
+	}
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	db := filepath.Join(tmp, "opencode.db")
+	script := `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/w','2026-01-02T03:00:00Z','2026-01-03T03:00:00Z');
+insert into message values('m1','s1',1767409200000,'{"role":"user"}');
+insert into part values('p1','m1','{"type":"text","text":"why does the pager stall"}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite setup: %v %s", err, out)
+	}
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_OPENCODE_DB", db)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	if err := os.Chmod(db, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
+	for _, l := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(l, "opencode\t") {
+			continue
+		}
+		if !strings.Contains(l, "cannot be read") {
+			t.Fatalf("the unreadable store reads as unused: %s", l)
+		}
+		return
+	}
+	t.Fatalf("no opencode row in:\n%s", out)
+}

--- a/internal/sources/exit_stderr_line_test.go
+++ b/internal/sources/exit_stderr_line_test.go
@@ -1,0 +1,26 @@
+package sources
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// The row names what sqlite3 said, not its exit code: the first stderr line,
+// or nothing when the error carries none (#3190).
+func TestExitStderrLineIsTheFirstLineSqliteWrote(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no sh")
+	}
+	cmd := exec.Command("sh", "-c", "echo 'Error: in prepare, file is not a database (26)' >&2; echo second >&2; exit 26")
+	_, err := cmd.Output()
+	if got := ExitStderrLine(err); got != "Error: in prepare, file is not a database (26)" {
+		t.Fatalf("line = %q", got)
+	}
+	if got := ExitStderrLine(errors.New("plain")); got != "" {
+		t.Fatalf("a plain error gave %q", got)
+	}
+	if got := ExitStderrLine(nil); got != "" {
+		t.Fatalf("nil gave %q", got)
+	}
+}

--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -430,4 +431,16 @@ func withStderr(err error, buf *bytes.Buffer) error {
 		msg = strings.TrimSpace(msg[:sqliteStderrMax]) + "…"
 	}
 	return fmt.Errorf("%s (%w)", msg, err)
+}
+
+// ExitStderrLine is the first line sqlite3 wrote to stderr before it exited,
+// or "" when the error carries none: "database is locked" says more than
+// "exit status 5".
+func ExitStderrLine(err error) string {
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return ""
+	}
+	line := strings.TrimSpace(strings.SplitN(string(ee.Stderr), "\n", 2)[0])
+	return line
 }


### PR DESCRIPTION

## Review

Reviewer (cavecrew): test fails before and passes after; the env set matches sources_excluded_test.go (HOME to a temp dir, the file roots pinned). Two findings, both taken: with sqlite3 missing the row would have carried both "(cannot be read — sqlite3: executable file not found)" and "(sqlite3 CLI not found …)" — the note now appears only when sqlite3 is present; and "exit status 5" said nothing, so the first stderr line sqlite3 wrote is the reason (`Error: in prepare, file is not a database (26)`).
