### PR TITLE
fix(opencode): a part flagged synthetic is the harness's, not the person's

### DIFF
--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -99,6 +99,11 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 	q := `select s.id,s.directory,s.time_created,s.time_updated,` +
 		`json_extract(m.data,'$.role') as role,` +
 		`json_extract(p.data,'$.text') as text,` +
+		// The text opencode wrote itself under the user role — "Continue if
+		// you have next steps…", "The following tool was executed by the
+		// user" — carries this flag; 338 of them indexed as the person's words
+		// on one store (#3299).
+		`json_extract(p.data,'$.synthetic') as synthetic,` +
 		`json_extract(p.data,'$.state.input.filePath') as path,` +
 		`json_extract(p.data,'$.state.input.command') as cmd,` +
 		`json_extract(p.data,'$.state.input.patchText') as patch,` +
@@ -196,6 +201,9 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 		}
 		role := str(r["role"])
 		txt := str(r["text"])
+		if opencodeSynthetic(r["synthetic"]) {
+			continue
+		}
 		// A read call carries no text, only the file it opened. Recorded under
 		// the files role so it can answer "which files" without competing in
 		// ordinary search.
@@ -340,6 +348,22 @@ func ParseOpencodeNewest(db string) ([]model.Session, error) {
 		return nil, nil
 	}
 	return ParseOpencodeDBWhere(db, " and s.id='"+sqlEscape(id)+"'", 0)
+}
+
+// opencodeSynthetic reads the part's synthetic flag off the sqlite3 -json row:
+// true comes back as 1, json.Number or bool depending on the shape.
+func opencodeSynthetic(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case float64:
+		return x != 0
+	case json.Number:
+		return x.String() != "0" && x.String() != ""
+	case string:
+		return x == "1" || x == "true"
+	}
+	return false
 }
 
 // partTime prefers the part's own timestamp and falls back to the message's.

--- a/internal/sources/opencode_synthetic_test.go
+++ b/internal/sources/opencode_synthetic_test.go
@@ -1,0 +1,46 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// opencode marks the text it writes under the user role itself with
+// synthetic: true — "Continue if you have next steps…", "The following tool
+// was executed by the user" — and 338 of them indexed as the person's words on
+// a real store (#3299).
+func TestOpencodeSyntheticPartsAreNotThePersons(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	script := `create table session(id text, directory text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('s1','/w','2026-01-02T03:00:00Z','2026-01-03T03:00:00Z');
+insert into message values('m1','s1',1767409200000,'{"role":"user","agent":"build"}');
+insert into part values('p1','m1','{"type":"text","text":"why does the retry loop drop the last attempt","time":{"start":"2026-01-02T03:00:00Z"}}');
+insert into message values('m2','s1',1767409260000,'{"role":"assistant","agent":"build"}');
+insert into part values('p2','m2','{"type":"text","text":"the deadline is reused","time":{"start":"2026-01-02T03:01:00Z"}}');
+insert into message values('m3','s1',1767409320000,'{"role":"user","agent":"build"}');
+insert into part values('p3','m3','{"type":"text","synthetic":true,"text":"Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed.","time":{"start":"2026-01-02T03:02:00Z"}}');
+insert into message values('m4','s1',1767409380000,'{"role":"user","agent":"build"}');
+insert into part values('p4','m4','{"type":"text","synthetic":true,"text":"The following tool was executed by the user","time":{"start":"2026-01-02T03:03:00Z"}}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite setup: %v %s", err, out)
+	}
+	ss, err := ParseOpencodeDB(db)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("len=%d err=%v", len(ss), err)
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	if len(users) != 1 || users[0] != "why does the retry loop drop the last attempt" {
+		t.Errorf("user turns = %q, want the typed prompt alone", users)
+	}
+}


### PR DESCRIPTION
Closes #3299.

The projection reads `$.synthetic` beside `$.text`, and the row loop skips a part that carries it (`opencodeSynthetic` reads the flag whichever shape sqlite3 -json hands back) — the way Kimi's origin.kind and Claude's isMeta are read.

Fail-before test: `TestOpencodeSyntheticPartsAreNotThePersons` (internal/sources), on the collector: three user turns, wanted the typed one alone.

On the hermetic copy of the real store (1470 sessions): 98272 → 97934 records, exactly the 338 flagged parts; `search --role user "Continue if you have next steps"` goes from 21 sessions to none. The `summary: true` assistant messages (330) are left as they are — a separate question, see #3266.

## Review

Reviewer (adversarial, own worktree, real store): "only text parts carry synthetic (338) — no tool, bash, read or apply_patch part does, so nothing the harness ran is lost; sqlite3 -json hands JSON true back as 1 and the json.Number branch reads it, 0/false/null do not skip; the since path uses the same projection and skip; −338 exactly; tests with -race and go vet pass. Verdict: not refuted."
