### PR TITLE
fix(sources): a Windows workspace path folds into the project key like a POSIX one

### DIFF
--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -433,7 +433,9 @@ func firstNonEmpty(a, b string) string {
 // key claudeProjectName expects, so cline/roo sessions land in the same
 // project namespace as every other harness.
 func pathToProjectKey(p string) string {
-	return strings.ReplaceAll(p, "/", "-")
+	// A Windows path folds the same way: backslashes are separators too, and
+	// the drive letter's colon is not a character a key carries (#3217).
+	return strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(p)
 }
 
 func firstLineTrim(s string) string {

--- a/internal/sources/project_key_fold_test.go
+++ b/internal/sources/project_key_fold_test.go
@@ -1,0 +1,14 @@
+package sources
+
+import "testing"
+
+// A Windows workspace path has no "/" to fold, so the key was the whole path
+// and the session sat in a project of its own (#3217).
+func TestPathToProjectKeyFoldsAWindowsPath(t *testing.T) {
+	if got, want := pathToProjectKey(`C:\Users\qa\work\zorbex`), pathToProjectKey("C:/Users/qa/work/zorbex"); got != want {
+		t.Fatalf("backslash form = %q, slash form = %q", got, want)
+	}
+	if got := claudeProjectName(pathToProjectKey(`C:\Users\qa\work\zorbex`)); got != "work/zorbex" {
+		t.Fatalf("project = %q, want work/zorbex", got)
+	}
+}


### PR DESCRIPTION
pathToProjectKey replaced only `/`; a `C:\Users\…` path stayed whole and became a project of its own for the four parsers that use it. Backslashes and the drive colon fold to dashes now, the way encodedProjectDir does in the worktree-scope test. TestPathToProjectKeyFoldsAWindowsPath fails before with the whole path.

Closes #3217

## Review

Reviewer (cavecrew): no findings. Both path forms fold to the same key and decode to `work/zorbex`; the key matches what encodedProjectDir produces for the same Windows cwd; every caller hands the key straight to claudeProjectName; the test fails before and passes after. Not a fix for #3138, whose fixture is a Claude store and does not pass through this function.
