### PR TITLE
fix(roo,cline): the host's environment_details block is not the person's words

### DIFF
--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -403,7 +403,7 @@ func clineContentText(raw json.RawMessage) string {
 // turn — visible files, open tabs, the clock, the cost, the mode, a workspace
 // listing. It opens and closes on lines of its own; a person's mention of the
 // tag mid-sentence is not one (#3255).
-var environmentDetailsRe = regexp.MustCompile(`(?ms)^[ \t]*<environment_details>[ \t]*\n.*?^[ \t]*</environment_details>[ \t]*(?:\n|$)`)
+var environmentDetailsRe = regexp.MustCompile(`(?ms)^[ \t]*<environment_details>[ \t]*\r?\n.*?^[ \t]*</environment_details>[ \t]*\r?(?:\n|$)`)
 
 // unwrapClineTask strips the legacy <task>...</task> envelope (and its modern
 // user-input equivalent) so the tags themselves are not indexed, and the

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -398,10 +399,17 @@ func clineContentText(raw json.RawMessage) string {
 	return strings.Join(parts, "\n")
 }
 
+// environmentDetailsRe is the block Roo Code and Cline append to every user
+// turn — visible files, open tabs, the clock, the cost, the mode, a workspace
+// listing. It opens and closes on lines of its own; a person's mention of the
+// tag mid-sentence is not one (#3255).
+var environmentDetailsRe = regexp.MustCompile(`(?ms)^[ \t]*<environment_details>[ \t]*\n.*?^[ \t]*</environment_details>[ \t]*(?:\n|$)`)
+
 // unwrapClineTask strips the legacy <task>...</task> envelope (and its modern
-// user-input equivalent) so the tags themselves are not indexed.
+// user-input equivalent) so the tags themselves are not indexed, and the
+// host's <environment_details> block, which is not the person's words.
 func unwrapClineTask(text string) string {
-	t := strings.TrimSpace(text)
+	t := strings.TrimSpace(environmentDetailsRe.ReplaceAllString(text, ""))
 	for _, tag := range []string{"task", "user_message", "user_input"} {
 		open := "<" + tag
 		if !strings.HasPrefix(t, open) {

--- a/internal/sources/cline_environment_details_test.go
+++ b/internal/sources/cline_environment_details_test.go
@@ -56,3 +56,11 @@ func TestUnwrapClineTaskKeepsWordsAroundTheBlock(t *testing.T) {
 		t.Errorf("got %q", got)
 	}
 }
+
+// A store written with CRLF carries the block with \r before every \n.
+func TestUnwrapClineTaskDropsACRLFBlock(t *testing.T) {
+	got := unwrapClineTask("<task>\r\nfix the build\r\n</task>\r\n<environment_details>\r\n# Current Cost\r\n$0.12\r\n</environment_details>\r\n")
+	if got != "fix the build" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/sources/cline_environment_details_test.go
+++ b/internal/sources/cline_environment_details_test.go
@@ -1,0 +1,58 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Roo Code and Cline append an <environment_details> block — visible files,
+// open tabs, the clock, the cost, the mode, a workspace listing — to every
+// user turn. It is the host's, not the person's, and it went into the index
+// inside the user message (#3255).
+func TestRooEnvironmentDetailsIsNotTheUsersText(t *testing.T) {
+	env := "<environment_details>\n# VSCode Visible Files\ninternal/retry/retry.go\n\n# Current Time\n" +
+		"Current time in ISO 8601 UTC format: 2026-09-08T01:33:20.000Z\n\n# Current Mode\n<slug>code</slug>\n<name>Code</name>\n</environment_details>"
+	turns := []map[string]any{
+		{"role": "user", "content": []map[string]string{
+			{"type": "text", "text": "<task>\nfix the flaky vantrell retry\n</task>"},
+			{"type": "text", "text": env},
+		}},
+		{"role": "assistant", "content": []map[string]string{{"type": "text", "text": "pinned the deadline per attempt"}}},
+		{"role": "user", "content": []map[string]string{
+			{"type": "text", "text": "also cover it with a test"},
+			{"type": "text", "text": env},
+		}},
+	}
+	dir := filepath.Join(t.TempDir(), "tasks", "1757300000001")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(turns)
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseRooTask(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	want := []string{"fix the flaky vantrell retry", "pinned the deadline per attempt", "also cover it with a test"}
+	if len(ss[0].Messages) != len(want) {
+		t.Fatalf("messages = %+v", ss[0].Messages)
+	}
+	for i, m := range ss[0].Messages {
+		if m.Text != want[i] {
+			t.Errorf("message %d = %q, want %q", i, m.Text, want[i])
+		}
+	}
+}
+
+// A person's sentence about the block stays; only the block itself goes.
+func TestUnwrapClineTaskKeepsWordsAroundTheBlock(t *testing.T) {
+	got := unwrapClineTask("<task>\nwhy is <environment_details> in my history\n</task>\n<environment_details>\n# Current Cost\n$0.12\n</environment_details>")
+	if got != "why is <environment_details> in my history" {
+		t.Errorf("got %q", got)
+	}
+}


### PR DESCRIPTION
Closes #3255.

`unwrapClineTask` (shared by the Roo reader and both Cline readers) drops the `<environment_details>` block before unwrapping `<task>`. The block has to open and close on lines of its own — a person's mention of the tag mid-sentence stays.

Fail-before test: `TestRooEnvironmentDetailsIsNotTheUsersText` and `TestUnwrapClineTaskKeepsWordsAroundTheBlock` (internal/sources), on the collector:

```
cline_environment_details_test.go:47: message 2 = "also cover it with a test\n<environment_details>\n# VSCode Visible Files\n…", want "also cover it with a test"
```

After, on the hermetic Roo task: `deja ctx vantrell` prints the task line alone; `deja search "VSCode visible files current cost"` total 1 → 0.

## Review

Reviewer (adversarial, own worktree):

- cline.go:406 HIGH: regex fails on CRLF; `\n` does not match `\r\n` — fixed in the follow-up commit (`\r?\n`), with `TestUnwrapClineTaskDropsACRLFBlock`.
- cline.go:412 MEDIUM: a user turn that is only the block becomes empty and is skipped — intended (Roo sends env-only turns after tool results).
- cline.go:269 LOW: the title from taskHistory `m.Task` is set before the block is appended, so it is unaffected.
- "All tests pass with LF; performance fine (regex compiled once). Modern Cline reader uses same stripping logic as legacy. Verdict: not refuted."
