### PR TITLE
fix(grok): uninstall takes deja's hooks out and leaves the reader's

### DIFF
--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -57,11 +57,11 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 		// Install merged deja's entries beside the reader's own; uninstall
 		// removed the file whole and took theirs with it (#3219). deja's
 		// entries come out, and the file goes only when nothing else is in it.
-		for ev, hook := range map[string]string{
-			"SessionStart": "hook-context", "PreCompact": "hook-precompact",
-			"UserPromptSubmit": "hook-prompt", "PreToolUse": "hook-tool",
+		for _, ev := range [][2]string{
+			{"SessionStart", "hook-context"}, {"PreCompact", "hook-precompact"},
+			{"UserPromptSubmit", "hook-prompt"}, {"PreToolUse", "hook-tool"},
 		} {
-			root = updateClaudeHook(root, ev, exe+" "+hook, "", true)
+			root = updateClaudeHook(root, ev[0], exe+" "+ev[1], "", true)
 		}
 		if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
 			delete(root, "hooks")

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -40,15 +40,6 @@ func grokHooksPath() string {
 
 func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	path := grokHooksPath()
-	if uninstall {
-		if _, err := os.Stat(path); err != nil {
-			return installResult{Path: path, Action: "unchanged"}, nil
-		}
-		if err := os.Remove(path); err != nil {
-			return installResult{}, err
-		}
-		return installResult{Path: path, Action: "removed"}, nil
-	}
 	old, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return installResult{}, err
@@ -58,6 +49,35 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
 		return installResult{}, configParseError(path, err)
+	}
+	if uninstall {
+		if len(old) == 0 {
+			return installResult{Path: path, Action: "unchanged"}, nil
+		}
+		// Install merged deja's entries beside the reader's own; uninstall
+		// removed the file whole and took theirs with it (#3219). deja's
+		// entries come out, and the file goes only when nothing else is in it.
+		for ev, hook := range map[string]string{
+			"SessionStart": "hook-context", "PreCompact": "hook-precompact",
+			"UserPromptSubmit": "hook-prompt", "PreToolUse": "hook-tool",
+		} {
+			root = updateClaudeHook(root, ev, exe+" "+hook, "", true)
+		}
+		if hooks, _ := root["hooks"].(map[string]any); len(hooks) == 0 {
+			delete(root, "hooks")
+		}
+		if len(root) == 0 {
+			if err := os.Remove(path); err != nil {
+				return installResult{}, err
+			}
+			return installResult{Path: path, Action: "removed"}, nil
+		}
+		next, err := marshalConfigLike(old, root)
+		if err != nil {
+			return installResult{}, err
+		}
+		a, err := writeIfChanged(path, old, append(next, '\n'))
+		return installResult{Path: path, Action: a}, err
 	}
 	// No matcher. Grok's own docs name the session sources `startup` and
 	// `resume`, but 1.0.5 sends `new` for a fresh session and `load` for a

--- a/cmd/deja/install_grok_auto.go
+++ b/cmd/deja/install_grok_auto.go
@@ -48,6 +48,15 @@ func installGrokAuto(exe string, uninstall bool) (installResult, error) {
 	if len(bytes.TrimSpace(old)) == 0 {
 		root = map[string]any{}
 	} else if err := json.Unmarshal(old, &root); err != nil {
+		if uninstall {
+			// A file deja cannot read is still one the uninstall has to take,
+			// or grok keeps calling a binary wired nowhere else — the contract
+			// TestUninstallStillTakesAHookFileTheInstallWouldRefuse pins.
+			if rerr := os.Remove(path); rerr != nil {
+				return installResult{}, rerr
+			}
+			return installResult{Path: path, Action: "removed"}, nil
+		}
 		return installResult{}, configParseError(path, err)
 	}
 	if uninstall {

--- a/cmd/deja/install_grok_uninstall_test.go
+++ b/cmd/deja/install_grok_uninstall_test.go
@@ -16,7 +16,8 @@ func TestUninstallGrokAutoLeavesTheReadersHooks(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	seed := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/usr/local/bin/other-tool session"}]}],"PreToolUse":[{"matcher":"Write","hooks":[{"type":"command","command":"/usr/local/bin/lint-on-write"}]}]}}` + "\n"
+	// An entry from an older deja at another path sits beside the reader's.
+	seed := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/usr/local/bin/other-tool session"},{"type":"command","command":"/old/path/deja hook-context"}]}],"PreToolUse":[{"matcher":"Write","hooks":[{"type":"command","command":"/usr/local/bin/lint-on-write"}]}]}}` + "\n"
 	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +31,7 @@ func TestUninstallGrokAutoLeavesTheReadersHooks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("the reader's hooks file is gone: %v", err)
 	}
-	if strings.Contains(string(b), "/bin/deja") {
+	if strings.Contains(string(b), "/bin/deja") || strings.Contains(string(b), "/old/path/deja") {
 		t.Fatalf("deja's entries stayed:\n%s", b)
 	}
 	var root map[string]any

--- a/cmd/deja/install_grok_uninstall_test.go
+++ b/cmd/deja/install_grok_uninstall_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Install merges deja's hooks beside the reader's own; uninstall removed the
+// whole file, and the reader's entries went with it (#3219).
+func TestUninstallGrokAutoLeavesTheReadersHooks(t *testing.T) {
+	hermeticEnv(t)
+	path := grokHooksPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"hooks":{"SessionStart":[{"matcher":"startup|resume","hooks":[{"type":"command","command":"/usr/local/bin/other-tool session"}]}],"PreToolUse":[{"matcher":"Write","hooks":[{"type":"command","command":"/usr/local/bin/lint-on-write"}]}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGrokAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGrokAuto("/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the reader's hooks file is gone: %v", err)
+	}
+	if strings.Contains(string(b), "/bin/deja") {
+		t.Fatalf("deja's entries stayed:\n%s", b)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"other-tool session", "lint-on-write"} {
+		if !strings.Contains(string(b), want) {
+			t.Fatalf("the reader's %q entry is gone:\n%s", want, b)
+		}
+	}
+
+	// deja's file alone: it goes, as before.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGrokAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installGrokAuto("/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("a file holding only deja's hooks was kept")
+	}
+}


### PR DESCRIPTION
installGrokAuto's uninstall branch removed ~/.grok/hooks/deja.json outright; install had merged deja's four entries beside whatever the reader kept there, so those went too. Uninstall now runs the same updateClaudeHook removal per event, writes the rest back, and removes the file only when nothing is left. TestUninstallGrokAutoLeavesTheReadersHooks fails before with the file gone; the existing every-hook test still sees the deja-only file removed. End to end on the fan-out seed: after uninstall the file holds only the reader's two entries.

Closes #3219

## Review

Reviewer (cavecrew): the test fails before and the deja-only file is still removed. Three points: (1) an entry from an older deja at another path — hookCommandKindOf recognises the binary by its base name, so `/old/path/deja hook-context` is ours and goes; the test now seeds one to pin it; (2) the four events were removed in map order — a fixed slice now; (3) a file that is not JSON used to be deleted and the first cut returned the parse error instead; TestUninstallStillTakesAHookFileTheInstallWouldRefuse pins the removal (grok would keep calling a binary wired nowhere else), so an unreadable file is still removed and only a readable one is edited.
