### PR TITLE
fix(fix): --json and the MCP fix mode name the file that changed next

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -197,6 +197,11 @@ type fixJSON struct {
 type fixRowJSON struct {
 	Error   string `json:"error"`
 	Command string `json:"command"`
+	// Edit is the file the sessions changed after the error, when the remedy
+	// was a change rather than a command (#2163); set instead of Command, and
+	// omitted when the remedy was a command. It reached the prose only, and a
+	// script read an empty command (#3261).
+	Edit string `json:"edit,omitempty"`
 	// Candidate is the half-evidence flag the prose renders as "ran next,
 	// unconfirmed": one session ran this after the error and nothing has
 	// confirmed it worked. A caller acting on a fix needs to know which it has.
@@ -212,6 +217,7 @@ func writeFixJSON(stdout io.Writer, pairs []index.FixPair) error {
 		row := fixRowJSON{
 			Error:     search.SafeLine(p.Error),
 			Command:   search.SafeCommand(p.Command),
+			Edit:      search.SafeLine(p.Edit),
 			Candidate: p.Candidate,
 		}
 		if !p.When.IsZero() {

--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -141,7 +141,7 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			if p.Candidate {
 				changed = "changed next, unconfirmed"
 			}
-			fmt.Fprintf(stdout, "  %s: %s\n", changed, search.SafeLine(p.Edit))
+			fmt.Fprintf(stdout, "  %s: %s\n", changed, search.SafePath(p.Edit))
 			continue
 		}
 		ran := "ran next"
@@ -217,7 +217,7 @@ func writeFixJSON(stdout io.Writer, pairs []index.FixPair) error {
 		row := fixRowJSON{
 			Error:     search.SafeLine(p.Error),
 			Command:   search.SafeCommand(p.Command),
-			Edit:      search.SafeLine(p.Edit),
+			Edit:      search.SafePath(p.Edit),
 			Candidate: p.Candidate,
 		}
 		if !p.When.IsZero() {

--- a/cmd/deja/fix_edit_remedy_surfaces_test.go
+++ b/cmd/deja/fix_edit_remedy_surfaces_test.go
@@ -23,7 +23,7 @@ func editRemedyStore(t *testing.T) string {
 			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"the pool test keeps failing"}}`,
 			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t` + id + `","input":{"command":"go test ./internal/pool"}}]}}`,
 			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` + id + `","content":"--- FAIL: TestPoolDrainsOnClose (0.09s)"}]}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/two  spaces/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
 		})
 	}
 	dir := index.DefaultDir()
@@ -33,7 +33,6 @@ func editRemedyStore(t *testing.T) string {
 	return dir
 }
 
-// The path keeps its spacing (#2044): a file is named, not read aloud.
 // The edit remedy reached the terminal `fix` only: --json printed an empty
 // command and no file, and the MCP fix mode printed "ran next:" with nothing
 // after it (#3261).
@@ -55,7 +54,7 @@ func TestFixJSONCarriesTheEditRemedy(t *testing.T) {
 	if len(got.Fixes) == 0 {
 		t.Fatalf("no fixes:\n%s", out)
 	}
-	if got.Fixes[0].Edit != "/tmp/app/internal/two  spaces/pool.go" || got.Fixes[0].Command != "" {
+	if got.Fixes[0].Edit != "/tmp/app/internal/pool.go" || got.Fixes[0].Command != "" {
 		t.Errorf("row = %+v, want the edited file and no command", got.Fixes[0])
 	}
 }
@@ -66,10 +65,22 @@ func TestMCPFixNamesTheFileThatChangedNext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fix: %v", err)
 	}
-	if !strings.Contains(got, "changed next: /tmp/app/internal/two  spaces/pool.go") {
+	if !strings.Contains(got, "changed next: /tmp/app/internal/pool.go") {
 		t.Errorf("the answer does not name the file:\n%s", got)
 	}
 	if strings.Contains(got, "ran next") {
 		t.Errorf("an edit was offered as a command to run:\n%s", got)
+	}
+}
+
+// The path keeps its spacing (#2044): a file is named, not read aloud. The
+// miner refuses paths with whitespace today, so this guards the renderer alone.
+func TestFixJSONKeepsTheEditedPathVerbatim(t *testing.T) {
+	var out strings.Builder
+	if err := writeFixJSON(&out, []index.FixPair{{Error: "--- FAIL: TestX", Edit: "/tmp/app/two  spaces/pool.go"}}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"edit": "/tmp/app/two  spaces/pool.go"`) {
+		t.Errorf("path not verbatim:\n%s", out.String())
 	}
 }

--- a/cmd/deja/fix_edit_remedy_surfaces_test.go
+++ b/cmd/deja/fix_edit_remedy_surfaces_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// editRemedyStore is the #2163 fixture: two sessions hit the same failing test
+// and changed the same file after it.
+func editRemedyStore(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i, id := range []string{"e1", "e2"} {
+		at := time.Now().Add(-time.Duration(i+1) * time.Hour).UTC().Format(time.RFC3339)
+		writeClaudeFixture(t, filepath.Join(root, "-tmp-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"the pool test keeps failing"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t` + id + `","input":{"command":"go test ./internal/pool"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` + id + `","content":"--- FAIL: TestPoolDrainsOnClose (0.09s)"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/pool/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The edit remedy reached the terminal `fix` only: --json printed an empty
+// command and no file, and the MCP fix mode printed "ran next:" with nothing
+// after it (#3261).
+func TestFixJSONCarriesTheEditRemedy(t *testing.T) {
+	editRemedyStore(t)
+	out, err := captureRun(t, "fix", "--json", "--- FAIL: TestPoolDrainsOnClose")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Fixes []struct {
+			Command string `json:"command"`
+			Edit    string `json:"edit"`
+		} `json:"fixes"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("not json: %v\n%s", err, out)
+	}
+	if len(got.Fixes) == 0 {
+		t.Fatalf("no fixes:\n%s", out)
+	}
+	if got.Fixes[0].Edit != "/tmp/app/internal/pool/pool.go" || got.Fixes[0].Command != "" {
+		t.Errorf("row = %+v, want the edited file and no command", got.Fixes[0])
+	}
+}
+
+func TestMCPFixNamesTheFileThatChangedNext(t *testing.T) {
+	dir := editRemedyStore(t)
+	got, err := callMCPTool(dir, "fix", json.RawMessage(`{"error":"--- FAIL: TestPoolDrainsOnClose"}`))
+	if err != nil {
+		t.Fatalf("fix: %v", err)
+	}
+	if !strings.Contains(got, "changed next: /tmp/app/internal/pool/pool.go") {
+		t.Errorf("the answer does not name the file:\n%s", got)
+	}
+	if strings.Contains(got, "ran next") {
+		t.Errorf("an edit was offered as a command to run:\n%s", got)
+	}
+}

--- a/cmd/deja/fix_edit_remedy_surfaces_test.go
+++ b/cmd/deja/fix_edit_remedy_surfaces_test.go
@@ -23,7 +23,7 @@ func editRemedyStore(t *testing.T) string {
 			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":"the pool test keeps failing"}}`,
 			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"t` + id + `","input":{"command":"go test ./internal/pool"}}]}}`,
 			`{"type":"user","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t` + id + `","content":"--- FAIL: TestPoolDrainsOnClose (0.09s)"}]}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/pool/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + at + `","cwd":"/tmp/app","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","id":"x` + id + `","input":{"file_path":"/tmp/app/internal/two  spaces/pool.go","old_string":"close(c)","new_string":"c.drain()"}}]}}`,
 		})
 	}
 	dir := index.DefaultDir()
@@ -33,6 +33,7 @@ func editRemedyStore(t *testing.T) string {
 	return dir
 }
 
+// The path keeps its spacing (#2044): a file is named, not read aloud.
 // The edit remedy reached the terminal `fix` only: --json printed an empty
 // command and no file, and the MCP fix mode printed "ran next:" with nothing
 // after it (#3261).
@@ -54,7 +55,7 @@ func TestFixJSONCarriesTheEditRemedy(t *testing.T) {
 	if len(got.Fixes) == 0 {
 		t.Fatalf("no fixes:\n%s", out)
 	}
-	if got.Fixes[0].Edit != "/tmp/app/internal/pool/pool.go" || got.Fixes[0].Command != "" {
+	if got.Fixes[0].Edit != "/tmp/app/internal/two  spaces/pool.go" || got.Fixes[0].Command != "" {
 		t.Errorf("row = %+v, want the edited file and no command", got.Fixes[0])
 	}
 }
@@ -65,7 +66,7 @@ func TestMCPFixNamesTheFileThatChangedNext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fix: %v", err)
 	}
-	if !strings.Contains(got, "changed next: /tmp/app/internal/pool/pool.go") {
+	if !strings.Contains(got, "changed next: /tmp/app/internal/two  spaces/pool.go") {
 		t.Errorf("the answer does not name the file:\n%s", got)
 	}
 	if strings.Contains(got, "ran next") {

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -674,6 +674,19 @@ func mcpFix(dir, name string, raw json.RawMessage) (string, int, error) {
 		if !p.When.IsZero() {
 			when = " (" + p.When.Local().Format("2006-01-02") + ")"
 		}
+		if p.Edit != "" {
+			// An edit is not something to run, so it is not offered as one:
+			// the file, in the words `deja fix` uses for the same pair
+			// (#2163). This surface said "ran next:" with nothing after it
+			// (#3261).
+			changed := "changed next"
+			if p.Candidate {
+				changed = "changed next, unconfirmed"
+			}
+			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, changed,
+				recallListingLine(p.Edit))
+			continue
+		}
 		ran := "ran next"
 		if p.Candidate {
 			ran = "ran next, unconfirmed"

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -684,7 +684,7 @@ func mcpFix(dir, name string, raw json.RawMessage) (string, int, error) {
 				changed = "changed next, unconfirmed"
 			}
 			fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, changed,
-				recallListingLine(p.Edit))
+				search.SafePath(p.Edit))
 			continue
 		}
 		ran := "ran next"

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -535,6 +535,21 @@ unconfirmed"*: one session ran this after the error and nothing has confirmed it
 worked. A caller acting on a fix automatically needs to know which half it is
 holding, so it is a field rather than a wording difference.
 
+When what followed the error was a change to a file rather than a command — the
+usual answer to a failing test — the row carries `edit` (the file's path) and an
+empty `command`; the prose renders it as *"changed next"*. `edit` is omitted
+when the remedy was a command.
+
+```json
+{
+  "error": "--- FAIL: TestPoolDrainsOnClose",
+  "command": "",
+  "edit": "/tmp/app/internal/pool/pool.go",
+  "candidate": false,
+  "when": "2026-08-29T18:02:44Z"
+}
+```
+
 As with `friction`, an empty result keeps the envelope and returns `fixes: []`.
 The prose path distinguishes "held but unconfirmed", "nothing recorded for that
 line" and "no session ran a command after that error" in three different


### PR DESCRIPTION
Closes #3261. Follow-on from #3259.

`writeFixJSON` carries `edit` (omitted when the remedy was a command); `mcpFix` renders an edit pair as `changed next: <file>` (`changed next, unconfirmed` for a candidate), the words the terminal `fix` already uses, instead of `ran next: ` with nothing after it.

Fail-before tests: `TestFixJSONCarriesTheEditRemedy` and `TestMCPFixNamesTheFileThatChangedNext` (cmd/deja), on the collector:

```
--- FAIL: TestPoolDrainsOnClose (2026-09-08)
  ran next: 
```

The environment block and the plan finding skip edit pairs on purpose (they quote a command to run) and are unchanged. Docs: the `--json` schema gains a field; `schema_version` stays 2 since the field is additive — say if you want it bumped.

## Review

Reviewer (adversarial, own worktree): "docs/json-output.md:15 medium: the JSON schema example does not document the new `edit` field. cmd/deja/fix.go:220 high: SafeLine used for a file path instead of SafePath — SafeLine collapses multiple spaces (#2044); use `search.SafePath`, as doctor.go and files.go do. Verdict: refuted." — both fixed in the follow-up commit: `search.SafePath` on the json row, the MCP line and the prose line; the contract doc gains the `edit` row; the test path now carries a double space.

Re-review after the fixes: "Verdict: not refuted — SafePath now guards all three renderings (JSON, MCP prose, CLI prose); docs/json-output.md documents the `edit` field with a worked example; `TestFixJSONKeepsTheEditedPathVerbatim` proves the double-space path survives."
