### PR TITLE
fix(opencode): a subagent run knows the session that spawned it

### DIFF
--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -270,7 +270,45 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 	for _, s := range by {
 		out = append(out, *s)
 	}
+	// A subagent run is its own session with parent_id naming the spawner —
+	// 922 of 1472 on one store; read without it, every child listed as a
+	// person's own session (#3301). Read beside the rows, best effort: a store
+	// from before the column keeps its sessions standalone.
+	if parents := opencodeParents(db); len(parents) > 0 {
+		for i := range out {
+			if p := parents[out[i].ID]; p != "" {
+				out[i].Kind = "subagent"
+				out[i].Parent = p
+			}
+		}
+	}
 	return out, nil
+}
+
+// opencodeParents maps a session id to its parent's, for the sessions that
+// have one. The column arrived with subagents; a query that fails is a store
+// without it, and nothing is stamped.
+func opencodeParents(db string) map[string]string {
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000",
+		`select id, parent_id from session where parent_id is not null and parent_id <> ''`)
+	b, err := cmd.Output()
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+	var rows []struct {
+		ID     string `json:"id"`
+		Parent string `json:"parent_id"`
+	}
+	if json.Unmarshal(b, &rows) != nil {
+		return nil
+	}
+	m := make(map[string]string, len(rows))
+	for _, r := range rows {
+		if r.ID != "" && r.Parent != "" && r.ID != r.Parent {
+			m[r.ID] = r.Parent
+		}
+	}
+	return m
 }
 
 func OpencodeCounts() (sessions, messages int, err error) {

--- a/internal/sources/opencode_parent_test.go
+++ b/internal/sources/opencode_parent_test.go
@@ -1,0 +1,45 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// opencode records a subagent run as its own session with parent_id pointing
+// at the spawner — 922 of 1472 sessions on a real store — and the reader never
+// read the column, so every child listed as a person's own session (#3301).
+func TestOpencodeSubagentSessionKnowsItsParent(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	script := `create table session(id text, parent_id text, directory text, title text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('ses_parent',NULL,'/w','Adversarial analysis','2026-01-02T03:00:00Z','2026-01-03T03:00:00Z');
+insert into session values('ses_child','ses_parent','/w','Review QA screenshots (@general subagent)','2026-01-02T03:10:00Z','2026-01-02T03:20:00Z');
+insert into message values('m1','ses_parent',1767409200000,'{"role":"user","agent":"build"}');
+insert into part values('p1','m1','{"type":"text","text":"review the screenshots","time":{"start":"2026-01-02T03:00:00Z"}}');
+insert into message values('m2','ses_child',1767409800000,'{"role":"user","agent":"general"}');
+insert into part values('p2','m2','{"type":"text","text":"Review QA screenshots in /w/shots and list the defects","time":{"start":"2026-01-02T03:10:00Z"}}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite setup: %v %s", err, out)
+	}
+	ss, err := ParseOpencodeDB(db)
+	if err != nil || len(ss) != 2 {
+		t.Fatalf("len=%d err=%v", len(ss), err)
+	}
+	for _, s := range ss {
+		switch s.ID {
+		case "ses_child":
+			if s.Kind != "subagent" || s.Parent != "ses_parent" {
+				t.Errorf("child kind=%q parent=%q, want subagent / ses_parent", s.Kind, s.Parent)
+			}
+		case "ses_parent":
+			if s.Kind != "" || s.Parent != "" {
+				t.Errorf("parent kind=%q parent=%q, want none", s.Kind, s.Parent)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #3301.

`opencodeParents` reads `select id, parent_id from session` beside the rows (best effort — a store from before the column stamps nothing) and `ParseOpencodeDBWhere` marks each child `Kind: "subagent"`, `Parent: <parent_id>`, the way the Crush reader does with `parent_session_id`.

Fail-before test: `TestOpencodeSubagentSessionKnowsItsParent` (internal/sources), on the collector: `child kind="" parent="", want subagent / ses_parent`.

On the hermetic copy of the real store the before/after `deja last 40 --harness opencode` counts of "(… subagent)" titles listed as sessions of their own are in the ledger's evidence path.

## Review

Reviewer (adversarial, own worktree, real store): "children stay visible in `deja last` (1165 rows — the listing does not fold Kind subagent; Claude uses \"sidechain\", Crush/opencode \"subagent\", a pre-existing inconsistency) and stay searchable; the since path goes through the same function; a locked store leaves sessions unstamped, acceptable; 0 nested and 0 self-parented rows on the store; tests and go vet pass. Verdict: not refuted."
