### PR TITLE
fix(install): grok-auto names config.toml and user-settings.json with the hooks it writes

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -707,10 +707,18 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		if err := readableStrictJSON(probe...); err != nil {
 			return installResult{}, err
 		}
-		if _, err := installGrok(exe, uninstall); err != nil {
+		base, err := installGrok(exe, uninstall)
+		if err != nil {
 			return installResult{}, err
 		}
-		return installGrokAuto(exe, uninstall)
+		hooks, err := installGrokAuto(exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		// Both halves in one result, in the order they run: the config and
+		// settings writes reached nobody while the first result was dropped
+		// (#3220, the #3185 shape).
+		return wroteAll(base, hooks), nil
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "qwen-auto":

--- a/cmd/deja/install_grok_auto_result_test.go
+++ b/cmd/deja/install_grok_auto_result_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// grok-auto writes config.toml and user-settings.json through installGrok and
+// the hooks file through installGrokAuto; the first result was dropped, so the
+// line named only the hooks (#3220).
+func TestGrokAutoResultNamesEveryFileItWrites(t *testing.T) {
+	hermeticEnv(t)
+	res, err := installTarget("grok-auto", "/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := res.Path + " " + res.Note
+	for _, want := range []string{"deja.json", "config.toml"} {
+		if !strings.Contains(all, want) {
+			t.Fatalf("install did not name %s: path=%q note=%q", want, res.Path, res.Note)
+		}
+	}
+}


### PR DESCRIPTION
installTarget dropped installGrok's result and returned only the hooks file's; both fold with wroteAll in the order they run, the #3185 shape. TestGrokAutoResultNamesEveryFileItWrites fails before with only deja.json named.

Closes #3220

## Review

Reviewer (cavecrew): no findings. Test fails before and passes after; on a hermetic HOME the install line names config.toml with deja.json riding along; the readableStrictJSON probe and the two error checks are untouched; the kept-snapshot count now sees the settings `.bak` through touched().
