### PR TITLE
fix(hermes): a session opened with a greeting is titled by the question, not the greeting

### DIFF
--- a/internal/index/hermes_title_test.go
+++ b/internal/index/hermes_title_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Hermes titled its sessions in the parser, so the index's greeting rule
+// (#790) never ran for it: a session opened with "hi" listed as "hi", with the
+// question one line below. The parser leaves the title to the index now, like
+// the other parsers do (#3251).
+func TestHermesGreetingDoesNotNameTheSession(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 is not installed")
+	}
+	dir := filepath.Join(t.TempDir(), "writer")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(dir, "state.db")
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(`CREATE TABLE messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		role TEXT NOT NULL,
+		content TEXT,
+		timestamp REAL NOT NULL);
+		INSERT INTO messages (session_id,role,content,timestamp) VALUES
+		 ('hi','user','hi',1785234496.0),
+		 ('hi','assistant','Hi! What can I help with?',1785234500.0),
+		 ('hi','user','hiddify configs: the routepilot import',1785234520.0),
+		 ('greet','assistant','hello, what shall we do about the ptarmigan cache',1785000000.0),
+		 ('greet','user','why does the ptarmigan cache miss on restart',1785000010.0),
+		 ('bot','assistant','nobody typed here',1785100000.0);`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3: %v\n%s", err, out)
+	}
+	ss, err := sources.ParseHermesDB(db)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := map[string]string{
+		"hi":    "hiddify configs: the routepilot import",
+		"greet": "why does the ptarmigan cache miss on restart",
+		"bot":   "nobody typed here",
+	}
+	for _, s := range ss {
+		if got := metaForSession(s).Title; got != want[s.ID] {
+			t.Errorf("session %s titled %q, want %q", s.ID, got, want[s.ID])
+		}
+	}
+}

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -201,18 +201,10 @@ func decodeHermesArray(dec *json.Decoder, project, path string) ([]model.Session
 		if len(s.Messages) == 0 {
 			continue
 		}
-		if s.Title == "" {
-			// The person's first line, as every other parser titles: a
-			// session Hermes opens with its own greeting was titled by the
-			// greeting (#3241). A session nobody typed in keeps its first line.
-			s.Title = firstLineTrim(s.Messages[0].Text)
-			for _, m := range s.Messages {
-				if m.Role == "user" {
-					s.Title = firstLineTrim(m.Text)
-					break
-				}
-			}
-		}
+		// No title here: the index derives one (the person's first line,
+		// a greeting giving way to the next turn, the agent's line when
+		// nobody typed). Titling in the parser skipped the greeting rule, so
+		// a session opened with "hi" listed as "hi" (#3241, #3251).
 		out = append(out, *s)
 	}
 	return out, nil

--- a/internal/sources/hermes_pg_test.go
+++ b/internal/sources/hermes_pg_test.go
@@ -46,8 +46,9 @@ func TestParseHermesPGReadsRowsLikeSQLite(t *testing.T) {
 	if ss[0].Project != "hermes" || ss[0].Harness != "hermes" {
 		t.Fatalf("project/harness = %q/%q", ss[0].Project, ss[0].Harness)
 	}
-	if ss[0].Title != "switch the pool to transaction mode" {
-		t.Fatalf("title = %q", ss[0].Title)
+	// The title is the index's to derive (#3251).
+	if ss[0].Title != "" {
+		t.Fatalf("title = %q, want none", ss[0].Title)
 	}
 }
 

--- a/internal/sources/hermes_test.go
+++ b/internal/sources/hermes_test.go
@@ -75,8 +75,9 @@ func TestParseHermesDB(t *testing.T) {
 	if first.Project != "architect" {
 		t.Fatalf("project = %q, want the profile name", first.Project)
 	}
-	if first.Title == "" {
-		t.Fatal("title not derived from the first message")
+	// The title is the index's to derive (#3251).
+	if first.Title != "" {
+		t.Fatalf("title = %q, want none", first.Title)
 	}
 }
 

--- a/internal/sources/hermes_title_test.go
+++ b/internal/sources/hermes_title_test.go
@@ -5,28 +5,24 @@ import (
 	"testing"
 )
 
-// A session Hermes opens with its own greeting was titled by that greeting;
-// the title is the person's first line, like every other parser (#3241).
-func TestHermesTitleIsThePersonsFirstLine(t *testing.T) {
+// A session Hermes opens with its own greeting was titled by that greeting
+// (#3241); titling in the parser then skipped the index's rule for a person's
+// greeting (#3251). The parser leaves the title empty, and the index derives it
+// the way it does for every other harness.
+func TestHermesLeavesTheTitleToTheIndex(t *testing.T) {
 	root := t.TempDir()
 	db := writeHermesDB(t, filepath.Join(root, "writer"), `
 		INSERT INTO messages (session_id,role,content,timestamp) VALUES
 		 ('greet','assistant','hello, what shall we do about the ptarmigan cache',1785000000.0),
 		 ('greet','user','why does the ptarmigan cache miss on restart',1785000010.0),
-		 ('greet','assistant','it is rebuilt from an empty map',1785000020.0),
 		 ('bot','assistant','nobody typed here',1785100000.0);`)
 	ss, err := ParseHermesDB(db)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	titles := map[string]string{}
 	for _, s := range ss {
-		titles[s.ID] = s.Title
-	}
-	if titles["greet"] != "why does the ptarmigan cache miss on restart" {
-		t.Fatalf("greet title = %q", titles["greet"])
-	}
-	if titles["bot"] != "nobody typed here" {
-		t.Fatalf("a session with no user line falls back to its first line; got %q", titles["bot"])
+		if s.Title != "" {
+			t.Errorf("session %s titled %q in the parser", s.ID, s.Title)
+		}
 	}
 }


### PR DESCRIPTION
Closes #3251.

`decodeHermesArray` no longer sets `Title`; `metaForSession` derives it like for every other harness, so a Hermes session opened with "hi" is titled by the next user turn, and the #3241 case (agent greets first) still resolves to the person's line because `sessionTitleFrom` looks at user turns before assistant ones.

Fail-before test: `TestHermesGreetingDoesNotNameTheSession` (internal/index), on the collector:

```
--- FAIL: TestHermesGreetingDoesNotNameTheSession (0.01s)
    hermes_title_test.go:54: session hi titled "hi", want "hiddify configs: the routepilot import"
```

Parser tests now assert the title is left empty (`TestHermesLeavesTheTitleToTheIndex`, `TestParseHermesDB`, `TestParseHermesPGReadsRowsLikeSQLite`).

## Review

Reviewer (adversarial, own worktree): "Verdict: refuted — PR #3252 is correct. The Hermes parser now leaves titles to the index layer (empty), and both full rebuild and incremental ingest paths properly call `sessionTitleFrom` to derive titles using the #790 greeting rule. All paths (retrieval, MCP, doctor) either work with index metadata or do not access the title field. Tests pass." — the word is misused; the findings refute nothing, so the fix stands.
