### PR TITLE
fix(aider): a logged slash command is not the person's question

### DIFF
--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -77,6 +77,24 @@ func LoadAider() []model.Session {
 
 const aiderSessionMark = "# aider chat started at "
 
+// aiderSlashCommand reports whether a logged input line is one of aider's own
+// commands: a slash, a bare word, then the end of the line or a space.
+func aiderSlashCommand(t string) bool {
+	if !strings.HasPrefix(t, "/") {
+		return false
+	}
+	word := strings.TrimPrefix(strings.Fields(t)[0], "/")
+	if word == "" {
+		return false
+	}
+	for _, r := range word {
+		if !(r >= 'a' && r <= 'z' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
 func ParseAiderFile(path string) ([]model.Session, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -152,11 +170,19 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		}
 		switch {
 		case strings.HasPrefix(line, "#### "):
+			t := strings.TrimPrefix(line, "#### ")
+			// aider logs its own commands the same way — `/undo`, `/clear`,
+			// `/add x` — and they are not the person's question; a message
+			// that merely opens with a path ("/etc/hosts is wrong") is (#3248).
+			if aiderSlashCommand(t) {
+				flush()
+				role = ""
+				continue
+			}
 			if role != "user" {
 				flush()
 				role = "user"
 			}
-			t := strings.TrimPrefix(line, "#### ")
 			if t == "<blank>" {
 				t = ""
 			}

--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -88,7 +88,7 @@ func aiderSlashCommand(t string) bool {
 		return false
 	}
 	for _, r := range word {
-		if !(r >= 'a' && r <= 'z' || r == '-') {
+		if (r < 'a' || r > 'z') && r != '-' {
 			return false
 		}
 	}

--- a/internal/sources/aider_slash_test.go
+++ b/internal/sources/aider_slash_test.go
@@ -1,0 +1,33 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// aider logs every input as a "#### " line, commands included; a line that is
+// only a slash command is not a question, and `/clear` was glued onto the
+// question typed after it (#3248).
+func TestParseAiderSkipsSlashCommands(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".aider.chat.history.md")
+	body := "# aider chat started at 2026-09-08 01:00:00\n\n#### /add src/pager.go\n\n#### /undo\n\n#### /clear\n\n#### why does the pager stall on the last page\n\nbecause the cursor overflows\n\n#### /etc/hosts is wrong on the staging box, fix the entry\n\ndone\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAiderFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("sessions=%d err=%v", len(ss), err)
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	want := []string{"why does the pager stall on the last page", "/etc/hosts is wrong on the staging box, fix the entry"}
+	if len(users) != len(want) || users[0] != want[0] || users[1] != want[1] {
+		t.Fatalf("user lines = %q, want %q", users, want)
+	}
+}


### PR DESCRIPTION
aider logs its own commands as `#### ` lines like any input; the parser folded them into the user turn, so `/undo` was a message and `/clear` was glued onto the next question. A line that is only a slash command — a slash, a bare word, then the end or a space — ends the turn and is not indexed; a message that opens with a path still is. TestParseAiderSkipsSlashCommands fails before with the commands inside the user line.

Closes #3248

## Review

Not refuted. Aider logs every user line, commands included, with `#### ` (aider/io.py 779-789); `flush(); role = ""` keeps role assignment intact for the next block; `/tmp` alone is filtered as a command, `/etc/hosts` is kept; `TestParseAiderSkipsSlashCommands` passes on the branch and does not exist on the base; all aider tests including fuzz pass.
