### PR TITLE
fix(openclaw): uninstall gives the hooks switch back even when the reader's own hooks remain

### DIFF
--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -102,14 +102,19 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		// records a block it created, so an uninstall gives back a setting the
 		// reader had rather than deleting one deja only overwrote (#2830, the
 		// rule the text writer got in #2811).
+		// The switch goes back whether or not the reader's own hooks remain:
+		// with an entry left the restore was skipped, and a hook the reader
+		// had switched off ran once deja was gone (#3204).
+		if was := hookSwitchWas(path); was == nil {
+			if len(entries) == 0 {
+				delete(internal, "enabled")
+			}
+		} else {
+			internal["enabled"] = was
+		}
+		forgetHookSwitch(path)
 		if len(entries) == 0 {
 			delete(internal, "entries")
-			if was := hookSwitchWas(path); was == nil {
-				delete(internal, "enabled")
-			} else {
-				internal["enabled"] = was
-			}
-			forgetHookSwitch(path)
 		}
 		if len(internal) == 0 {
 			delete(hooks, "internal")

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -105,10 +105,10 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		// The switch goes back whether or not the reader's own hooks remain:
 		// with an entry left the restore was skipped, and a hook the reader
 		// had switched off ran once deja was gone (#3204).
+		// No record means deja set the switch on a file that had none: the
+		// key goes, entries or not — what the JSONC writer does.
 		if was := hookSwitchWas(path); was == nil {
-			if len(entries) == 0 {
-				delete(internal, "enabled")
-			}
+			delete(internal, "enabled")
 		} else {
 			internal["enabled"] = was
 		}

--- a/cmd/deja/openclaw_parsed_switch_test.go
+++ b/cmd/deja/openclaw_parsed_switch_test.go
@@ -37,6 +37,14 @@ func TestTheParsedPathGivesBackASwitchTheReaderSet(t *testing.T) {
 			start: map[string]any{},
 			want:  nil,
 		},
+		{
+			// The reader's own hook stays, and so must their switch: with an
+			// entry left behind the restore was skipped and their hook, which
+			// they had off, ran after deja was gone (#3204).
+			name:  "the reader had it off and keeps a hook of their own",
+			start: map[string]any{"hooks": map[string]any{"internal": map[string]any{"enabled": false, "entries": map[string]any{"theirs": map[string]any{"enabled": true}}}}},
+			want:  false,
+		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			hermeticEnv(t)

--- a/cmd/deja/openclaw_parsed_switch_test.go
+++ b/cmd/deja/openclaw_parsed_switch_test.go
@@ -41,6 +41,11 @@ func TestTheParsedPathGivesBackASwitchTheReaderSet(t *testing.T) {
 			// The reader's own hook stays, and so must their switch: with an
 			// entry left behind the restore was skipped and their hook, which
 			// they had off, ran after deja was gone (#3204).
+			name:  "the reader had no switch and keeps a hook of their own",
+			start: map[string]any{"hooks": map[string]any{"internal": map[string]any{"entries": map[string]any{"theirs": map[string]any{"enabled": true}}}}},
+			want:  nil,
+		},
+		{
 			name:  "the reader had it off and keeps a hook of their own",
 			start: map[string]any{"hooks": map[string]any{"internal": map[string]any{"enabled": false, "entries": map[string]any{"theirs": map[string]any{"enabled": true}}}}},
 			want:  false,


### PR DESCRIPTION
The parsed-JSON writer restored `hooks.internal.enabled` only when the entries block emptied, so a reader who had the switch off and a hook of their own found the hook running after deja was gone; the JSONC path already restored it regardless. The restore now runs whenever deja recorded the value it overwrote. New case in TestTheParsedPathGivesBackASwitchTheReaderSet fails before with `after uninstall the switch is true, want false`.

Closes #3204

## Review

Reviewer (cavecrew): the new case fails before and passes after; forgetHookSwitch running unconditionally is fine, uninstall is terminal. One divergence from the JSONC path taken: with no record (deja set the switch on a file that had none) and the reader's entries remaining, the parsed path left `enabled: true` while the JSONC writer removes the key — the key goes now in both, with a table case for it.
