### PR TITLE
fix(aider): a flow list under read: is a list, not a scalar

### DIFF
--- a/cmd/deja/install_aider.go
+++ b/cmd/deja/install_aider.go
@@ -41,7 +41,10 @@ func installAider(_ string, uninstall bool) (installResult, error) {
 	}
 	next := removeAiderReadEntry(string(old))
 	if !uninstall {
-		next = addAiderReadEntry(next, aiderContextPath())
+		var aerr error
+		if next, aerr = addAiderReadEntry(next, aiderContextPath()); aerr != nil {
+			return installResult{}, fmt.Errorf("%s: %w", shortHome(path), aerr)
+		}
 	}
 	a, werr := writeIfChanged(path, old, []byte(next))
 	if werr != nil {
@@ -61,22 +64,92 @@ func installAider(_ string, uninstall bool) (installResult, error) {
 
 // addAiderReadEntry keeps whatever list is already under read: — a user with
 // their own CONVENTIONS.md there must not lose it.
-func addAiderReadEntry(s, ctx string) string {
+func addAiderReadEntry(s, ctx string) (string, error) {
 	entry := "  - " + ctx + "\n"
 	if i := strings.Index("\n"+s, "\nread:\n"); i >= 0 {
 		at := i + len("\nread:\n") - 1
-		return s[:at] + entry + s[at:]
+		return s[:at] + entry + s[at:], nil
 	}
 	// The scalar form takes a single file; promote it to a list so both survive.
 	for _, line := range strings.Split(s, "\n") {
-		if v, ok := strings.CutPrefix(line, "read: "); ok && strings.TrimSpace(v) != "" {
-			return strings.Replace(s, line+"\n", "read:\n  - "+strings.TrimSpace(v)+"\n"+entry, 1)
+		v, ok := strings.CutPrefix(line, "read: ")
+		if !ok || strings.TrimSpace(v) == "" {
+			continue
 		}
+		// A flow list is not a scalar. Taken as one, `read: [a.md, b.md]`
+		// became a single entry `- [a.md, b.md]` and aider looked for a file
+		// with that name — the reader's two files gone from its view, reported
+		// as a successful install (#3197).
+		if items, isFlow := yamlFlowItems(strings.TrimSpace(v)); isFlow {
+			if items == nil {
+				// A shape this cannot take apart safely. Refuse, the way the
+				// goose and Continue writers do, rather than rewrite it wrong.
+				return "", fmt.Errorf("read: %s is a list deja cannot rewrite \u2014 move it to a block list and run this again", strings.TrimSpace(v))
+			}
+			var b strings.Builder
+			b.WriteString("read:\n")
+			for _, it := range items {
+				b.WriteString("  - " + it + "\n")
+			}
+			b.WriteString(entry)
+			return strings.Replace(s, line+"\n", b.String(), 1), nil
+		}
+		return strings.Replace(s, line+"\n", "read:\n  - "+strings.TrimSpace(v)+"\n"+entry, 1), nil
 	}
 	if s != "" && !strings.HasSuffix(s, "\n") {
 		s += "\n"
 	}
-	return s + "read:\n" + entry
+	return s + "read:\n" + entry, nil
+}
+
+// yamlFlowItems takes apart a YAML flow list \u2014 `[a, b]` \u2014 into its items, and
+// says whether the value was one at all. It gives nil items for a flow list
+// holding anything but plain scalars: a nested list or mapping, or a quote that
+// never closes. The caller refuses those rather than guess.
+func yamlFlowItems(v string) ([]string, bool) {
+	if !strings.HasPrefix(v, "[") {
+		return nil, false
+	}
+	if !strings.HasSuffix(v, "]") {
+		return nil, true
+	}
+	inner := strings.TrimSpace(v[1 : len(v)-1])
+	if inner == "" {
+		return []string{}, true
+	}
+	var items []string
+	var cur strings.Builder
+	quote := byte(0)
+	for i := 0; i < len(inner); i++ {
+		c := inner[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+			cur.WriteByte(c)
+		case c == '\'' || c == '"':
+			quote = c
+			cur.WriteByte(c)
+		case c == '[' || c == ']' || c == '{' || c == '}':
+			return nil, true
+		case c == ',':
+			items = append(items, strings.TrimSpace(cur.String()))
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if quote != 0 {
+		return nil, true
+	}
+	items = append(items, strings.TrimSpace(cur.String()))
+	for _, it := range items {
+		if it == "" {
+			return nil, true
+		}
+	}
+	return items, true
 }
 
 func removeAiderReadEntry(s string) string {

--- a/cmd/deja/install_aider_flowlist_test.go
+++ b/cmd/deja/install_aider_flowlist_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `read: [a.md, b.md]` is a list, and the writer took it for the scalar form —
+// so it wrote `- [a.md, b.md]` as one entry and aider looked for a file with
+// that name. The reader's two files were gone from its view and the install
+// reported success (#3197).
+func TestAiderKeepsAFlowListOfReadFiles(t *testing.T) {
+	const ctx = "/home/me/.config/deja/aider-context.md"
+
+	got, err := addAiderReadEntry("read: [CONVENTIONS.md, notes.md]\n", ctx)
+	if err != nil {
+		t.Fatalf("a plain flow list was refused: %v", err)
+	}
+	for _, want := range []string{"  - CONVENTIONS.md\n", "  - notes.md\n", "  - " + ctx + "\n"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the rewritten config lost %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "- [") {
+		t.Errorf("the list is still nested inside one entry:\n%s", got)
+	}
+
+	// Quotes, spacing and an empty list are the same list.
+	for _, in := range []string{
+		`read: ["a b.md", 'c.md']`,
+		"read: [a.md,b.md]",
+		"read: [ a.md , b.md ]",
+	} {
+		got, err := addAiderReadEntry(in+"\n", ctx)
+		if err != nil {
+			t.Errorf("%s was refused: %v", in, err)
+			continue
+		}
+		if strings.Contains(got, "- [") || !strings.Contains(got, "  - "+ctx) {
+			t.Errorf("%s came out wrong:\n%s", in, got)
+		}
+	}
+
+	// A shape it cannot take apart is refused, not rewritten. Aider's config is
+	// the reader's file, and a wrong rewrite is worse than no install.
+	for _, in := range []string{
+		"read: [a.md, [b.md, c.md]]",
+		`read: [{file: a.md}]`,
+		`read: ["unclosed, b.md]`,
+		"read: [a.md, ]",
+		// A flow list YAML would continue on the next line: there is no
+		// closing bracket on this one, so what the list holds is not here.
+		"read: [a.md, b.md",
+	} {
+		if _, err := addAiderReadEntry(in+"\n", ctx); err == nil {
+			t.Errorf("%s was rewritten instead of refused", in)
+		}
+	}
+
+	// The shapes that already worked still do.
+	got, err = addAiderReadEntry("read: CONVENTIONS.md\n", ctx)
+	if err != nil || !strings.Contains(got, "  - CONVENTIONS.md\n") || !strings.Contains(got, "  - "+ctx) {
+		t.Fatalf("the scalar form broke: %v\n%s", err, got)
+	}
+	got, err = addAiderReadEntry("read:\n  - CONVENTIONS.md\n", ctx)
+	if err != nil || !strings.Contains(got, "  - CONVENTIONS.md\n") || !strings.Contains(got, "  - "+ctx) {
+		t.Fatalf("the block form broke: %v\n%s", err, got)
+	}
+	got, err = addAiderReadEntry("", ctx)
+	if err != nil || !strings.HasPrefix(got, "read:\n") {
+		t.Fatalf("an empty config broke: %v\n%s", err, got)
+	}
+}


### PR DESCRIPTION
`read: [CONVENTIONS.md, notes.md]` was taken for the scalar form, so it came out as one entry — `- [CONVENTIONS.md, notes.md]` — and aider looked for a file with that name. The reader's two files left aider's view, on an install that reported success.

A flow list of plain scalars is now rewritten as a block list with deja's entry appended; quotes, spacing and an empty list are the same list. Anything the parser cannot take apart safely — a nested list or mapping, an unclosed quote, an empty item, a list whose closing bracket is on another line — is refused with the message the goose and Continue writers use, because a wrong rewrite of the reader's config is worse than no install.

The test carries both lists: the shapes that must come through, and the shapes that must be refused. Five mutations, all red.

Closes #3197.
