### PR TITLE
fix(goose): stop deleting the reader's own .goosehints

### DIFF
--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -502,7 +502,7 @@ func refreshGooseHintsFor(cwd string) error {
 		body = frameRecall(startLead(gooseLead) + digest)
 	}
 	if strings.TrimSpace(body) == "" {
-		body = "No matching history yet.\n"
+		body = gooseNoHistory
 	}
 	path := gooseRecallPath()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -535,15 +535,50 @@ func dropGooseRecallBlock(path string) error {
 	return err
 }
 
-// dropRetiredGooseHints removes the file deja used to write, once it holds
-// nothing but what deja put there.
+// dropRetiredGooseHints takes deja's block out of the file it used to write,
+// and removes the file only when nothing else was in it.
+//
+// It said that and did not do it: a Stat and a Remove, with no look at the
+// content. deja stopped writing this file when the block moved to AGENTS.md,
+// so anyone keeping their own global hints there lost them — on every install,
+// every uninstall, and every turn, since hook-goose calls this too (#3196).
+// The rule already existed one function up, for the file that replaced it.
 func dropRetiredGooseHints() error {
 	path := retiredGooseHintsPath()
-	if _, err := os.Stat(path); err != nil {
+	old, err := readConfig(path)
+	if err != nil || len(old) == 0 {
 		return nil
 	}
-	return os.Remove(path)
+	if strings.Contains(string(old), gooseRecallStart) {
+		return dropGooseRecallBlock(path)
+	}
+	// An older deja wrote this file whole and unmarked, so there is no block to
+	// cut — but what it wrote is still recognisable: the recall frame, or the
+	// placeholder it used when there was nothing to recall. Anything else in
+	// the file is the reader's.
+	if isRetiredGooseRecall(string(old)) {
+		return os.Remove(path)
+	}
+	return nil
 }
+
+// isRetiredGooseRecall reports that a file holds what deja used to write here
+// and nothing else.
+func isRetiredGooseRecall(s string) bool {
+	t := strings.TrimSpace(s)
+	if t == "" {
+		return true
+	}
+	if t == strings.TrimSpace(gooseNoHistory) {
+		return true
+	}
+	return strings.HasPrefix(t, strings.TrimSpace(recallFrameHeader)) &&
+		strings.HasSuffix(t, strings.TrimSpace(recallFrameFooter))
+}
+
+// gooseNoHistory is what goes in the file when there is nothing to recall, so
+// a later pass can tell deja's own placeholder from something the reader wrote.
+const gooseNoHistory = "No matching history yet.\n"
 
 const gooseLead = "The sessions below are from this project's recent history. " +
 	"If any is relevant to what the user asks next, say so and use it. " +

--- a/cmd/deja/install_goose_agents_test.go
+++ b/cmd/deja/install_goose_agents_test.go
@@ -36,7 +36,11 @@ func TestGooseRecallClearsTheFileItUsedToWrite(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(retired), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(retired, []byte("recall from an older deja\n"), 0o644); err != nil {
+	// What an older deja actually wrote there: the recall frame, whole. The
+	// fixture used to be a line of plain prose — which is what the reader's own
+	// hints look like — and the code deleted the file on sight, so anyone
+	// keeping global hints there lost them on every turn (#3196).
+	if err := os.WriteFile(retired, []byte(frameRecall("recall from an older deja\n")), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := installGooseAuto("/bin/deja", false); err != nil {
@@ -44,6 +48,57 @@ func TestGooseRecallClearsTheFileItUsedToWrite(t *testing.T) {
 	}
 	if _, err := os.Stat(retired); !os.IsNotExist(err) {
 		t.Errorf("the retired file survived the install: %v", err)
+	}
+}
+
+// The same file, holding what the reader wrote. deja stopped writing here when
+// the block moved to AGENTS.md, so there is nothing of deja's to take out and
+// nothing to remove — on install, on uninstall, and on every hook-goose turn,
+// which is where it was seen (#3196).
+func TestGooseLeavesTheReadersOwnRetiredHints(t *testing.T) {
+	cfg := gooseHomeForTest(t)
+	retired := filepath.Join(cfg, "goose", ".goosehints")
+	if err := os.MkdirAll(filepath.Dir(retired), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const mine = "my own hints, written by the user\nalways run the linter first\n"
+	if err := os.WriteFile(retired, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range []func() error{
+		func() error { _, err := installGooseAuto("/bin/deja", false); return err },
+		dropRetiredGooseHints,
+		func() error { _, err := installGooseAuto("/bin/deja", true); return err },
+	} {
+		if err := step(); err != nil {
+			t.Fatal(err)
+		}
+		b, err := os.ReadFile(retired)
+		if err != nil {
+			t.Fatalf("deja deleted hints it did not write: %v", err)
+		}
+		if string(b) != mine {
+			t.Fatalf("the reader's hints changed:\n%s", b)
+		}
+	}
+
+	// And a file holding both: deja's block comes out, theirs stays.
+	both := mine + "\n" + gooseRecallStart + "\nold recall\n" + gooseRecallEnd + "\n"
+	if err := os.WriteFile(retired, []byte(both), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := dropRetiredGooseHints(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(retired)
+	if err != nil {
+		t.Fatalf("the file went with deja's block: %v", err)
+	}
+	if !strings.Contains(string(b), "always run the linter first") {
+		t.Fatalf("the reader's half went with deja's:\n%s", b)
+	}
+	if strings.Contains(string(b), gooseRecallStart) {
+		t.Fatalf("deja's block stayed:\n%s", b)
 	}
 }
 

--- a/docs/registry/goose.html
+++ b/docs/registry/goose.html
@@ -62,8 +62,10 @@
 <li><strong>Auto-recall</strong>: <code>SessionStart</code> and <code>UserPromptSubmit</code> hooks in</li>
 </ul>
 <p><code>~/.agents/plugins/deja/hooks/hooks.json</code>. Goose discards what a hook prints,</p>
-<p>so neither answers on stdout: they write the file Goose re-reads, which is</p>
-<p><code>.goosehints</code> at session start and the MOIM file per prompt.</p>
+<p>so neither answers on stdout: they write the file Goose re-reads, which is a</p>
+<p>marked block in <code>~/.config/goose/AGENTS.md</code> at session start and the MOIM file</p>
+<p>per prompt. <code>.goosehints</code> is where the block used to go; what deja wrote there</p>
+<p>is cleared, and anything else in that file is left alone.</p>
 <ul>
 <li><strong>Resume</strong>: <code>goose session --resume --session-id &lt;id&gt;</code>.</li>
 <li><strong>Handoff</strong>: exec, <code>goose run -t</code>.</li>

--- a/docs/registry/goose.md
+++ b/docs/registry/goose.md
@@ -19,8 +19,10 @@ seconds) and `content` blocks (`type: text` only for v1). SQLite: `sessions` joi
   commands directory, so `/deja` is a recipe entry there.
 - **Auto-recall**: `SessionStart` and `UserPromptSubmit` hooks in
   `~/.agents/plugins/deja/hooks/hooks.json`. Goose discards what a hook prints,
-  so neither answers on stdout: they write the file Goose re-reads, which is
-  `.goosehints` at session start and the MOIM file per prompt.
+  so neither answers on stdout: they write the file Goose re-reads, which is a
+  marked block in `~/.config/goose/AGENTS.md` at session start and the MOIM file
+  per prompt. `.goosehints` is where the block used to go; what deja wrote there
+  is cleared, and anything else in that file is left alone.
 - **Resume**: `goose session --resume --session-id <id>`.
 - **Handoff**: exec, `goose run -t`.
 - **Prerequisite**: the per-prompt half needs `GOOSE_MOIM_MESSAGE_FILE`, which


### PR DESCRIPTION
`dropRetiredGooseHints` said it removed the file "once it holds nothing but what deja put there" and did a `Stat` and a `Remove`. deja stopped writing `.goosehints` when the block moved to `AGENTS.md`, so anyone keeping their own global hints there lost them — on install, on uninstall, and on every turn, since `hook-goose` calls it too.

```
                                          before   after
printf '{}' | deja hook-goose             DELETED  kept: my own hints, written by the user
```

Three cases now, and only the first two touch anything: a file carrying deja's markers loses the block and survives if anything else was in it; a file that is recognisably what an older deja wrote whole — the recall frame, or the "No matching history yet." placeholder — is removed; anything else is left. The rule for the first case already existed one function up, for the file that replaced this one.

The test that covered this asserted the deletion, with a fixture of plain prose — which is exactly what the reader's own hints look like. Its fixture is now what deja actually wrote, and the reader's-file case is a test of its own across install, hook and uninstall. Four mutations, all red.

`docs/registry/goose.md` said the hooks write `.goosehints`; it now says `AGENTS.md` and what happens to the retired file (#3210).

Closes #3196, closes #3210.
