### PR TITLE
fix(qwen): a tool_result record is indexed as tool output, error included

### DIFF
--- a/internal/sources/qwen.go
+++ b/internal/sources/qwen.go
@@ -53,6 +53,19 @@ func parseQwenFileFromOffset(path string, offset int64) ([]model.Session, error)
 	}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		typ, _ := m["type"].(string)
+		if typ == "tool_result" {
+			// Every tool result is its own record, role user, parts holding
+			// the functionResponse. Skipped with the other types, a failing
+			// command's error never reached search or the fix pairs (#3281).
+			t := parseTimeAny(m["timestamp"])
+			if msg, ok := m["message"].(map[string]any); ok {
+				if recs := qwenWorkRecords(msg["parts"], t); len(recs) > 0 {
+					s.Touch(t)
+					s.Messages = append(s.Messages, recs...)
+				}
+			}
+			return
+		}
 		if typ != "user" && typ != "assistant" {
 			return
 		}
@@ -131,8 +144,14 @@ func qwenWorkRecords(v any, t time.Time) []model.Message {
 		if resp, ok := m["functionResponse"].(map[string]any); ok {
 			r, _ := resp["response"].(map[string]any)
 			out, _ := r["output"].(string)
-			if out = strings.TrimSpace(out); out != "" {
-				results = append(results, out)
+			if out = strings.TrimSpace(out); out == "" {
+				// A failed call answers in `error`, the field the fix pairs
+				// are mined from (#3281).
+				out, _ = r["error"].(string)
+				out = strings.TrimSpace(out)
+			}
+			if out != "" {
+				results = append(results, capParsedMessage(out))
 			}
 		}
 	}

--- a/internal/sources/qwen.go
+++ b/internal/sources/qwen.go
@@ -58,11 +58,11 @@ func parseQwenFileFromOffset(path string, offset int64) ([]model.Session, error)
 			// the functionResponse. Skipped with the other types, a failing
 			// command's error never reached search or the fix pairs (#3281).
 			t := parseTimeAny(m["timestamp"])
+			// Touched like a user or assistant record, output or not: the
+			// session's clock moves with every record it holds.
+			s.Touch(t)
 			if msg, ok := m["message"].(map[string]any); ok {
-				if recs := qwenWorkRecords(msg["parts"], t); len(recs) > 0 {
-					s.Touch(t)
-					s.Messages = append(s.Messages, recs...)
-				}
+				s.Messages = append(s.Messages, qwenWorkRecords(msg["parts"], t)...)
 			}
 			return
 		}

--- a/internal/sources/qwen_tool_result_test.go
+++ b/internal/sources/qwen_tool_result_test.go
@@ -1,0 +1,48 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Qwen Code writes every tool result as a type:"tool_result" record whose
+// functionResponse carries output or error; the reader kept user and
+// assistant records only, so a failing command's error never reached search
+// or the fix pairs (#3281). Shapes from a real 0.20.0 store.
+func TestQwenToolResultIsIndexedAsToolOutput(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_QWEN_ROOT", root)
+	dir := filepath.Join(root, "projects", "-w-app", "chats")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rows := []string{
+		`{"sessionId":"s1","timestamp":"2026-09-08T06:21:00.000Z","type":"user","cwd":"/w/app","message":{"role":"user","parts":[{"text":"build the missing package"}]}}`,
+		`{"sessionId":"s1","timestamp":"2026-09-08T06:21:10.000Z","type":"assistant","cwd":"/w/app","message":{"role":"model","parts":[{"functionCall":{"id":"call_1","name":"run_shell_command","args":{"command":"go build ./missingpkg"}}}]}}`,
+		`{"sessionId":"s1","timestamp":"2026-09-08T06:21:22.504Z","type":"tool_result","cwd":"/w/app","message":{"role":"user","parts":[{"functionResponse":{"id":"call_1","name":"run_shell_command","response":{"error":"Command: go build ./missingpkg\nDirectory: (root)\nOutput: go: go.mod file not found in current directory or any parent directory; see 'go help modules'\nError: (none)\nExit Code: 1"}}}]},"toolCallResult":{"callId":"call_1","status":"error"}}`,
+		`{"sessionId":"s1","timestamp":"2026-09-08T06:21:30.000Z","type":"tool_result","cwd":"/w/app","message":{"role":"user","parts":[{"functionResponse":{"id":"call_2","name":"agent","response":{"output":"Cannot use working_dir: /w is not a git repository."}}}]},"toolCallResult":{"callId":"call_2","status":"success"}}`,
+		`{"sessionId":"s1","timestamp":"2026-09-08T06:21:40.000Z","type":"assistant","cwd":"/w/app","message":{"role":"model","parts":[{"text":"go.mod is missing; I will init the module."}]}}`,
+	}
+	path := filepath.Join(dir, "s1.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseQwenFile(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var toolOut []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleToolOutput {
+			toolOut = append(toolOut, m.Text)
+		}
+		if m.Role == "user" && strings.Contains(m.Text, "go.mod file not found") {
+			t.Errorf("tool output indexed as the user's words: %q", m.Text)
+		}
+	}
+	if len(toolOut) != 2 || !strings.Contains(toolOut[0], "go.mod file not found") || !strings.Contains(toolOut[1], "not a git repository") {
+		t.Fatalf("tool output = %q, want the error and the output of the two results", toolOut)
+	}
+}


### PR DESCRIPTION
Closes #3281.

`parseQwenFileFromOffset` hands a `type: "tool_result"` record's parts to `qwenWorkRecords`, and `qwenWorkRecords` reads `functionResponse.response.error` when `output` is empty — the field a failed call answers in — capped like every other tool output.

Fail-before test: `TestQwenToolResultIsIndexedAsToolOutput` (internal/sources), on the collector:

```
qwen_tool_result_test.go:46: tool output = [], want the error and the output of the two results
```

On the hermetic store the live Qwen 0.20.0 run wrote (8 sessions): 18 → 25 messages; `deja search --role tool "go.mod file not found"` finds the two sessions that hit it (nothing before). `deja fix` for that error still answers nothing on those sessions — they carry no later command that succeeded, which is what a pair needs — so the fix-pair half of #3281 is verified only by the unit test's shape, not end-to-end.

## Review

Reviewer (adversarial, own worktree; 4 real + 8 live sessions, 12 tool_result records — `response` is always an object with `output` or `error`, never both, never a string or array): "qwen.go:63 high: s.Touch(t) is called only when records were produced, unlike user/assistant which touch unconditionally — a tool_result with empty output leaves the session clock behind. Deja's own MCP recall results are now tool output too (no exemption by tool name). Gemini reader untouched. Tests and go vet pass. Verdict: refuted." — fixed in the follow-up commit: the record touches the session before its parts are read.

Re-review after the follow-up: "Verdict: not refuted — the session time now advances for every tool_result record, empty output included, matching user/assistant; tests and go vet pass."
