### PR TITLE
fix(goose): the retired .goosehints goes only when it was deja's

### DIFF
--- a/cmd/deja/goose_hints_user_file_test.go
+++ b/cmd/deja/goose_hints_user_file_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// deja used to write ~/.config/goose/.goosehints and now writes AGENTS.md; the
+// retired file goes only when it holds nothing but deja's block. A person's
+// own hints there were deleted on every turn (#3196).
+func TestRetiredGooseHintsKeepsThePersonsOwnFile(t *testing.T) {
+	hermeticEnv(t)
+	path := retiredGooseHintsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	own := "my own hints, written by the user\n"
+	if err := os.WriteFile(path, []byte(own+gooseRecallStart+"\nrecall\n"+gooseRecallEnd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dropRetiredGooseHints(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the person's file is gone: %v", err)
+	}
+	if strings.TrimRight(string(got), "\n") != strings.TrimRight(own, "\n") {
+		t.Fatalf("file = %q, want the person's hints alone", got)
+	}
+	// A file with no deja block at all is not touched either.
+	if err := os.WriteFile(path, []byte(own), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dropRetiredGooseHints(); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != own {
+		t.Fatalf("a file with no deja block was changed: %q", got)
+	}
+	// deja's block alone: the file goes, as before.
+	if err := os.WriteFile(path, []byte(gooseRecallStart+"\nrecall\n"+gooseRecallEnd+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dropRetiredGooseHints(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("a file holding only deja's block was kept")
+	}
+}

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -535,14 +535,24 @@ func dropGooseRecallBlock(path string) error {
 	return err
 }
 
-// dropRetiredGooseHints removes the file deja used to write, once it holds
-// nothing but what deja put there.
+// dropRetiredGooseHints takes deja's block out of the file deja used to write
+// and removes the file only when nothing else was in it — the rule AGENTS.md
+// gets. It removed the file outright, and a person's own global hints went
+// with it on every turn (#3196).
 func dropRetiredGooseHints() error {
 	path := retiredGooseHintsPath()
-	if _, err := os.Stat(path); err != nil {
+	old, err := readConfig(path)
+	if err != nil || len(old) == 0 {
 		return nil
 	}
-	return os.Remove(path)
+	// What an older deja wrote there whole: the framed recall, or the line
+	// it left when there was nothing to recall. Either way the file was
+	// deja's and goes.
+	text := strings.TrimSpace(string(old))
+	if strings.HasPrefix(text, strings.TrimSpace(recallFrameHeader)) || text == "No matching history yet." {
+		return os.Remove(path)
+	}
+	return dropGooseRecallBlock(path)
 }
 
 const gooseLead = "The sessions below are from this project's recent history. " +

--- a/cmd/deja/install_goose_agents_test.go
+++ b/cmd/deja/install_goose_agents_test.go
@@ -36,7 +36,8 @@ func TestGooseRecallClearsTheFileItUsedToWrite(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(retired), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(retired, []byte("recall from an older deja\n"), 0o644); err != nil {
+	// The shape an older deja wrote there whole: the framed recall.
+	if err := os.WriteFile(retired, []byte(frameRecall("recall from an older deja\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := installGooseAuto("/bin/deja", false); err != nil {


### PR DESCRIPTION
dropRetiredGooseHints did os.Stat then os.Remove. It now removes the file when it holds what an older deja wrote there whole (the framed recall, or the no-history line) and otherwise takes deja's block out and leaves the rest, the rule AGENTS.md already had. The existing upgrade test seeded a made-up string; it now seeds the framed shape the old code wrote. TestRetiredGooseHintsKeepsThePersonsOwnFile fails before with the file gone.

Closes #3196

## Review

Reviewer (cavecrew): no findings. Checked the git history of what older versions wrote to .goosehints (the framed recall through frameRecall, including the DEJA_RECALL=aggressive lead, and the no-history line — the predicate covers both), the risk of a person's file that opens with the frame (accepted), the unreadable-file path (now returns nil instead of removing), the seed change in the upgrade test (the old seed was not a shape deja ever wrote), and that the new test fails before and every Goose test passes after.
