### PR TITLE
fix(roo,cline): a task's tool calls are its commands and files

### DIFF
--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -294,6 +294,9 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 				s.Touch(ts)
 				s.Messages = append(s.Messages, tool...)
 			}
+		} else if work := rooWorkRecords(m.Content, ts); len(work) > 0 {
+			s.Touch(ts)
+			s.Messages = append(s.Messages, work...)
 		}
 		text := clineContentText(m.Content)
 		if m.Role == "user" {
@@ -324,6 +327,41 @@ var clineDialect = toolDialect{
 	commandKey:  "commands",
 	editTools:   map[string]bool{"editor": true},
 	oldKey:      "old_text",
+}
+
+// rooDialect is what the Roo Code and the legacy Cline extension call their
+// tools: execute_command with `command`, and `path` on the file tools —
+// read_file, write_to_file, apply_diff, insert_content, search_and_replace,
+// replace_in_file. Neither reader emitted a call as a work record before
+// #3295. The edit span is not read: apply_diff carries a SEARCH/REPLACE
+// block, not an old_string.
+var rooDialect = toolDialect{
+	pathKey: "path",
+	pathTools: map[string]bool{"read_file": true, "write_to_file": true, "apply_diff": true,
+		"insert_content": true, "search_and_replace": true, "replace_in_file": true},
+	shellTool: "execute_command",
+	editTools: map[string]bool{},
+}
+
+// rooWorkRecords is clineWorkRecords for the task files: the command a call
+// ran and the files it named, under the same switches.
+func rooWorkRecords(raw json.RawMessage, ts time.Time) []model.Message {
+	var blocks []any
+	if json.Unmarshal(raw, &blocks) != nil {
+		return nil
+	}
+	var out []model.Message
+	if IndexToolPaths() {
+		if p := toolPathsIn(blocks, rooDialect); p != "" {
+			out = append(out, model.Message{Role: RoleFiles, Text: p, Time: ts})
+		}
+	}
+	if IndexCommands() {
+		for _, cmd := range commandsIn(blocks, rooDialect) {
+			out = append(out, model.Message{Role: RoleCommand, Text: cmd, Time: ts})
+		}
+	}
+	return out
 }
 
 // clineWorkRecords turns the tool blocks of one message into work records.

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -320,6 +320,9 @@ func ParseRooTask(path string) ([]model.Session, error) {
 				s.Touch(ts)
 				s.Messages = append(s.Messages, tool...)
 			}
+		} else if work := rooWorkRecords(m.Content, ts); len(work) > 0 {
+			s.Touch(ts)
+			s.Messages = append(s.Messages, work...)
 		}
 		text := clineContentText(m.Content)
 		if m.Role == "user" {

--- a/internal/sources/roo_work_records_test.go
+++ b/internal/sources/roo_work_records_test.go
@@ -1,0 +1,66 @@
+package sources
+
+import (
+	"github.com/vshulcz/deja-vu/internal/model"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Roo and the legacy Cline extension name their tools execute_command,
+// read_file, write_to_file, apply_diff / replace_in_file; the readers took the
+// assistant's prose and none of the calls, so no command or file record ever
+// came out of them (#3295). Shape from Roo's own Task.ts.
+func writeRooTask(t *testing.T, root string) string {
+	t.Helper()
+	dir := filepath.Join(root, "tasks", "1788845325718")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `[
+	 {"role":"user","content":[{"type":"text","text":"<task>\nrun go test and fix whatever fails\n</task>"}]},
+	 {"role":"assistant","content":[{"type":"text","text":"Running the tests."},{"type":"tool_use","id":"t1","name":"execute_command","input":{"command":"go test ./..."}}]},
+	 {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"Exit code: 1\nOutput:\npkg/parser.go:42:9: undefined: frobnicateWidget\nFAIL"}]},
+	 {"role":"assistant","content":[{"type":"text","text":"Renaming the call."},{"type":"tool_use","id":"t2","name":"read_file","input":{"path":"pkg/parser.go"}}]},
+	 {"role":"assistant","content":[{"type":"tool_use","id":"t3","name":"apply_diff","input":{"path":"pkg/parser.go","diff":"<<<<<<< SEARCH\n\tout := frobnicateWidget(w)\n=======\n\tout := frobnicate(w)\n>>>>>>> REPLACE"}}]}
+	]`
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRooToolCallsBecomeCommandAndFileRecords(t *testing.T) {
+	path := writeRooTask(t, t.TempDir())
+	ss, err := ParseRooTask(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	checkRooWork(t, "roo", ss[0].Messages)
+	ss, err = parseClineLegacyTask(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("legacy parse: %v, %d sessions", err, len(ss))
+	}
+	checkRooWork(t, "cline legacy", ss[0].Messages)
+}
+
+func checkRooWork(t *testing.T, reader string, ms []model.Message) {
+	t.Helper()
+	var cmds, files []string
+	for _, m := range ms {
+		switch m.Role {
+		case RoleCommand:
+			cmds = append(cmds, m.Text)
+		case RoleFiles:
+			files = append(files, m.Text)
+		}
+	}
+	if len(cmds) != 1 || cmds[0] != "$ go test ./..." {
+		t.Errorf("%s: commands = %q, want the execute_command", reader, cmds)
+	}
+	if len(files) == 0 || !strings.Contains(strings.Join(files, "\n"), "pkg/parser.go") {
+		t.Errorf("%s: files = %q, want pkg/parser.go", reader, files)
+	}
+}


### PR DESCRIPTION
Closes #3295.

`rooDialect` (execute_command with `command`; `path` on read_file, write_to_file, apply_diff, insert_content, search_and_replace, replace_in_file) and `rooWorkRecords` give the Roo reader and the legacy Cline reader the command and files records the modern reader already emits, behind the same switches. Edit spans are not read: apply_diff carries a SEARCH/REPLACE block, not an old_string — queued as its own item.

Fail-before test: `TestRooToolCallsBecomeCommandAndFileRecords` (internal/sources), on the collector, both readers:

```
roo_work_records_test.go:46: roo: commands = [], want the execute_command
roo_work_records_test.go:46: roo: files = [], want pkg/parser.go
```

On the hermetic Roo task (Roo's own shape) the before/after `search --role command`, `blame` and `fix` runs are in the ledger's evidence path.

## Review

Reviewer (adversarial, own worktree): "rooDialect: pathKey path, shellTool execute_command; execute_command, read_file and apply_diff verified, the other declared file tools untested but harmless; editTools is an empty non-nil map, so editSpansIn falls to path+old_string, which Roo never has — no accidental edit from apply_diff (diff) or search_and_replace (search/replace); rooWorkRecords and clineTurnToolOutput correct; tests for both readers and go vet green. Verdict: not refuted."
