### PR TITLE
fix(hermes): a session is titled by the person's first line, not the greeting

### DIFF
--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -202,7 +202,16 @@ func decodeHermesArray(dec *json.Decoder, project, path string) ([]model.Session
 			continue
 		}
 		if s.Title == "" {
+			// The person's first line, as every other parser titles: a
+			// session Hermes opens with its own greeting was titled by the
+			// greeting (#3241). A session nobody typed in keeps its first line.
 			s.Title = firstLineTrim(s.Messages[0].Text)
+			for _, m := range s.Messages {
+				if m.Role == "user" {
+					s.Title = firstLineTrim(m.Text)
+					break
+				}
+			}
 		}
 		out = append(out, *s)
 	}

--- a/internal/sources/hermes_title_test.go
+++ b/internal/sources/hermes_title_test.go
@@ -1,0 +1,32 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// A session Hermes opens with its own greeting was titled by that greeting;
+// the title is the person's first line, like every other parser (#3241).
+func TestHermesTitleIsThePersonsFirstLine(t *testing.T) {
+	root := t.TempDir()
+	db := writeHermesDB(t, filepath.Join(root, "writer"), `
+		INSERT INTO messages (session_id,role,content,timestamp) VALUES
+		 ('greet','assistant','hello, what shall we do about the ptarmigan cache',1785000000.0),
+		 ('greet','user','why does the ptarmigan cache miss on restart',1785000010.0),
+		 ('greet','assistant','it is rebuilt from an empty map',1785000020.0),
+		 ('bot','assistant','nobody typed here',1785100000.0);`)
+	ss, err := ParseHermesDB(db)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	titles := map[string]string{}
+	for _, s := range ss {
+		titles[s.ID] = s.Title
+	}
+	if titles["greet"] != "why does the ptarmigan cache miss on restart" {
+		t.Fatalf("greet title = %q", titles["greet"])
+	}
+	if titles["bot"] != "nobody typed here" {
+		t.Fatalf("a session with no user line falls back to its first line; got %q", titles["bot"])
+	}
+}


### PR DESCRIPTION
hermes.go titled with Messages[0] whatever its role; the first user line wins now, with the first line of any role as the fallback for a session nobody typed in. TestHermesTitleIsThePersonsFirstLine fails before with the assistant's greeting as the title.

Closes #3241

## Review

Reviewer (cavecrew): the test fails before and passes after. One note, not a change: a title the parser sets bypasses the index's greeting rule (metaForSession applies it only when the title is empty), so a session opened with "hi" is titled "hi" — the same as before this change, since the parser always set the title; leaving the title to the index is a wider change for another PR, queued.
