### PR TITLE
fix(install): vscode and roo name every host they write, not the last

### DIFF
--- a/cmd/deja/install_roo.go
+++ b/cmd/deja/install_roo.go
@@ -32,6 +32,7 @@ func rooMCPSettingsPaths() []string {
 func installRoo(exe string, uninstall bool) (installResult, error) {
 	paths := rooMCPSettingsPaths()
 	var last installResult
+	var results []installResult
 	var unread, unwritable []string
 	skip := map[string]bool{}
 	wrote := false
@@ -110,10 +111,15 @@ func installRoo(exe string, uninstall bool) (installResult, error) {
 				res.Action = "updated"
 			}
 		}
-		last = res
+		results = append(results, res)
 		if res.Action != "unchanged" {
 			wrote = true
 		}
+	}
+	// Every host's result, folded: the last host's alone was the answer and
+	// the others were written in silence (#3233).
+	if len(results) > 0 {
+		last = wroteAll(results...)
 	}
 	if note := rooLeftNote(unread, unwritable); note != "" {
 		// A host that was there and was skipped is not "no host found": deja

--- a/cmd/deja/install_vscode.go
+++ b/cmd/deja/install_vscode.go
@@ -79,15 +79,17 @@ func installVSCodeMCP(exe string, uninstall bool) (installResult, error) {
 		}
 		dirs = []string{vsCodeDefaultUserDir()}
 	}
-	var last installResult
+	// Every host's result, folded: the last host's alone was the answer, and
+	// the others were written in silence (#3233).
+	var results []installResult
 	for _, dir := range dirs {
 		r, err := installVSCodeMCPAt(filepath.Join(dir, "mcp.json"), exe, uninstall)
 		if err != nil {
 			return installResult{}, err
 		}
-		last = r
+		results = append(results, r)
 	}
-	return last, nil
+	return wroteAll(results...), nil
 }
 
 // installVSCodeMCPAt writes one mcp.json. deja's entry is merged into the

--- a/cmd/deja/install_vscode_hosts_named_test.go
+++ b/cmd/deja/install_vscode_hosts_named_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Three hosts written, one named: the result of the last host was the whole
+// answer, so Code and Insiders were updated in silence (#3233).
+func TestInstallVSCodeNamesEveryHostItWrites(t *testing.T) {
+	a, b := t.TempDir(), t.TempDir()
+	t.Setenv("DEJA_VSCODE_USER_DIRS", a+string(os.PathListSeparator)+b)
+	res, err := installVSCodeMCP("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := res.Path + " " + res.Note
+	for _, dir := range []string{a, b} {
+		if !strings.Contains(all, filepath.Join(dir, "mcp.json")) && !strings.Contains(all, shortHome(filepath.Join(dir, "mcp.json"))) {
+			t.Fatalf("host %s not named: path=%q note=%q", dir, res.Path, res.Note)
+		}
+	}
+}
+
+func TestInstallRooNamesEveryHostItWrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{
+		rooStorage(t, home, "Code"),
+		rooStorage(t, home, "Cursor"),
+	}, string(os.PathListSeparator)))
+	res, err := installRoo("/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := res.Path + " " + res.Note
+	for _, host := range []string{"Code", "Cursor"} {
+		if !strings.Contains(all, host) {
+			t.Fatalf("host %s not named: path=%q note=%q", host, res.Path, res.Note)
+		}
+	}
+}


### PR DESCRIPTION
Both loops kept only the last host's result; the others were written in silence and their .bak files never counted. Each host's result folds with wroteAll — the shape the -auto targets have since #3172 — so the line names the first host that changed and the rest ride along. TestInstallVSCodeNamesEveryHostItWrites and TestInstallRooNamesEveryHostItWrites fail before with one host named.

Closes #3233

## Review

Reviewer (cavecrew): no findings. Checked the all-unchanged case (the last host stands, as before), roo's note joining and its no-host branch with an empty fold, uninstall on both paths, snapshot counting through touched() with the dedup in keptSnapshotsLine, and that both tests fail before with one host named and pass after.
