### PR TITLE
fix(cursor): the hook's conversation_id is the session, so recall is not repeated every prompt

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -331,6 +331,9 @@ func runHookContextMode(dir string, plain, once bool) error {
 	var input struct {
 		Source    string `json:"source"`
 		SessionID string `json:"session_id"`
+		// Cursor's sessionStart names the conversation conversation_id
+		// (#3287); the once mark and the audit log key on it.
+		ConversationID string `json:"conversation_id"`
 		CWD       string `json:"cwd"`
 		// Cursor leaves cwd empty and names the project here instead.
 		WorkspaceRoots []string `json:"workspace_roots"`
@@ -351,7 +354,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 	// that sent nothing at all (#2161).
 	payload := readHookStdin()
 	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
-	input.SessionID = adoptGrok(input.SessionID, input.grokEnvelope.SessionID)
+	input.SessionID = adoptGrok(adoptGrok(input.SessionID, input.grokEnvelope.SessionID), input.ConversationID)
 	if once {
 		input.Once = true
 	}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -334,7 +334,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 		// Cursor's sessionStart names the conversation conversation_id
 		// (#3287); the once mark and the audit log key on it.
 		ConversationID string `json:"conversation_id"`
-		CWD       string `json:"cwd"`
+		CWD            string `json:"cwd"`
 		// Cursor leaves cwd empty and names the project here instead.
 		WorkspaceRoots []string `json:"workspace_roots"`
 		// Grok spells all of this in camelCase. See hook_grok.go.

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -47,6 +47,10 @@ const dejaVuMaxMessages = 300
 type promptHookInput struct {
 	Prompt    hookPromptText `json:"prompt"`
 	SessionID string         `json:"session_id"`
+	// Cursor names the conversation conversation_id and sends no session_id;
+	// read as no session at all, the cooldown never recorded and the same
+	// block went out on every prompt of the conversation (#3287).
+	ConversationID string `json:"conversation_id"`
 	// CWD is what the harness says the project is. Reading only the
 	// environment meant a host that sends the payload without exporting
 	// CLAUDE_PROJECT_DIR recalled nothing (#759).
@@ -60,7 +64,7 @@ type promptHookInput struct {
 // adopt fills in what grok spells differently, so this prompt's recall is filed
 // under the session that asked for it.
 func (i *promptHookInput) adopt() {
-	i.SessionID = adoptGrok(i.SessionID, i.grokEnvelope.SessionID)
+	i.SessionID = adoptGrok(adoptGrok(i.SessionID, i.grokEnvelope.SessionID), i.ConversationID)
 	i.WorkspaceRoots = adoptGrokRoots(i.WorkspaceRoots, i.WorkspaceRoot)
 }
 

--- a/cmd/deja/hook_prompt_cursor_conversation_test.go
+++ b/cmd/deja/hook_prompt_cursor_conversation_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Cursor's beforeSubmitPrompt names the conversation conversation_id and sends
+// no session_id. Read as no session at all, the cooldown never recorded and
+// the same block went out on every prompt of the conversation (#3287).
+func TestCursorConversationIDIsTheSession(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "one.jsonl"), "repeatterm", []string{
+		`{"type":"user","sessionId":"repeatterm","timestamp":"` + old +
+			`","message":{"role":"user","content":"pgbouncer runs in transaction mode and prepared statements are off"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	ask := func(conversation string) string {
+		t.Helper()
+		var out bytes.Buffer
+		in := strings.NewReader(`{"conversation_id":"` + conversation + `","prompt":"do we need pgbouncer here","workspace_roots":["` + cwd + `"]}`)
+		if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+	if first := ask("conv-x"); !strings.Contains(first, "transaction mode") {
+		t.Fatalf("the first prompt got no memory, so there is nothing to repeat:\n%q", first)
+	}
+	if again := ask("conv-x"); strings.Contains(again, "transaction mode") {
+		t.Errorf("the same conversation was handed the same session again:\n%q", again)
+	}
+}


### PR DESCRIPTION
Closes #3287.

`promptHookInput` and the session-start input read `conversation_id` and adopt it as the session id when `session_id` (and Grok's `sessionId`) is absent — the same adoption Grok's spelling gets. The cooldown, the once mark and the audit log then key on Cursor's conversation.

Fail-before test: `TestCursorConversationIDIsTheSession` (cmd/deja), on the collector: the second prompt of the same conversation is handed the same session again.

Hermetic replay, one indexed session, three `beforeSubmitPrompt` payloads with `conversation_id` X, X, Y: before 722, 722, 722 bytes; after 722, 0, 0.

## Review

Reviewer (adversarial, own worktree): "Cursor's hooks send conversation_id and no session_id (qa-cursor2/item3 evidence); precedence session_id → Grok sessionId → conversation_id is right; generation_id is correctly not read; both prompt and context hooks adopt it; tests and go vet pass. Caveat: toolHookInput has no ConversationID — Cursor wires neither preToolUse nor postToolUse, so out of scope. Verdict: not refuted."
