### PR TITLE
fix(amp): every thread opens with the session digest, not only the first in the process

### DIFF
--- a/cmd/deja/install_amp.go
+++ b/cmd/deja/install_amp.go
@@ -136,7 +136,10 @@ function run(args: string[], input: string, timeout = 10000): string {
 }
 
 export default function (amp: any) {
-  let injected = false
+  // The thread that has had its digest. Amp keeps one process across threads,
+  // and a flag set once per process left every thread after the first with no
+  // memory (#3263).
+  let injected = ""
   // Amp's events carry the thread, and the thread id is what recall dedupes on:
   // without it the same block goes out on every message of the session.
   let thread = ""
@@ -162,8 +165,8 @@ export default function (amp: any) {
   amp.on("agent.start", async (event: any, ctx: any) => {
     try {
       const id = threadID(event)
-      if (!injected) {
-        injected = true
+      if (injected !== (id || "*")) {
+        injected = id || "*"
         const raw = run(["hook-context"], "")
         let digest = raw
         let receipt = ""

--- a/cmd/deja/install_amp.go
+++ b/cmd/deja/install_amp.go
@@ -167,7 +167,13 @@ export default function (amp: any) {
       const id = threadID(event)
       if (injected !== (id || "*")) {
         injected = id || "*"
-        const raw = run(["hook-context"], "")
+        // The thread goes with it, so deja's own once-per-session mark holds
+        // across a restart of the process the way it does for Claude Code.
+        const raw = run(["hook-context"], JSON.stringify({
+          session_id: id,
+          cwd: process.cwd(),
+          deja_once: true,
+        }))
         let digest = raw
         let receipt = ""
         try {

--- a/cmd/deja/install_amp_threads_test.go
+++ b/cmd/deja/install_amp_threads_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Amp keeps one process across threads. The plugin injected the session
+// digest once per process, so the second thread of the day opened with no
+// memory (#3263). Driven the way Amp drives it: default(amp) once, then the
+// events of two threads, with a stub deja that answers hook-context.
+func TestAmpPluginInjectsTheDigestOncePerThread(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stub deja is a shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not installed")
+	}
+	if err := exec.Command(node, "--experimental-strip-types", "-e", "").Run(); err != nil {
+		t.Skip("this node cannot strip types")
+	}
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "deja")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+
+		`case "$1" in hook-context) echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<deja-recall>\nrecent history\n</deja-recall>"},"systemMessage":"deja recalled 1 session"}';; *) cat >/dev/null; echo "";; esac`+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plugin := filepath.Join(dir, "deja.ts")
+	if err := os.WriteFile(plugin, []byte(ampPluginTS(stub)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	drive := filepath.Join(dir, "drive.mjs")
+	if err := os.WriteFile(drive, []byte(`
+const mod = await import(process.argv[2]);
+const handlers = {};
+const amp = { on(n, f) { (handlers[n] ||= []).push(f); }, registerCommand() { return { dispose() {} }; } };
+mod.default(amp);
+const ctx = { ui: { notify: async () => {}, input: async () => "" } };
+async function fire(name, event) {
+  let out = "";
+  for (const fn of handlers[name] || []) {
+    const r = await fn(event, ctx);
+    if (r && r.message && r.message.content) out += r.message.content;
+  }
+  return out;
+}
+for (const id of ["T-A", "T-B"]) {
+  await fire("session.start", { thread: { id } });
+  const first = await fire("agent.start", { thread: { id }, message: "hello", id: id + "-1" });
+  const second = await fire("agent.start", { thread: { id }, message: "hello again", id: id + "-2" });
+  console.log(id, first.includes("recent history") ? "digest" : "nothing", second.includes("recent history") ? "digest" : "nothing");
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(node, "--experimental-strip-types", "--no-warnings", drive, plugin)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("node: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	want := "T-A digest nothing\nT-B digest nothing"
+	if got != want {
+		t.Errorf("threads got:\n%s\nwant:\n%s", got, want)
+	}
+}


### PR DESCRIPTION
Closes #3263.

The plugin remembers which thread got the digest (`event.thread.id`, which it already reads for hook-prompt) instead of a process-wide flag, so the first `agent.start` of every thread carries it. A thread without an id keeps the old once-per-process behaviour.

Fail-before test: `TestAmpPluginInjectsTheDigestOncePerThread` (cmd/deja; node with `--experimental-strip-types`, a stub deja, two threads through one plugin instance; skipped without such a node and on Windows), on the collector:

```
T-A digest nothing
T-B nothing nothing
want:
T-A digest nothing
T-B digest nothing
```

Re-driven through the plugin regenerated by `deja install amp-auto`: thread B's first `agent.start` goes from nothing to the 1892 B digest; thread A is unchanged.

## Review

Reviewer (adversarial, own worktree): "install_amp.go: hook-context is run with no session_id, so `sessionHadDigest(dir, \"\")` never holds and a thread resumed after a process restart is injected again — pass `{session_id: id}` as hook-prompt already does. install_amp_threads_test.go high: the Go job in ci.yml sets up no node, so the test skips on CI and proves nothing. :168 the per-thread check is sound. go vet / tests pass. Verdict: refuted." — first point fixed in the follow-up commit: hook-context now gets `{session_id, cwd, deja_once: true}`, so deja's own once-per-session mark holds across a restart. On the second: the runners' images ship node 22, the same skip-if-absent pattern the OpenClaw and Cline plugin tests already use; no setup-node step is added here.

Re-review after the follow-up: "Verdict: not refuted — every thread gets its digest once per thread, once per process lifetime, and the mark survives across restarts via session_id in hook-context stdin. Skip logic sound: runs on the ubuntu/macos runners where node 22 with --experimental-strip-types is available, matching the OpenClaw/Cline plugin tests. Tests and go vet pass."
