### PR TITLE
test(amp): the stub deja drains stdin, so the runner's EPIPE cannot fake a silent thread

### DIFF
--- a/cmd/deja/install_amp_threads_test.go
+++ b/cmd/deja/install_amp_threads_test.go
@@ -27,7 +27,11 @@ func TestAmpPluginInjectsTheDigestOncePerThread(t *testing.T) {
 	dir := t.TempDir()
 	stub := filepath.Join(dir, "deja")
 	if err := os.WriteFile(stub, []byte("#!/bin/sh\n"+
-		`case "$1" in hook-context) echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<deja-recall>\nrecent history\n</deja-recall>"},"systemMessage":"deja recalled 1 session"}';; *) cat >/dev/null; echo "";; esac`+"\n"), 0o755); err != nil {
+		// The stub drains stdin on every branch: the plugin hands hook-context a
+		// JSON payload since #3264, and a child that exits without reading it
+		// gives execFileSync EPIPE on the runners, which the plugin swallows
+		// into "nothing" (#3283).
+		`cat >/dev/null; case "$1" in hook-context) echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<deja-recall>\nrecent history\n</deja-recall>"},"systemMessage":"deja recalled 1 session"}';; *) echo "";; esac`+"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	plugin := filepath.Join(dir, "deja.ts")


### PR DESCRIPTION
Closes #3283.

Test-only. The stub reads stdin before answering on every branch; with the plugin now writing a JSON payload to hook-context (#3264), a stub that exited without reading gave execFileSync EPIPE on the ubuntu runner and the thread read as silent (run 34194679298 on #3280).

## Review

Reviewer (adversarial, own worktree): "EPIPE on unread stdin is real Node behaviour for execFileSync with input when the child exits early, seen on Linux runners; the plugin's run() catches it into an empty string; the stub still answers hook-context with the digest and everything else with nothing; 10 of 10 runs pass; go vet clean. Verdict: not refuted."
