### PR TITLE
fix(hermes): sessions land in the project they were worked in

### DIFF
--- a/docs/registry/hermes.html
+++ b/docs/registry/hermes.html
@@ -46,8 +46,11 @@
 </ul>
 <p>A flat <code>messages</code> table, grouped by <code>session_id</code>: <code>role</code>, <code>content</code>, and <code>timestamp</code></p>
 <p>as REAL epoch seconds. Rows with <code>role</code> of <code>tool</code> carry no prose and are skipped, as</p>
-<p>are rows with a null <code>content</code>. There is no working directory in the schema, so the</p>
-<p>profile name stands in for the project.</p>
+<p>are rows with a null <code>content</code>. A <code>sessions</code> table beside it carries <code>id</code>, <code>cwd</code>,</p>
+<p><code>git_repo_root</code> and <code>title</code>; the <code>cwd</code> is where the work happened and is what names</p>
+<p>the project, the same way a Cline or Roo workspace does. A store without that table,</p>
+<p>or a session whose row has no <code>cwd</code>, falls back to the profile name. The title is left</p>
+<p>to the index rather than taken from the first row.</p>
 <ul>
 <li><strong>MCP</strong>: <code>mcp_servers</code> in <code>~/.hermes/config.yaml</code>; <code>deja install hermes-auto</code> also drops a plugin whose <code>pre_llm_call</code> hook injects recall and registers <code>/deja</code>, and a memory provider (<code>deja-memory</code>) that <code>hermes memory setup</code> lists next to mem0 and supermemory — the same recall in the <code>memory.provider</code> slot, with <code>deja_recall</code>, <code>deja_fix</code> and <code>deja_blame</code> as its tools.</li>
 <li><strong>Resume</strong>: Hermes has its own session commands; nothing documented that starts a session from a prompt.</li>

--- a/docs/registry/hermes.md
+++ b/docs/registry/hermes.md
@@ -8,8 +8,11 @@
 
 A flat `messages` table, grouped by `session_id`: `role`, `content`, and `timestamp`
 as REAL epoch seconds. Rows with `role` of `tool` carry no prose and are skipped, as
-are rows with a null `content`. There is no working directory in the schema, so the
-profile name stands in for the project.
+are rows with a null `content`. A `sessions` table beside it carries `id`, `cwd`,
+`git_repo_root` and `title`; the `cwd` is where the work happened and is what names
+the project, the same way a Cline or Roo workspace does. A store without that table,
+or a session whose row has no `cwd`, falls back to the profile name. The title is left
+to the index rather than taken from the first row.
 
 - **MCP**: `mcp_servers` in `~/.hermes/config.yaml`; `deja install hermes-auto` also drops a plugin whose `pre_llm_call` hook injects recall and registers `/deja`, and a memory provider (`deja-memory`) that `hermes memory setup` lists next to mem0 and supermemory — the same recall in the `memory.provider` slot, with `deja_recall`, `deja_fix` and `deja_blame` as its tools.
 - **Resume**: Hermes has its own session commands; nothing documented that starts a session from a prompt.

--- a/internal/sources/hermes.go
+++ b/internal/sources/hermes.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -170,7 +171,57 @@ func parseHermesDBWhere(db, where string) ([]model.Session, error) {
 	if err := cmd.Wait(); err != nil {
 		return nil, err
 	}
+	applyHermesCWD(out, hermesSessionCWD(db))
 	return out, nil
+}
+
+// applyHermesCWD moves each session into the project it was worked in, where
+// the store says. Sessions the table does not name keep the profile.
+func applyHermesCWD(ss []model.Session, cwd map[string]string) {
+	for i := range ss {
+		dir := strings.TrimSpace(cwd[ss[i].ID])
+		if dir == "" {
+			continue
+		}
+		if name := claudeProjectName(pathToProjectKey(dir)); name != "" {
+			ss[i].Project = name
+		}
+	}
+}
+
+// hermesSessionCWD reads where each session was worked, from the `sessions`
+// table Hermes keeps beside `messages`.
+//
+// Every session used to be stamped with the profile directory — "hermes" —
+// because the schema was read as having no working directory. It has one, and
+// the cost of missing it is that the per-prompt hook, which ranks the payload's
+// project, never served a Hermes session to the project it was about: measured
+// on a real store, the same prompt returned 2,006 bytes from ~/hermes and
+// nothing at all from the project the sessions actually name (#3257).
+//
+// Best-effort by design: an older store has no such table, and a Hermes that
+// renames the column should cost the grouping rather than the harness. A failed
+// query gives an empty map and every session keeps the profile.
+func hermesSessionCWD(db string) map[string]string {
+	out, err := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000",
+		"select id, coalesce(cwd,'') as cwd from sessions where cwd is not null and cwd <> ''").Output()
+	if err != nil || len(bytes.TrimSpace(out)) == 0 {
+		return nil
+	}
+	var rows []struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	}
+	if json.Unmarshal(out, &rows) != nil {
+		return nil
+	}
+	m := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if r.ID != "" && r.CWD != "" {
+			m[r.ID] = r.CWD
+		}
+	}
+	return m
 }
 
 // decodeHermesArray reads a json array of {session_id,role,content,timestamp}
@@ -213,9 +264,12 @@ func decodeHermesArray(dec *json.Decoder, project, path string) ([]model.Session
 		if len(s.Messages) == 0 {
 			continue
 		}
-		if s.Title == "" {
-			s.Title = firstLineTrim(s.Messages[0].Text)
-		}
+		// No title from here. Setting one in the parser skipped the index's own
+		// rule: a one- or two-word opener gives way to the next user turn that
+		// can name the session (#790), and the first row is not always the
+		// user's — a store opening with the assistant's greeting was titled by
+		// the greeting (#3241, #3251). Every other parser leaves this empty
+		// unless the harness recorded a title of its own.
 		out = append(out, *s)
 	}
 	return out, nil

--- a/internal/sources/hermes_pg_test.go
+++ b/internal/sources/hermes_pg_test.go
@@ -46,8 +46,9 @@ func TestParseHermesPGReadsRowsLikeSQLite(t *testing.T) {
 	if ss[0].Project != "hermes" || ss[0].Harness != "hermes" {
 		t.Fatalf("project/harness = %q/%q", ss[0].Project, ss[0].Harness)
 	}
-	if ss[0].Title != "switch the pool to transaction mode" {
-		t.Fatalf("title = %q", ss[0].Title)
+	// Same as the SQLite path: the title is the index's to derive.
+	if ss[0].Title != "" {
+		t.Fatalf("the parser titled the session %q", ss[0].Title)
 	}
 }
 

--- a/internal/sources/hermes_project_test.go
+++ b/internal/sources/hermes_project_test.go
@@ -1,0 +1,88 @@
+package sources
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// hermesStoreWithSessions writes a store carrying both tables — the shape a
+// current Hermes writes. The helper beside this one predates the sessions
+// table, and a fixture without it is what let the cwd go unread.
+func hermesStoreWithSessions(t *testing.T, dir, rows string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 is not installed")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := filepath.Join(dir, "state.db")
+	schema := `CREATE TABLE messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT,
+		tool_call_id TEXT, tool_calls TEXT, tool_name TEXT,
+		timestamp REAL NOT NULL, token_count INTEGER, finish_reason TEXT);
+	CREATE TABLE sessions (
+		id TEXT PRIMARY KEY, cwd TEXT, git_repo_root TEXT, title TEXT);` + rows
+	cmd := exec.Command("sqlite3", db)
+	cmd.Stdin = strings.NewReader(schema)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("seed: %v: %s", err, out)
+	}
+	return db
+}
+
+// Every Hermes session was stamped with the profile directory while the store
+// says where the person was working, so the per-prompt hook — which ranks the
+// payload's project — never served a Hermes session to the project it was
+// about (#3257).
+func TestHermesSessionsLandInTheProjectTheyWereWorkedIn(t *testing.T) {
+	db := hermesStoreWithSessions(t, filepath.Join(t.TempDir(), "architect"), `
+INSERT INTO sessions VALUES ('s1','/Users/me/coding/routepilot',NULL,NULL);
+INSERT INTO sessions VALUES ('s2',NULL,NULL,NULL);
+INSERT INTO messages (session_id,role,content,timestamp) VALUES ('s1','user','why does the vantrell import drop configs',1785000000.5);
+INSERT INTO messages (session_id,role,content,timestamp) VALUES ('s1','assistant','the parser skips a null host',1785000001);
+INSERT INTO messages (session_id,role,content,timestamp) VALUES ('s2','user','and the unrelated one',1785000002);
+`)
+	ss, err := ParseHermesDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, s := range ss {
+		got[s.ID] = s.Project
+	}
+	// The same name a Cline or Roo session from that workspace gets — two
+	// segments, so two projects called "api" under different parents stay
+	// apart — which is what makes the hook's project scoping match.
+	want := claudeProjectName(pathToProjectKey("/Users/me/coding/routepilot"))
+	if want == "" || want == "hermes" || want == "architect" {
+		t.Fatalf("the shared naming gave %q, so this test proves nothing", want)
+	}
+	if got["s1"] != want {
+		t.Errorf("s1 project = %q, want %q — the directory it was worked in", got["s1"], want)
+	}
+	// A session the table does not place keeps the profile, which is the only
+	// grouping such a row has.
+	if got["s2"] != "architect" {
+		t.Errorf("s2 project = %q, want the profile name", got["s2"])
+	}
+}
+
+// An older store has no sessions table at all, and that must cost the grouping
+// rather than the harness.
+func TestHermesWithoutASessionsTableStillParses(t *testing.T) {
+	db := writeHermesDB(t, filepath.Join(t.TempDir(), "architect"), `
+INSERT INTO messages (session_id,role,content,timestamp) VALUES ('s1','user','the old store still reads',1785000000);
+`)
+	ss, err := ParseHermesDB(db)
+	if err != nil {
+		t.Fatalf("an older store failed to parse: %v", err)
+	}
+	if len(ss) != 1 || ss[0].Project != "architect" {
+		t.Fatalf("sessions = %#v", ss)
+	}
+}

--- a/internal/sources/hermes_test.go
+++ b/internal/sources/hermes_test.go
@@ -75,8 +75,11 @@ func TestParseHermesDB(t *testing.T) {
 	if first.Project != "architect" {
 		t.Fatalf("project = %q, want the profile name", first.Project)
 	}
-	if first.Title == "" {
-		t.Fatal("title not derived from the first message")
+	// No title from the parser: setting one here skipped the index's own rule,
+	// which prefers the first user line and steps past a one- or two-word
+	// opener (#790, #3241, #3251).
+	if first.Title != "" {
+		t.Fatalf("the parser titled the session %q; that is the index's job", first.Title)
 	}
 }
 


### PR DESCRIPTION
Three Hermes reports, two changes to the parser.

**#3257 — every session was project "hermes".** The store's `sessions` table carries `cwd`, and the parser read `messages` only, so each session was stamped with the profile directory. On a copy of the real store:

```
before  {'hermes': 5}
after   {'goprojects/routepilot': 4, 'hermes': 1}
```

— the same 4-of-6 split the issue names. The project is derived the way Cline and Roo derive theirs from a workspace, so the hook's project scoping matches. Best-effort by design: an older store has no such table and a session whose row carries no `cwd` keeps the profile, both covered by tests.

I could not reproduce the hook's before/after on my stand — the same prompt returned nothing from either directory there, where the issue measured 2,006 bytes from `~/.hermes`. So the grouping is what I am claiming; the hook consequence follows from the scoping the issue diagnosed, not from a number I took.

**#3241, #3251 — the title.** The parser set it from `s.Messages[0]` whatever the role, which both took the assistant's greeting when it came first and skipped the index's own rule: prefer the first user line, and step past a one- or two-word opener to the next turn that can name the session (#790). It sets no title now, like every other parser that has none to carry, and `sessionTitleFrom` does both jobs. The two tests that asserted the old behaviour now assert the new one and say why.

`registry/hermes.md` said "there is no working directory in the schema" — corrected, with the fallback and the titling. Four mutations, all red.

Closes #3257, closes #3251, closes #3241.
