### PR TITLE
fix(gemini): toolCalls and the functionResponse turn are the work, indexed like Qwen's

### DIFF
--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -94,6 +94,11 @@ type geminiMessage struct {
 	Type      string          `json:"type"`
 	Content   json.RawMessage `json:"content"`
 	Model     string          `json:"model"`
+	// ToolCalls is what the model ran: id, name, args and the result the
+	// tool answered with. The reply also arrives as the next user record,
+	// content [{functionResponse}], which is where the output is read from
+	// so it is indexed once (#3293).
+	ToolCalls json.RawMessage `json:"toolCalls"`
 }
 
 func parseGeminiJSON(path string) ([]model.Session, error) {
@@ -211,17 +216,58 @@ func appendGeminiMessages(s *model.Session, msgs []geminiMessage) {
 		default:
 			continue // info/error/warning noise
 		}
-		text := geminiContentText(m.Content)
-		if text == "" {
-			continue
-		}
 		t, _ := time.Parse(time.RFC3339Nano, m.Timestamp)
 		if t.IsZero() {
 			t = s.Started
 		}
+		// The work rides on the same records as the talk: a gemini record's
+		// toolCalls name the command and the file, a user record made of
+		// functionResponse parts carries what came back. Read as text only,
+		// a Gemini store yielded no command, no tool output and no fix pair
+		// (#3293). Qwen's dialect follows Gemini's tool names, so the same
+		// reader serves both.
+		if work := geminiWorkRecords(m, t); len(work) > 0 {
+			s.Touch(t)
+			s.Messages = append(s.Messages, work...)
+		}
+		text := geminiContentText(m.Content)
+		if text == "" {
+			continue
+		}
 		s.Touch(t)
 		s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: t})
 	}
+}
+
+// geminiWorkRecords turns a record's toolCalls (the calls, without their
+// results) and its functionResponse parts (the results) into work records.
+func geminiWorkRecords(m geminiMessage, t time.Time) []model.Message {
+	var parts []any
+	if len(m.ToolCalls) > 0 {
+		var calls []struct {
+			Name string         `json:"name"`
+			Args map[string]any `json:"args"`
+		}
+		if json.Unmarshal(m.ToolCalls, &calls) == nil {
+			for _, c := range calls {
+				if c.Name != "" && c.Args != nil {
+					parts = append(parts, map[string]any{"functionCall": map[string]any{"name": c.Name, "args": c.Args}})
+				}
+			}
+		}
+	}
+	var blocks []map[string]any
+	if json.Unmarshal(m.Content, &blocks) == nil {
+		for _, p := range blocks {
+			if resp, ok := p["functionResponse"]; ok {
+				parts = append(parts, map[string]any{"functionResponse": resp})
+			}
+		}
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	return qwenWorkRecords(parts, t)
 }
 
 // content is a string or an array of Part objects ({"text": ...} и др.)

--- a/internal/sources/gemini_tools_test.go
+++ b/internal/sources/gemini_tools_test.go
@@ -1,0 +1,50 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Gemini keeps what a tool ran on the gemini record's toolCalls and what came
+// back on the next user record's functionResponse; the reader read neither, so
+// a Gemini store yielded no command, no tool output and no fix pair (#3293).
+// Shapes from a real 2026-07 store.
+func TestGeminiToolCallsBecomeCommandAndToolOutput(t *testing.T) {
+	_, chats := geminiTree(t)
+	lines := `{"sessionId":"sess-tools-1","projectHash":"abc","startTime":"2026-07-20T21:07:00.000Z","lastUpdated":"2026-07-20T21:08:00.000Z","kind":"main"}
+{"id":"u1","timestamp":"2026-07-20T21:07:01.000Z","type":"user","content":[{"text":"run the tests"}]}
+{"id":"g1","timestamp":"2026-07-20T21:07:10.000Z","type":"gemini","content":"","model":"gemini-3","toolCalls":[{"id":"run_shell_command__1","name":"run_shell_command","args":{"command":"go test ./..."},"result":[{"functionResponse":{"id":"run_shell_command__1","name":"run_shell_command","response":{"error":"Command: go test ./...\nExit Code: 1\nOutput: pkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL"}}}]}]}
+{"id":"u2","timestamp":"2026-07-20T21:07:12.000Z","type":"user","content":[{"functionResponse":{"id":"run_shell_command__1","name":"run_shell_command","response":{"error":"Command: go test ./...\nExit Code: 1\nOutput: pkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL"}}}]}
+{"id":"g2","timestamp":"2026-07-20T21:07:20.000Z","type":"gemini","content":"frobnicateWidget was renamed; fixing the call site.","model":"gemini-3"}
+`
+	p := filepath.Join(chats, "session-2026-07-20T21-07-sess-tools-1.jsonl")
+	if err := os.WriteFile(p, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseGeminiFile(p)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var cmds, tool, users []string
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case RoleCommand:
+			cmds = append(cmds, m.Text)
+		case RoleToolOutput:
+			tool = append(tool, m.Text)
+		case "user":
+			users = append(users, m.Text)
+		}
+	}
+	if len(cmds) != 1 || !strings.Contains(cmds[0], "go test ./...") {
+		t.Errorf("commands = %q, want the run_shell_command", cmds)
+	}
+	if len(tool) != 1 || !strings.Contains(tool[0], "undefined: frobnicateWidget") {
+		t.Errorf("tool output = %q, want the failing command's error, once", tool)
+	}
+	if len(users) != 1 || users[0] != "run the tests" {
+		t.Errorf("user turns = %q, want the typed prompt alone", users)
+	}
+}


### PR DESCRIPTION
Closes #3293.

`geminiMessage` decodes `toolCalls`; `geminiWorkRecords` hands the calls (name, args) and the user record's `functionResponse` parts to `qwenWorkRecords` — Qwen's dialect follows Gemini's tool names — so a `run_shell_command` becomes a command record, file tools give files/edits, and the reply turn's output or error becomes tool output, once (the result inside `toolCalls` is not read a second time).

Fail-before test: `TestGeminiToolCallsBecomeCommandAndToolOutput` (internal/sources), on the collector:

```
gemini_tools_test.go:42: commands = [], want the run_shell_command
gemini_tools_test.go:45: tool output = [], want the failing command's error, once
```

On the real store the only tool-bearing session is an `mcp_deja_recall` call whose output is deja's own recall block; it is indexed and then removed by the self-recall strip, so `search --role tool` stays empty there by design — the shell case is covered by the test's shape, not by a real failing command (none on this machine).

## Review

Reviewer (adversarial, own worktree): "run_shell_command with {command} matches qwenDialect; toolCalls is unmarshalled into {Name, Args} so its result field is never read and functionResponse comes from the content only — no double indexing; a toolCalls record inside a $set snapshot takes the same path; on the hermetic real store the mcp_deja_recall output is indexed and the untrusted wrapper is not searchable; tests, go vet and the build pass. Verdict: not refuted."
