### PR TITLE
fix(doctor): Copilot's vscode.metadata.json is the IDE's bookkeeping, not a transcript deja missed

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -726,9 +726,10 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printFiles := func(name, path string, present bool, seen []string) {
 		printFilesSkipping(name, path, present, seen, nil)
 	}
-	// printFilesBeside is printFiles for a harness whose store keeps a file
-	// beside the transcripts that deja reads but does not index — Continue's
-	// sessions.json, the list. Counted with the files, it made `doctor`
+	// printFilesBeside is printFiles for a harness whose store keeps files
+	// beside the transcripts that are not transcripts — Continue's
+	// sessions.json (the list, which deja reads), Copilot's vscode.metadata.json
+	// (the IDE's bookkeeping, #3303). Counted with the files, it made `doctor`
 	// disagree with `deja sources` by one; counted as unread, it made every
 	// store report a file deja could not read (#3297). So it is neither: the
 	// count is the transcripts, and the note leaves the list alone.
@@ -802,7 +803,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 		printRow("openclaw", db, doctorFilePresent(db), doctorSQLiteDetail(db, sqlite))
 	}
 	copilotRoot := sources.CopilotRoot()
-	printFiles("copilot", copilotRoot, doctorExists(copilotRoot), sources.CopilotSessionFiles())
+	printFilesBeside("copilot", copilotRoot, doctorExists(copilotRoot), sources.CopilotSessionFiles(), sources.CopilotSidecarFiles()...)
 	chatFiles := len(sources.CopilotChatSessionFiles())
 	chatLoc := "VS Code Copilot Chat"
 	if roots := sources.CopilotChatRoots(); len(roots) > 0 {

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -726,6 +726,20 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printFiles := func(name, path string, present bool, seen []string) {
 		printFilesSkipping(name, path, present, seen, nil)
 	}
+	// printFilesBeside is printFiles for a harness whose store keeps a file
+	// beside the transcripts that deja reads but does not index — Continue's
+	// sessions.json, the list. Counted with the files, it made `doctor`
+	// disagree with `deja sources` by one; counted as unread, it made every
+	// store report a file deja could not read (#3297). So it is neither: the
+	// count is the transcripts, and the note leaves the list alone.
+	printFilesBeside := func(name, path string, present bool, seen []string, beside ...string) {
+		detail := doctorCount(len(seen), "file")
+		placed := append(append([]string{}, seen...), beside...)
+		if unread, _ := unplacedFiles(path, placed, nil); unread > 0 {
+			detail += fmt.Sprintf(", %d not recognised here", unread)
+		}
+		printRow(name, path, present, detail)
+	}
 
 	claudeRoot := sources.ClaudeRoot()
 	printFilesSkipping("claude", claudeRoot, doctorExists(claudeRoot), sources.ClaudeFiles(),
@@ -777,14 +791,8 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
 
 	continueDir := filepath.Join(sources.ContinueRoot(), "sessions")
-	// sessions.json is the list beside the documents: read for titles and
-	// dates, never a transcript. Counted with the files deja placed, or every
-	// Continue store reports one file it could not read (#3297).
-	continueSeen := sources.ContinueSessionFiles()
-	if list := filepath.Join(continueDir, "sessions.json"); doctorExists(list) {
-		continueSeen = append(continueSeen, list)
-	}
-	printFiles("continue", continueDir, doctorExists(continueDir), continueSeen)
+	printFilesBeside("continue", continueDir, doctorExists(continueDir), sources.ContinueSessionFiles(),
+		filepath.Join(continueDir, "sessions.json"))
 
 	piRoot := sources.PiRoot()
 	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -777,7 +777,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printRow("roo", rooLoc, rooFiles > 0, doctorCount(rooFiles, "file"))
 
 	continueDir := filepath.Join(sources.ContinueRoot(), "sessions")
-	printFiles("continue", continueDir, doctorExists(continueDir), sources.ContinueSessionFiles())
+	// sessions.json is the list beside the documents: read for titles and
+	// dates, never a transcript. Counted with the files deja placed, or every
+	// Continue store reports one file it could not read (#3297).
+	continueSeen := sources.ContinueSessionFiles()
+	if list := filepath.Join(continueDir, "sessions.json"); doctorExists(list) {
+		continueSeen = append(continueSeen, list)
+	}
+	printFiles("continue", continueDir, doctorExists(continueDir), continueSeen)
 
 	piRoot := sources.PiRoot()
 	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())

--- a/cmd/deja/doctor_continue_list_test.go
+++ b/cmd/deja/doctor_continue_list_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Continue keeps sessions.json beside the session documents as their list;
+// the reader reads it for titles and dates and skips it as a transcript on
+// purpose, and doctor counted it as "1 not recognised here" on every Continue
+// store (#3297).
+func TestDoctorDoesNotCallContinuesListUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "continue", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sid := "8f1c2a3e-0000-4000-8000-000000000000"
+	if err := os.WriteFile(filepath.Join(dir, sid+".json"), []byte(`{"sessionId":"`+sid+`","title":"retry loop","workspaceDirectory":"/w/api","history":[{"message":{"role":"user","content":"why does the retry loop drop the last attempt"}}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte(`[{"sessionId":"`+sid+`","title":"retry loop","dateCreated":"2026-08-02T10:00:00.000Z","workspaceDirectory":"/w/api"}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CONTINUE_ROOT", filepath.Join(tmp, "continue"))
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "continue") && strings.Contains(line, "not recognised") {
+			t.Errorf("the list file is counted as a transcript deja failed to read: %q", line)
+		}
+	}
+}

--- a/cmd/deja/doctor_copilot_metadata_test.go
+++ b/cmd/deja/doctor_copilot_metadata_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Copilot CLI keeps vscode.metadata.json beside each session's events.jsonl;
+// it is the IDE's bookkeeping, not a transcript, and doctor reported every
+// session as a file it could not read (#3303).
+func TestDoctorDoesNotCallCopilotsMetadataUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "copilot", "session-state", "7dad4ddc-5bc8-4ded-bead-2bcad486028d")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(`{"type":"user.message","data":{"content":"why does the retry loop drop the last attempt"},"timestamp":"2026-08-02T10:00:00.000Z"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vscode.metadata.json"), []byte(`{"workspaceFolder":"/w/api"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_COPILOT_ROOT", filepath.Join(tmp, "copilot", "session-state"))
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "copilot") && strings.Contains(line, "not recognised") {
+			t.Errorf("the IDE's metadata is counted as a transcript deja failed to read: %q", line)
+		}
+	}
+}

--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -21,6 +21,15 @@ func CopilotSessionFiles() []string {
 	})
 }
 
+// CopilotSidecarFiles lists the IDE's bookkeeping beside each session —
+// vscode.metadata.json — which doctor counted as a transcript deja could not
+// read, once per session (#3303).
+func CopilotSidecarFiles() []string {
+	return walkFiles(CopilotRoot(), func(p string) bool {
+		return filepath.Base(p) == "vscode.metadata.json"
+	})
+}
+
 // LoadCopilot loads all Copilot CLI sessions.
 func LoadCopilot() []model.Session { return parseFiles(CopilotSessionFiles(), ParseCopilotFile) }
 


### PR DESCRIPTION
Closes #3303. Stacked on #3298 (printFilesBeside); the diff shrinks to this change once that merges.

`sources.CopilotSidecarFiles` lists the per-session vscode.metadata.json files and the copilot row hands them to `printFilesBeside` as placed, so they are neither counted as transcripts nor called unread.

Fail-before test: `TestDoctorDoesNotCallCopilotsMetadataUnrecognised` (cmd/deja). On the hermetic copy of the real store the row goes from `(15 files, 15 not recognised here, 15 indexed sessions)` to `(15 files, 15 indexed sessions)`.

## Review

Reviewer (adversarial, own worktree, real store): "16 session dirs, 15 with events.jsonl and vscode.metadata.json; all 30 .json/.jsonl files placed, 0 unread; `deja sources` and `doctor --json` both report 15 files; the second walk is acceptable for doctor; tests and go vet pass. Verdict: not refuted."
