### PR TITLE
fix(install): --auto looks for the six harnesses it had targets for and never detected

### DIFF
--- a/cmd/deja/existing_targets_test.go
+++ b/cmd/deja/existing_targets_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// `--auto` wires what it finds, and it found nineteen harnesses of twenty-five:
+// Amp, prime-agent, Crush, Continue, Zed and VS Code had install targets and
+// were in the published matrix with nothing looking for them, so a machine that
+// had them got the others wired and no word about these (#3192).
+//
+// Derived from the target list rather than written beside it: a harness that
+// gains a target and no way to be detected fails here, which is the check that
+// was missing.
+func TestEveryInstallTargetCanBeDetected(t *testing.T) {
+	hermeticEnv(t)
+	checks := existingTargetChecks()
+	// Detection reports Claude under the name its target does not use, and
+	// Copilot Chat is wired by the vscode target.
+	alias := map[string]string{"claude": "claude-code", "copilot-chat": "vscode"}
+	// Not harnesses: one is this machine's own status line, the other a timer.
+	notAHarness := map[string]bool{"statusline": true, "sync-timer": true}
+
+	var missing []string
+	for _, target := range installTargetNames() {
+		base := strings.TrimSuffix(target, "-auto")
+		if notAHarness[base] {
+			continue
+		}
+		if a, ok := alias[base]; ok {
+			base = a
+		}
+		if _, ok := checks[base]; !ok {
+			missing = append(missing, base)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("install targets nothing looks for, so --auto never wires them: %s",
+			strings.Join(unique(missing), ", "))
+	}
+}
+
+func unique(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// The other half: a directory deja writes itself must not count as the harness
+// being here, or one install makes every machine look like every machine.
+func TestDetectionDoesNotFireOnWhatDejaWrites(t *testing.T) {
+	home := hermeticEnv(t)
+	home = filepath.Join(home, "home")
+
+	// The configs install writes, for the six harnesses this test is about.
+	written := []string{
+		filepath.Join(home, ".config", "crush", "crush.json"),
+		filepath.Join(home, ".continue", "config.yaml"),
+		filepath.Join(home, ".agents", "skills", "deja-history", "SKILL.md"),
+	}
+	for _, p := range written {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range existingTargets() {
+		if name == "crush" || name == "continue" {
+			t.Errorf("a config deja writes made the machine look like a %s machine", name)
+		}
+	}
+
+	// And with what the harness itself writes, the same machine is detected.
+	for _, d := range []string{
+		filepath.Join(home, ".local", "share", "crush"),
+		filepath.Join(home, ".continue", "sessions"),
+		filepath.Join(home, ".local", "share", "amp", "threads"),
+		filepath.Join(home, ".prime", "agent", "sessions"),
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".local", "share", "crush", "projects.json"),
+		[]byte(`{"projects":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, name := range existingTargets() {
+		got[name] = true
+	}
+	for _, name := range []string{"crush", "continue", "amp", "prime"} {
+		if !got[name] {
+			t.Errorf("%s was not detected from the directory it writes for itself", name)
+		}
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -610,8 +610,12 @@ func refusalRemedy(errs []error) string {
 	return "fix what each one reports and run it again"
 }
 
-func existingTargets() []string {
-	checks := map[string]string{
+// existingTargetChecks is what says a harness is on this machine: one path the
+// harness itself creates, per install target. Named rather than inline so the
+// test that holds it to the target list can ask for a path instead of
+// repeating the platform switches (#3192).
+func existingTargetChecks() map[string]string {
+	return map[string]string{
 		"claude-code": sources.ClaudeConfigDir(),
 		"codex":       sources.CodexHome(),
 		"opencode":    filepath.Join(opencodeConfigHome(), "opencode"),
@@ -637,7 +641,37 @@ func existingTargets() []string {
 		// machine after one install.
 		"goose": sources.GooseRoot(),
 		"roo":   rooFirstRoot(),
+		// These six have install targets and were in the matrix with nothing
+		// looking for them, so `--auto` wired the other nineteen and said
+		// nothing about Amp, prime-agent, Crush, Continue, Zed or VS Code on a
+		// machine that had them (#3192). Each is keyed on something the harness
+		// writes for itself, for the reason goose's entry gives.
+		//
+		// Amp's thread store rather than its settings file: deja writes into
+		// the settings file.
+		"amp": sources.AmpRoot(),
+		// prime-agent's sessions directory, and it honours the harness's own
+		// relocation variables, so a moved store is still found.
+		"prime": sources.PrimeRoot(),
+		// Crush's project registry, in its data home. Its config directory is
+		// where deja writes crush.json, so keying on that would make every
+		// machine a Crush machine after one install.
+		"crush": filepath.Join(sources.CrushDataHome(), "projects.json"),
+		// Continue's session directory. The folder above it holds the config
+		// deja writes, and Continue creates the sessions directory on its
+		// first conversation — so a Continue that has been installed and never
+		// used is not detected, which is the same bar the aider entry sets.
+		"continue": filepath.Join(sources.ContinueRoot(), "sessions"),
+		// Zed's data directory, not the config file deja edits.
+		"zed": sources.ZedRoot(),
+		// VS Code's own User folder, which the editor creates on first run;
+		// deja only ever writes inside it.
+		"vscode": vsCodeFirstRoot(),
 	}
+}
+
+func existingTargets() []string {
+	checks := existingTargetChecks()
 	var out []string
 	for name, p := range checks {
 		if _, err := os.Stat(p); err == nil {

--- a/cmd/deja/install_vscode.go
+++ b/cmd/deja/install_vscode.go
@@ -67,6 +67,17 @@ func vsCodeGuidanceDir() string {
 	return vsCodeDefaultUserDir()
 }
 
+// vsCodeFirstRoot is the User folder of a host that is actually here, for the
+// detection `--auto` does. It differs from vsCodeGuidanceDir on purpose: that
+// one falls back to a default so an install can write ahead of the editor,
+// which as a detection would report VS Code on every machine (#3192).
+func vsCodeFirstRoot() string {
+	if dirs := vsCodeUserDirs(); len(dirs) > 0 {
+		return dirs[0]
+	}
+	return filepath.Join(os.DevNull, "vscode")
+}
+
 func installVSCodeMCP(exe string, uninstall bool) (installResult, error) {
 	dirs := vsCodeUserDirs()
 	if len(dirs) == 0 {


### PR DESCRIPTION
On a HOME holding every harness's own directory:

```
before  15 targets wired
after   21 — the six that had targets and nothing looking for them
        amp-auto  prime-auto  crush-auto  continue  vscode  zed
```

Each is keyed on something the harness writes for itself, for the reason the goose entry already gives: Amp's thread store rather than the settings file deja edits, Crush's project registry rather than the config directory deja writes `crush.json` into, Continue's sessions directory rather than the folder holding the config, Zed's data directory, and VS Code's User folder — with `vsCodeFirstRoot` separate from `vsCodeGuidanceDir`, because the latter falls back to a default so an install can write ahead of the editor and as a detection would report VS Code on every machine.

Continue creates its sessions directory on the first conversation, so a Continue installed and never used is still not detected — the same bar the aider entry sets, and said in the map rather than left out.

The test derives the list from `installTargetNames()` instead of repeating it, so the next harness with a target and no detection fails here. Eight mutations, all red: dropping any of the six entries, and re-keying Crush or Continue on the directory deja writes.

Closes #3192.
