### PR TITLE
fix(hermes): follow HERMES_HOME, the variable Hermes itself reads

### DIFF
--- a/cmd/deja/coverage_extra_test.go
+++ b/cmd/deja/coverage_extra_test.go
@@ -74,6 +74,10 @@ func hermeticEnv(t *testing.T) string {
 	// a developer who exports either would put their own projects in a golden.
 	t.Setenv("DEJA_CRUSH_ROOT", "")
 	t.Setenv("CRUSH_GLOBAL_CONFIG", "")
+	// Hermes's own variable, now that deja follows it: a developer who exports
+	// it would put their real store in a golden.
+	t.Setenv("HERMES_HOME", "")
+	t.Setenv("DEJA_HERMES_HOME", "")
 	t.Setenv("NO_COLOR", "1")
 	return tmp
 }

--- a/docs/registry/hermes.html
+++ b/docs/registry/hermes.html
@@ -40,6 +40,7 @@
 <ul>
 <li><strong>ID</strong>: <code>hermes</code></li>
 <li><strong>Store</strong>: <code>~/.hermes/state.db</code> (0.17+) or <code>~/.hermes/profiles/&lt;profile&gt;/state.db</code> (older builds, one store per profile)</li>
+<li><strong>Home</strong>: <code>HERMES_HOME</code>, Hermes&#39;s own variable, is followed — profiles, plugins and <code>config.yaml</code> are read and written under it. <code>DEJA_HERMES_HOME</code> overrides it.</li>
 <li><strong>Read overrides</strong>: <code>DEJA_HERMES_PROFILES_ROOT</code> for the profiles directory, <code>DEJA_HERMES_DB</code> to pin a single store</li>
 <li><strong>Format</strong>: SQLite relational store</li>
 </ul>

--- a/docs/registry/hermes.md
+++ b/docs/registry/hermes.md
@@ -2,6 +2,7 @@
 
 - **ID**: `hermes`
 - **Store**: `~/.hermes/state.db` (0.17+) or `~/.hermes/profiles/<profile>/state.db` (older builds, one store per profile)
+- **Home**: `HERMES_HOME`, Hermes's own variable, is followed — profiles, plugins and `config.yaml` are read and written under it. `DEJA_HERMES_HOME` overrides it.
 - **Read overrides**: `DEJA_HERMES_PROFILES_ROOT` for the profiles directory, `DEJA_HERMES_DB` to pin a single store
 - **Format**: SQLite relational store
 

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -14,8 +14,19 @@ import (
 )
 
 // HermesHome is the Hermes root: profiles, plugins and config.yaml live here.
+//
+// HERMES_HOME is Hermes's own variable, and deja reads it for the reason
+// PrimeRoot gives: a machine that moved its store has moved it for deja too,
+// and asking for a second variable saying what the first already said is the
+// kind of silence doctor cannot explain. Before this, a relocated Hermes was
+// installed into ~/.hermes — a directory Hermes does not read — and indexed as
+// nothing (#3203). DEJA_HERMES_HOME still wins, for tests and for a store that
+// is neither.
 func HermesHome() string {
 	if p := os.Getenv("DEJA_HERMES_HOME"); p != "" {
+		return p
+	}
+	if p := os.Getenv("HERMES_HOME"); p != "" {
 		return p
 	}
 	return filepath.Join(Home(), ".hermes")

--- a/internal/sources/hermes_home_test.go
+++ b/internal/sources/hermes_home_test.go
@@ -1,0 +1,41 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Hermes finds its own home through HERMES_HOME, and deja read only its own
+// variable — so on a relocated Hermes, install wrote into ~/.hermes, a
+// directory Hermes does not read, and the real store indexed as nothing while
+// doctor reported it missing (#3203).
+func TestHermesFollowsItsOwnHomeVariable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_HERMES_HOME", "")
+	t.Setenv("HERMES_HOME", "")
+	t.Setenv("DEJA_HERMES_PROFILES_ROOT", "")
+
+	if got, want := HermesHome(), filepath.Join(home, ".hermes"); got != want {
+		t.Fatalf("default home = %q, want %q", got, want)
+	}
+
+	alt := filepath.Join(home, "hermes-alt")
+	t.Setenv("HERMES_HOME", alt)
+	if got := HermesHome(); got != alt {
+		t.Errorf("HERMES_HOME ignored: home = %q, want %q", got, alt)
+	}
+	// Everything hanging off the home follows it, which is the half that made
+	// the store invisible.
+	if got, want := HermesProfilesRoot(), filepath.Join(alt, "profiles"); got != want {
+		t.Errorf("profiles root = %q, want %q", got, want)
+	}
+
+	// deja's own variable still wins, for tests and for a store that is neither.
+	mine := filepath.Join(home, "deja-says")
+	t.Setenv("DEJA_HERMES_HOME", mine)
+	if got := HermesHome(); got != mine {
+		t.Errorf("DEJA_HERMES_HOME lost to HERMES_HOME: %q", got)
+	}
+}

--- a/internal/sources/registry_test.go
+++ b/internal/sources/registry_test.go
@@ -45,7 +45,7 @@ func TestFormatRegistryConformance(t *testing.T) {
 		"DEJA_INCLUDE_SUBAGENTS", "DEJA_OPENCODE_DB", "GEMINI_CLI_HOME",
 		"GROK_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
 		"DEJA_ZED_ROOT", "DEJA_ZED_DB", "FLATPAK_XDG_DATA_HOME",
-		"DEJA_NOTES_FILE",
+		"DEJA_NOTES_FILE", "HERMES_HOME", "DEJA_HERMES_HOME",
 	} {
 		t.Setenv(key, "")
 	}


### PR DESCRIPTION
Hermes finds its own home through `HERMES_HOME`; deja read only `DEJA_HERMES_HOME`. So a relocated Hermes got installed into `~/.hermes` — a directory Hermes does not read — while its real store indexed as nothing:

```
before  hermes: created /tmp/h2/.hermes/config.yaml
        doctor: hermes  missing  ~/.hermes/profiles  (0 stores)
after   hermes: created /tmp/h2/hermes-alt/config.yaml
        doctor: hermes  missing  ~/hermes-alt/profiles  (0 stores)
```

`DEJA_HERMES_HOME` still wins, for tests and for a store that is neither — the precedence `PrimeRoot` already uses for the same reason: a machine that moved its store has moved it for deja too.

Both hermetic test environments now clear `HERMES_HOME`, or a developer who exports it would put their real store in a golden. `registry/hermes.md` gains the line; two mutations, both red.

Closes #3203.
