### PR TITLE
fix(hook-precompact): a compaction forgets the session start and the once mark too

### DIFF
--- a/cmd/deja/hook_precompact_forget_keys_test.go
+++ b/cmd/deja/hook_precompact_forget_keys_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A compaction throws away what the session was shown; the seen list has to
+// forget all of it. The session-start rows (start:<sid>) and the once mark
+// (once:<sid>) outlived the compaction, so the digest the model had just lost
+// was the one deja refused to send again (#3307). Kimi is where it shows most:
+// those two are the only rows it ever writes.
+func TestPrecompactForgetsTheStartRowsAndTheOnceMark(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seen := dir + ".hookseen"
+	lines := []string{
+		"start:sess-1 other-session 2026-09-08T08:13:38Z start:proj",
+		"once:sess-1 once-digest",
+		"sess-1 block-fingerprint",
+		"start:sess-2 other-session 2026-09-08T08:13:39Z start:proj",
+		"once:sess-2 once-digest",
+		"sess-2 someone-elses-block",
+	}
+	if err := os.WriteFile(seen, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	forgetInjected(dir, "sess-1")
+	b, err := os.ReadFile(seen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, gone := range []string{"start:sess-1", "once:sess-1", "sess-1 block-fingerprint"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived the compaction:\n%s", gone, got)
+		}
+	}
+	for _, kept := range []string{"start:sess-2", "once:sess-2", "sess-2 someone-elses-block"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("another session's row %q was dropped:\n%s", kept, got)
+		}
+	}
+}

--- a/cmd/deja/hook_precompact_forget_keys_test.go
+++ b/cmd/deja/hook_precompact_forget_keys_test.go
@@ -48,3 +48,36 @@ func TestPrecompactForgetsTheStartRowsAndTheOnceMark(t *testing.T) {
 		}
 	}
 }
+
+// A session id shaped like one of deja's own key prefixes forgets only its own
+// rows: the prefixed forms would belong to another session (#3307 review).
+func TestPrecompactDoesNotReachAcrossAPrefixedSessionID(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seen := dir + ".hookseen"
+	lines := []string{
+		"once:xyz once-digest",
+		"once:once:xyz block",
+		"xyz block-fingerprint",
+	}
+	if err := os.WriteFile(seen, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	forgetInjected(dir, "once:xyz")
+	b, err := os.ReadFile(seen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if strings.Contains(got, "once:xyz once-digest") {
+		t.Errorf("the id's own row survived:\n%s", got)
+	}
+	for _, kept := range []string{"once:once:xyz block", "xyz block-fingerprint"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("a prefixed id reached across into %q:\n%s", kept, got)
+		}
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -918,12 +918,24 @@ func forgetInjected(dir, sid string) {
 		return
 	}
 	key := hookseenKey(sid)
+	// Every key this session's rows are written under, not just the one the
+	// per-prompt path uses: the session start writes `start:<sid>`
+	// (hook_context.go) and the once gate writes `once:<sid>`. Forgetting the
+	// prompt rows alone left the digest the compaction had just thrown away as
+	// the one thing recall would not send again — on a harness whose only rows
+	// are those two, the next start was silent (#3307).
+	keys := map[string]bool{
+		key:                         true,
+		sessionStartKeyPrefix + key: true,
+		onceDigestKey(key):          true,
+		antigravityDigestKey(key):   true,
+	}
 	var kept []string
 	for _, line := range strings.Split(string(b), "\n") {
 		if line == "" {
 			continue
 		}
-		if parts := strings.Fields(line); len(parts) >= 2 && parts[0] == key {
+		if parts := strings.Fields(line); len(parts) >= 2 && keys[parts[0]] {
 			continue
 		}
 		kept = append(kept, line)

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -903,6 +903,18 @@ func recentlyInjected(dir, sid string, window int) map[string]bool {
 	return out
 }
 
+// hookseenPrefixed reports whether a key already carries one of the prefixes
+// deja writes its own rows under, so a session id shaped like one of them does
+// not reach across into another session's rows.
+func hookseenPrefixed(key string) bool {
+	for _, p := range []string{sessionStartKeyPrefix, "once:", "agy:"} {
+		if strings.HasPrefix(key, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // forgetInjected drops one agent session's entries from the seen list, so
 // recall may send it again what it was already shown. Used when the harness
 // truncates the conversation and the blocks go with it.
@@ -924,11 +936,15 @@ func forgetInjected(dir, sid string) {
 	// prompt rows alone left the digest the compaction had just thrown away as
 	// the one thing recall would not send again — on a harness whose only rows
 	// are those two, the next start was silent (#3307).
-	keys := map[string]bool{
-		key:                         true,
-		sessionStartKeyPrefix + key: true,
-		onceDigestKey(key):          true,
-		antigravityDigestKey(key):   true,
+	keys := map[string]bool{key: true}
+	// Only for an id that is not itself one of those keys. No harness writes a
+	// session id beginning with a prefix deja owns, and if one ever did, the
+	// prefixed forms would be another session's rows rather than this one's —
+	// so the narrow, exact behaviour is what that case gets.
+	if !hookseenPrefixed(key) {
+		keys[sessionStartKeyPrefix+key] = true
+		keys[onceDigestKey(key)] = true
+		keys[antigravityDigestKey(key)] = true
 	}
 	var kept []string
 	for _, line := range strings.Split(string(b), "\n") {


### PR DESCRIPTION
Closes #3307.

`forgetInjected` drops every row keyed to the session, not just the per-prompt one: `<sid>`, `start:<sid>` (the session-start rows), `once:<sid>` (the once mark) and `agy:<sid>` (Antigravity's). Rows another session wrote that merely mention this one as content stay.

Fail-before test: `TestPrecompactForgetsTheStartRowsAndTheOnceMark` (cmd/deja), on the collector: `start:sess-1` and `once:sess-1` survive.

On the real `.hookseen` a live Kimi session left behind (18 lines): before, the precompact hook changes nothing and 10 rows for that session remain; after, the file drops to 10 lines and the only 2 rows still naming the session are another session's rows that were shown it.

## Review

Reviewer (adversarial, own worktree): "hook_prompt.go:931 HIGH: keys built as `start:`+key / `once:`+key collide with rows of a session whose id itself starts with one of those prefixes. hook_antigravity_prompt.go:302 LOW: the second forgetInjected call is now redundant, harmless. The 3- and 4-field project rows still match correctly, so recentlyInjectedInProject survives a precompact. Verdict: refuted." — fixed in the follow-up commit: an id that already carries one of deja's prefixes builds no prefixed keys, so it forgets only its own rows (`TestPrecompactDoesNotReachAcrossAPrefixedSessionID`). The redundant Antigravity call is left as it is: it costs one read and keeps that path's intent visible.

Re-review after the guard: "Verdict: not refuted — hookseenPrefixed prevents the collision; when the id already starts with start:, once: or agy: no prefixed keys are built, so forgetInjected drops only the session's own rows."
