### PR TITLE
fix(index): version 35, so a store re-reads its sources after the parser fixes

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -122,7 +122,9 @@ import (
 // Kimi's origin.kind (#3235), Roo and Cline's environment block (#3256) and
 // tool results (#3269), Claude's isMeta records (#3267), Qwen's tool results
 // (#3281), Grok's tool input (#3285), Antigravity's edits (#3279), Zed's
-// tool results (#3291). A store
+// tool results (#3291), Gemini's toolCalls (#3293), Roo and legacy Cline's
+// tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
+// (#3301). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -118,7 +118,13 @@ import (
 // check — an index directory that cannot be locked is served without one —
 // gets errCorruptIndex rather than session ids that are wrong without saying
 // so (#492).
-const version = 34
+// 35: the readers changed what they take from seven harnesses on one branch —
+// Kimi's origin.kind (#3235), Roo and Cline's environment block (#3256) and
+// tool results (#3269), Claude's isMeta records (#3267), Qwen's tool results
+// (#3281), Grok's tool input (#3285), Antigravity's edits (#3279). A store
+// built before holds skill bodies as the person's words and none of the new
+// tool output, and nothing re-reads a source without the bump (#3289).
+const version = 35
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -124,7 +124,7 @@ import (
 // (#3281), Grok's tool input (#3285), Antigravity's edits (#3279), Zed's
 // tool results (#3291), Gemini's toolCalls (#3293), Roo and legacy Cline's
 // tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
-// (#3301). A store
+// (#3301), Copilot's injected skills (#3305). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -121,7 +121,8 @@ import (
 // 35: the readers changed what they take from seven harnesses on one branch —
 // Kimi's origin.kind (#3235), Roo and Cline's environment block (#3256) and
 // tool results (#3269), Claude's isMeta records (#3267), Qwen's tool results
-// (#3281), Grok's tool input (#3285), Antigravity's edits (#3279). A store
+// (#3281), Grok's tool input (#3285), Antigravity's edits (#3279), Zed's
+// tool results (#3291). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/index/version_bump_test.go
+++ b/internal/index/version_bump_test.go
@@ -1,0 +1,16 @@
+package index
+
+import "testing"
+
+// Seven parser fixes changed what the readers index (#3289); a store built
+// at the previous version keeps the old rows until it is rebuilt, and the
+// rebuild only happens when the version says so.
+func TestAStoreFromBeforeTheParserFixesIsNotCurrent(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeManifestOnly(dir, Manifest{Version: 34}); err != nil {
+		t.Fatal(err)
+	}
+	if IsCurrentVersion(dir) {
+		t.Fatal("a version-34 store reads as current, so nothing re-reads the sources after the parser fixes")
+	}
+}

--- a/internal/index/version_bump_test.go
+++ b/internal/index/version_bump_test.go
@@ -4,10 +4,11 @@ import "testing"
 
 // Seven parser fixes changed what the readers index (#3289); a store built
 // at the previous version keeps the old rows until it is rebuilt, and the
-// rebuild only happens when the version says so.
+// rebuild only happens when the version says so. A store at 34 with its
+// sessions file present is exactly what an upgrade finds on disk.
 func TestAStoreFromBeforeTheParserFixesIsNotCurrent(t *testing.T) {
 	dir := t.TempDir()
-	if err := writeManifestOnly(dir, Manifest{Version: 34}); err != nil {
+	if err := writeManifest(dir, Manifest{Version: 34}); err != nil {
 		t.Fatal(err)
 	}
 	if IsCurrentVersion(dir) {


### PR DESCRIPTION
Closes #3289.

`version` 34 → 35 with the same shape of note the previous bumps carry (#2905, #2875, #1383); the bucket bytes are unchanged, so `bucketMagic` stays. Fail-before test: `TestAStoreFromBeforeTheParserFixesIsNotCurrent` (internal/index) — a manifest at version 34 read as current on the collector.

Effect for an installed store: the next `deja index` (or hook) rebuilds once and the seven readers' changes reach every session already on disk.

## Review

Reviewer (adversarial, own worktree): "bucketMagic stays — none of the seven fixes changes bucket encoding; FormatDirection detects old/new via the version; doctor's \"written by an older deja\" line, the rebuild notice and the hook's \"index is being rebuilt\" line are already in place; export/import omits the version; no fixture pins 34; the bump follows the 33→34 and 32→33 precedent, full rebuild on first run after upgrade is the historical behaviour; internal/index and cmd/deja pass, go vet clean. Verdict: refuted — the change is clean." — the word is misused; the findings refute nothing, so the bump stands.
