### PR TITLE
fix(zed): the block takes the file's line ending, and uninstall takes the CR with it

### DIFF
--- a/cmd/deja/install_zed.go
+++ b/cmd/deja/install_zed.go
@@ -94,12 +94,18 @@ func zedSettingsWith(text, entry string, uninstall bool) (string, error) {
 		if uninstall {
 			return text, nil
 		}
+		// The file's own line ending: Zed on Windows keeps CRLF, and a block
+		// written with LF left the file mixed (#3231).
+		eol := "\n"
+		if strings.Contains(text, "\r\n") {
+			eol = "\r\n"
+		}
 		if block := zedFindKey(text, open+1, zedServerKey); block != nil {
-			insert := fmt.Sprintf("\n    %q: %s,", zedServerID, entry)
+			insert := fmt.Sprintf("%s    %q: %s,", eol, zedServerID, entry)
 			return text[:block.valueOpen+1] + insert + text[block.valueOpen+1:], nil
 		}
 		open = zedTopLevelOpen(text)
-		insert := fmt.Sprintf("\n  %q: {\n    %q: %s\n  },", zedServerKey, zedServerID, entry)
+		insert := fmt.Sprintf("%s  %q: {%s    %q: %s%s  },", eol, zedServerKey, eol, zedServerID, entry, eol)
 		return text[:open+1] + insert + text[open+1:], nil
 	}
 	// The same id is the extension's, and Zed writes its own entry there when
@@ -201,7 +207,7 @@ type zedSpan struct {
 // behind is still well formed.
 func zedEntrySpan(text string, s *zedSpan) [2]int {
 	start := s.keyStart
-	for start > 0 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n') {
+	for start > 0 && (text[start-1] == ' ' || text[start-1] == '\t' || text[start-1] == '\n' || text[start-1] == '\r') {
 		start--
 	}
 	end := s.valueEnd

--- a/cmd/deja/install_zed_crlf_test.go
+++ b/cmd/deja/install_zed_crlf_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Zed on Windows keeps settings.json with CRLF endings; the insert wrote LF
+// lines into it and the uninstall left a stray CR behind (#3231).
+func TestInstallZedKeepsTheFilesLineEndings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	seed := "// hdr\r\n{\r\n  \"theme\": \"x\",\r\n}\r\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	for i, line := range strings.SplitAfter(string(b), "\n") {
+		if line != "" && strings.HasSuffix(line, "\n") && !strings.HasSuffix(line, "\r\n") {
+			t.Fatalf("line %d ends with a bare LF in a CRLF file:\n%q", i+1, b)
+		}
+	}
+	if _, err := installZedMCP(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != seed {
+		t.Fatalf("uninstall did not give the file back:\n%q\nwant\n%q", got, seed)
+	}
+}


### PR DESCRIPTION
On a CRLF settings.json the insert wrote LF lines and zedEntrySpan did not widen over '\r', so uninstall left `{\r\r`. The insert uses the file's own ending now and the span takes the CR. TestInstallZedKeepsTheFilesLineEndings fails before with the stray CR.

Closes #3231

## Review

Reviewer (cavecrew): not refuted — traced the widened span on a CRLF line (it takes the entry's own CRLF, never the previous line's), the test fails before with `{\r\r\n` and passes after, all Zed tests pass. Noted: writeIfChanged already normalises bare LF to the file's ending through matchLineEndings, so the replacement path that splices the JSON entry is covered on disk; the fresh-file branch writes LF, which Zed accepts.
