### PR TITLE
fix(parsers): the host's block and aider's own commands are not the user's words

### DIFF
--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -160,6 +160,14 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 			if t == "<blank>" {
 				t = ""
 			}
+			// aider writes every input as a #### line, its own commands
+			// included, so `/undo` became a user message and `/clear` was
+			// glued onto the question typed after it (#3248). A command ends
+			// the turn rather than joining it.
+			if aiderSlashCommand(t) {
+				flush()
+				continue
+			}
 			buf = append(buf, t)
 		case strings.HasPrefix(line, "> "), line == ">":
 			// tool/system output: ends any assistant block, not indexed as a message
@@ -176,6 +184,39 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 	}
 	endSession()
 	return out, nil
+}
+
+// aiderCommands are aider's own inputs, which it records in the transcript the
+// same way it records a question. Only the ones that take no prose, or whose
+// argument is a path or a shell line rather than something the person said —
+// `/ask` and `/code` carry a real question and stay.
+var aiderCommands = map[string]bool{
+	"add": true, "architect": true, "chat-mode": true, "clear": true, "clipboard": true,
+	"code": false, "commit": true, "copy": true, "diff": true, "drop": true,
+	"editor": true, "exit": true, "git": true, "help": true, "lint": true, "load": true,
+	"ls": true, "map": true, "map-refresh": true, "model": true, "models": true,
+	"multiline-mode": true, "paste": true, "quit": true, "read-only": true, "report": true,
+	"reset": true, "run": true, "save": true, "settings": true, "test": true,
+	"tokens": true, "undo": true, "voice": true, "web": true,
+}
+
+// aiderSlashCommand reports that a line is one of aider's own commands rather
+// than something the person asked.
+//
+// The name has to be one aider has, not merely a leading slash: "/etc/hosts is
+// wrong on the build box" opens the same way and is the reader's, and so is a
+// line that starts with any absolute path.
+func aiderSlashCommand(line string) bool {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "/") || len(t) < 2 {
+		return false
+	}
+	name := t[1:]
+	if i := strings.IndexAny(name, " \t"); i >= 0 {
+		name = name[:i]
+	}
+	drop, known := aiderCommands[strings.ToLower(name)]
+	return known && drop
 }
 
 // aider has no session ids; derive a stable one from file path + ordinal.

--- a/internal/sources/aider_commands_test.go
+++ b/internal/sources/aider_commands_test.go
@@ -1,0 +1,93 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// aider writes every input as a `#### ` line, its own commands included, so
+// `/undo` became a user message of its own and `/clear` was glued onto the
+// question typed after it (#3248).
+func TestAiderDropsItsOwnCommands(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.md")
+	const doc = `# aider chat started at 2026-08-01 10:00:00
+
+#### /clear
+#### why does the vantrell fetcher time out
+
+the pool is exhausted before the second attempt
+
+#### /undo
+#### /add internal/retry/retry.go
+#### and what did we settle about the retry cap
+
+four, and the backoff is on the deadline
+
+#### /etc/hosts is wrong on the build box
+
+that is a different machine
+`
+	if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAiderFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(ss))
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	want := []string{
+		"why does the vantrell fetcher time out",
+		"and what did we settle about the retry cap",
+		// A message that merely opens with a path is the person's.
+		"/etc/hosts is wrong on the build box",
+	}
+	if strings.Join(users, "|") != strings.Join(want, "|") {
+		t.Fatalf("user turns =\n  %s\nwant\n  %s",
+			strings.Join(users, "\n  "), strings.Join(want, "\n  "))
+	}
+	// And the answers are untouched.
+	found := false
+	for _, m := range ss[0].Messages {
+		if m.Role == "assistant" && strings.Contains(m.Text, "pool is exhausted") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("an answer went with the commands")
+	}
+}
+
+// The classifier itself, since the list is what decides.
+func TestAiderSlashCommandKnowsWhatIsACommand(t *testing.T) {
+	for _, cmd := range []string{
+		"/undo", "/clear", "/add internal/retry/retry.go", "/run go test ./...",
+		"/drop", "/model gpt-5", "/tokens", "  /quit  ", "/GIT status",
+	} {
+		if !aiderSlashCommand(cmd) {
+			t.Errorf("%q is one of aider's commands", cmd)
+		}
+	}
+	for _, mine := range []string{
+		"/etc/hosts is wrong on the build box",
+		"/usr/local/bin/deja is on PATH now",
+		"/ask why the retry cap is four",
+		"/code add a backoff",
+		"/",
+		"why does /undo not work here",
+		"",
+	} {
+		if aiderSlashCommand(mine) {
+			t.Errorf("%q is the reader's, not a command", mine)
+		}
+	}
+}

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -401,7 +401,7 @@ func clineContentText(raw json.RawMessage) string {
 // unwrapClineTask strips the legacy <task>...</task> envelope (and its modern
 // user-input equivalent) so the tags themselves are not indexed.
 func unwrapClineTask(text string) string {
-	t := strings.TrimSpace(text)
+	t := stripClineHostBlocks(strings.TrimSpace(text))
 	for _, tag := range []string{"task", "user_message", "user_input"} {
 		open := "<" + tag
 		if !strings.HasPrefix(t, open) {
@@ -420,6 +420,44 @@ func unwrapClineTask(text string) string {
 		return strings.TrimSpace(rest)
 	}
 	return t
+}
+
+// clineHostBlocks are the envelopes Roo Code and Cline append to a user turn:
+// the workspace listing, the open tabs, the clock, the running cost, the mode.
+// They are the host's words inside the person's message, so before this a query
+// on "files", "current", "time" or any open tab's path hit every Roo and Cline
+// session, and `ctx` printed the listing where the reader's own question goes
+// (#3255).
+//
+// Stripped at the parser rather than at display: the block lands in the store,
+// so every surface that reads a message sees it — search, titles, the digest,
+// the excerpt. `internal/digest/harness_blocks.go` does the same job for text
+// that only ever passes through a prompt.
+var clineHostBlocks = []string{"environment_details", "workspace_diagnostics", "slash_command"}
+
+// stripClineHostBlocks removes those blocks wherever they sit in the message.
+// Roo appends them after the task text in the same turn, so a prefix check
+// would miss every one of them.
+func stripClineHostBlocks(t string) string {
+	for _, tag := range clineHostBlocks {
+		open, close := "<"+tag+">", "</"+tag+">"
+		for {
+			i := strings.Index(t, open)
+			if i < 0 {
+				break
+			}
+			j := strings.Index(t[i:], close)
+			if j < 0 {
+				// An unterminated block runs to the end of the message: the
+				// listing was cut mid-write, and what follows it is not the
+				// person's either.
+				t = t[:i]
+				break
+			}
+			t = t[:i] + t[i+j+len(close):]
+		}
+	}
+	return strings.TrimSpace(t)
 }
 
 func firstNonEmpty(a, b string) string {

--- a/internal/sources/cline_environment_test.go
+++ b/internal/sources/cline_environment_test.go
@@ -1,0 +1,103 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Roo Code and Cline append an <environment_details> block to every user turn —
+// visible files, open tabs, the clock, the running cost, the mode, a workspace
+// listing — and deja indexed it inside the person's message. So a query on
+// "files", "current" or any open tab's path hit every Roo and Cline session,
+// and ctx printed the listing where the reader's own question goes (#3255).
+func TestClineDropsTheHostsBlockFromAUserTurn(t *testing.T) {
+	const question = "fix the flaky vantrell retry: the second attempt reuses the first timeout"
+	env := "<environment_details>\n# VSCode Visible Files\ninternal/retry/retry.go\n" +
+		"# VSCode Open Tabs\ninternal/retry/retry.go\n" +
+		"# Current Time\nCurrent time in ISO 8601 UTC format: 2026-09-08T01:33:20.000Z\n" +
+		"# Current Cost\n$0.12\n# Current Mode\n<slug>code</slug>\n</environment_details>"
+
+	for _, tc := range []struct{ name, in string }{
+		// Roo appends the block after the task text, in the same turn.
+		{"after the text", question + "\n" + env},
+		// And inside the <task> envelope, which is where Cline puts it.
+		{"inside the task envelope", "<task>\n" + question + "\n" + env + "\n</task>"},
+		{"before the text", env + "\n" + question},
+	} {
+		got := unwrapClineTask(tc.in)
+		if got != question {
+			t.Errorf("%s: user turn =\n  %q\nwant\n  %q", tc.name, got, question)
+		}
+	}
+
+	// An unterminated block — the listing cut mid-write — takes the rest with
+	// it rather than leaving half a listing in the message.
+	if got := unwrapClineTask(question + "\n<environment_details>\n# VSCode Visible"); got != question {
+		t.Errorf("an unterminated block survived: %q", got)
+	}
+
+	// Two blocks in one turn, which a resumed task carries.
+	if got := unwrapClineTask(env + "\n" + question + "\n" + env); got != question {
+		t.Errorf("a second block survived: %q", got)
+	}
+
+	// What the person wrote is untouched, including a message that talks about
+	// the block or opens with a path.
+	for _, mine := range []string{
+		"why is environment_details in my context",
+		"/etc/hosts is wrong on the build box",
+		question,
+	} {
+		if got := unwrapClineTask(mine); got != mine {
+			t.Errorf("the reader's message changed: %q -> %q", mine, got)
+		}
+	}
+}
+
+// The same through the parser, since the block lands in the store: it has to be
+// gone from the message every surface reads, not only from the unwrapper.
+func TestRooTaskIndexesTheQuestionWithoutTheListing(t *testing.T) {
+	const question = "fix the flaky vantrell retry"
+	dir := filepath.Join(t.TempDir(), "tasks", "1767225700000")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turns := []map[string]any{
+		{"role": "user", "content": question +
+			"\n<environment_details>\n# Current Cost\n$0.12\n</environment_details>"},
+		{"role": "assistant", "content": "the second attempt reuses the deadline, not the timeout"},
+	}
+	b, err := json.Marshal(turns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseRooTask(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	for _, m := range ss[0].Messages {
+		if strings.Contains(m.Text, "environment_details") || strings.Contains(m.Text, "Current Cost") {
+			t.Errorf("the host's block reached the index as %s: %q", m.Role, m.Text)
+		}
+	}
+	found := false
+	for _, m := range ss[0].Messages {
+		if strings.TrimSpace(m.Text) == question {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the question did not survive: %#v", ss[0].Messages)
+	}
+}


### PR DESCRIPTION
Two parsers filing the host's words under the person's — the same family as the Kimi one (#3199) and the hook echoes (#3168).

**#3255 — `<environment_details>`.** Roo Code and Cline append it to every user turn: visible files, open tabs, the clock, the running cost, the mode, a workspace listing. `unwrapClineTask` knew `<task>`, `<user_message>` and `<user_input>`, so the block rode inside the message — a query on `files`, `current` or any open tab's path hit every Roo and Cline session, and `ctx` printed the listing where the reader's question goes.

Stripped at the parser rather than at display, because it lands in the store and every surface reads it. Wherever it sits, not only as a prefix — Roo appends it after the task text — and an unterminated block takes the rest of the message with it, since a listing cut mid-write is not the person's either.

**#3248 — aider's own commands.** aider writes every input as a `#### ` line, so `/undo` became a user message and `/clear` was glued onto the question typed after it. A command now ends the turn instead of joining it, matched by name against aider's own list: `/etc/hosts is wrong on the build box` opens the same way and stays the reader's, and `/ask` and `/code` carry a real question so they stay too.

Six mutations, all red — including dropping the second block in one turn, and keeping `/ask`.

Closes #3255, closes #3248.
