### PR TITLE
fix(grok): a tool_call's rawInput is the command and the file it worked on

### DIFF
--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -137,6 +137,7 @@ func parseGrokFileFromOffset(path string, offset int64) ([]model.Session, error)
 		s.Touch(t)
 
 		if role == RoleToolOutput {
+			s.Messages = append(s.Messages, grokWorkRecords(event, t)...)
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
 			return
 		}
@@ -162,8 +163,15 @@ type grokUpdateEvent struct {
 			Content  json.RawMessage `json:"content"`
 			Title    string          `json:"title"`
 			ToolKind string          `json:"kind"`
+			// RawInput is the call's input, the ACP field Grok's own guide
+			// names: the command for run_terminal_command, the file for
+			// read_file and the edit tools (#3285).
+			RawInput json.RawMessage `json:"rawInput"`
 			Meta     struct {
 				PromptIndex *int `json:"promptIndex"`
+				Tool        struct {
+					Name string `json:"name"`
+				} `json:"x.ai/tool"`
 			} `json:"_meta"`
 		} `json:"update"`
 		Meta struct {
@@ -171,6 +179,36 @@ type grokUpdateEvent struct {
 			AgentTimestamp json.Number `json:"agentTimestampMs"`
 		} `json:"_meta"`
 	} `json:"params"`
+}
+
+// grokWorkRecords reads what a tool_call was asked to do off its rawInput:
+// the command for run_terminal_command, the file for the tools that take one.
+// The reader indexed the title and the output and dropped the input, so no
+// Grok session ever yielded a command or a file record (#3285).
+func grokWorkRecords(event grokUpdateEvent, t time.Time) []model.Message {
+	if event.Params.Update.Kind != "tool_call" || len(event.Params.Update.RawInput) == 0 {
+		return nil
+	}
+	var in map[string]any
+	if json.Unmarshal(event.Params.Update.RawInput, &in) != nil {
+		return nil
+	}
+	name := event.Params.Update.Meta.Tool.Name
+	if name == "" {
+		name = strings.TrimSpace(event.Params.Update.Title)
+	}
+	var out []model.Message
+	if name == "run_terminal_command" && IndexCommands() {
+		if cmd, _ := in["command"].(string); strings.TrimSpace(cmd) != "" && worthIndexing(cmd) {
+			out = append(out, model.Message{Role: RoleCommand, Text: "$ " + strings.TrimSpace(cmd), Time: t})
+		}
+	}
+	if IndexToolPaths() {
+		if p, _ := in["target_file"].(string); strings.TrimSpace(p) != "" {
+			out = append(out, model.Message{Role: RoleFiles, Text: strings.TrimSpace(p), Time: t})
+		}
+	}
+	return out
 }
 
 func grokMessageKey(role string, event grokUpdateEvent) string {

--- a/internal/sources/grok_commands_test.go
+++ b/internal/sources/grok_commands_test.go
@@ -1,0 +1,48 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Grok records what a tool ran in the tool_call event's rawInput; the reader
+// kept the title and the output and dropped the input, so no Grok session ever
+// yielded a command or a file record (#3285). Shape from the real store.
+func TestGrokToolCallInputBecomesCommandAndFileRecords(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_GROK_ROOT", root)
+	dir := filepath.Join(root, "sessions", "%2Fw%2Fapp", "01a03432-4d92-7243-ab6c-8cdd1c697738")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rows := []string{
+		`{"timestamp":1787582100,"method":"session/update","params":{"sessionId":"01a03432-4d92-7243-ab6c-8cdd1c697738","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"run the grok tests"}},"_meta":{"promptId":"p1","agentTimestampMs":1787582100000}}}`,
+		`{"timestamp":1787582112,"method":"session/update","params":{"sessionId":"01a03432-4d92-7243-ab6c-8cdd1c697738","update":{"sessionUpdate":"tool_call","toolCallId":"call-1","title":"run_terminal_command","rawInput":{"command":"go test ./internal/sources/ -run Grok"},"_meta":{"x.ai/tool":{"version":1,"name":"run_terminal_command","kind":"run_terminal_command","namespace":"grok_build","label":"Run Terminal Command","read_only":false}}},"_meta":{"promptId":"p1","agentTimestampMs":1787582112336}}}`,
+		`{"timestamp":1787582115,"method":"session/update","params":{"sessionId":"01a03432-4d92-7243-ab6c-8cdd1c697738","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"ok  \tgithub.com/x/y\t0.4s"}}]},"_meta":{"promptId":"p1","agentTimestampMs":1787582115000}}}`,
+		`{"timestamp":1787582120,"method":"session/update","params":{"sessionId":"01a03432-4d92-7243-ab6c-8cdd1c697738","update":{"sessionUpdate":"tool_call","toolCallId":"call-2","title":"read_file","rawInput":{"target_file":"/w/app/internal/sources/grok.go"},"_meta":{"x.ai/tool":{"version":1,"name":"read_file","kind":"read_file","namespace":"grok_build","label":"Read File","read_only":true}}},"_meta":{"promptId":"p1","agentTimestampMs":1787582120000}}}`,
+	}
+	if err := os.WriteFile(filepath.Join(dir, "updates.jsonl"), []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGrokFile(filepath.Join(dir, "updates.jsonl"))
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var cmds, files []string
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case RoleCommand:
+			cmds = append(cmds, m.Text)
+		case RoleFiles:
+			files = append(files, m.Text)
+		}
+	}
+	if len(cmds) != 1 || cmds[0] != "$ go test ./internal/sources/ -run Grok" {
+		t.Errorf("commands = %q, want the run_terminal_command input", cmds)
+	}
+	if len(files) != 1 || !strings.Contains(files[0], "/w/app/internal/sources/grok.go") {
+		t.Errorf("files = %q, want the read_file target", files)
+	}
+}


### PR DESCRIPTION
Closes #3285.

`grokUpdateEvent` decodes `rawInput` and the tool name under `_meta."x.ai/tool"`; `grokWorkRecords` turns a `tool_call` into a command record (`$ <command>` for `run_terminal_command`) and a files record (`target_file` for read_file and the edit tools), behind the existing `IndexCommands` / `IndexToolPaths` switches, emitted before the call's tool output.

Fail-before test: `TestGrokToolCallInputBecomesCommandAndFileRecords` (internal/sources), on the collector:

```
grok_commands_test.go:43: commands = [], want the run_terminal_command input
grok_commands_test.go:46: files = [], want the read_file target
```

On the hermetic copy of the real store (11 sessions): 130 → 143 records; `deja search --role command` goes from "this index holds no command records at all" to the sessions' git and go commands.

## Review

Reviewer (adversarial, own worktree, real store): "grok.go:189 the Kind guard keeps the 37 tool_call_update events from duplicating commands; every tool_call carries _meta.x.ai/tool.name, Title is a safe fallback; all 8 run_terminal_command calls have a command and pass worthIndexing; read_file uses target_file, no edit tools in the store yet (a different key later would be missed — not a present defect). 26/26 Grok tests and go vet pass. Verdict: not refuted."
