### PR TITLE
fix(prime): PRIME_AGENT_CODING_AGENT_DIR moves deja with it, and the session variables read in prime's order

### DIFF
--- a/docs/registry/prime.md
+++ b/docs/registry/prime.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **Format** | JSONL transcript |
 | **Default store path** | `~/.prime/agent/sessions/<uuid7>.jsonl` |
-| **Env override** | `DEJA_PRIME_ROOT`, `PRIME_AGENT_SESSION_DIR`, `PRIME_AGENT_CODING_AGENT_SESSION_DIR` |
+| **Env override** | `DEJA_PRIME_ROOT`, `PRIME_AGENT_SESSION_DIR`, `PRIME_AGENT_CODING_AGENT_SESSION_DIR`; `PRIME_AGENT_CODING_AGENT_DIR` moves the whole `~/.prime/agent` directory (settings, extensions, the default session root) for prime and for deja alike |
 | **deja parser** | `internal/sources/prime.go` |
 | **Last verified** | 2026-08-30 |
 

--- a/internal/sources/prime.go
+++ b/internal/sources/prime.go
@@ -28,7 +28,12 @@ import (
 // variables, deja wrote settings.json where prime never looked and called it
 // wired (#3276).
 func PrimeConfigDir() string {
-	return EnvPath("PRIME_AGENT_CODING_AGENT_DIR", filepath.Join(Home(), ".prime", "agent"))
+	// prime expands a leading ~ itself (config.ts expandTildePath); read the
+	// same value the same way.
+	if p := EnvPath("PRIME_AGENT_CODING_AGENT_DIR", ""); p != "" {
+		return expandTilde(p)
+	}
+	return filepath.Join(Home(), ".prime", "agent")
 }
 
 // PrimeRoot returns the session store root.

--- a/internal/sources/prime.go
+++ b/internal/sources/prime.go
@@ -22,8 +22,14 @@ import (
 // shape a live install has. Reported with the paths and the version they were
 // read from (#2529).
 
-// PrimeConfigDir is the prime-agent configuration directory.
-func PrimeConfigDir() string { return filepath.Join(Home(), ".prime", "agent") }
+// PrimeConfigDir is the prime-agent user directory — settings, extensions,
+// skills and the default session root. PRIME_AGENT_CODING_AGENT_DIR moves it
+// (config.ts getAgentDir), and moves it for deja too: read only the session
+// variables, deja wrote settings.json where prime never looked and called it
+// wired (#3276).
+func PrimeConfigDir() string {
+	return EnvPath("PRIME_AGENT_CODING_AGENT_DIR", filepath.Join(Home(), ".prime", "agent"))
+}
 
 // PrimeRoot returns the session store root.
 //
@@ -36,7 +42,10 @@ func PrimeRoot() string {
 	if p := EnvPath("DEJA_PRIME_ROOT", ""); p != "" {
 		return p
 	}
-	for _, name := range []string{"PRIME_AGENT_CODING_AGENT_SESSION_DIR", "PRIME_AGENT_SESSION_DIR"} {
+	// The current name first, the legacy one second — prime's own order
+	// (config.ts: ENV_SESSION_DIR ?? ENV_LEGACY_SESSION_DIR), so the two
+	// agree on the root when both are set (#3277).
+	for _, name := range []string{"PRIME_AGENT_SESSION_DIR", "PRIME_AGENT_CODING_AGENT_SESSION_DIR"} {
 		if p := EnvPath(name, ""); p != "" {
 			return p
 		}

--- a/internal/sources/prime_env_test.go
+++ b/internal/sources/prime_env_test.go
@@ -42,3 +42,16 @@ func TestPrimeSessionDirPrecedenceMatchesPrime(t *testing.T) {
 		t.Errorf("root = %q, want the current variable %q", got, want)
 	}
 }
+
+// A leading ~ is prime's own spelling for the variable (its README shows it);
+// prime expands it, so deja does too.
+func TestPrimeAgentDirExpandsTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_PRIME_ROOT", "")
+	t.Setenv("PRIME_AGENT_CODING_AGENT_DIR", "~/custom/agent")
+	if got, want := PrimeConfigDir(), filepath.Join(home, "custom", "agent"); got != want {
+		t.Errorf("config dir = %q, want %q", got, want)
+	}
+}

--- a/internal/sources/prime_env_test.go
+++ b/internal/sources/prime_env_test.go
@@ -1,0 +1,44 @@
+package sources
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// PRIME_AGENT_CODING_AGENT_DIR moves prime-agent's whole user directory —
+// settings, extensions, skills and the default session root — and prime's own
+// docs name it as the override (config.ts getAgentDir). deja read only the
+// session variables, so on a relocated install it wrote settings.json where
+// prime would not look and called it wired (#3276).
+func TestPrimeAgentDirMovesConfigAndSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_PRIME_ROOT", "")
+	t.Setenv("PRIME_AGENT_SESSION_DIR", "")
+	t.Setenv("PRIME_AGENT_CODING_AGENT_SESSION_DIR", "")
+	moved := filepath.Join(home, "elsewhere", "agent")
+	t.Setenv("PRIME_AGENT_CODING_AGENT_DIR", moved)
+	if got := PrimeConfigDir(); got != moved {
+		t.Errorf("config dir = %q, want %q", got, moved)
+	}
+	if got, want := PrimeRoot(), filepath.Join(moved, "sessions"); got != want {
+		t.Errorf("session root = %q, want %q", got, want)
+	}
+}
+
+// With both session variables set prime reads PRIME_AGENT_SESSION_DIR first and
+// the legacy PRIME_AGENT_CODING_AGENT_SESSION_DIR second (config.ts:628); deja
+// had them the other way round, so the two disagreed on the root (#3277).
+func TestPrimeSessionDirPrecedenceMatchesPrime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("DEJA_PRIME_ROOT", "")
+	t.Setenv("PRIME_AGENT_CODING_AGENT_DIR", "")
+	t.Setenv("PRIME_AGENT_SESSION_DIR", filepath.Join(home, "new"))
+	t.Setenv("PRIME_AGENT_CODING_AGENT_SESSION_DIR", filepath.Join(home, "legacy"))
+	if got, want := PrimeRoot(), filepath.Join(home, "new"); got != want {
+		t.Errorf("root = %q, want the current variable %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #3276, closes #3277.

`PrimeConfigDir` honours `PRIME_AGENT_CODING_AGENT_DIR` (prime's `getAgentDir`), so install, doctor, the extension path and the default session root follow a relocated install; `PrimeRoot` reads `PRIME_AGENT_SESSION_DIR` before the legacy `PRIME_AGENT_CODING_AGENT_SESSION_DIR`, prime's own order. `DEJA_PRIME_ROOT` still wins.

Fail-before tests: `TestPrimeAgentDirMovesConfigAndSessions` and `TestPrimeSessionDirPrecedenceMatchesPrime` (internal/sources), on the collector:

```
prime_env_test.go:26: session root = ".../.prime/agent/sessions", want ".../elsewhere/agent/sessions"
prime_env_test.go:42: root = ".../legacy", want the current variable ".../new"
```

Hermetic `deja install prime-auto` with the variable set: before, the files land in `~/.prime/agent` and the moved directory stays empty; after, settings.json and extensions/deja.ts are written under it.

## Review

Reviewer (adversarial, own worktree): "prime.go:31 MEDIUM: EnvPath does not expand a leading ~ while prime's getAgentDir does, so `PRIME_AGENT_CODING_AGENT_DIR=~/path` diverges. docs/registry/prime.md:7 LOW: the variable is not listed as an override. prime_env_test.go MEDIUM: no tilde case. Verdict: refuted." — all three fixed in the follow-up commit: `expandTilde` on the value (the same helper the Roo reader uses), `TestPrimeAgentDirExpandsTilde`, and the registry row names the variable.

Re-review after the follow-up: "Verdict: not refuted — PrimeConfigDir expands ~ via expandTilde; the registry row names PRIME_AGENT_CODING_AGENT_DIR; TestPrimeAgentDirExpandsTilde covers ~/custom/agent; all Prime tests (11 in sources, 8 in cmd/deja) and go vet pass."
