### PR TITLE
fix(goose): uninstall names the hooks plugin it removes

### DIFF
--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -282,6 +282,10 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 	if uninstall {
 		// The hook lives in its own plugin directory; leaving it behind means
 		// Goose keeps running a command that no longer exists.
+		hooks := installResult{Path: gooseHookPath(), Action: "unchanged"}
+		if _, statErr := os.Stat(gooseHookPath()); statErr == nil {
+			hooks.Action = "removed"
+		}
 		_ = os.RemoveAll(filepath.Dir(filepath.Dir(gooseHookPath())))
 		// The recall now lives in the reader's own AGENTS.md, so uninstall
 		// takes deja's block out and leaves the file. Removing it was right
@@ -293,7 +297,9 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 		if rerr := dropRetiredGooseHints(); rerr != nil {
 			return installResult{}, rerr
 		}
-		return res, nil
+		// The plugin's removal rides with the result, the way the install
+		// names its creation (#3208).
+		return wroteAll(res, hooks), nil
 	}
 	if err := refreshGooseHints(); err != nil {
 		return installResult{}, err

--- a/cmd/deja/install_goose_uninstall_line_test.go
+++ b/cmd/deja/install_goose_uninstall_line_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The install names the hooks plugin it creates; the uninstall removed it in
+// silence (#3208).
+func TestUninstallGooseAutoNamesTheHooksItRemoves(t *testing.T) {
+	gooseHomeForTest(t)
+	if _, err := installGooseAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	res, err := installGooseAuto("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Path+" "+res.Note, "hooks.json") {
+		t.Fatalf("uninstall did not name the hooks plugin: path=%q note=%q", res.Path, res.Note)
+	}
+}


### PR DESCRIPTION
installGooseAuto removed ~/.agents/plugins/deja on uninstall and returned only the config.yaml result; the removal now folds in with wroteAll like the other -auto targets (`also removed ~/.agents/plugins/deja/hooks/hooks.json`). TestUninstallGooseAutoNamesTheHooksItRemoves fails before with an empty note.

Closes #3208

## Review

Reviewer (cavecrew): no findings. Checked wroteAll's choice of primary in both cases (the line reads `goose-auto: removed ~/.agents/plugins/deja/hooks/hooks.json` on a hermetic HOME), that no `.bak` beside hooks.json can survive to be counted, that the install side already names the file it creates, and that the test fails before and every Goose test passes after.
