### PR TITLE
fix(doctor): Continue's session list is a file deja read, not one it missed

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -726,6 +726,20 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printFiles := func(name, path string, present bool, seen []string) {
 		printFilesSkipping(name, path, present, seen, nil)
 	}
+	// printFilesBeside is printFiles for a harness whose store keeps a file
+	// beside the transcripts that deja reads but does not index — Continue's
+	// sessions.json, the list. Counted with the files, it made `doctor`
+	// disagree with `deja sources` by one; counted as unread, it made every
+	// store report a file deja could not read (#3297). So it is neither: the
+	// count is the transcripts, and the note leaves the list alone.
+	printFilesBeside := func(name, path string, present bool, seen []string, beside ...string) {
+		detail := doctorCount(len(seen), "file")
+		placed := append(append([]string{}, seen...), beside...)
+		if unread, _ := unplacedFiles(path, placed, nil); unread > 0 {
+			detail += fmt.Sprintf(", %d not recognised here", unread)
+		}
+		printRow(name, path, present, detail)
+	}
 
 	claudeRoot := sources.ClaudeRoot()
 	printFilesSkipping("claude", claudeRoot, doctorExists(claudeRoot), sources.ClaudeFiles(),
@@ -777,14 +791,8 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
 
 	continueDir := filepath.Join(sources.ContinueRoot(), "sessions")
-	// sessions.json is the list beside the documents: read for titles and
-	// dates, never a transcript. Counted with the files deja placed, or every
-	// Continue store reports one file it could not read (#3297).
-	continueSeen := sources.ContinueSessionFiles()
-	if list := filepath.Join(continueDir, "sessions.json"); doctorExists(list) {
-		continueSeen = append(continueSeen, list)
-	}
-	printFiles("continue", continueDir, doctorExists(continueDir), continueSeen)
+	printFilesBeside("continue", continueDir, doctorExists(continueDir), sources.ContinueSessionFiles(),
+		filepath.Join(continueDir, "sessions.json"))
 
 	piRoot := sources.PiRoot()
 	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -777,7 +777,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
 
 	continueDir := filepath.Join(sources.ContinueRoot(), "sessions")
-	printFiles("continue", continueDir, doctorExists(continueDir), sources.ContinueSessionFiles())
+	// sessions.json is the list beside the documents: read for titles and
+	// dates, never a transcript. Counted with the files deja placed, or every
+	// Continue store reports one file it could not read (#3297).
+	continueSeen := sources.ContinueSessionFiles()
+	if list := filepath.Join(continueDir, "sessions.json"); doctorExists(list) {
+		continueSeen = append(continueSeen, list)
+	}
+	printFiles("continue", continueDir, doctorExists(continueDir), continueSeen)
 
 	piRoot := sources.PiRoot()
 	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())

--- a/cmd/deja/doctor_continue_list_test.go
+++ b/cmd/deja/doctor_continue_list_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Continue keeps sessions.json beside the session documents as their list;
+// the reader reads it for titles and dates and skips it as a transcript on
+// purpose, and doctor counted it as "1 not recognised here" on every Continue
+// store (#3297).
+func TestDoctorDoesNotCallContinuesListUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "continue", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "8f1c2a3e-0000-4000-8000-000000000000"
+	if err := os.WriteFile(filepath.Join(dir, sid+".json"), []byte(`{"sessionId":"`+sid+`","title":"retry loop","workspaceDirectory":"/w/api","history":[{"message":{"role":"user","content":"why does the retry loop drop the last attempt"}}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte(`[{"sessionId":"`+sid+`","title":"retry loop","dateCreated":"2026-08-02T10:00:00.000Z","workspaceDirectory":"/w/api"}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CONTINUE_ROOT", filepath.Join(tmp, "continue"))
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "continue") && strings.Contains(line, "not recognised") {
+			t.Errorf("the list file is counted as a transcript deja failed to read: %q", line)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3297.

The continue row hands `unplacedFiles` the session documents plus `sessions.json` (the list the reader opens for titles and dates), so the note that flags a layout deja could not read no longer flags the one file it reads on purpose. The file count includes the list, which it now says it read.

Fail-before test: `TestDoctorDoesNotCallContinuesListUnrecognised` (cmd/deja), on the collector: `(1 file, 1 not recognised here)`. On the hermetic Continue store the row goes from `(4 files, 1 not recognised here, 4 indexed sessions)` to `(5 files, 4 indexed sessions)`.

Wording question: "5 files, 4 indexed sessions" counts the list as a file; if you would rather keep "4 files", the list can stay out of the count and only out of the unrecognised set.

## Review

Reviewer (adversarial, own worktree): "doctor.go:783 defect: the human `doctor` count (5 files) now differs from `deja doctor --json` and `deja sources` (4), which both use ContinueSessionFiles — exclude the list from the count and add it only to the placed set. countSubagentFiles harmless. Roo's history_item.json, OpenClaw's sessions.json, Codex's history.jsonl are already excluded by their filters. Test and go vet pass. Verdict: refuted." — fixed in the follow-up commit: `printFilesBeside` counts the transcripts alone and hands the list to `unplacedFiles` as placed; the row reads `(4 files, 4 indexed sessions)`, matching `deja sources`.

Re-review after the follow-up: "the first cut made the human doctor count differ from deja sources and doctor --json; printFilesBeside counts only the transcripts while keeping sessions.json out of the unread set — all three commands now report 4 files for Continue on the hermetic store."
