### PR TITLE
fix(doctor): stop calling Grok's own bookkeeping transcripts deja could not read

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -762,8 +762,11 @@ func doctorHarnesses(w io.Writer, dir string) {
 
 	printRow("antigravity", doctorAntigravityLocation(), len(sources.AntigravityRoots()) > 0, doctorCount(len(sources.AntigravityTranscripts()), "file"))
 
-	grokRoot := sources.GrokRoot()
-	printFiles("grok", grokRoot, doctorExists(grokRoot), sources.GrokSessionFiles())
+	// The store root also holds Grok's settings, credentials and caches, which
+	// are not transcripts and never will be; the sessions directory is what the
+	// count is about (#3319).
+	grokRoot := filepath.Join(sources.GrokRoot(), "sessions")
+	printFilesBeside("grok", grokRoot, doctorExists(grokRoot), sources.GrokSessionFiles(), sources.GrokSidecarFiles()...)
 
 	qwenRoot := filepath.Join(sources.QwenRoot(), "projects")
 	printFiles("qwen", qwenRoot, doctorExists(qwenRoot), sources.QwenSessionFiles())

--- a/cmd/deja/doctor_grok_files_test.go
+++ b/cmd/deja/doctor_grok_files_test.go
@@ -72,3 +72,32 @@ func TestDoctorDoesNotCallGroksOwnFilesUnrecognised(t *testing.T) {
 		}
 	}
 }
+
+// The row and the JSON name the same place. doctorStoreChecks keeps its own
+// path per harness, and leaving grok's at the store root made `doctor --json`
+// say ~/.grok where the row says ~/.grok/sessions — and, on a store deja is
+// not allowed to read, turned "denied" into "missing" (review of #3319).
+func TestDoctorJSONNamesTheSameGrokPathAsTheRow(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "grok")
+	dir := filepath.Join(root, "sessions", "%2Fw%2Fapi", "6f0a1b2c-0000-4000-8000-000000000001")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GROK_ROOT", root)
+	if err := os.WriteFile(filepath.Join(dir, "updates.jsonl"),
+		[]byte(`{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"why does the retry loop drop the last attempt"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "sessions")
+	for _, c := range doctorStoreChecks() {
+		if c.name != "grok" {
+			continue
+		}
+		if len(c.paths) != 1 || c.paths[0] != want {
+			t.Fatalf("grok paths = %v, want %q — the row says that one", c.paths, want)
+		}
+		return
+	}
+	t.Fatal("no grok entry in doctorStoreChecks at all")
+}

--- a/cmd/deja/doctor_grok_files_test.go
+++ b/cmd/deja/doctor_grok_files_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A Grok store keeps nine files of its own beside each transcript and eleven
+// configuration files at the root; doctor counted every one of them as a
+// transcript it could not read — 94 of them on a store with 11 sessions
+// (#3319). The row's job is to say when a transcript went unread, and a number
+// that size says the opposite.
+func TestDoctorDoesNotCallGroksOwnFilesUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "grok")
+	dir := filepath.Join(root, "sessions", "%2Fw%2Fapi", "6f0a1b2c-0000-4000-8000-000000000001")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GROK_ROOT", root)
+
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(dir, "updates.jsonl"),
+		`{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"why does the retry loop drop the last attempt"}}`+"\n")
+	write(filepath.Join(dir, "summary.json"), `{"info":{"id":"6f0a1b2c-0000-4000-8000-000000000001"}}`)
+	for _, name := range []string{
+		"chat_history.jsonl", "events.jsonl", "rewind_points.jsonl", "prompt_context.json",
+		"announcement_state.json", "signals.json", "resources_state.json",
+	} {
+		write(filepath.Join(dir, name), "{}\n")
+	}
+	write(filepath.Join(root, "sessions", "%2Fw%2Fapi", "prompt_history.jsonl"), "{}\n")
+	for _, name := range []string{"settings.json", "user-settings.json", "auth.json", "models_cache.json"} {
+		write(filepath.Join(root, name), "{}")
+	}
+
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	var row string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "grok") && strings.Contains(l, "file") {
+			row = l
+			break
+		}
+	}
+	if row == "" {
+		t.Fatal("no grok file row in the report at all")
+	}
+	if strings.Contains(row, "not recognised") {
+		t.Errorf("row = %q, want no such note — every file beside the transcript is Grok's own", row)
+	}
+
+	// And the note is still there for the thing it exists for: a transcript
+	// under a name the reader does not take.
+	write(filepath.Join(dir, "updates.v2.jsonl"), "{}\n")
+	buf.Reset()
+	doctorHarnesses(&buf, t.TempDir())
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "grok") && strings.Contains(l, "file") {
+			if !strings.Contains(l, "1 not recognised here") {
+				t.Errorf("row = %q, want it to name the one file deja did not read", l)
+			}
+			break
+		}
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -428,7 +428,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		{"gemini", []string{sources.GeminiRoot()}, sources.GeminiChatFiles(), sources.ParseGeminiFile},
 		{"cursor", []string{sources.CursorUserRoot(), sources.CursorCLIRoot()}, cursorFiles, parseDoctorCursor},
 		{"antigravity", sources.AntigravityRoots(), sources.AntigravityTranscripts(), sources.ParseAntigravityFile},
-		{"grok", []string{sources.GrokRoot()}, sources.GrokSessionFiles(), sources.ParseGrokFile},
+		{"grok", []string{filepath.Join(sources.GrokRoot(), "sessions")}, sources.GrokSessionFiles(), sources.ParseGrokFile},
 		{"hermes", []string{sources.HermesHome(), sources.HermesProfilesRoot()}, sources.HermesSessionFiles(), parseDoctorHermes},
 		{"qwen", []string{filepath.Join(sources.QwenRoot(), "projects")}, sources.QwenSessionFiles(), sources.ParseQwenFile},
 		{"kimi", []string{filepath.Join(sources.KimiRoot(), "sessions")}, sources.KimiSessionFiles(), sources.ParseKimiFile},

--- a/cmd/deja/testdata/doctor.json
+++ b/cmd/deja/testdata/doctor.json
@@ -70,7 +70,7 @@
       "name": "grok",
       "state": "missing",
       "paths": [
-        "<tmp>/grok"
+        "<tmp>/grok/sessions"
       ],
       "files": 0,
       "indexed_sessions": 0

--- a/internal/sources/grok.go
+++ b/internal/sources/grok.go
@@ -40,6 +40,22 @@ func GrokSessionFiles() []string {
 	})
 }
 
+// GrokSidecarFiles lists what a Grok store keeps beside its transcripts: the
+// summary the reader opens itself for the metadata, and the bookkeeping the
+// CLI writes per session. doctor counted all of it as transcripts it could not
+// read — 94 of them on a store with 11 sessions (#3319).
+func GrokSidecarFiles() []string {
+	return walkFiles(filepath.Join(GrokRoot(), "sessions"), func(p string) bool {
+		switch filepath.Base(p) {
+		case "summary.json", "chat_history.jsonl", "events.jsonl", "rewind_points.jsonl",
+			"prompt_context.json", "announcement_state.json", "signals.json",
+			"resources_state.json", "prompt_history.jsonl":
+			return true
+		}
+		return false
+	})
+}
+
 func LoadGrok() []model.Session {
 	return parseFiles(GrokSessionFiles(), ParseGrokFile)
 }


### PR DESCRIPTION
Closes #3319.

`GrokSidecarFiles` names what a Grok store keeps beside the transcript — the `summary.json` the reader opens itself plus the per-session bookkeeping (`chat_history.jsonl`, `events.jsonl`, `rewind_points.jsonl`, `prompt_context.json`, `announcement_state.json`, `signals.json`, `resources_state.json`, `prompt_history.jsonl`) — and the row moves to `printFilesBeside`, as Continue (#3297), Copilot (#3303), Kimi (#3309) and OpenClaw (#3317) did.

The count also moves from the whole `~/.grok` to `~/.grok/sessions`: the root holds settings, credentials and caches, which are not transcripts and were eleven of the 94. That changes the location the row prints, the same way Kimi's says `~/.kimi-code/sessions` and Continue's `~/.continue/sessions` — flagging it in case you want the row to keep saying `~/.grok`.

Fail-before test: `TestDoctorDoesNotCallGroksOwnFilesUnrecognised` (cmd/deja), on the collector: `(1 file, 13 not recognised here)`, want no such note. Its second half plants an `updates.v2.jsonl` and requires the note to come back as `1 not recognised here`, so the row still does what it exists for.

Real store, read-only:

```
before:  grok  found  ~/.grok           (11 files, 94 not recognised here, 11 indexed sessions)
after:   grok  found  ~/.grok/sessions  (11 files, 11 indexed sessions)
```
