### PR TITLE
fix(sources): the grok row counts grok.db sessions with the JSONL ones

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2955,7 +2955,10 @@ func printSources(dir string) {
 		{"gemini", sources.GeminiRoot(), []string{filepath.Join(sources.GeminiRoot(), "tmp")}, sources.GeminiChatFiles, sources.LoadGemini},
 		{"cursor", strings.Join([]string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, string(os.PathListSeparator)), []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorReadFiles, sources.LoadCursor},
 		{"antigravity", antigravityLocation, antigravityRoots, sources.AntigravityTranscripts, sources.LoadAntigravity},
-		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.GrokSessionFiles, sources.LoadGrok},
+		// Both stores, as the registry loads them: the JSONL reader alone read a
+		// Grok Build grok.db as sessions=0 while doctor counted it (#3225).
+		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.GrokSessionFiles,
+			func() []model.Session { return append(sources.LoadGrok(), sources.LoadGrokDB()...) }},
 		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles, sources.LoadQwen},
 		{"kimi", filepath.Join(sources.KimiRoot(), "sessions"), []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles, sources.LoadKimi},
 		{"goose", filepath.Join(sources.GooseRoot(), "sessions"), []string{filepath.Join(sources.GooseRoot(), "sessions")}, sources.GooseSessionFiles, sources.LoadGoose},

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2957,7 +2957,16 @@ func printSources(dir string) {
 		{"antigravity", antigravityLocation, antigravityRoots, sources.AntigravityTranscripts, sources.LoadAntigravity},
 		// Both stores, as the registry loads them: the JSONL reader alone read a
 		// Grok Build grok.db as sessions=0 while doctor counted it (#3225).
-		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()}, sources.GrokSessionFiles,
+		{"grok", sources.GrokRoot(), []string{sources.GrokRoot()},
+			func() []string {
+				files := sources.GrokSessionFiles()
+				if db := sources.GrokDB(); db != "" {
+					if _, err := os.Stat(db); err == nil {
+						files = append(files, db)
+					}
+				}
+				return files
+			},
 			func() []model.Session { return append(sources.LoadGrok(), sources.LoadGrokDB()...) }},
 		{"qwen", filepath.Join(sources.QwenRoot(), "projects"), []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles, sources.LoadQwen},
 		{"kimi", filepath.Join(sources.KimiRoot(), "sessions"), []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles, sources.LoadKimi},

--- a/cmd/deja/sources_grok_db_test.go
+++ b/cmd/deja/sources_grok_db_test.go
@@ -20,6 +20,7 @@ func TestSourcesCountsGrokDBSessions(t *testing.T) {
 	t.Setenv("HERMES_HOME", "")
 	db := filepath.Join(tmp, "grok.db")
 	t.Setenv("DEJA_GROK_DB", db)
+	t.Setenv("DEJA_GROK_ROOT", filepath.Join(tmp, "grok"))
 	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
 	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
 	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
@@ -39,7 +40,7 @@ INSERT INTO messages VALUES ('g2',0,'user','{"content":"a second session"}','202
 	out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
 	for _, l := range strings.Split(out, "\n") {
 		if strings.HasPrefix(l, "grok\t") {
-			if !strings.Contains(l, "sessions=2") {
+			if !strings.Contains(l, "sessions=2") || strings.Contains(l, "size=0 B") {
 				t.Fatalf("grok row misses the store's sessions: %s", l)
 			}
 			return

--- a/cmd/deja/sources_grok_db_test.go
+++ b/cmd/deja/sources_grok_db_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The grok row loaded the JSONL reader alone; a Grok Build store in grok.db
+// read as sessions=0 while doctor and search saw it (#3225).
+func TestSourcesCountsGrokDBSessions(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HERMES_HOME", "")
+	db := filepath.Join(tmp, "grok.db")
+	t.Setenv("DEJA_GROK_DB", db)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	sql := `CREATE TABLE workspaces (id TEXT PRIMARY KEY, canonical_path TEXT);
+CREATE TABLE sessions (id TEXT PRIMARY KEY, workspace_id TEXT, title TEXT, cwd_last TEXT, created_at TEXT);
+CREATE TABLE messages (session_id TEXT, seq INTEGER, role TEXT, message_json TEXT, created_at TEXT);
+INSERT INTO sessions VALUES ('g1','w','Pool timeouts','/work/api','2026-07-27T10:00:00.000Z');
+INSERT INTO messages VALUES ('g1',0,'user','{"content":"why does the pool time out"}','2026-07-27T10:00:00.000Z');
+INSERT INTO sessions VALUES ('g2','w','Quiet one','/work/api','2026-07-26T10:00:00.000Z');
+INSERT INTO messages VALUES ('g2',0,'user','{"content":"a second session"}','2026-07-26T10:00:00.000Z');`
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(sql)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3: %v: %s", err, out)
+	}
+	out := captureStdout(t, func() { printSources(filepath.Join(tmp, "index.db")) })
+	for _, l := range strings.Split(out, "\n") {
+		if strings.HasPrefix(l, "grok\t") {
+			if !strings.Contains(l, "sessions=2") {
+				t.Fatalf("grok row misses the store's sessions: %s", l)
+			}
+			return
+		}
+	}
+	t.Fatalf("no grok row in:\n%s", out)
+}


### PR DESCRIPTION
printSources loaded grok with the JSONL reader alone while the registry loads both readers, so a Grok Build store read as sessions=0 on the one screen the empty-machine advice sends people to. The row loads what the registry loads. TestSourcesCountsGrokDBSessions fails before with sessions=0.

Closes #3225

## Review

Reviewer (cavecrew): the test fails before and passes after, LoadGrokDB is quiet on a missing or locked store. Two gaps taken: the row's files func left grok.db out, so the size column read 0 B for a db-only store — it now appends the db the way the registry does, and the test pins a non-zero size; the test now pins DEJA_GROK_ROOT to a temp dir like the other roots.
