### PR TITLE
fix(opencode): a session is named by opencode's own title, unless that says less than its first line

### DIFF
--- a/internal/sources/opencode.go
+++ b/internal/sources/opencode.go
@@ -290,6 +290,18 @@ func ParseOpencodeDBWhere(db, where string, limit int) ([]model.Session, error) 
 			}
 		}
 	}
+	// opencode names every session, and for the 922 subagent runs of one real
+	// store that name is the only short thing about them — the first user line
+	// there is the whole brief (#3315). Read beside the rows, not in the main
+	// projection: a store from before the column would fail the whole query
+	// and take the harness with it.
+	if titles := opencodeTitles(db); len(titles) > 0 {
+		for i := range out {
+			if t := titles[out[i].ID]; t != "" {
+				out[i].Title = t
+			}
+		}
+	}
 	return out, nil
 }
 
@@ -402,6 +414,45 @@ func opencodeSynthetic(v any) bool {
 		return x == "1" || x == "true"
 	}
 	return false
+}
+
+// opencodeTitles maps a session id to the name opencode gave it, for the names
+// worth having. A store without the column stamps nothing.
+func opencodeTitles(db string) map[string]string {
+	cmd := exec.Command("sqlite3", "-readonly", "-json", sqliteTarget(db), ".timeout 5000",
+		`select id, title from session where title is not null and title <> ''`)
+	b, err := cmd.Output()
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+	var rows []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	if json.Unmarshal(b, &rows) != nil {
+		return nil
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		t := strings.TrimSpace(r.Title)
+		if r.ID == "" || opencodeThinTitle(t) {
+			continue
+		}
+		out[r.ID] = t
+	}
+	return out
+}
+
+// opencodeThinTitle reports whether opencode's own name for a session says
+// less than its first line would: its "New session - <timestamp>" placeholder
+// (31 of 1472 on a real store), or a name of two words or fewer and short —
+// "done" ×12, "ok", "Greeting" ×11 there, where the first line is the better
+// name. Same shape as Continue's placeholders (#3274).
+func opencodeThinTitle(t string) bool {
+	if strings.HasPrefix(t, "New session - ") || t == "New session" {
+		return true
+	}
+	return len(strings.Fields(t)) <= 2 && len([]rune(t)) <= 12
 }
 
 // partTime prefers the part's own timestamp and falls back to the message's.

--- a/internal/sources/opencode_title_test.go
+++ b/internal/sources/opencode_title_test.go
@@ -1,0 +1,44 @@
+package sources
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// opencode names every session; the reader ignored the column and titled a
+// session by its first user line, which for a subagent run is the whole brief
+// (#3315). A thin name — "done", "ok", "Greeting", 28 of 1472 on a real store —
+// is left to the index, as Continue's placeholders are (#3274).
+func TestOpencodeTakesTheSessionTitleUnlessItIsThin(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	db := filepath.Join(t.TempDir(), "opencode.db")
+	script := `create table session(id text, parent_id text, directory text, title text, time_created any, time_updated any);
+create table message(id text, session_id text, time_created any, data text);
+create table part(id text, message_id text, data text);
+insert into session values('ses_named',NULL,'/w','Review route overlap fix (@code-reviewer subagent)','2026-01-02T03:00:00Z','2026-01-02T03:30:00Z');
+insert into message values('m1','ses_named',1767409200000,'{"role":"user"}');
+insert into part values('p1','m1','{"type":"text","text":"Read-only review of the current uncommitted RoutePilot route overlap change","time":{"start":"2026-01-02T03:00:00Z"}}');
+insert into session values('ses_thin',NULL,'/w','done','2026-01-02T04:00:00Z','2026-01-02T04:30:00Z');
+insert into message values('m2','ses_thin',1767412800000,'{"role":"user"}');
+insert into part values('p2','m2','{"type":"text","text":"render the plots for the report","time":{"start":"2026-01-02T04:00:00Z"}}');`
+	if out, err := exec.Command("sqlite3", db, script).CombinedOutput(); err != nil {
+		t.Fatalf("sqlite setup: %v %s", err, out)
+	}
+	ss, err := ParseOpencodeDB(db)
+	if err != nil || len(ss) != 2 {
+		t.Fatalf("len=%d err=%v", len(ss), err)
+	}
+	got := map[string]string{}
+	for _, s := range ss {
+		got[s.ID] = s.Title
+	}
+	if got["ses_named"] != "Review route overlap fix (@code-reviewer subagent)" {
+		t.Errorf("named session titled %q", got["ses_named"])
+	}
+	if got["ses_thin"] != "" {
+		t.Errorf("a thin name was taken as the title: %q", got["ses_thin"])
+	}
+}


### PR DESCRIPTION
Closes #3315.

`opencodeTitles` reads `select id, title from session` beside the rows (best effort, like the parent query — a store from before the column stamps nothing and the harness keeps working) and stamps the name unless it says less than the first line would: opencode's `New session - <timestamp>` placeholder (31 of 1472 on the real store) or a name of two words or fewer and short (`done` ×12, `Greeting` ×11, `ok` ×3). The same rule Continue's placeholders get (#3274).

Fail-before test: `TestOpencodeTakesTheSessionTitleUnlessItIsThin` (internal/sources), on the collector: the named session comes back with an empty title.

On the hermetic copy of the real store, `deja last 5 --harness opencode`:

```
before: Read-only review of the current uncommitted Widgetd route overlap change
after:  Review route overlap fix (@code-reviewer subagent)
```

and the session opencode named `New session - 2026-07-23T…` keeps `почему не поднимается локальный прокси`.

A first cut put `s.title` in the main projection; two tests caught it — a fixture whose `session` table has no `title` column failed the whole query with "the store schema may have changed", which would take the harness down on an older store. Hence the separate query.

