### PR TITLE
fix(kimi): only what the person wrote is a user turn

### DIFF
--- a/internal/sources/kimi.go
+++ b/internal/sources/kimi.go
@@ -67,14 +67,17 @@ type kimiState struct {
 }
 
 // kimiPersonsOrigin reports whether a message's origin says a person wrote it:
-// kind "user" (and the user's own slash commands), or no origin at all.
+// kind "user", a skill or plugin command the person typed (Kimi marks those
+// with trigger "user-slash"), or no origin at all — the same disposition
+// Kimi's own context builder applies.
 func kimiPersonsOrigin(origin any) bool {
 	o, ok := origin.(map[string]any)
 	if !ok {
 		return true
 	}
 	kind, _ := o["kind"].(string)
-	return kind == "" || kind == "user" || strings.HasPrefix(kind, "user")
+	trigger, _ := o["trigger"].(string)
+	return kind == "" || kind == "user" || strings.HasPrefix(kind, "user") || trigger == "user-slash"
 }
 
 func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error) {
@@ -124,6 +127,9 @@ func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error)
 			// are user turns; a message with no origin is an older protocol's
 			// and was always the person's (#3199).
 			if role == "user" && !kimiPersonsOrigin(msg["origin"]) {
+				// The host's line still moves the clock: a session whose
+				// last record is a hook's output ended when that arrived.
+				s.Touch(parseTimeAny(m["time"]))
 				return
 			}
 			if role == "assistant" {

--- a/internal/sources/kimi.go
+++ b/internal/sources/kimi.go
@@ -66,6 +66,17 @@ type kimiState struct {
 	UpdatedAt string `json:"updatedAt"`
 }
 
+// kimiPersonsOrigin reports whether a message's origin says a person wrote it:
+// kind "user" (and the user's own slash commands), or no origin at all.
+func kimiPersonsOrigin(origin any) bool {
+	o, ok := origin.(map[string]any)
+	if !ok {
+		return true
+	}
+	kind, _ := o["kind"].(string)
+	return kind == "" || kind == "user" || strings.HasPrefix(kind, "user")
+}
+
 func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error) {
 	// .../sessions/<workDirKey>/<sessionId>/agents/main/wire.jsonl
 	sessionDir := filepath.Dir(filepath.Dir(filepath.Dir(path)))
@@ -105,6 +116,14 @@ func parseKimiFileFromOffset(path string, offset int64) ([]model.Session, error)
 			}
 			role, _ := msg["role"].(string)
 			if role != "user" && role != "assistant" {
+				return
+			}
+			// Kimi appends the host's own lines under role user too — an
+			// injected reminder, a hook's wrapped stdout, a background task's
+			// notice — and names the author in origin.kind. Only the person's
+			// are user turns; a message with no origin is an older protocol's
+			// and was always the person's (#3199).
+			if role == "user" && !kimiPersonsOrigin(msg["origin"]) {
 				return
 			}
 			if role == "assistant" {

--- a/internal/sources/kimi_origin_test.go
+++ b/internal/sources/kimi_origin_test.go
@@ -1,0 +1,37 @@
+package sources
+
+import (
+	"os"
+	"testing"
+)
+
+// Kimi writes every message it appends under role user and says who wrote it
+// in origin.kind: the person, an injected reminder, a hook's wrapped stdout, a
+// background task. Only the person's are user turns (#3199).
+func TestParseKimiKeepsOnlyThePersonsLinesAsUser(t *testing.T) {
+	_, wire := kimiFixture(t)
+	body := `{"type":"metadata","protocol_version":"1.4","created_at":1782295200000}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"why does glimwrax drop the trailing newline"}],"origin":{"kind":"user"}},"time":1782295201000}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"<hook_result hook_event=\"UserPromptSubmit\">\ndeja-vu — you have been here: zorbflax retry fix\n</hook_result>"}],"origin":{"kind":"hook_result","event":"UserPromptSubmit"}},"time":1782295201200}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>\nAuto permission mode is active.\n</system-reminder>"}],"origin":{"kind":"injection","variant":"permission_mode"}},"time":1782295201300}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"quuxnotify: background task 7 finished"}],"origin":{"kind":"background_task"}},"time":1782295201400}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"older protocol, no origin"}]},"time":1782295201500}
+{"type":"context.append_message","message":{"role":"assistant","content":[{"type":"text","text":"the tokenizer trims it"}]},"time":1782295202000}
+`
+	if err := os.WriteFile(wire, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseKimiFile(wire)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("sessions=%d err=%v", len(ss), err)
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	if len(users) != 2 || users[0] != "why does glimwrax drop the trailing newline" || users[1] != "older protocol, no origin" {
+		t.Fatalf("user lines = %q", users)
+	}
+}

--- a/internal/sources/kimi_origin_test.go
+++ b/internal/sources/kimi_origin_test.go
@@ -16,6 +16,7 @@ func TestParseKimiKeepsOnlyThePersonsLinesAsUser(t *testing.T) {
 {"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"<system-reminder>\nAuto permission mode is active.\n</system-reminder>"}],"origin":{"kind":"injection","variant":"permission_mode"}},"time":1782295201300}
 {"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"quuxnotify: background task 7 finished"}],"origin":{"kind":"background_task"}},"time":1782295201400}
 {"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"older protocol, no origin"}]},"time":1782295201500}
+{"type":"context.append_message","message":{"role":"user","content":[{"type":"text","text":"/review the tokenizer"}],"origin":{"kind":"skill_activation","trigger":"user-slash"}},"time":1782295201600}
 {"type":"context.append_message","message":{"role":"assistant","content":[{"type":"text","text":"the tokenizer trims it"}]},"time":1782295202000}
 `
 	if err := os.WriteFile(wire, []byte(body), 0o644); err != nil {
@@ -31,7 +32,7 @@ func TestParseKimiKeepsOnlyThePersonsLinesAsUser(t *testing.T) {
 			users = append(users, m.Text)
 		}
 	}
-	if len(users) != 2 || users[0] != "why does glimwrax drop the trailing newline" || users[1] != "older protocol, no origin" {
+	if len(users) != 3 || users[0] != "why does glimwrax drop the trailing newline" || users[1] != "older protocol, no origin" || users[2] != "/review the tokenizer" {
 		t.Fatalf("user lines = %q", users)
 	}
 }


### PR DESCRIPTION
Kimi writes every appended message under role user and names the author in `message.origin.kind`; the parser keyed on role alone, so a hook's wrapped stdout, an injected reminder and a background task's notice were the person's lines — and the prompt hook then recalled deja's own status line. Only `origin.kind: user` (and the user's slash-command kinds), or a message with no origin (older protocols), is a user turn now. TestParseKimiKeepsOnlyThePersonsLinesAsUser fails before with all five lines as the user's.

Closes #3199

End to end on the fan-out fixture: `kimi: 1 session, 7 messages` → `5 messages`; `search zorbflax` no longer returns the Kimi session (only the qwen fixture, which is its own item); `ctx glimwrax` shows no hook_result or background-task line under user.


## Review

Reviewer (cavecrew), against Kimi 0.28's bundle: not refuted, two gaps taken — `skill_activation` and `plugin_command` messages with `trigger: "user-slash"` are the person's in Kimi's own disposition and were dropped (now kept, with a case in the test); a dropped line skipped `s.Touch`, so a session whose last record was a hook's output kept an earlier updated time (the clock moves now). The `user*` prefix stays as a guard for kinds this bundle does not have.
