### PR TITLE
fix(aider): a flow-list read: is spread into the list, not kept as one item

### DIFF
--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -67,16 +67,42 @@ func addAiderReadEntry(s, ctx string) string {
 		at := i + len("\nread:\n") - 1
 		return s[:at] + entry + s[at:]
 	}
-	// The scalar form takes a single file; promote it to a list so both survive.
+	// The scalar form takes a single file; promote it to a list so both
+	// survive. A flow list — `read: [a, b]` — is spread the same way: taken
+	// for a scalar it became one item holding both names, and aider dropped
+	// both files (#3197).
 	for _, line := range strings.Split(s, "\n") {
 		if v, ok := strings.CutPrefix(line, "read: "); ok && strings.TrimSpace(v) != "" {
-			return strings.Replace(s, line+"\n", "read:\n  - "+strings.TrimSpace(v)+"\n"+entry, 1)
+			items := "  - " + strings.TrimSpace(v) + "\n"
+			if flow, ok := aiderFlowItems(strings.TrimSpace(v)); ok {
+				items = ""
+				for _, it := range flow {
+					items += "  - " + it + "\n"
+				}
+			}
+			return strings.Replace(s, line+"\n", "read:\n"+items+entry, 1)
 		}
 	}
 	if s != "" && !strings.HasSuffix(s, "\n") {
 		s += "\n"
 	}
 	return s + "read:\n" + entry
+}
+
+// aiderFlowItems reads a YAML flow list of plain or quoted names; anything
+// else is not one.
+func aiderFlowItems(v string) ([]string, bool) {
+	if !strings.HasPrefix(v, "[") || !strings.HasSuffix(v, "]") {
+		return nil, false
+	}
+	var out []string
+	for _, it := range strings.Split(v[1:len(v)-1], ",") {
+		it = strings.Trim(strings.TrimSpace(it), "\"'")
+		if it != "" {
+			out = append(out, it)
+		}
+	}
+	return out, len(out) > 0
 }
 
 func removeAiderReadEntry(s string) string {

--- a/cmd/deja/install_aider_test.go
+++ b/cmd/deja/install_aider_test.go
@@ -112,3 +112,28 @@ func TestInstallAiderPromotesAScalarRead(t *testing.T) {
 		t.Fatalf("both files must end up in the list:\n%s", conf)
 	}
 }
+
+// A flow list — `read: [a, b]` — is a list already; treated as the scalar form
+// it became one item holding both names, and aider dropped both files (#3197).
+func TestInstallAiderSpreadsAFlowListRead(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	path := filepath.Join(home, ".aider.conf.yml")
+	if err := os.WriteFile(path, []byte("model: gpt-4o\nread: [CONVENTIONS.md, \"notes.md\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installAider("/bin/echo", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	conf := aiderConf(t, home)
+	if strings.Contains(conf, "[CONVENTIONS.md") {
+		t.Fatalf("the flow list was kept as one item:\n%s", conf)
+	}
+	for _, want := range []string{"  - CONVENTIONS.md\n", "  - notes.md\n", "aider-context.md"} {
+		if !strings.Contains(conf, want) {
+			t.Fatalf("missing %q in:\n%s", want, conf)
+		}
+	}
+}


### PR DESCRIPTION
addAiderReadEntry took `read: [a, b]` for the scalar form and wrote `- [a, b]` — one item holding both names, which real aider reports as a missing file and skips. The flow list is now spread into the block list with deja's entry after it. TestInstallAiderSpreadsAFlowListRead fails before with the bracketed item kept.

Closes #3197

End to end with aider 0.86.2 on the seed `read: [CONVENTIONS.md, notes.md]`: before, `Error: Read-only file …/['CONVENTIONS.md', 'notes.md'] does not exist. Skipping.`; after, `Added CONVENTIONS.md`, `Added notes.md` and the deja context file, all read-only.

## Review

Reviewer (cavecrew): the test fails before and the spread is right for the plain case; three gaps taken — a comma inside quotes (`["notes, v2.md"]`) was split into two names (a small tokenizer honours quotes now, and the test's seed carries one); an unclosed bracket, a comment after the list and an empty list fell through to the scalar path and were rewritten wrong — those are refused with a message naming the file and the line to add by hand, pinned by TestInstallAiderRefusesAFlowListItCannotRead, which also checks the file is left byte-for-byte.
