### PR TITLE
fix(uninstall): give openclaw's hook switch back, and say the goose plugin was removed

### DIFF
--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -282,7 +282,9 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 	if uninstall {
 		// The hook lives in its own plugin directory; leaving it behind means
 		// Goose keeps running a command that no longer exists.
-		_ = os.RemoveAll(filepath.Dir(filepath.Dir(gooseHookPath())))
+		plugin := filepath.Dir(filepath.Dir(gooseHookPath()))
+		removed := isRealDir(plugin)
+		_ = os.RemoveAll(plugin)
 		// The recall now lives in the reader's own AGENTS.md, so uninstall
 		// takes deja's block out and leaves the file. Removing it was right
 		// while the target was a `.goosehints` deja owned outright; against
@@ -292,6 +294,13 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 		}
 		if rerr := dropRetiredGooseHints(); rerr != nil {
 			return installResult{}, rerr
+		}
+		// Say what was taken away. Install names the hook file it creates and
+		// uninstall named only config.yaml, so the plugin deja had written
+		// went silently — where `uninstall codex-auto` says "also removed"
+		// about the same thing (#3208).
+		if removed {
+			return wroteAll(installResult{Path: gooseHookPath(), Action: "removed"}, res), nil
 		}
 		return res, nil
 	}

--- a/cmd/deja/install_goose_uninstall_test.go
+++ b/cmd/deja/install_goose_uninstall_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The hooks plugin is the whole of what goose-auto adds, and uninstall removed
+// it without a word: three "unchanged" lines about config.yaml and nothing
+// about the directory that had just been deleted. `uninstall codex-auto` says
+// "also removed ~/.codex/hooks.json" about the same thing (#3208).
+func TestGooseUninstallNamesThePluginItRemoved(t *testing.T) {
+	gooseHomeForTest(t)
+	if _, err := installGooseAuto("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	plugin := filepath.Dir(filepath.Dir(gooseHookPath()))
+	if _, err := os.Stat(plugin); err != nil {
+		t.Fatalf("the install wrote no plugin to remove: %v", err)
+	}
+
+	r, err := installGooseAuto("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	said := r.Path + " " + r.Action + " " + r.Note
+	if !strings.Contains(said, gooseHookPath()) && !strings.Contains(said, shortHome(gooseHookPath())) {
+		t.Errorf("uninstall did not name the plugin it deleted: %q", said)
+	}
+	if !strings.Contains(said, "removed") {
+		t.Errorf("uninstall did not say the plugin was removed: %q", said)
+	}
+	if _, err := os.Stat(plugin); !os.IsNotExist(err) {
+		t.Errorf("the plugin survived: %v", err)
+	}
+
+	// A second uninstall has nothing to remove and must not claim it did.
+	r, err = installGooseAuto("/bin/deja", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Path == gooseHookPath() && r.Action == "removed" {
+		t.Errorf("a second uninstall reported removing a plugin that was gone: %#v", r)
+	}
+	if strings.Contains(r.Note, "removed "+shortHome(gooseHookPath())) {
+		t.Errorf("a second uninstall carried the removal in its note: %#v", r)
+	}
+}

--- a/cmd/deja/install_openclaw.go
+++ b/cmd/deja/install_openclaw.go
@@ -102,14 +102,20 @@ func setOpenClawHookEnabled(on bool) (string, error) {
 		// records a block it created, so an uninstall gives back a setting the
 		// reader had rather than deleting one deja only overwrote (#2830, the
 		// rule the text writer got in #2811).
+		//
+		// The switch goes back whether or not other entries remain. Restoring
+		// it only inside the empty case meant a reader with a hook of their own
+		// and the switch off got it back on: deja gone, their hook running
+		// where it had not been. The JSONC writer restored it either way, so
+		// the two spellings of the same file disagreed (#3204).
+		if was := hookSwitchWas(path); was == nil {
+			delete(internal, "enabled")
+		} else {
+			internal["enabled"] = was
+		}
+		forgetHookSwitch(path)
 		if len(entries) == 0 {
 			delete(internal, "entries")
-			if was := hookSwitchWas(path); was == nil {
-				delete(internal, "enabled")
-			} else {
-				internal["enabled"] = was
-			}
-			forgetHookSwitch(path)
 		}
 		if len(internal) == 0 {
 			delete(hooks, "internal")

--- a/cmd/deja/install_openclaw_switch_test.go
+++ b/cmd/deja/install_openclaw_switch_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The switch that turns openclaw's internal hooks on is the reader's setting,
+// and deja only borrows it. Uninstall restored it only when no other entry was
+// left, so a reader with a hook of their own and the switch off got it back on
+// — deja gone, their hook running where it had not been. The JSONC writer
+// restored it either way, so the two spellings of one file disagreed (#3204).
+func TestOpenClawUninstallGivesTheSwitchBack(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		seed   string
+		want   any // what "enabled" must be afterwards; nil = the key is gone
+		theirs bool
+	}{
+		{
+			name:   "off, with an entry of their own",
+			seed:   `{"hooks":{"internal":{"enabled":false,"entries":{"theirs":{"command":"x"}}}}}`,
+			want:   false,
+			theirs: true,
+		},
+		{
+			name: "off, with nothing else",
+			seed: `{"hooks":{"internal":{"enabled":false}}}`,
+			want: false,
+		},
+		{
+			name:   "on already, with an entry of their own",
+			seed:   `{"hooks":{"internal":{"enabled":true,"entries":{"theirs":{"command":"x"}}}}}`,
+			want:   true,
+			theirs: true,
+		},
+		{
+			name: "no switch at all — deja's to remove",
+			seed: `{"hooks":{"internal":{"entries":{}}}}`,
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.OpenClawStateDir(), "openclaw.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(tc.seed+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := setOpenClawHookEnabled(true); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := setOpenClawHookEnabled(false); err != nil {
+				t.Fatal(err)
+			}
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var root map[string]any
+			if err := json.Unmarshal(b, &root); err != nil {
+				t.Fatalf("%v: %s", err, b)
+			}
+			hooks, _ := root["hooks"].(map[string]any)
+			internal, _ := hooks["internal"].(map[string]any)
+			got, present := internal["enabled"]
+			if tc.want == nil {
+				if present {
+					t.Errorf("deja left a switch it had added: %s", b)
+				}
+			} else if got != tc.want {
+				t.Errorf("enabled = %v, want %v — the reader's setting changed:\n%s", got, tc.want, b)
+			}
+			// And their own entry is still there.
+			if tc.theirs {
+				entries, _ := internal["entries"].(map[string]any)
+				if _, ok := entries["theirs"]; !ok {
+					t.Errorf("uninstall took the reader's hook with it:\n%s", b)
+				}
+			}
+			// Never ours.
+			if entries, _ := internal["entries"].(map[string]any); entries != nil {
+				if _, ok := entries[openclawHookName]; ok {
+					t.Errorf("deja's own entry survived uninstall:\n%s", b)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two uninstall reports, one file each.

**#3204 — the switch stayed on.** `hooks.internal.enabled` was restored only inside `if len(entries) == 0`, so a reader with a hook of their own and the switch off got it back on: deja gone, their hook running where it had not been. The JSONC writer restored it either way, so the two spellings of one file disagreed. On the seed from the issue:

```
before  {"hooks": {"internal": {"enabled": true,  "entries": {"theirs": …}}}}
after   {"hooks": {"internal": {"enabled": false, "entries": {"theirs": …}}}}
```

The switch now goes back whenever deja was the one that flipped it, entries or not; a switch deja itself added is still removed. Four seeds in the test — off with their entry, off with nothing else, already on, and no switch at all.

**#3208 — the plugin went silently.** `uninstall goose-auto` deletes the hooks plugin, which is the whole of what `-auto` adds over the plain target, and printed three "unchanged" lines about `config.yaml`:

```
before  goose-auto: unchanged …/config.yaml
after   goose-auto: removed   …/.agents/plugins/deja/hooks/hooks.json
```

Folded through `wroteAll` like every other `-auto` target's second write, and only when there was something there — a second uninstall does not claim a removal.

Both reproduced on a build of main first, then fixed; four mutations, all red.

Closes #3204, closes #3208.
