### PR TITLE
fix(docs): the Copilot skill no longer says deja cannot read Copilot

### DIFF
--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -165,10 +165,12 @@ func instructionsFile(body string) string {
 
 func guidanceText(harness string) string {
 	if guidanceOwnsWholeFile(harness) {
+		// Copilot used to open with "deja does not index Copilot history. It is
+		// a consumer…", written in #133 when that was true. The parser landed
+		// in #655 and the registry has documented the store since, so the same
+		// binary was indexing Copilot sessions and telling Copilot it did not
+		// (#3222). It gets the same skill as every other harness.
 		body := skillBody
-		if harness == "copilot" {
-			body = "deja does not index Copilot history. It is a consumer: search the memory the other harnesses on this machine wrote.\n\n" + skillBody
-		}
 		if harness == "pi" {
 			body = `If the deja MCP tools are available (via pi-mcp-adapter), use them:
 

--- a/cmd/deja/guidance_claims_test.go
+++ b/cmd/deja/guidance_claims_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A skill deja writes for a harness must not tell that harness deja cannot read
+// it. Copilot's opened with "deja does not index Copilot history" — true when it
+// was written, false since the parser landed, and the same binary was indexing
+// Copilot sessions while saying so (#3222).
+//
+// Derived from the registry rather than a list beside it: a harness deja reads
+// and writes guidance for fails here if its own text denies the reading.
+func TestNoSkillDeniesTheHarnessItIsWrittenFor(t *testing.T) {
+	hermeticEnv(t)
+	for _, h := range registryHarnessesForGuidance(t) {
+		id := h
+		if v, ok := map[string]string{"claude": "claude-code", "copilot-chat": "vscode"}[h]; ok {
+			id = v
+		}
+		if guidancePath(id) == "" {
+			continue
+		}
+		text := guidanceText(id)
+		low := strings.ToLower(text)
+		for _, deny := range []string{
+			"does not index",
+			"deja cannot read",
+			"is not indexed",
+		} {
+			if strings.Contains(low, deny) {
+				t.Errorf("the %s skill says %q about a harness deja indexes:\n%s", h, deny, text)
+			}
+		}
+	}
+}
+
+// registryHarnessesForGuidance is the harnesses the format registry lists,
+// which is the same source the capability matrix is built from.
+func registryHarnessesForGuidance(t *testing.T) []string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("..", "..", "docs", "registry", "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reg capRegistry
+	if err := json.Unmarshal(b, &reg); err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, h := range reg.Harnesses {
+		if h.ID != "deja" {
+			out = append(out, h.ID)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no harnesses in the registry, so this test checks nothing")
+	}
+	return out
+}

--- a/cmd/deja/registry_skill_path_test.go
+++ b/cmd/deja/registry_skill_path_test.go
@@ -47,10 +47,13 @@ func TestRegistryPagesNameTheSkillPathInstallWrites(t *testing.T) {
 		}
 		for _, m := range claim.FindAllStringSubmatch(string(b), -1) {
 			said := strings.TrimSuffix(strings.TrimSpace(m[1]), "/")
-			// Compare home-relative, and accept the directory as well as the
-			// file: a page may name either.
-			got := strings.TrimSuffix(strings.TrimPrefix(want, home), "/")
-			got = "~" + got
+			// Compare home-relative and in the docs' own separator: the pages
+			// are written with "/" on every platform while guidancePath answers
+			// in the host's, which made this pass everywhere and fail on the
+			// Windows leg alone. Accept the directory as well as the file — a
+			// page may name either.
+			got := "~" + filepath.ToSlash(strings.TrimPrefix(want, home))
+			got = strings.TrimSuffix(got, "/")
 			if said != got && said != strings.TrimSuffix(got, "/SKILL.md") {
 				t.Errorf("docs/registry/%s says the skill lands at %s; install writes %s",
 					e.Name(), said, got)

--- a/cmd/deja/registry_skill_path_test.go
+++ b/cmd/deja/registry_skill_path_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A registry page that names the file deja's skill lands in has to name the one
+// install writes. The kimi page said `$KIMI_CODE_HOME/skills/deja-history/`
+// while install writes the shared `~/.agents/skills/…` (#3212), and the goose
+// page said `.goosehints` for a block that moved to AGENTS.md (#3210) — the
+// same drift twice in one night, in the reference people are pointed at.
+//
+// Only the deja-history path is checked. A page naming a directory the harness
+// scans, or another tool's, is describing the harness rather than claiming
+// where deja puts its file.
+func TestRegistryPagesNameTheSkillPathInstallWrites(t *testing.T) {
+	home := hermeticEnv(t)
+	home = filepath.Join(home, "home")
+	dir := filepath.Join("..", "..", "docs", "registry")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// `~/x/skills/deja-history/…` or `$VAR/skills/deja-history/…`, in backticks.
+	claim := regexp.MustCompile("`([^`]*skills/deja-history[^`]*)`")
+	alias := map[string]string{"claude-code": "claude", "copilot-chat": "vscode"}
+	checked := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" || e.Name() == "README.md" {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".md")
+		if a, ok := alias[id]; ok {
+			id = a
+		}
+		want := guidancePath(id)
+		if want == "" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range claim.FindAllStringSubmatch(string(b), -1) {
+			said := strings.TrimSuffix(strings.TrimSpace(m[1]), "/")
+			// Compare home-relative, and accept the directory as well as the
+			// file: a page may name either.
+			got := strings.TrimSuffix(strings.TrimPrefix(want, home), "/")
+			got = "~" + got
+			if said != got && said != strings.TrimSuffix(got, "/SKILL.md") {
+				t.Errorf("docs/registry/%s says the skill lands at %s; install writes %s",
+					e.Name(), said, got)
+			}
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no page names a skill path, so this test checks nothing")
+	}
+}

--- a/docs/registry/kimi.html
+++ b/docs/registry/kimi.html
@@ -54,7 +54,7 @@
 </ul>
 <p><code>$KIMI_CODE_HOME/mcp.json</code> (common JSON shape, existing entries preserved).</p>
 <ul>
-<li><strong>Guidance</strong>: a skill at <code>$KIMI_CODE_HOME/skills/deja-history/</code>. Kimi Code scans that directory; the <code>~/.kimi/skills/</code> in some write-ups belongs to <code>MoonshotAI/kimi-cli</code>, a different tool with the same name. An older deja wrote a block into the global <code>AGENTS.md</code>, which install now removes.</li>
+<li><strong>Guidance</strong>: the shared skill at <code>~/.agents/skills/deja-history/SKILL.md</code>. Kimi Code 0.28.1 scans both that directory and <code>$KIMI_CODE_HOME/skills</code>, and deja writes the shared one so a machine with several harnesses keeps one copy. The <code>~/.kimi/skills/</code> in some write-ups belongs to <code>MoonshotAI/kimi-cli</code>, a different tool with the same name. An older deja wrote a block into the global <code>AGENTS.md</code>, which install now removes.</li>
 <li><strong>Resume</strong>: <code>kimi --session &lt;sessionId&gt;</code> (verified live on 0.28.1).</li>
 <li><strong>Handoff</strong>: paste — the CLI has no documented start-with-prompt flag.</li>
 </ul>

--- a/docs/registry/kimi.md
+++ b/docs/registry/kimi.md
@@ -14,7 +14,7 @@ histories under `agents/agent-*`, tool payloads and media are out of scope.
 
 - **MCP**: `deja install kimi` writes `mcpServers.deja` into
   `$KIMI_CODE_HOME/mcp.json` (common JSON shape, existing entries preserved).
-- **Guidance**: a skill at `$KIMI_CODE_HOME/skills/deja-history/`. Kimi Code scans that directory; the `~/.kimi/skills/` in some write-ups belongs to `MoonshotAI/kimi-cli`, a different tool with the same name. An older deja wrote a block into the global `AGENTS.md`, which install now removes.
+- **Guidance**: the shared skill at `~/.agents/skills/deja-history/SKILL.md`. Kimi Code 0.28.1 scans both that directory and `$KIMI_CODE_HOME/skills`, and deja writes the shared one so a machine with several harnesses keeps one copy. The `~/.kimi/skills/` in some write-ups belongs to `MoonshotAI/kimi-cli`, a different tool with the same name. An older deja wrote a block into the global `AGENTS.md`, which install now removes.
 - **Resume**: `kimi --session <sessionId>` (verified live on 0.28.1).
 - **Handoff**: paste — the CLI has no documented start-with-prompt flag.
 


### PR DESCRIPTION
Two stale claims, and a test apiece so the class stops recurring.

**#3222** — the skill `deja install copilot` writes opened with "deja does not index Copilot history. It is a consumer…". True when it was written in #133; false since the parser landed in #655, and the same binary had just indexed the machine's Copilot sessions. Copilot now gets the same skill as every other harness. The test asks every harness in the registry whether the guidance deja writes for it denies the reading — derived from the registry, not a list beside it.

**#3212** — `registry/kimi.md` said the skill lands at `$KIMI_CODE_HOME/skills/deja-history/`; install writes the shared `~/.agents/skills/…`. Kimi 0.28.1 scans both, so the placement was right and the sentence was not. The second test holds every registry page's stated `skills/deja-history` path to what `guidancePath` returns.

That second one is the useful part: this is the third page in a night to name a path install had moved away from (#3210 said `.goosehints` for a block now in `AGENTS.md`), and the reference is what people are pointed at. Three mutations, all red — the kimi page's old wording, a page naming another harness's directory, and one naming a directory install never writes.

Closes #3222, closes #3212.
