### PR TITLE
fix(hook-tool-after): name the file that changed next when the remedy was an edit

### DIFF
--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -453,10 +453,14 @@ func fixLine(p index.FixPair, sessions int) string {
 	// the line reads as an instruction, so it should not start with a shell
 	// prompt the reader would have to mentally strip.
 	cmd, ok := withoutFailedExit(strings.TrimPrefix(strings.TrimSpace(search.SafeText(p.Command)), "$ "))
+	// An edit remedy (#2163) has no command: what fixed a failing test was a
+	// change to a file, and the useful half is which file. `deja fix` said so;
+	// the hook, the surface that fires at the failure, said nothing (#3259).
+	edit := strings.TrimSpace(search.SafeLine(p.Edit))
 	// codex and opencode record the exit status on the command; a remedy that
 	// exited non-zero is not one, and handing it over as "what followed it"
 	// tells an agent to run something that already failed here.
-	if !ok || cmd == "" {
+	if (!ok || cmd == "") && edit == "" {
 		return ""
 	}
 	when := ""
@@ -485,6 +489,15 @@ func fixLine(p index.FixPair, sessions int) string {
 	// the same error is evidence it worked; one session doing something is what
 	// one session did, and an agent handed it at the moment it is stuck has to
 	// be told which of the two it is holding.
+	if edit != "" && (!ok || cmd == "") {
+		// Not something to run, so not offered as one: the file, in the words
+		// `deja fix` uses for the same pair.
+		if p.Candidate {
+			return "deja: this error came up" + how + " " + where + " before" + when +
+				" — one session changed this file after it, and nothing confirms it worked: " + edit
+		}
+		return "deja: this error came up" + how + " " + where + " before" + when + " — changed next: " + edit
+	}
 	if p.Candidate {
 		return "deja: this error came up" + how + " " + where + " before" + when +
 			" — one session ran this after it, and nothing confirms it worked: " + cmd

--- a/cmd/deja/hook_tool_after_edit_test.go
+++ b/cmd/deja/hook_tool_after_edit_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A pair whose remedy is a file edit (#2163) reached `deja fix` and never the
+// hook: fixLine wanted a command and gave the failing test nothing (#3259).
+func TestFixLineNamesTheFileThatChangedNext(t *testing.T) {
+	p := index.FixPair{
+		Error:   "--- FAIL: TestLifecycleGatesTheGiveUpPenalty",
+		Edit:    "internal/search/outcome_rank_test.go",
+		Project: "deja-vu",
+		When:    time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	}
+	got := fixLine(p, 1)
+	if got == "" {
+		t.Fatal("an edit remedy produced no line")
+	}
+	for _, want := range []string{"deja: this error came up", "in deja-vu", "changed next", "internal/search/outcome_rank_test.go"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("line %q lacks %q", got, want)
+		}
+	}
+	if strings.Contains(got, "what followed it") || strings.Contains(got, " ran this ") {
+		t.Errorf("an edit is offered as a command: %q", got)
+	}
+	p.Candidate = true
+	if got := fixLine(p, 1); !strings.Contains(got, "nothing confirms") {
+		t.Errorf("an unconfirmed edit reads as confirmed: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #3259.

`fixLine` now reads `p.Edit`: a pair whose remedy is a file edit gets the same line the command case gets, ending in `changed next: <file>` (the words `deja fix` already uses for that pair), and the candidate case says a session changed this file and nothing confirms it worked. A pair with a failed command and no edit still gets nothing.

Fail-before test: `TestFixLineNamesTheFileThatChangedNext` (cmd/deja), on the collector:

```
hook_tool_after_edit_test.go:22: an edit remedy produced no line
```

On the hermetic HOME with the real transcripts and the captured 2.1.263 `PostToolUse` payload, `hook-tool-after --plain` goes from 0 B to:

```
deja: this error came up in goprojects/deja-vu before (2026-08-10) — changed next: /Users/shulcz/coding/goprojects/deja-vu/internal/search/outcome_rank_test.go
```

Wording question: the edit line reuses `changed next` from `deja fix`; the unconfirmed variant says "one session changed this file after it, and nothing confirms it worked". Change either if you want them worded differently.

## Review

Reviewer (adversarial, own worktree): "hook_tool_after.go:453 no issue — edit extraction uses `search.SafeLine`, consistent with `deja fix` (fix.go:144). :463 no issue — `(!ok || cmd == \"\") && edit == \"\"` returns empty iff a bad or missing command AND no edit; Command-only, Edit-only, and both-present (Command wins, per the never-beside doc) are covered. :491–499 no issue — plain and JSON both route through fixPairLine → fixLine; frameRecall/truncateToolLine keep the 420-byte budget. Only caller is fixPairLine; the PreToolUse path has its own logic. Tests and `go vet` pass. Verdict: not refuted."
