### PR TITLE
fix(aider): the banner and a multi-line output block are not the assistant speaking

### DIFF
--- a/internal/sources/aider.go
+++ b/internal/sources/aider.go
@@ -109,6 +109,16 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 	var buf []string
 	inFence := false
 	idx := 0
+	// aider marks its own output with "> " on the first line only: the
+	// --verbose configuration dump and a multi-line commit message continue
+	// unprefixed, and those lines read as the assistant speaking — one of them
+	// went on to title the session (#3311). Two rules cover what aider writes:
+	// nothing before the session's first `#### ` turn is speech (the banner
+	// and the dump come before anyone has asked anything, and the dump has
+	// blank lines inside it), and a line directly under a "> " line is the
+	// rest of that block.
+	afterOutput := false
+	seenUser := false
 
 	flush := func() {
 		if cur == nil || len(buf) == 0 {
@@ -151,6 +161,7 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 			id := aiderSessionID(path, idx)
 			cur = &model.Session{Harness: "aider", ID: id, Project: project, Path: path, Started: ts, Updated: ts}
 			inFence = false
+			afterOutput, seenUser = false, false
 			continue
 		}
 		if cur == nil {
@@ -158,6 +169,7 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		}
 		if strings.HasPrefix(line, "```") {
 			inFence = !inFence
+			afterOutput = false
 			if role == "" {
 				role = "assistant"
 			}
@@ -170,6 +182,8 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		}
 		switch {
 		case strings.HasPrefix(line, "#### "):
+			afterOutput = false
+			seenUser = true
 			t := strings.TrimPrefix(line, "#### ")
 			// aider logs its own commands the same way — `/undo`, `/clear`,
 			// `/add x` — and they are not the person's question; a message
@@ -190,8 +204,15 @@ func ParseAiderFile(path string) ([]model.Session, error) {
 		case strings.HasPrefix(line, "> "), line == ">":
 			// tool/system output: ends any assistant block, not indexed as a message
 			flush()
+			afterOutput = true
 		case strings.TrimSpace(line) == "":
+			afterOutput = false
 			buf = append(buf, "")
+		case afterOutput, !seenUser:
+			// The rest of the output block the "> " line opened, or the
+			// banner and the --verbose dump aider prints before the first
+			// turn.
+			continue
 		default:
 			if role != "assistant" {
 				flush()

--- a/internal/sources/aider_continuation_test.go
+++ b/internal/sources/aider_continuation_test.go
@@ -1,0 +1,58 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// aider prefixes its own output with "> " on the first line only: the
+// --verbose dump and a multi-line commit message continue unprefixed, and the
+// reader took those lines as the assistant speaking (#3311). Shape from a real
+// 0.86.2 history.
+func TestAiderOutputContinuationsAreNotSpeech(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".aider.chat.history.md")
+	body := strings.Join([]string{
+		"",
+		"# aider chat started at 2026-09-08 11:14:39",
+		"",
+		"> Command Line Args:   --verbose --model openai/mock-1",
+		"Config File (/w/.aider.conf.yml):",
+		"  read:              ['/w/.config/deja/aider-context.md']",
+		"Defaults:",
+		"  --map-refresh:     auto",
+		"",
+		"#### why does the query miss the tenant predicate",
+		"",
+		"The join drops it; I will add the predicate.",
+		"",
+		"> Applied edit to query.go",
+		"> Commit 5ee830b add the tenant predicate",
+		"    and keep the join order stable",
+		"",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseAiderFile(path)
+	if err != nil || len(ss) != 1 {
+		t.Fatalf("parse: %v, %d sessions", err, len(ss))
+	}
+	var users, assistants []string
+	for _, m := range ss[0].Messages {
+		switch m.Role {
+		case "user":
+			users = append(users, m.Text)
+		case "assistant":
+			assistants = append(assistants, m.Text)
+		}
+	}
+	if len(users) != 1 || users[0] != "why does the query miss the tenant predicate" {
+		t.Errorf("user turns = %q", users)
+	}
+	if len(assistants) != 1 || assistants[0] != "The join drops it; I will add the predicate." {
+		t.Errorf("assistant turns = %q, want the reply alone — the dump and the commit tail are output", assistants)
+	}
+}


### PR DESCRIPTION
Closes #3311.

Two rules, both from what aider actually writes: nothing before a session's first `#### ` turn is speech (the banner and the `--verbose` dump come before anyone has asked anything, and that dump has blank lines inside it), and a line directly under a `> ` line is the rest of that output block (a long commit message).

Fail-before test: `TestAiderOutputContinuationsAreNotSpeech` (internal/sources), on the collector: the dump and the commit tail come back as assistant turns.

On the real history a live aider 0.86.2 wrote: 7 sessions / 19 messages → 6 / 18, and the session titled `agent: Config File (/private/tmp/qa-aider2/home/.aider.conf.yml): r…` is gone — it held nothing but the dump. The other six keep their titles and their turns.
