### PR TITLE
fix(doctor): Kimi's state.json is a file deja opens, not one it missed

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -729,7 +729,8 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// printFilesBeside is printFiles for a harness whose store keeps files
 	// beside the transcripts that are not transcripts — Continue's
 	// sessions.json (the list, which deja reads), Copilot's vscode.metadata.json
-	// (the IDE's bookkeeping, #3303). Counted with the files, it made `doctor`
+	// (the IDE's bookkeeping, #3303), Kimi's per-session state.json (the title
+	// and working directory, #3309). Counted with the files, it made `doctor`
 	// disagree with `deja sources` by one; counted as unread, it made every
 	// store report a file deja could not read (#3297). So it is neither: the
 	// count is the transcripts, and the note leaves the list alone.
@@ -768,7 +769,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 	printFiles("qwen", qwenRoot, doctorExists(qwenRoot), sources.QwenSessionFiles())
 
 	kimiRoot := filepath.Join(sources.KimiRoot(), "sessions")
-	printFiles("kimi", kimiRoot, doctorExists(kimiRoot), sources.KimiSessionFiles())
+	printFilesBeside("kimi", kimiRoot, doctorExists(kimiRoot), sources.KimiSessionFiles(), sources.KimiSidecarFiles()...)
 
 	gooseRoot := filepath.Join(sources.GooseRoot(), "sessions")
 	printRow("goose", gooseRoot, doctorExists(gooseRoot) || doctorFilePresent(sources.GooseDB()), doctorGooseDetail(sqlite))

--- a/cmd/deja/doctor_kimi_state_test.go
+++ b/cmd/deja/doctor_kimi_state_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Kimi keeps state.json beside each session's agents/main/wire.jsonl and the
+// reader opens it for the title and the working directory; doctor counted one
+// per session as a file it could not read (#3309).
+func TestDoctorDoesNotCallKimisStateUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "kimi-code")
+	dir := filepath.Join(root, "sessions", "wd_proj_abc", "session_1")
+	if err := os.MkdirAll(filepath.Join(dir, "agents", "main"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agents", "main", "wire.jsonl"),
+		[]byte(`{"role":"user","content":"why does the retry loop drop the last attempt","origin":{"kind":"user"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{"title":"retry loop","workDir":"/w/api"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KIMI_CODE_HOME", root)
+	t.Setenv("DEJA_KIMI_ROOT", root)
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(line, "kimi") && strings.Contains(line, "not recognised") {
+			t.Errorf("the session's own state file is counted as a transcript deja failed to read: %q", line)
+		}
+	}
+}

--- a/internal/sources/kimi.go
+++ b/internal/sources/kimi.go
@@ -35,6 +35,15 @@ func KimiSessionFiles() []string {
 	})
 }
 
+// KimiSidecarFiles lists the per-session state.json the reader opens itself
+// for the title and the working directory. doctor counted one per session as a
+// transcript it could not read (#3309).
+func KimiSidecarFiles() []string {
+	return walkFiles(filepath.Join(KimiRoot(), "sessions"), func(p string) bool {
+		return filepath.Base(p) == "state.json"
+	})
+}
+
 func LoadKimi() []model.Session { return parseFiles(KimiSessionFiles(), ParseKimiFile) }
 
 func ParseKimiFile(path string) ([]model.Session, error) {


### PR DESCRIPTION
Closes #3309. Third of the same shape after #3297 (Continue) and #3303 (Copilot).

`sources.KimiSidecarFiles` lists the per-session state.json files and the kimi row hands them to `printFilesBeside` as placed, so they are neither counted as transcripts nor called unread.

Fail-before test: `TestDoctorDoesNotCallKimisStateUnrecognised` (cmd/deja). On the hermetic copy of the real store the row goes from `(8 files, 8 not recognised here, 7 indexed sessions)` to `(8 files, 7 indexed sessions)`.

## Review

Reviewer (adversarial, own worktree, real store): "Verdict: not refuted — the fix correctly distinguishes Kimi's state.json as a sidecar deja reads for context but does not transcribe, so the false \"not recognised\" count goes."
