### PR TITLE
fix(copilot): a skill Copilot injects is the host's, not the person's words

### DIFF
--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -25,7 +25,6 @@ func CopilotSessionFiles() []string {
 // LoadCopilot loads all Copilot CLI sessions.
 func LoadCopilot() []model.Session { return parseFiles(CopilotSessionFiles(), ParseCopilotFile) }
 
-// ParseCopilotFile parses a single Copilot events.jsonl.
 // copilotSkillContextRe is the wrapper Copilot CLI puts around a skill's body
 // when it injects it as a user.message: the block is the host's, and the
 // whole skill indexed as the person's words (#3305). A person's words beside
@@ -39,6 +38,7 @@ func copilotStripSkillContext(txt string) string {
 	return strings.TrimSpace(copilotSkillContextRe.ReplaceAllString(txt, ""))
 }
 
+// ParseCopilotFile parses a single Copilot events.jsonl.
 func ParseCopilotFile(path string) ([]model.Session, error) {
 	return parseCopilotFileFromOffset(path, 0)
 }

--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -25,6 +26,19 @@ func CopilotSessionFiles() []string {
 func LoadCopilot() []model.Session { return parseFiles(CopilotSessionFiles(), ParseCopilotFile) }
 
 // ParseCopilotFile parses a single Copilot events.jsonl.
+// copilotSkillContextRe is the wrapper Copilot CLI puts around a skill's body
+// when it injects it as a user.message: the block is the host's, and the
+// whole skill indexed as the person's words (#3305). A person's words beside
+// it stay.
+var copilotSkillContextRe = regexp.MustCompile(`(?s)<skill-context\b[^>]*>.*?</skill-context>`)
+
+func copilotStripSkillContext(txt string) string {
+	if !strings.Contains(txt, "<skill-context") {
+		return txt
+	}
+	return strings.TrimSpace(copilotSkillContextRe.ReplaceAllString(txt, ""))
+}
+
 func ParseCopilotFile(path string) ([]model.Session, error) {
 	return parseCopilotFileFromOffset(path, 0)
 }
@@ -79,7 +93,11 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 				role = "assistant"
 			}
 			s.Touch(t)
-			if txt, _ := data["content"].(string); txt != "" {
+			txt, _ := data["content"].(string)
+			if role == "user" {
+				txt = copilotStripSkillContext(txt)
+			}
+			if txt != "" {
 				s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 			}
 		case "tool.execution_start":

--- a/internal/sources/copilot_skill_context_test.go
+++ b/internal/sources/copilot_skill_context_test.go
@@ -1,0 +1,42 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Copilot CLI injects a skill's body as a user.message wrapped in
+// <skill-context>; the reader indexed the whole skill as the person's words
+// (#3305). Shape from a real 1.0.79 store.
+func TestCopilotSkillContextIsNotThePersons(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_COPILOT_ROOT", root)
+	dir := filepath.Join(root, "a553c093-4f69-48ce-8e82-669ece70637d")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rows := []string{
+		`{"type":"session.start","data":{"sessionId":"a553c093-4f69-48ce-8e82-669ece70637d"},"timestamp":"2026-09-08T10:00:00.000Z"}`,
+		`{"type":"user.message","data":{"content":"<skill-context name=\"deja-history\">\nBase directory for this skill: /Users/me/.copilot/skills/deja-history\n\ndeja does not index Copilot history. It is a consumer: use the deja MCP tools to search memory from the other harnesses.\n</skill-context>"},"timestamp":"2026-09-08T10:00:01.000Z"}`,
+		`{"type":"user.message","data":{"content":"<skill-context name=\"deja-history\">\nBase directory for this skill: /Users/me/.copilot/skills/deja-history\n</skill-context>\n\nwhat did we settle about the checkout worker"},"timestamp":"2026-09-08T10:00:02.000Z"}`,
+		`{"type":"assistant.message","data":{"content":"It keeps one connection per worker."},"timestamp":"2026-09-08T10:00:05.000Z"}`,
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(strings.Join(rows, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCopilotFile(filepath.Join(dir, "events.jsonl"))
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	if len(users) != 1 || users[0] != "what did we settle about the checkout worker" {
+		t.Errorf("user turns = %q, want the typed question alone", users)
+	}
+}


### PR DESCRIPTION
Closes #3305.

`copilotStripSkillContext` removes every `<skill-context …>…</skill-context>` block from a user.message before it is indexed; a message that was only the block is skipped, words beside it stay — the same treatment the Cline reader gives `<environment_details>` (#3256).

Fail-before test: `TestCopilotSkillContextIsNotThePersons` (internal/sources), on the collector: two user turns holding the skill body, wanted the typed question alone.

On the hermetic copy of the real store the before/after `search --role user "deja does not index Copilot history"` runs are in the ledger's evidence path.

## Review

Reviewer (adversarial, own worktree, real store): "only properly closed skill-context blocks appear in the real store; multiple blocks strip correctly, an unterminated one is left alone; the theoretical case of a person quoting the tag before a real block would eat the text between, not seen in practice. The incremental offset path shares the switch. `skill-context` is already in harnessBlockTags, so digests classify it once version 35 rebuilds. 32 Copilot tests, go vet and the doc-comment test pass. Verdict: not refuted."
