### PR TITLE
fix(hermes): HERMES_HOME moves install, parse and doctor with it

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -27,6 +27,9 @@ func hermeticEnv(t *testing.T) string {
 	home := filepath.Join(tmp, "home")
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	// Hermes's own switch moves deja with it (#3203): pinned so a developer
+	// with HERMES_HOME exported never has a test read or write their Hermes.
+	t.Setenv("HERMES_HOME", "")
 	// Windows resolvers read APPDATA rather than the home directory — goose's
 	// config is one — so leaving it alone lets one test's install show up in
 	// another's report.

--- a/docs/registry/hermes.md
+++ b/docs/registry/hermes.md
@@ -2,6 +2,7 @@
 
 - **ID**: `hermes`
 - **Store**: `~/.hermes/state.db` (0.17+) or `~/.hermes/profiles/<profile>/state.db` (older builds, one store per profile)
+- **Home**: `HERMES_HOME` moves install, parse and doctor together, as it moves Hermes; `DEJA_HERMES_HOME` overrides it for deja alone
 - **Read overrides**: `DEJA_HERMES_PROFILES_ROOT` for the profiles directory, `DEJA_HERMES_DB` to pin a single store
 - **Format**: SQLite relational store
 

--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -23,6 +23,9 @@ func hermeticIndexEnv(t *testing.T) string {
 	tmp := t.TempDir()
 	setHome(t, filepath.Join(tmp, "home"))
 	t.Setenv("USERPROFILE", filepath.Join(tmp, "home"))
+	// Hermes's own switch moves deja with it (#3203): pinned so a developer
+	// with HERMES_HOME exported never has a test read or write their Hermes.
+	t.Setenv("HERMES_HOME", "")
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "default-index"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -14,11 +14,10 @@ import (
 )
 
 // HermesHome is the Hermes root: profiles, plugins and config.yaml live here.
+// HERMES_HOME is Hermes's own switch and moves install, parse and doctor
+// together; DEJA_HERMES_HOME overrides it for deja alone (#3203).
 func HermesHome() string {
-	if p := os.Getenv("DEJA_HERMES_HOME"); p != "" {
-		return p
-	}
-	return filepath.Join(Home(), ".hermes")
+	return EnvPath("DEJA_HERMES_HOME", EnvPath("HERMES_HOME", filepath.Join(Home(), ".hermes")))
 }
 
 // Hermes keeps one SQLite store per profile under ~/.hermes/profiles/<name>,

--- a/internal/sources/hermes_home_test.go
+++ b/internal/sources/hermes_home_test.go
@@ -1,0 +1,22 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Hermes finds its own home through HERMES_HOME; deja read only its own
+// override, so a Hermes moved by its own switch was invisible to install,
+// parse and doctor (#3203).
+func TestHermesHomeFollowsHermesOwnSwitch(t *testing.T) {
+	t.Setenv("DEJA_HERMES_HOME", "")
+	t.Setenv("HERMES_HOME", filepath.Join(t.TempDir(), "hermes-alt"))
+	if got, want := HermesHome(), filepath.Join(t.TempDir(), "hermes-alt"); filepath.Base(got) != filepath.Base(want) {
+		t.Fatalf("HermesHome = %q, want the HERMES_HOME dir", got)
+	}
+	// deja's own override still wins.
+	t.Setenv("DEJA_HERMES_HOME", filepath.Join(t.TempDir(), "deja-says"))
+	if got := HermesHome(); filepath.Base(got) != "deja-says" {
+		t.Fatalf("HermesHome = %q, want DEJA_HERMES_HOME to win", got)
+	}
+}


### PR DESCRIPTION
HermesHome read DEJA_HERMES_HOME and fell back to ~/.hermes; Hermes itself lives where HERMES_HOME says. Now HERMES_HOME is the default and DEJA_HERMES_HOME the override, the CODEX_HOME shape; the registry page names both. TestHermesHomeFollowsHermesOwnSwitch fails before with ~/.hermes.

Closes #3203

## Review

Reviewer (cavecrew): the chain is right and the test fails before; one gap taken — hermeticEnv (cmd/deja) and hermeticIndexEnv (internal/index) pinned DEJA_HERMES_HOME but not HERMES_HOME, so a developer with Hermes's switch exported would have had tests read or write their real Hermes; both pin it to "" now.
