### PR TITLE
fix(claude): the harness's own user-role records (isMeta) are not the person's words

### DIFF
--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -192,6 +192,11 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 		if typ != "user" && typ != "assistant" {
 			return
 		}
+		if meta, _ := m["isMeta"].(bool); meta && typ == "user" {
+			// The harness's own user-role record (#3267); the typed parser
+			// skips it the same way.
+			return
+		}
 		side, _ := m["isSidechain"].(bool)
 		agent, _ := m["agentId"].(string)
 		if side && agent != "" {

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -41,6 +41,11 @@ type claudeLine struct {
 	IsSidechain      bool   `json:"isSidechain"`
 	AgentID          string `json:"agentId"`
 	AttributionAgent string `json:"attributionAgent"`
+	// IsMeta marks a user-role record Claude Code wrote itself — a loaded
+	// skill's body, a prompt a cron job re-fired, the /fork notice, an image
+	// placeholder. Indexed as the person's words, a skill body became 52
+	// questions nobody asked on one machine (#3267).
+	IsMeta bool `json:"isMeta"`
 }
 
 type claudeMessage struct {
@@ -62,6 +67,9 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 			return
 		}
 		if v.Type != "user" && v.Type != "assistant" {
+			return
+		}
+		if v.Type == "user" && v.IsMeta {
 			return
 		}
 		if v.IsSidechain && v.AgentID != "" {

--- a/internal/sources/claude_ismeta_test.go
+++ b/internal/sources/claude_ismeta_test.go
@@ -1,0 +1,44 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Claude Code marks the user-role records it writes itself — a loaded skill's
+// body, a prompt a cron job re-fired, the /fork notice, an image placeholder —
+// with isMeta: true. They were indexed as the person's words (#3267).
+func TestClaudeIsMetaRecordsAreNotThePersons(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s1.jsonl")
+	body := `{"type":"user","sessionId":"s1","timestamp":"2026-08-10T10:00:00Z","isMeta":true,"message":{"role":"user","content":"# /loop — schedule a recurring or self-paced prompt\n\nParse the input below into [interval] <prompt…> and schedule it."}}` + "\n" +
+		`{"type":"user","sessionId":"s1","timestamp":"2026-08-10T10:00:01Z","message":{"role":"user","content":"/loop 1m follow the night protocol"}}` + "\n" +
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-08-10T10:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"scheduled"}]}}` + "\n" +
+		`{"type":"user","sessionId":"s1","timestamp":"2026-08-10T10:01:00Z","isMeta":true,"userType":"external","message":{"role":"user","content":"The fork runs as its own separate session — nothing it does arrives in this conversation."}}` + "\n" +
+		`{"type":"user","sessionId":"s1","timestamp":"2026-08-10T10:02:00Z","message":{"role":"user","content":"why does the pool test still fail"}}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, parse := range map[string]func(string, int64) ([]model.Session, error){
+		"typed":   parseClaudeTypedFromOffset,
+		"generic": parseClaudeGenericFromOffset,
+	} {
+		ss, err := parse(path, 0)
+		if err != nil || len(ss) != 1 {
+			t.Fatalf("%s: %v, %d sessions", name, err, len(ss))
+		}
+		want := []string{"/loop 1m follow the night protocol", "scheduled", "why does the pool test still fail"}
+		if len(ss[0].Messages) != len(want) {
+			t.Errorf("%s: messages = %+v", name, ss[0].Messages)
+			continue
+		}
+		for i, m := range ss[0].Messages {
+			if m.Text != want[i] {
+				t.Errorf("%s: message %d = %q, want %q", name, i, m.Text, want[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #3267.

Both Claude readers skip a user-role record with `isMeta: true` — the harness's own writes (a loaded skill's body, a prompt a cron job re-fired, the `/fork` notice, `[Image: …]` placeholders, the local-command caveat). The typed and generic parsers get the same rule, so the equivalence tests hold.

Fail-before test: `TestClaudeIsMetaRecordsAreNotThePersons` (internal/sources), on the collector: both parsers return five messages including the skill body and the fork notice; wanted three.

On the real transcript from #3266 (hermetic copy): 485 → 481 messages, and the `/fork` notice no longer appears under "User problem statement(s)" in `deja handoff`.

Question: records already indexed keep the old rows until a rebuild; does this warrant a format-version bump so existing stores re-read Claude files, or is the next natural rebuild enough?

## Review

Reviewer (adversarial, own worktree): "claude_decode.go:72 and claude.go:195 — both parsers skip `type==\"user\" && isMeta` identically; the equivalence test confirms it. Real corpus audit: 54 skill `/loop` bodies, 2 image placeholders, 3 local-command caveats, 1 continuation prompt — all harness-generated, never the person's own words; 0 tool_result blocks inside isMeta user records across 10 files; 0 sessions made only of isMeta users. Equivalence tests on 40 real transcripts pass; go vet clean; the incremental offset path applies the skip; titles now derive from the first non-isMeta message. Verdict: not refuted."
