### PR TITLE
fix(install): no snapshot of a file this run created

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1026,6 +1026,22 @@ func backupOnce(path string) (bool, error) {
 	return true, os.WriteFile(bak, b, 0o600)
 }
 
+// backupOnceUnlessCreated is backupOnce for a file that was already there
+// before this run; one this run created is deja's and needs no snapshot. The
+// record holds the path as given, the write may have followed a symlink, so
+// both forms are compared.
+func backupOnceUnlessCreated(path string) (bool, error) {
+	for _, p := range createdByThisRun {
+		if p == path {
+			return false, nil
+		}
+		if r, err := filepath.EvalSymlinks(p); err == nil && r == path {
+			return false, nil
+		}
+	}
+	return backupOnce(path)
+}
+
 // removingWiring is set for the length of an uninstall run. Thirty-seven call
 // sites write configs through writeIfChanged, and on the uninstall path each
 // one computes "the file without deja in it" — which, for a file that does not
@@ -1266,7 +1282,11 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 			return "", err
 		}
 	}
-	if _, err := backupOnce(path); err != nil {
+	// No snapshot of a file this run created: a second write to it in the
+	// same run — roo allows deja's tool right after writing the entry — was
+	// backing up deja's own file from a moment before, and the uninstall then
+	// called it a config the reader already had (#3245).
+	if _, err := backupOnceUnlessCreated(path); err != nil {
 		return "", err
 	}
 	// On the way out, a snapshot that itself contains deja's wiring is deja's

--- a/cmd/deja/install_roo_no_self_bak_test.go
+++ b/cmd/deja/install_roo_no_self_bak_test.go
@@ -23,3 +23,27 @@ func TestInstallRooDoesNotSnapshotItsOwnFreshWrite(t *testing.T) {
 		t.Fatalf("a snapshot of deja's own fresh write: %v", baks)
 	}
 }
+
+// A settings file the reader already had still gets its snapshot on the first
+// write, as before.
+func TestInstallRooStillSnapshotsAFileTheReaderHad(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	store := rooStorage(t, home, "Code")
+	t.Setenv("DEJA_ROO_ROOTS", store)
+	path := filepath.Join(store, "settings", "mcp_settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	theirs := `{"mcpServers":{"other":{"command":"x","args":[]}}}` + "\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(path + ".bak"); err != nil || string(got) != theirs {
+		t.Fatalf("the reader's file was not snapshotted before the first write: %v %q", err, got)
+	}
+}

--- a/cmd/deja/install_roo_no_self_bak_test.go
+++ b/cmd/deja/install_roo_no_self_bak_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A host with no settings file gets one from deja, then a second write in the
+// same run allowed deja's tool — and snapshotted deja's own file from a moment
+// before as a .bak the uninstall then called a config the reader already had.
+func TestInstallRooDoesNotSnapshotItsOwnFreshWrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_ROO_ROOTS", strings.Join([]string{rooStorage(t, home, "Code")}, string(os.PathListSeparator)))
+	if _, err := installRoo("/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	baks, _ := filepath.Glob(filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "*.bak"))
+	if len(baks) != 0 {
+		t.Fatalf("a snapshot of deja's own fresh write: %v", baks)
+	}
+}


### PR DESCRIPTION
writeIfChanged took a backup on every write of an existing file, including a file the same run had just created — roo writes the entry and then allows deja's tool in a second write, so a host with no settings file ended up with a .bak of deja's own write that uninstall then called a config the reader already had. The backup now skips paths in createdByThisRun, comparing the symlink-resolved form too. TestInstallRooDoesNotSnapshotItsOwnFreshWrite fails before with the .bak present.

Closes #3245

## Review

Reviewer (cavecrew): not refuted — goose's uninstall ends in the same clean state (the snapshot it used to take and then delete is simply never taken), the recorded path is always the unresolved one so the one-way symlink comparison is enough, and a shared file created by one harness and written by another in the same run is still deja's own. One gap taken: a test that a file the reader already had still gets its snapshot on the first write.
