### PR TITLE
fix(grok): grok-auto names config.toml and user-settings.json too

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -739,10 +739,18 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 		if err := readableStrictJSON(probe...); err != nil {
 			return installResult{}, err
 		}
-		if _, err := installGrok(exe, uninstall); err != nil {
+		// Both halves. Discarding the first meant `install grok-auto` named
+		// GROK.md and the hook file while it had also written config.toml and
+		// user-settings.json — the shape #3185 fixed for gemini-auto (#3220).
+		mcp, err := installGrok(exe, uninstall)
+		if err != nil {
 			return installResult{}, err
 		}
-		return installGrokAuto(exe, uninstall)
+		hooks, err := installGrokAuto(exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		return wroteAll(mcp, hooks), nil
 	case "qwen":
 		return installMCPJSON(filepath.Join(sources.QwenConfigDir(), "settings.json"), exe, uninstall)
 	case "qwen-auto":

--- a/cmd/deja/install_grok_auto_report_test.go
+++ b/cmd/deja/install_grok_auto_report_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// grok-auto discarded the MCP half's result, so it reported GROK.md and the
+// hook file while it had also written config.toml and user-settings.json — the
+// shape #3185 fixed for gemini-auto (#3220).
+func TestGrokAutoNamesBothHalves(t *testing.T) {
+	hermeticEnv(t)
+	out := captureStdout(t, func() {
+		if err := runInstall(index.DefaultDir(), []string{"grok-auto", "--no-index"}, false); err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, want := range []string{"config.toml", "hooks/deja.json"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report does not name %s:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/deja/install_grok_auto_report_test.go
+++ b/cmd/deja/install_grok_auto_report_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -17,8 +18,11 @@ func TestGrokAutoNamesBothHalves(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+	// Through ToSlash: the report prints the host's separator, so a literal
+	// "hooks/deja.json" passes everywhere and fails on the Windows leg alone.
+	slashed := filepath.ToSlash(out)
 	for _, want := range []string{"config.toml", "hooks/deja.json"} {
-		if !strings.Contains(out, want) {
+		if !strings.Contains(slashed, want) {
 			t.Errorf("the report does not name %s:\n%s", want, out)
 		}
 	}


### PR DESCRIPTION
`installTarget`'s `grok-auto` case did `if _, err := installGrok(...)`, so the MCP half's result went in the bin: install reported GROK.md and `hooks/deja.json` while it had also written `config.toml` and `user-settings.json`. Folded with `wroteAll` in the order they run, like the other paired targets.

Closes #3220.

While there I wrote the general form of this check — install each `-auto` target on an empty HOME and require the report to name every file that appeared — and it finds the same gap in most targets, not just grok. That inventory is #3254 rather than this PR: closing it is a decision about how much install should say, not a one-line fold.
