### PR TITLE
fix(opencode): a switched-off deja MCP entry does not count as wired

### DIFF
--- a/extensions/opencode/lib.js
+++ b/extensions/opencode/lib.js
@@ -65,7 +65,10 @@ export function configPaths(env, home) {
 export function mcpWired(text) {
   try {
     const config = JSON.parse(stripJSONComments(String(text || "")))
-    return Boolean(config && config.mcp && config.mcp.deja)
+    const entry = config && config.mcp && config.mcp.deja
+    // A server kept in the file but switched off offers nothing, so the
+    // tools here are not a second copy of it.
+    return Boolean(entry) && entry.enabled !== false
   } catch {
     return false
   }

--- a/extensions/opencode/test/pure.test.js
+++ b/extensions/opencode/test/pure.test.js
@@ -159,6 +159,10 @@ test("mcpWired reads the entry the installer writes, comments and all", () => {
 }`
   assert.equal(mcpWired(config), true)
   assert.equal(mcpWired(`{"mcp": {"other": {}}}`), false)
+  // opencode keeps a switched-off server in the file; switched off, it offers
+  // nothing, so the package's tools are not a second copy (#3193).
+  assert.equal(mcpWired(`{"mcp": {"deja": {"type": "local", "command": ["deja", "mcp"], "enabled": false}}}`), false)
+  assert.equal(mcpWired(`{"mcp": {"deja": {"type": "local", "command": ["deja", "mcp"], "enabled": true}}}`), true)
   assert.equal(mcpWired("{}"), false)
   assert.equal(mcpWired("not json"), false)
   assert.equal(mcpWired(""), false)


### PR DESCRIPTION
mcpWired answered true for any `mcp.deja` entry, including one opencode has switched off with `enabled: false`, so the package dropped its tools and the model had neither. The entry now counts only when it is not switched off; the two new assertions in pure.test.js fail before.

Closes #3193

## Review

Reviewer (cavecrew): no findings. Checked opencode's schema (`enabled: boolean` on an MCP entry, including the standalone disabler form), the one caller (contributions() gates tool registration on it and nothing else assumes the server runs), that `deja install opencode` writes no `enabled` and keeps one it finds, and that both new assertions fail before and pass after.
