### PR TITLE
fix(doctor): name the target that adds the hook, not an install that cannot

### DIFF
--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -120,7 +120,10 @@ func doctorAutoRecall(w io.Writer) {
 		case err != nil:
 			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "missing", reportPath(path), note)
 		case a.marker != "" && !strings.Contains(string(b), a.marker):
-			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — reinstall)\n", a.name, "stale", reportPath(path), a.marker)
+			// "reinstall" was the advice, and for the common way to get here
+			// it cannot work: the MCP install writes this same file, and only
+			// the -auto target writes the hook (#3313). Name that target.
+			fmt.Fprintf(w, "  %-12s %-11s %s  (no %s call — `deja install %s-auto`)\n", a.name, "stale", reportPath(path), a.marker, a.name)
 		default:
 			fmt.Fprintf(w, "  %-12s %-11s %s%s\n", a.name, "wired", reportPath(path), note)
 			// Only the rows that run the binary. aider's file is a digest of

--- a/cmd/deja/doctor_auto_advice_test.go
+++ b/cmd/deja/doctor_auto_advice_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The MCP install writes the same config the hooks live in, so doctor found a
+// file without the hook marker and told the reader to reinstall — which writes
+// the MCP entry again and no hook. The hook comes from the -auto target
+// (#3313).
+func TestDoctorNamesTheAutoTargetForAnMCPOnlyInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	if _, err := installCrushMCP("/usr/local/bin/deja", false); err != nil {
+		t.Fatalf("install crush: %v", err)
+	}
+	var buf bytes.Buffer
+	doctorAutoRecall(&buf)
+	var line string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(l), "crush ") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no crush row:\n%s", buf.String())
+	}
+	if !strings.Contains(line, "deja install crush-auto") {
+		t.Errorf("the row does not name the command that adds the hook: %q", line)
+	}
+	if strings.Contains(line, "reinstall)") {
+		t.Errorf("the row still advises the install that cannot fix it: %q", line)
+	}
+	_ = os.Remove(filepath.Join(home, ".config", "crush", "crush.json"))
+}


### PR DESCRIPTION
Closes #3313.

The row that says a harness's config carries no hook call now names `deja install <name>-auto` instead of "reinstall" — the MCP install writes that same file, so re-running it changes nothing.

Fail-before test: `TestDoctorNamesTheAutoTargetForAnMCPOnlyInstall` (cmd/deja), on the collector: `(no hook-tool call — reinstall)`.

On a hermetic HOME after `deja install crush` and `deja install qwen`:

```
  crush        stale       ~/.config/crush/crush.json  (no hook-tool call — `deja install crush-auto`)
  qwen         stale       ~/.qwen/settings.json  (no hook-prompt call — `deja install qwen-auto`)
```

Wording question: the state is still called `stale`, which reads as "it went bad" where the machine simply never asked for the hooks. If you want a second word for that case (`mcp only`? `not wired`?), say which and I will split the state; the mechanism to tell them apart is there — the file exists and holds deja's MCP entry but no hook marker.
