### PR TITLE
fix(doctor): the OpenClaw row says when a transcript went unread

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -799,7 +799,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 	piRoot := sources.PiRoot()
 	printFiles("pi", piRoot, doctorExists(piRoot), sources.PiSessionFiles())
 	openclawRoot := sources.OpenClawRoot()
-	printRow("openclaw", openclawRoot, doctorExists(openclawRoot), doctorCount(len(sources.OpenClawSessionFiles()), "file"))
+	printFilesBeside("openclaw", openclawRoot, doctorExists(openclawRoot), sources.OpenClawSessionFiles(), sources.OpenClawSidecarFiles()...)
 	for _, db := range sources.OpenClawAgentDBs() {
 		printRow("openclaw", db, doctorFilePresent(db), doctorSQLiteDetail(db, sqlite))
 	}

--- a/cmd/deja/doctor_openclaw_files_test.go
+++ b/cmd/deja/doctor_openclaw_files_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The OpenClaw row printed a count and nothing else, so a transcript deja
+// could not read was invisible there while every other file-listing harness
+// named it (#3317). The store keeps files beside the transcripts that the
+// reader skips on purpose — the per-session trajectory-path.json, the
+// sessions.json list, checkpoint snapshots and the archive of a reset whose
+// live file is still there — and none of those is a failure either.
+func TestDoctorNamesAnUnreadOpenClawTranscriptButNotItsSidecars(t *testing.T) {
+	tmp := hermeticEnv(t)
+	agents := filepath.Join(tmp, "openclaw", "agents")
+	sessions := filepath.Join(agents, "main", "sessions")
+	if err := os.MkdirAll(filepath.Join(sessions, "2026-09"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCLAW_ROOT", agents)
+
+	sid := "4a1b2c3d-0000-4000-8000-000000000001"
+	line := `{"type":"message","role":"user","content":"why does the retry loop drop the last attempt","timestamp":"2026-09-01T10:00:00.000Z"}` + "\n"
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(sessions, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(sid+".jsonl", line)
+	write(sid+".trajectory-path.json", `{"path":"/w/api"}`)
+	write("sessions.json", `[{"id":"`+sid+`"}]`)
+	write(sid+".checkpoint.4a1b2c3d-0000-4000-8000-000000000002.jsonl", line)
+	write(sid+".jsonl.reset.1756713600", line)
+	// A transcript one directory deeper than the reader looks: the file deja
+	// holds nothing from, and the only thing the row has to say.
+	if err := os.WriteFile(filepath.Join(sessions, "2026-09", "moved.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	var row string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "openclaw") && strings.Contains(l, "file") {
+			row = l
+			break
+		}
+	}
+	if row == "" {
+		t.Fatal("no openclaw file row in the report at all")
+	}
+	if !strings.Contains(row, "1 not recognised here") {
+		t.Errorf("row = %q, want it to name the one transcript deja did not read", row)
+	}
+	if strings.Contains(row, "2 not recognised") || strings.Contains(row, "3 not recognised") ||
+		strings.Contains(row, "4 not recognised") || strings.Contains(row, "5 not recognised") {
+		t.Errorf("row = %q, the files the reader skips on purpose are counted as failures", row)
+	}
+}

--- a/internal/sources/openclaw.go
+++ b/internal/sources/openclaw.go
@@ -89,9 +89,10 @@ func OpenClawSessionFiles() []string {
 
 // OpenClawSidecarFiles lists the json and jsonl files an OpenClaw store keeps
 // beside its transcripts that the reader declines on purpose: the per-session
-// trajectory-path.json, the sessions.json list, the checkpoint snapshots and
-// the archive of a reset whose live transcript is still there. doctor counted
-// them as transcripts it could not read, once per session (#3317).
+// trajectory-path.json, the sessions.json list and the checkpoint snapshots.
+// doctor counted them as transcripts it could not read, once per session
+// (#3317). An archive of a reset needs no entry: its name ends in the
+// timestamp or .zst, so the walk never reaches it.
 func OpenClawSidecarFiles() []string {
 	root := OpenClawRoot()
 	return walkFiles(root, func(p string) bool {
@@ -104,8 +105,6 @@ func OpenClawSidecarFiles() []string {
 		case filepath.Base(p) == "sessions.json":
 			return true
 		case openclawCheckpointRE.MatchString(p):
-			return true
-		case openclawArchiveRE.MatchString(p):
 			return true
 		}
 		return false

--- a/internal/sources/openclaw.go
+++ b/internal/sources/openclaw.go
@@ -87,6 +87,31 @@ func OpenClawSessionFiles() []string {
 	return walkFiles(root, func(p string) bool { return openclawTranscript(root, p) })
 }
 
+// OpenClawSidecarFiles lists the json and jsonl files an OpenClaw store keeps
+// beside its transcripts that the reader declines on purpose: the per-session
+// trajectory-path.json, the sessions.json list, the checkpoint snapshots and
+// the archive of a reset whose live transcript is still there. doctor counted
+// them as transcripts it could not read, once per session (#3317).
+func OpenClawSidecarFiles() []string {
+	root := OpenClawRoot()
+	return walkFiles(root, func(p string) bool {
+		if openclawTranscript(root, p) {
+			return false
+		}
+		switch {
+		case strings.HasSuffix(p, ".trajectory-path.json"):
+			return true
+		case filepath.Base(p) == "sessions.json":
+			return true
+		case openclawCheckpointRE.MatchString(p):
+			return true
+		case openclawArchiveRE.MatchString(p):
+			return true
+		}
+		return false
+	})
+}
+
 // LoadOpenClaw loads all OpenClaw sessions.
 func LoadOpenClaw() []model.Session {
 	ss := parseFiles(OpenClawSessionFiles(), ParseOpenClawFile)


### PR DESCRIPTION
Closes #3317.

The OpenClaw row moves from `printRow` to `printFilesBeside`, the same pattern Continue (#3297), Copilot (#3303) and Kimi (#3309) already use. `OpenClawSidecarFiles` lists what the reader declines on purpose so none of it reads as a failure: the per-session `trajectory-path.json`, the `sessions.json` list, the `.checkpoint.<uuid>.jsonl` snapshots and the archive of a reset whose live transcript is still there.

Fail-before test: `TestDoctorNamesAnUnreadOpenClawTranscriptButNotItsSidecars` (cmd/deja), on the collector: `row = "openclaw … (1 file)", want it to name the one transcript deja did not read`.

On a hermetic copy of the real store (13 transcripts, 13 trajectory files, one sessions.json), with one transcript moved a directory deeper:

```
before:  openclaw  found  ~/.openclaw/agents  (13 files)
after:   openclaw  found  ~/.openclaw/agents  (13 files, 1 not recognised here)
control: kimi      found  ~/.kimi-code/sessions  (5 files, 1 not recognised here)
```

The untouched copy of the same store still reports `(13 files)` with no note, so the fourteen sidecars are not counted as failures.
