### PR TITLE
fix(zed): what a tool returned is indexed as tool output

### DIFF
--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -416,9 +417,11 @@ func zedMessage(raw json.RawMessage) (role, text string) {
 // measured there: 797 ToolUse blocks against 69 Agent.Text ones, so the parser
 // was indexing the talk and none of the work.
 //
-// Tool results are not here to be indexed: Zed stores the call and not what
-// came back, so a Zed session cannot pair an error with the command that
-// followed it the way `deja fix` does elsewhere.
+// Tool results ride on the same agent message, `tool_results` keyed by the
+// call id — tool_name, is_error, content.Text and output. This comment used
+// to say Zed stores the call and not what came back; a real store held 3059
+// results, 97 of them failed terminal runs, and none reached search or the
+// fix pairs (#3291). They are indexed as tool output like every other reader's.
 //
 // Modern threads only. An agent-1 message carries `segments` rather than a
 // tagged content array, and whether tool calls appear there is not something
@@ -446,12 +449,40 @@ func zedWork(raw json.RawMessage, t time.Time) []model.Message {
 				Input json.RawMessage `json:"input"`
 			} `json:"ToolUse"`
 		} `json:"content"`
+		ToolResults map[string]struct {
+			Content struct {
+				Text string `json:"Text"`
+			} `json:"content"`
+			Output json.RawMessage `json:"output"`
+		} `json:"tool_results"`
 	}
 	if json.Unmarshal(body, &msg) != nil {
 		return nil
 	}
 	var out []model.Message
 	var paths []string
+	if IndexToolOutput() && len(msg.ToolResults) > 0 {
+		// A map, so the order is fixed by the call id rather than by the
+		// decoder: the same thread indexes the same way twice.
+		ids := make([]string, 0, len(msg.ToolResults))
+		for id := range msg.ToolResults {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			r := msg.ToolResults[id]
+			text := strings.TrimSpace(r.Content.Text)
+			if text == "" {
+				var s string
+				if json.Unmarshal(r.Output, &s) == nil {
+					text = strings.TrimSpace(s)
+				}
+			}
+			if text != "" {
+				out = append(out, model.Message{Role: RoleToolOutput, Text: capParsedMessage(text), Time: t})
+			}
+		}
+	}
 	for _, block := range msg.Content {
 		if block.ToolUse == nil {
 			continue

--- a/internal/sources/zed_tool_results_test.go
+++ b/internal/sources/zed_tool_results_test.go
@@ -1,0 +1,32 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Zed keeps what a tool returned on the agent message, tool_results keyed by
+// tool_use_id; the reader took the ToolUse blocks and not the results, and
+// the comment said Zed stores none (#3291). Shape from a real thread.
+func TestZedToolResultsAreIndexedAsToolOutput(t *testing.T) {
+	msg := `{"Agent":{"content":[{"Text":"Running the tests."},{"ToolUse":{"id":"call_1","name":"terminal","input":{"command":"go test ./...","cd":"."}}}],
+	 "tool_results":{"call_1":{"tool_use_id":"call_1","tool_name":"terminal","is_error":false,"content":{"Text":"Command \"go test ./...\" failed with exit code 1.\n\n# app/pkg\npkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL"},"output":"…"},
+	  "call_0":{"tool_use_id":"call_0","tool_name":"list_directory","is_error":true,"content":{"Text":"Path .} not found in project"},"output":"Path .} not found in project"}}}}`
+	at := time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC)
+	var toolOut []string
+	for _, m := range zedWork([]byte(msg), at) {
+		if m.Role == RoleToolOutput {
+			toolOut = append(toolOut, m.Text)
+		}
+	}
+	if len(toolOut) != 2 {
+		t.Fatalf("tool output = %q, want both results", toolOut)
+	}
+	joined := strings.Join(toolOut, "\n")
+	for _, want := range []string{"failed with exit code 1", "undefined: frobnicateWidget", "not found in project"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("tool output lacks %q:\n%s", want, joined)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3291.

`zedWork` decodes the agent message's `tool_results` map (content.Text, else the output string) and emits each as tool output, in call-id order so a thread indexes the same way twice, capped and behind `IndexToolOutput`; the comment that said Zed stores no results is corrected.

Fail-before test: `TestZedToolResultsAreIndexedAsToolOutput` (internal/sources), on the collector:

```
zed_tool_results_test.go:24: tool output = [], want both results
```

On the hermetic copy of the real store (30 threads) the before/after `search --role tool "failed with exit code"` runs are in the ledger's evidence path.

## Review

Reviewer (adversarial, own worktree, 3059 real results): "content is always {Text} (0 Image/list/string variants); output is an object in 1442 cases where the fallback silently fails — no loss, the 3 empty-content cases have empty output too; is_error ignored by design; 3715 → 6771 is exactly +3056 results, one record each, deterministic order; legacy agent-1 threads untouched; test and go vet pass. Verdict: not refuted."
