### PR TITLE
test(readme): compare the Cursor skill path with forward slashes on Windows too

### DIFF
--- a/cmd/deja/readme_guidance_claims_test.go
+++ b/cmd/deja/readme_guidance_claims_test.go
@@ -99,7 +99,8 @@ func TestReadmeCursorGetsASkill(t *testing.T) {
 	}
 	// The directory the installer writes, not a path the test remembers:
 	// the skill moved to the shared ~/.agents/skills and the README lagged (#3187).
-	want := shortHome(filepath.Dir(filepath.Dir(r.Path)))
+	// The README writes the path with forward slashes on every platform.
+	want := filepath.ToSlash(shortHome(filepath.Dir(filepath.Dir(r.Path))))
 	if !strings.Contains(para, want) {
 		t.Errorf("README does not say where Cursor's skill goes (%s):\n%s", want, para)
 	}


### PR DESCRIPTION
The #3188 test derived the expected path with filepath and got `~\.agents\skills` on Windows while the README writes `~/.agents/skills`; ToSlash before comparing. Seen on the windows-latest run of #3218.

Refs #3187