### PR TITLE
fix(continue): a placeholder title or the first line again is no title

### DIFF
--- a/internal/sources/continuedev.go
+++ b/internal/sources/continuedev.go
@@ -156,7 +156,33 @@ func ParseContinueFile(path string) ([]model.Session, error) {
 	if len(s.Messages) == 0 {
 		return nil, nil
 	}
+	if continuePlaceholderTitle(s.Title, s.Messages) {
+		// Continue's own stand-ins and a title that is only the first line
+		// typed are no titles: left empty, the index derives one and looks
+		// past a greeting the way it does for every other harness (#3274).
+		s.Title = ""
+	}
 	return []model.Session{s}, nil
+}
+
+// continuePlaceholderTitle reports whether a title is Continue's placeholder —
+// "New Session" (NEW_SESSION_TITLE) or the CLI's "Untitled Session"
+// (DEFAULT_SESSION_TITLE) — or just the first user line again.
+func continuePlaceholderTitle(title string, ms []model.Message) bool {
+	t := strings.TrimSpace(title)
+	if t == "" {
+		return false
+	}
+	switch strings.ToLower(t) {
+	case "new session", "untitled session":
+		return true
+	}
+	for _, m := range ms {
+		if m.Role == "user" {
+			return strings.EqualFold(t, firstLineTrim(m.Text))
+		}
+	}
+	return false
 }
 
 // continueText reads the two shapes message.content takes: a plain string, or

--- a/internal/sources/continuedev_title_test.go
+++ b/internal/sources/continuedev_title_test.go
@@ -1,0 +1,37 @@
+package sources
+
+import (
+	"testing"
+)
+
+// Continue's placeholders — "New Session" (NEW_SESSION_TITLE) and "Untitled
+// Session" (the CLI's DEFAULT_SESSION_TITLE) — and a title that is only the
+// first user line are no titles: left empty, the index derives one and looks
+// past a greeting (#3274).
+func TestContinuePlaceholderTitleIsLeftToTheIndex(t *testing.T) {
+	for _, tc := range []struct {
+		title, first, want string
+	}{
+		{"New Session", "fix the flaky retry test", ""},
+		{"Untitled Session", "fix the flaky retry test", ""},
+		{"hi", "hi", ""},
+		{"Explaining how ContinueRoot picks its directory", "where does ContinueRoot look", "Explaining how ContinueRoot picks its directory"},
+	} {
+		root := t.TempDir()
+		sid := "8f1c2a3e-0000-4000-8000-000000000000"
+		path := writeContinueStore(t, root, map[string]any{
+			"sessionId": sid, "title": tc.title, "workspaceDirectory": "/w/api",
+			"history": []map[string]any{
+				{"message": map[string]any{"role": "user", "content": tc.first}},
+				{"message": map[string]any{"role": "assistant", "content": "on it"}},
+			},
+		}, nil)
+		ss, err := ParseContinueFile(path)
+		if err != nil || len(ss) != 1 {
+			t.Fatalf("%q: parse: %v, %d sessions", tc.title, err, len(ss))
+		}
+		if ss[0].Title != tc.want {
+			t.Errorf("title %q with first line %q → %q, want %q", tc.title, tc.first, ss[0].Title, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3274.

`ParseContinueFile` clears the title when it is Continue's placeholder (`New Session`, the CLI's `Untitled Session`) or just the first user line again, so `metaForSession` derives one and the greeting rule (#790) runs; a title Continue generated stays.

Fail-before test: `TestContinuePlaceholderTitleIsLeftToTheIndex` (internal/sources), on the collector:

```
continuedev_title_test.go:34: title "Untitled Session" with first line "fix the flaky retry test" → "Untitled Session", want ""
continuedev_title_test.go:34: title "hi" with first line "hi" → "hi", want ""
```

(`New Session` alone did not fail before the change — check the run above if you want to know why; the rule now names both constants explicitly.)

## Review

Reviewer (adversarial, own worktree): "continuedev.go:159 — `continuePlaceholderTitle` clears the two placeholders (case-insensitive) and a title equal to the first user line. The base has no placeholder logic, so the New Session case is a real fix (the test is new). `continueList` is read once and merged before the check; nothing re-titles later. A model title equal to the first line comes back the same from `sessionTitleFrom`, no loss. Goose/Kimi/Cline carry no such placeholder. Titles from sessions.json go through the same check but lack an explicit test. All Continue tests and go vet pass. Verdict: not refuted."
