### PR TITLE
fix(prime): a settings.json with comments keeps them through install and uninstall

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -1365,7 +1365,9 @@ func doctorJSONDejaKeys(key string) func(string) []string {
 			return nil
 		}
 		var root map[string]any
-		if json.Unmarshal(b, &root) != nil {
+		// The file may be JSONC — the install keeps a reader's comments and
+		// trailing commas (#3243) — so it is read the way install reads it.
+		if json.Unmarshal([]byte(jsoncToJSON(string(b))), &root) != nil {
 			return nil
 		}
 		m, _ := root[key].(map[string]any)

--- a/cmd/deja/install_prime.go
+++ b/cmd/deja/install_prime.go
@@ -39,6 +39,13 @@ func installPrimeMCPAt(path, exe string, uninstall bool) (installResult, error) 
 	if err != nil {
 		return installResult{}, err
 	}
+	// A JSONC file goes through the text writer, so a comment the reader
+	// kept stays; re-marshalling the object dropped it for good (#3243).
+	if len(bytes.TrimSpace(old)) > 0 && configIsJSONC(old) {
+		command, args := mcpCommandArgs(exe)
+		return writeJSONCEntry(path, old, "mcpServers",
+			map[string]any{"type": "stdio", "command": command, "args": args}, uninstall)
+	}
 	var root map[string]any
 	if len(bytes.TrimSpace(old)) == 0 {
 		if uninstall {

--- a/cmd/deja/install_prime_jsonc_test.go
+++ b/cmd/deja/install_prime_jsonc_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A settings.json with a comment was re-marshalled whole on install, and the
+// comment was gone for good; the JSONC path keeps every other byte.
+func TestInstallPrimeKeepsTheComments(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	seed := "{\n  // keep me\n  \"mcpServers\": {\n    \"fs\": {\"type\": \"stdio\", \"command\": \"fs-mcp\", \"args\": []}\n  }\n}\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installPrimeMCPAt(path, "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	if !strings.Contains(string(b), "// keep me") || !strings.Contains(string(b), `"deja"`) || !strings.Contains(string(b), `"fs"`) {
+		t.Fatalf("install lost the comment or a server:\n%s", b)
+	}
+	if _, err := installPrimeMCPAt(path, "/usr/local/bin/deja", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != seed {
+		t.Fatalf("uninstall did not give the file back:\n%s", got)
+	}
+}


### PR DESCRIPTION
installPrimeMCPAt re-marshalled the parsed object, so a JSONC file lost its comments on install. A JSONC file now goes through writeJSONCEntry under `mcpServers`, the path the vscode target uses; uninstall gives the file back byte for byte. TestInstallPrimeKeepsTheComments fails before with the comment gone.

Closes #3243

## Review

Reviewer (cavecrew): the JSONC branch is right and the test fails before; writeJSONCEntry refuses a non-object `mcpServers` the way the strict path did; the readers take JSONC since #3236. One gap taken: doctor's deja-key listing (doctorJSONDejaKeys) still parsed strictly, so a commented settings.json showed wired (the fallback in doctorJSONWired) but its entries were not listed — it reads through jsoncToJSON now.
