### PR TITLE
fix(doctor): count what Codex left unread in sessions, not its caches

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -704,13 +704,9 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// — the one thing `doctor` exists to rule out (#701).
 	// printFilesSkipping is printFiles for a harness that declines some of its
 	// own files by a rule, so the two can be told apart in the row.
-	// printFilesUnder is printFilesSkipping for a store whose transcripts live
-	// in one subtree while the row names the store: Codex keeps its plugin
-	// cache, model cache, hooks and credentials beside `sessions`, and walking
-	// the root reported all of it as transcripts deja could not read (#3321).
-	printFilesUnder := func(name, path, walk string, present bool, seen []string, skipped func(string) bool) {
+	printFilesSkipping := func(name, path string, present bool, seen []string, skipped func(string) bool) {
 		detail := doctorCount(len(seen), "file")
-		unread, byRule := unplacedFiles(walk, seen, skipped)
+		unread, byRule := unplacedFiles(path, seen, skipped)
 		if byRule > 0 {
 			// The variable named the way it was read as the cause of the
 			// skip — "skipped (DEJA_INCLUDE_SUBAGENTS=1)" — so somebody who
@@ -726,9 +722,6 @@ func doctorHarnesses(w io.Writer, dir string) {
 			detail += fmt.Sprintf(", %d not recognised here", unread)
 		}
 		printRow(name, path, present, detail)
-	}
-	printFilesSkipping := func(name, path string, present bool, seen []string, skipped func(string) bool) {
-		printFilesUnder(name, path, path, present, seen, skipped)
 	}
 	printFiles := func(name, path string, present bool, seen []string) {
 		printFilesSkipping(name, path, present, seen, nil)
@@ -755,7 +748,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 		func(p string) bool { return !sources.ClaudeFileWanted(p) })
 
 	codexRoot := sources.CodexRoot()
-	printFilesUnder("codex", codexRoot, filepath.Join(codexRoot, "sessions"), doctorExists(codexRoot), sources.CodexFiles(), nil)
+	printFilesBeside("codex", codexRoot, doctorExists(codexRoot), sources.CodexFiles(), sources.CodexSidecarFiles()...)
 
 	ocDB := sources.OpencodeDB()
 	printRow("opencode", ocDB, doctorFilePresent(ocDB), doctorSQLiteDetail(ocDB, sqlite))

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -704,9 +704,13 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// — the one thing `doctor` exists to rule out (#701).
 	// printFilesSkipping is printFiles for a harness that declines some of its
 	// own files by a rule, so the two can be told apart in the row.
-	printFilesSkipping := func(name, path string, present bool, seen []string, skipped func(string) bool) {
+	// printFilesUnder is printFilesSkipping for a store whose transcripts live
+	// in one subtree while the row names the store: Codex keeps its plugin
+	// cache, model cache, hooks and credentials beside `sessions`, and walking
+	// the root reported all of it as transcripts deja could not read (#3321).
+	printFilesUnder := func(name, path, walk string, present bool, seen []string, skipped func(string) bool) {
 		detail := doctorCount(len(seen), "file")
-		unread, byRule := unplacedFiles(path, seen, skipped)
+		unread, byRule := unplacedFiles(walk, seen, skipped)
 		if byRule > 0 {
 			// The variable named the way it was read as the cause of the
 			// skip — "skipped (DEJA_INCLUDE_SUBAGENTS=1)" — so somebody who
@@ -722,6 +726,9 @@ func doctorHarnesses(w io.Writer, dir string) {
 			detail += fmt.Sprintf(", %d not recognised here", unread)
 		}
 		printRow(name, path, present, detail)
+	}
+	printFilesSkipping := func(name, path string, present bool, seen []string, skipped func(string) bool) {
+		printFilesUnder(name, path, path, present, seen, skipped)
 	}
 	printFiles := func(name, path string, present bool, seen []string) {
 		printFilesSkipping(name, path, present, seen, nil)
@@ -748,7 +755,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 		func(p string) bool { return !sources.ClaudeFileWanted(p) })
 
 	codexRoot := sources.CodexRoot()
-	printFiles("codex", codexRoot, doctorExists(codexRoot), sources.CodexFiles())
+	printFilesUnder("codex", codexRoot, filepath.Join(codexRoot, "sessions"), doctorExists(codexRoot), sources.CodexFiles(), nil)
 
 	ocDB := sources.OpencodeDB()
 	printRow("opencode", ocDB, doctorFilePresent(ocDB), doctorSQLiteDetail(ocDB, sqlite))

--- a/cmd/deja/doctor_codex_caches_test.go
+++ b/cmd/deja/doctor_codex_caches_test.go
@@ -67,4 +67,12 @@ func TestDoctorDoesNotCallCodexCachesUnrecognised(t *testing.T) {
 	if got := row(); !strings.Contains(got, "2 not recognised here") {
 		t.Errorf("row = %q, want the stray rollout at the store root counted too", got)
 	}
+	// Neither does the cache swallow a transcript: a .jsonl under it, and a
+	// .json at the root under a name deja does not know, are both files it
+	// cannot account for (review of #3321).
+	write(filepath.Join(root, "plugins", "cache", "openai-templates", "queue.jsonl"), "{}\n")
+	write(filepath.Join(root, "newformat-transcript.json"), "{}")
+	if got := row(); !strings.Contains(got, "4 not recognised here") {
+		t.Errorf("row = %q, want the cache jsonl and the unknown root json counted as well", got)
+	}
 }

--- a/cmd/deja/doctor_codex_caches_test.go
+++ b/cmd/deja/doctor_codex_caches_test.go
@@ -60,4 +60,11 @@ func TestDoctorDoesNotCallCodexCachesUnrecognised(t *testing.T) {
 	if got := row(); !strings.Contains(got, "1 not recognised here") {
 		t.Errorf("row = %q, want it to name the one file in sessions deja did not read", got)
 	}
+	// And a transcript in the wrong place is exactly what the row is for: a
+	// rollout restored to the store root, outside the sessions tree, must not
+	// disappear from the count (review of #3321).
+	write(filepath.Join(root, "rollout-2026-09-07T11-00-00-"+sid+".jsonl"), "{}\n")
+	if got := row(); !strings.Contains(got, "2 not recognised here") {
+		t.Errorf("row = %q, want the stray rollout at the store root counted too", got)
+	}
 }

--- a/cmd/deja/doctor_codex_caches_test.go
+++ b/cmd/deja/doctor_codex_caches_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A Codex store keeps its plugin cache, model cache, hooks and credentials
+// beside the sessions directory; doctor walked the whole root and reported all
+// of it as transcripts it could not read — 29 of them on this machine (#3321).
+func TestDoctorDoesNotCallCodexCachesUnrecognised(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "codex")
+	day := filepath.Join(root, "sessions", "2026", "09", "07")
+	if err := os.MkdirAll(filepath.Join(root, "plugins", "cache", "openai-templates"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(day, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", root)
+
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sid := "2f7c1b90-0000-4000-8000-000000000001"
+	write(filepath.Join(day, "rollout-2026-09-07T10-00-00-"+sid+".jsonl"),
+		`{"type":"session_meta","payload":{"id":"`+sid+`","timestamp":"2026-09-07T10:00:00Z","cwd":"/w/api"}}`+"\n"+
+			`{"type":"event_msg","payload":{"type":"user_message","message":"why does the retry loop drop the last attempt"}}`+"\n")
+	write(filepath.Join(root, "history.jsonl"), `{"session_id":"`+sid+`","text":"why does the retry loop drop the last attempt"}`+"\n")
+	for _, name := range []string{"version.json", "models_cache.json", "hooks.json", "auth.json"} {
+		write(filepath.Join(root, name), "{}")
+	}
+	write(filepath.Join(root, "plugins", "cache", "openai-templates", "manifest.json"), "{}")
+
+	row := func() string {
+		t.Helper()
+		var buf bytes.Buffer
+		doctorHarnesses(&buf, t.TempDir())
+		for _, l := range strings.Split(buf.String(), "\n") {
+			if strings.Contains(l, "codex") && strings.Contains(l, "file") {
+				return l
+			}
+		}
+		t.Fatal("no codex file row in the report at all")
+		return ""
+	}
+	if got := row(); strings.Contains(got, "not recognised") {
+		t.Errorf("row = %q, want no such note — the caches and the credentials are not transcripts", got)
+	}
+	// The note still does what it exists for: a rollout under a name the
+	// reader does not take.
+	write(filepath.Join(day, "rollout.v2.jsonl"), "{}\n")
+	if got := row(); !strings.Contains(got, "1 not recognised here") {
+		t.Errorf("row = %q, want it to name the one file in sessions deja did not read", got)
+	}
+}

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -69,13 +69,23 @@ func CodexSidecarFiles() []string {
 			return false
 		}
 		parts := strings.Split(filepath.ToSlash(rel), "/")
+		// The caches hold json the CLI wrote for itself. A .jsonl under them is
+		// not configuration, and swallowing it would hide a transcript restored
+		// into the wrong place, which is the one thing the row is for (review
+		// of #3321).
 		if len(parts) > 1 && (parts[0] == "plugins" || parts[0] == "cache") {
-			return true
+			return strings.HasSuffix(rel, ".json")
 		}
-		// The store's own settings sit at the root; history.jsonl is read and
-		// is already counted, and a .jsonl the reader does not take is not
-		// configuration.
-		return len(parts) == 1 && strings.HasSuffix(parts[0], ".json")
+		// The store's own settings sit at the root, and they are named rather
+		// than matched by extension: a .json arriving there under a name deja
+		// does not know may be a transcript in a format it cannot read yet.
+		if len(parts) == 1 {
+			switch parts[0] {
+			case "version.json", "models_cache.json", "hooks.json", "auth.json", "config.json":
+				return true
+			}
+		}
+		return false
 	})
 }
 

--- a/internal/sources/codex.go
+++ b/internal/sources/codex.go
@@ -53,6 +53,32 @@ func codexRolloutWanted(p string) bool {
 	return strings.HasSuffix(p, ".jsonl") && strings.Contains(filepath.Base(p), "rollout-")
 }
 
+// CodexSidecarFiles lists what a Codex store keeps beside its transcripts: the
+// plugin and app-server caches, and the configuration and credentials at the
+// root. doctor counted all of it as transcripts it could not read — 29 of them
+// on a store with 35 (#3321). Anything else, a rollout in the wrong place
+// included, stays unaccounted for, which is what the row is for.
+func CodexSidecarFiles() []string {
+	root := CodexRoot()
+	return walkFiles(root, func(p string) bool {
+		if codexRolloutWanted(p) {
+			return false
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return false
+		}
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) > 1 && (parts[0] == "plugins" || parts[0] == "cache") {
+			return true
+		}
+		// The store's own settings sit at the root; history.jsonl is read and
+		// is already counted, and a .jsonl the reader does not take is not
+		// configuration.
+		return len(parts) == 1 && strings.HasSuffix(parts[0], ".json")
+	})
+}
+
 // CodexFiles lists the rollout transcripts (plus history.jsonl when present)
 // without parsing them — a cheap count for diagnostics.
 func CodexFiles() []string {


### PR DESCRIPTION
Closes #3321.

`printFilesUnder` is `printFilesSkipping` with the walked subtree given separately from the path the row names, so Codex's row keeps saying `~/.codex` — `history.jsonl` at the root is one of the files it counts — while the unread number comes from `sessions` alone. Every other caller goes through the old signature unchanged.

Fail-before test: `TestDoctorDoesNotCallCodexCachesUnrecognised` (cmd/deja), on the collector: `(2 files, 5 not recognised here)`, want no such note. Its second half plants `rollout.v2.jsonl` inside the sessions tree and requires `1 not recognised here` to come back.

Real store, read-only:

```
before:  codex  found  ~/.codex  (35 files, 29 not recognised here, 30 indexed sessions)
after:   codex  found  ~/.codex  (35 files, 30 indexed sessions)
```

The 29 were the plugin cache (23), the app-server caches (3), `version.json`, `models_cache.json`, `hooks.json` and `auth.json`.
