### PR TITLE
fix(install): a JSONC config with trailing commas is JSONC, not a broken file

### DIFF
--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -481,7 +481,7 @@ func installSettingsHookRetiring(path, event, matcher string, timeout int, cmd s
 	jsonc := configIsJSONC(old)
 	source := old
 	if jsonc {
-		source = []byte(stripJSONComments(string(old)))
+		source = []byte(jsoncToJSON(string(old)))
 	}
 	if len(bytes.TrimSpace(source)) == 0 {
 		root = map[string]any{}

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -25,8 +25,7 @@ func configIsJSONC(b []byte) bool {
 	if json.Unmarshal(b, &probe) == nil {
 		return false
 	}
-	stripped := stripTrailingCommas(stripJSONComments(string(b)))
-	return json.Unmarshal([]byte(stripped), &probe) == nil
+	return json.Unmarshal([]byte(jsoncToJSON(string(b))), &probe) == nil
 }
 
 // jsoncToJSON is what a strict decoder can read of an editor's JSONC: comments
@@ -292,7 +291,7 @@ func jsoncEntryText(entry map[string]any) (string, error) {
 func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]any, uninstall bool) (installResult, error) {
 	text := string(old)
 	var root map[string]any
-	if err := json.Unmarshal([]byte(stripTrailingCommas(stripJSONComments(text))), &root); err != nil {
+	if err := json.Unmarshal([]byte(jsoncToJSON(text)), &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	// A key that is there but holds something else — null, a list, a string.

--- a/cmd/deja/jsonc_entry.go
+++ b/cmd/deja/jsonc_entry.go
@@ -25,8 +25,41 @@ func configIsJSONC(b []byte) bool {
 	if json.Unmarshal(b, &probe) == nil {
 		return false
 	}
-	stripped := stripJSONComments(string(b))
+	stripped := stripTrailingCommas(stripJSONComments(string(b)))
 	return json.Unmarshal([]byte(stripped), &probe) == nil
+}
+
+// jsoncToJSON is what a strict decoder can read of an editor's JSONC: comments
+// and trailing commas blanked, every other byte where it was.
+func jsoncToJSON(text string) string { return stripTrailingCommas(stripJSONComments(text)) }
+
+// stripTrailingCommas blanks a comma that only whitespace separates from the
+// `}` or `]` after it — the other thing an editor's JSONC carries besides
+// comments (#3223). Offsets are kept the way stripJSONComments keeps them.
+func stripTrailingCommas(text string) string {
+	out := []byte(text)
+	for i := 0; i < len(text); {
+		switch text[i] {
+		case '"':
+			end := zedStringEnd(text, i)
+			if end < 0 {
+				return string(out)
+			}
+			i = end
+		case ',':
+			j := i + 1
+			for j < len(text) && (text[j] == ' ' || text[j] == '\t' || text[j] == '\n' || text[j] == '\r') {
+				j++
+			}
+			if j < len(text) && (text[j] == '}' || text[j] == ']') {
+				out[i] = ' '
+			}
+			i++
+		default:
+			i++
+		}
+	}
+	return string(out)
 }
 
 // stripJSONComments blanks out comments, keeping every other byte where it is
@@ -259,7 +292,7 @@ func jsoncEntryText(entry map[string]any) (string, error) {
 func writeJSONCEntry(path string, old []byte, blockKey string, want map[string]any, uninstall bool) (installResult, error) {
 	text := string(old)
 	var root map[string]any
-	if err := json.Unmarshal([]byte(stripJSONComments(text)), &root); err != nil {
+	if err := json.Unmarshal([]byte(stripTrailingCommas(stripJSONComments(text))), &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	// A key that is there but holds something else — null, a list, a string.

--- a/cmd/deja/jsonc_trailing_comma_test.go
+++ b/cmd/deja/jsonc_trailing_comma_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// VS Code writes mcp.json with trailing commas; the JSONC probe stripped
+// comments and then demanded strict JSON, so such a file refused the whole
+// target (#3223).
+func TestJSONCWithTrailingCommasIsJSONC(t *testing.T) {
+	for _, s := range []string{
+		"{\n \"a\": 1,\n}",
+		"{\n \"a\": [1, 2,],\n}",
+		"{ // c\n \"a\": {\"b\": 1,}, }\n",
+	} {
+		if !configIsJSONC([]byte(s)) {
+			t.Errorf("not taken for JSONC: %q", s)
+		}
+	}
+	for _, s := range []string{`{"a": 1}`, `{"a": ,}`, `{"a": 1,`, `{"a": "x,"}`} {
+		if configIsJSONC([]byte(s)) {
+			t.Errorf("taken for JSONC: %q", s)
+		}
+	}
+}
+
+func TestInstallVSCodeTakesAFileWithTrailingCommas(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, "mcp.json")
+	seed := "{\n\t\"servers\": {\n\t\t\"playwright\": {\n\t\t\t\"type\": \"stdio\",\n\t\t\t\"command\": \"npx\",\n\t\t\t\"args\": [\"@playwright/mcp@latest\"],\n\t\t},\n\t},\n}\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installVSCodeMCPAt(path, "/bin/deja", false); err != nil {
+		t.Fatalf("install refused the editor's own file: %v", err)
+	}
+	b, _ := os.ReadFile(path)
+	var root map[string]any
+	if err := json.Unmarshal([]byte(stripTrailingCommas(stripJSONComments(string(b)))), &root); err != nil {
+		t.Fatalf("the result is not JSONC any more: %v\n%s", err, b)
+	}
+	servers, _ := root["servers"].(map[string]any)
+	if servers["deja"] == nil || servers["playwright"] == nil {
+		t.Fatalf("servers = %v\n%s", servers, b)
+	}
+	if !strings.Contains(string(b), "@playwright/mcp@latest\"],") {
+		t.Fatalf("the reader's own trailing comma did not survive:\n%s", b)
+	}
+	if _, err := installVSCodeMCPAt(path, "/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != seed {
+		t.Fatalf("uninstall did not give the file back:\n%s", got)
+	}
+}


### PR DESCRIPTION
configIsJSONC stripped comments and then demanded strict JSON, so a trailing comma — the other thing an editor's JSONC carries — refused the whole target with a message blaming the comment. Trailing commas are blanked the way comments are, in the probe and in writeJSONCEntry's own parse; the text insert already coped with them, and uninstall gives the file back byte for byte. TestJSONCWithTrailingCommasIsJSONC and TestInstallVSCodeTakesAFileWithTrailingCommas fail before with `invalid character '}'`.

Closes #3223

## Review

Reviewer (cavecrew): stripTrailingCommas handles a comma before a comment before the bracket and an escaped quote in a string; the vscode test checks the produced file parses and comes back byte for byte. Two findings taken: the settings-hook reader in install_auto.go stripped comments only, so a file the probe now calls JSONC could still fail its parse — it reads through jsoncToJSON now; and jsoncToJSON was defined and unused — it is the one entry point for the probe, writeJSONCEntry and that reader. The five other readers that strip comments alone (amp, gemini ×2, openclaw, prime) are a follow-up, in the queue.
