### PR TITLE
fix(install): the amp, gemini, openclaw and prime readers take trailing commas off with the comments

### DIFF
--- a/cmd/deja/install_amp.go
+++ b/cmd/deja/install_amp.go
@@ -29,7 +29,7 @@ func installAmpMCPAt(path, exe string, uninstall bool) (installResult, error) {
 			return installResult{Path: path, Action: "unchanged"}, nil
 		}
 		root = map[string]any{}
-	} else if err := json.Unmarshal([]byte(stripJSONComments(string(old))), &root); err != nil {
+	} else if err := json.Unmarshal([]byte(jsoncToJSON(string(old))), &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	servers, _ := root[ampServersKey].(map[string]any)

--- a/cmd/deja/install_amp_jsonc_test.go
+++ b/cmd/deja/install_amp_jsonc_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// An editor's JSONC carries trailing commas as well as comments; the amp
+// reader stripped comments and then demanded strict JSON (#3236).
+func TestInstallAmpTakesAFileWithATrailingComma(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := filepath.Join(home, "settings.json")
+	t.Setenv("AMP_SETTINGS_FILE", path)
+	before := "{\n  // mine\n  \"amp.mcpServers\": {\"context7\": {\"command\": \"npx\", \"args\": [\"-y\"],},},\n  \"amp.notifications.enabled\": true,\n}\n"
+	if err := os.WriteFile(path, []byte(before), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installAmpMCP("/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install refused the editor's own file: %v", err)
+	}
+	root := ampSettings(t, path)
+	servers, _ := root[ampServersKey].(map[string]any)
+	if servers["context7"] == nil || servers["deja"] == nil {
+		t.Fatalf("install did not sit beside the existing server: %v", root)
+	}
+}

--- a/cmd/deja/install_gemini.go
+++ b/cmd/deja/install_gemini.go
@@ -127,7 +127,7 @@ func geminiHooksEnabled() bool {
 		return false
 	}
 	var root map[string]any
-	if err := json.Unmarshal([]byte(stripJSONComments(string(b))), &root); err != nil {
+	if err := json.Unmarshal([]byte(jsoncToJSON(string(b))), &root); err != nil {
 		return false
 	}
 	cfg, _ := root["hooksConfig"].(map[string]any)
@@ -176,7 +176,7 @@ func enableGeminiHooks() error {
 // and the switch written by text so everything else stays put.
 func enableGeminiHooksJSONC(path string, old []byte) error {
 	var root map[string]any
-	if err := json.Unmarshal([]byte(stripJSONComments(string(old))), &root); err != nil {
+	if err := json.Unmarshal([]byte(jsoncToJSON(string(old))), &root); err != nil {
 		return fmt.Errorf("gemini settings: %w", err)
 	}
 	cfg, _ := root["hooksConfig"].(map[string]any)

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -228,7 +228,7 @@ func flagRecordKey(keys []string, flagKey string) string {
 func setOpenClawEntryJSONC(path string, old []byte, blockKey, id, flagKey string, on bool) (string, error) {
 	text := string(old)
 	var root map[string]any
-	if err := json.Unmarshal([]byte(stripJSONComments(text)), &root); err != nil {
+	if err := json.Unmarshal([]byte(jsoncToJSON(text)), &root); err != nil {
 		return "", configParseError(path, err)
 	}
 	keys := strings.Split(blockKey, ".")

--- a/cmd/deja/install_prime.go
+++ b/cmd/deja/install_prime.go
@@ -45,7 +45,7 @@ func installPrimeMCPAt(path, exe string, uninstall bool) (installResult, error) 
 			return installResult{Path: path, Action: "unchanged"}, nil
 		}
 		root = map[string]any{}
-	} else if err := json.Unmarshal([]byte(stripJSONComments(string(old))), &root); err != nil {
+	} else if err := json.Unmarshal([]byte(jsoncToJSON(string(old))), &root); err != nil {
 		return installResult{}, configParseError(path, err)
 	}
 	servers, _ := root["mcpServers"].(map[string]any)


### PR DESCRIPTION
Five reads did json.Unmarshal(stripJSONComments(…)) and refused a trailing comma; they go through jsoncToJSON now, the helper #3223 gave the probe and writeJSONCEntry. TestInstallAmpTakesAFileWithATrailingComma fails before with `invalid character '}'`.

Closes #3236

## Review

Reviewer (cavecrew): no findings. Per site: amp and prime re-marshal (comments and commas gone on write, as before for a commented file); gemini's hooks-enabled probe reads only; gemini's and openclaw's JSONC writers validate through the parse and then edit the text character by character, so a trailing comma in the block survives untouched. All OpenClaw tests pass; the amp test fails before and passes after.
