### PR TITLE
fix(hermes): a session belongs to the directory it was recorded in, not to the profile

### DIFF
--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -158,6 +158,12 @@ func parseHermesDBWhere(db, where string) ([]model.Session, error) {
 	if err := cmd.Wait(); err != nil {
 		return nil, err
 	}
+	cwds := hermesSessionCwds(db)
+	for i := range out {
+		if cwd := cwds[out[i].ID]; cwd != "" {
+			out[i].Project = claudeProjectName(pathToProjectKey(cwd))
+		}
+	}
 	return out, nil
 }
 
@@ -248,8 +254,36 @@ func nonEmptyFile(p string) bool {
 	return err == nil && fi.Size() > 0
 }
 
-// hermesProfile names the session's project after the profile directory, the
-// only grouping Hermes stores — there is no working directory in the schema.
+// hermesSessionCwds reads the directory each session was recorded in, from the
+// sessions table Hermes keeps beside messages. Stamped with the profile alone,
+// every session fell into one project, and the prompt hook — which ranks the
+// payload's project only — never served a Hermes session in the directory it
+// was about (#3257). Best effort: a store from before the table, or a row with
+// no cwd, keeps the profile.
+func hermesSessionCwds(db string) map[string]string {
+	q := `select id,cwd from sessions where cwd is not null and cwd <> ''`
+	out, err := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000", q).Output()
+	if err != nil {
+		return nil
+	}
+	var rows []struct {
+		ID  string `json:"id"`
+		Cwd string `json:"cwd"`
+	}
+	if json.Unmarshal(out, &rows) != nil {
+		return nil
+	}
+	cwds := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if r.ID != "" && strings.TrimSpace(r.Cwd) != "" {
+			cwds[r.ID] = strings.TrimSpace(r.Cwd)
+		}
+	}
+	return cwds
+}
+
+// hermesProfile names the session's project after the profile directory when
+// the store says nothing about where the session was recorded.
 func hermesProfile(db string) string {
 	name := filepath.Base(filepath.Dir(db))
 	// The root store has no profile directory to be named after.

--- a/internal/sources/hermes_project_test.go
+++ b/internal/sources/hermes_project_test.go
@@ -1,0 +1,59 @@
+package sources
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A Hermes session is about the directory it was recorded in — the store's
+// sessions.cwd — not the profile that ran it. Stamped with the profile, every
+// session fell into one project and the prompt hook in the real directory
+// never served it (#3257). The name follows the other parsers: the last two
+// segments of a path that is not on this machine.
+func TestHermesProjectComesFromTheStoresCwd(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 is not installed")
+	}
+	dir := filepath.Join(t.TempDir(), "writer")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(dir, "state.db")
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(`CREATE TABLE messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL,
+		role TEXT NOT NULL,
+		content TEXT,
+		timestamp REAL NOT NULL);
+		CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT NOT NULL, started_at REAL NOT NULL, cwd TEXT, title TEXT);
+		INSERT INTO sessions (id,source,started_at,cwd) VALUES
+		 ('routed','cli',1785000000.0,'/home/qa/work/routepilot'),
+		 ('nowhere','telegram',1785000000.0,NULL),
+		 ('blank','cli',1785000000.0,'');
+		INSERT INTO messages (session_id,role,content,timestamp) VALUES
+		 ('routed','user','why does the import drop the second profile',1785000010.0),
+		 ('nowhere','user','what is the weather in the mountains',1785000020.0),
+		 ('blank','user','remind me of the plan',1785000030.0),
+		 ('orphan','user','a session the sessions table never recorded',1785000040.0);`)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("sqlite3: %v\n%s", err, out)
+	}
+	ss, err := ParseHermesDB(db)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := map[string]string{}
+	for _, s := range ss {
+		got[s.ID] = s.Project
+	}
+	want := map[string]string{"routed": "work/routepilot", "nowhere": "writer", "blank": "writer", "orphan": "writer"}
+	for id, p := range want {
+		if got[id] != p {
+			t.Errorf("session %s project = %q, want %q", id, got[id], p)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3257.

`parseHermesDBWhere` asks the `sessions` table for each session's `cwd` (best effort: a store without the table or a row without a cwd keeps the profile name) and stamps the project the way the Cline and Roo readers do, `claudeProjectName(pathToProjectKey(cwd))`. The Postgres reader is untouched — its schema is not known to carry `sessions`; same shape if it does.

Fail-before test: `TestHermesProjectComesFromTheStoresCwd` (internal/sources), on the collector:

```
hermes_project_test.go:55: session routed project = "writer", want "work/routepilot"
```

On a hermetic copy of the real store: `deja last` shows the four routepilot sessions under `goprojects/routepilot` instead of `hermes`; `deja hook-context --plain` with that cwd goes from 0 B to 1680 B with the Hermes sessions in the digest, and stays 0 B for the profile directory.

## Review

Reviewer (adversarial, own worktree): "hermes.go:265 warning: when `.timeout 5000` expires on a locked database, `hermesSessionCwds` silently returns nil and every session falls back to `hermesProfile` — acceptable best-effort. Incremental path: `ParseHermesDBSince` returns sessions with possibly changed projects and the index updates them in place since the key (`harness:id`) is unchanged. Windows paths: `pathToProjectKey` folds `\\` and `:`. No caller assumes Project == profile for Hermes in doctor, sources or elsewhere. Test passes, `go vet` clean, `go test ./internal/sources ./internal/index` pass. Verdict: not refuted."
