### PR TITLE
fix(roo,cline): a command's output in a tool_result is indexed as tool output

### DIFF
--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -371,7 +371,7 @@ func clineTurnToolOutput(raw json.RawMessage, ts time.Time) []model.Message {
 	}
 	var out []model.Message
 	for _, body := range clineToolResults(blocks) {
-		out = append(out, model.Message{Role: RoleToolOutput, Text: body, Time: ts})
+		out = append(out, model.Message{Role: RoleToolOutput, Text: capParsedMessage(body), Time: ts})
 	}
 	return out
 }

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -288,6 +288,13 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 		if m.Role != "user" && m.Role != "assistant" {
 			continue
 		}
+		ts := base.Add(time.Duration(ti) * time.Second)
+		if m.Role == "user" {
+			if tool := clineTurnToolOutput(m.Content, ts); len(tool) > 0 {
+				s.Touch(ts)
+				s.Messages = append(s.Messages, tool...)
+			}
+		}
 		text := clineContentText(m.Content)
 		if m.Role == "user" {
 			text = unwrapClineTask(text)
@@ -295,7 +302,6 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 		if text == "" {
 			continue
 		}
-		ts := base.Add(time.Duration(ti) * time.Second)
 		s.Touch(ts)
 		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
 	}
@@ -346,6 +352,26 @@ func clineWorkRecords(raw json.RawMessage, ts time.Time) []model.Message {
 		for _, body := range clineToolResults(blocks) {
 			out = append(out, model.Message{Role: RoleToolOutput, Text: body, Time: ts})
 		}
+	}
+	return out
+}
+
+// clineTurnToolOutput is what a turn's tool_result blocks printed, for the
+// legacy Cline and the Roo task files, which put a command's output there and
+// the person's words (if any) in text blocks beside it. Read as text blocks
+// only, a failing command's error reached neither search nor the fix pairs
+// (#3269). The same switch and the same role the modern reader uses.
+func clineTurnToolOutput(raw json.RawMessage, ts time.Time) []model.Message {
+	if !IndexToolOutput() {
+		return nil
+	}
+	var blocks []any
+	if json.Unmarshal(raw, &blocks) != nil {
+		return nil
+	}
+	var out []model.Message
+	for _, body := range clineToolResults(blocks) {
+		out = append(out, model.Message{Role: RoleToolOutput, Text: body, Time: ts})
 	}
 	return out
 }

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -314,6 +314,13 @@ func ParseRooTask(path string) ([]model.Session, error) {
 		if m.Role != "user" && m.Role != "assistant" {
 			continue
 		}
+		ts := base.Add(time.Duration(ti) * time.Second)
+		if m.Role == "user" {
+			if tool := clineTurnToolOutput(m.Content, ts); len(tool) > 0 {
+				s.Touch(ts)
+				s.Messages = append(s.Messages, tool...)
+			}
+		}
 		text := clineContentText(m.Content)
 		if m.Role == "user" {
 			text = unwrapClineTask(text)
@@ -321,7 +328,6 @@ func ParseRooTask(path string) ([]model.Session, error) {
 		if text == "" {
 			continue
 		}
-		ts := base.Add(time.Duration(ti) * time.Second)
 		s.Touch(ts)
 		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
 	}

--- a/internal/sources/roo_tool_result_test.go
+++ b/internal/sources/roo_tool_result_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,5 +72,28 @@ func TestClineLegacyToolResultIsIndexedAsToolOutput(t *testing.T) {
 	}
 	if len(toolOut) != 1 || !strings.Contains(toolOut[0], "undefined: frobnicateWidget") {
 		t.Fatalf("tool output = %q, want the failing command's output", toolOut)
+	}
+}
+
+// A build log of a few megabytes is capped like every other harness's tool
+// output.
+func TestRooToolResultIsCapped(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks", "1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	big := strings.Repeat("line of build output\n", maxParsedMessage/10)
+	quoted, _ := json.Marshal(big)
+	body := `[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":` + string(quoted) + `}]}]`
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseRooTask(path)
+	if err != nil || len(ss) != 1 || len(ss[0].Messages) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	if n := len(ss[0].Messages[0].Text); n > maxParsedMessage+64 {
+		t.Errorf("tool output not capped: %d bytes", n)
 	}
 }

--- a/internal/sources/roo_tool_result_test.go
+++ b/internal/sources/roo_tool_result_test.go
@@ -1,0 +1,75 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Roo puts a failing command's output in the tool_result block of the next
+// user turn; the reader took text blocks only, so the error reached neither
+// search nor the fix pairs (#3269).
+func TestRooToolResultIsIndexedAsToolOutput(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks", "1788845325718")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `[
+	 {"role":"user","content":[{"type":"text","text":"<task>\nrun go test and fix whatever fails in widgetd\n</task>"},{"type":"text","text":"<environment_details>\n# Current Cost\n$0.04\n</environment_details>"}]},
+	 {"role":"assistant","content":[{"type":"text","text":"I'll run the tests first."},{"type":"tool_use","id":"toolu_01roo","name":"execute_command","input":{"command":"go test ./..."}}]},
+	 {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01roo","content":"Command executed in terminal within working directory '/Users/qa/proj/widgetd'. Command execution was not successful, inspect the cause and adjust as needed.\nExit code: 1\nOutput:\n# widgetd/pkg\npkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL\twidgetd/pkg [build failed]\nFAIL"},{"type":"text","text":"<environment_details>\n# Current Cost\n$0.05\n</environment_details>"}]},
+	 {"role":"assistant","content":[{"type":"text","text":"frobnicateWidget was renamed to frobnicate; I'll fix the call site."},{"type":"tool_use","id":"toolu_02roo","name":"apply_diff","input":{"path":"pkg/parser.go","diff":"x"}}]}
+	]`
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseRooTask(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var toolOut []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleToolOutput {
+			toolOut = append(toolOut, m.Text)
+		}
+		if m.Role == "user" && strings.Contains(m.Text, "Exit code") {
+			t.Errorf("tool output indexed as the user's words: %q", m.Text)
+		}
+	}
+	if len(toolOut) != 1 || !strings.Contains(toolOut[0], "undefined: frobnicateWidget") {
+		t.Fatalf("tool output = %q, want the failing command's output", toolOut)
+	}
+}
+
+// The legacy Cline task file has the same shape and shared the same gap.
+func TestClineLegacyToolResultIsIndexedAsToolOutput(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "tasks", "1788845325718")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `[
+	 {"role":"user","content":[{"type":"text","text":"<task>\nrun go test in widgetd\n</task>"}]},
+	 {"role":"assistant","content":[{"type":"text","text":"Running."},{"type":"tool_use","id":"t1","name":"execute_command","input":{"command":"go test ./..."}}]},
+	 {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"Exit code: 1\nOutput:\npkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL"}]}
+	]`
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := parseClineLegacyTask(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var toolOut []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleToolOutput {
+			toolOut = append(toolOut, m.Text)
+		}
+	}
+	if len(toolOut) != 1 || !strings.Contains(toolOut[0], "undefined: frobnicateWidget") {
+		t.Fatalf("tool output = %q, want the failing command's output", toolOut)
+	}
+}


### PR DESCRIPTION
Closes #3269.

`clineTurnToolOutput` (internal/sources/cline.go) reads a user turn's `tool_result` blocks through the same `clineToolResults` the modern reader uses, under `RoleToolOutput` and behind the same `DEJA_INDEX_TOOL_OUTPUT` switch; `ParseRooTask` and `parseClineLegacyTask` emit them before the turn's own text. A turn that is only tool_result + environment block now keeps its output instead of being dropped.

Fail-before tests: `TestRooToolResultIsIndexedAsToolOutput` and `TestClineLegacyToolResultIsIndexedAsToolOutput` (internal/sources), on the collector:

```
roo_tool_result_test.go:42: tool output = [], want the failing command's output
```

On the hermetic Roo task written in Roo's own shape: `deja search "build failed"` goes from no match to the task (6 messages indexed, was 4). `deja fix` still answers nothing for the error: the pair needs the edit that followed, and the Roo reader does not read `apply_diff` / `write_to_file` tool_use blocks as edits — a separate gap, queued.

## Review

Reviewer (adversarial, own worktree): "cline.go:374 / roo.go:319 medium: clineTurnToolOutput does not apply capParsedMessage to tool output, unlike crush.go and goose.go — cap it. cline.go:293-295 not refuted: the legacy reader emits no RoleCommand, so the miner can search the output but not pair it with a command (pre-existing). Ordering and timestamps correct (output first, then text); modern reader untouched; both string and array content shapes handled. Verdict: refuted — the missing cap." — fixed in the follow-up commit (`capParsedMessage` on each tool output, `TestRooToolResultIsCapped`); the missing RoleCommand for the legacy/Roo readers is queued.

Re-review after the follow-up: "Verdict: not refuted — the size-cap issue is resolved (`capParsedMessage` at clineTurnToolOutput, `TestRooToolResultIsCapped`); the legacy/Roo readers' missing RoleCommand is recorded separately and does not block this change."
