### PR TITLE
fix(ctx): the context is what people said, not the host's own turns

### DIFF
--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -55,28 +55,36 @@ var harnessBlockRe = func() *regexp.Regexp {
 	return regexp.MustCompile(`(?is)<(` + strings.Join(alts, "|") + `)(?:\s[^>]*)?>(?:.*?</\s*` + "(?:" + strings.Join(alts, "|") + `)\s*>|.*$)`)
 }()
 
-// closedHarnessBlockRe is harnessBlockRe without the run-to-the-end arm: only
-// a block that is closed. An unclosed tag is not always the host — a person
-// asking "why does <system-reminder> show up in my prompt?" opens one and
-// never closes it, and taking everything after it would take the question
-// (review of #3323).
-var closedHarnessBlockRe = func() *regexp.Regexp {
-	alts := make([]string, 0, len(harnessBlockTags))
+// closedHarnessBlockREs is one regexp per tag: a block that opens and closes
+// with the same name. harnessBlockRe closes on any listed name, which is what
+// a nested Cursor block needs, but on a turn where two different envelopes
+// stand apart it swallowed the sentence between them (review of #3323).
+var closedHarnessBlockREs = func() []*regexp.Regexp {
+	out := make([]*regexp.Regexp, 0, len(harnessBlockTags))
 	for _, t := range harnessBlockTags {
-		alts = append(alts, regexp.QuoteMeta(t))
+		q := regexp.QuoteMeta(t)
+		out = append(out, regexp.MustCompile(`(?is)<`+q+`(?:\s[^>]*)?>.*?</\s*`+q+`\s*>`))
 	}
-	return regexp.MustCompile(`(?is)<(` + strings.Join(alts, "|") + `)(?:\s[^>]*)?>.*?</\s*(?:` + strings.Join(alts, "|") + `)\s*>`)
+	return out
 }()
 
-// StripClosedHarnessBlocks removes the envelopes a harness closed and leaves
-// everything else as it stands. The prompt hook wants the stricter rule — a
-// truncated notification is still not the person — but a surface that prints
-// the turn back must not lose words to a tag somebody typed themselves.
+// StripClosedHarnessBlocks removes the envelopes a harness opened and closed
+// under one name, and leaves everything else as it stands. The prompt hook
+// wants the stricter rule — a truncated notification is still not the person —
+// but a surface that prints the turn back must not lose words to a tag
+// somebody typed themselves.
 func StripClosedHarnessBlocks(text string) string {
 	if !strings.Contains(text, "<") {
 		return strings.TrimSpace(text)
 	}
-	return strings.TrimSpace(closedHarnessBlockRe.ReplaceAllString(text, ""))
+	for _, re := range closedHarnessBlockREs {
+		text = re.ReplaceAllString(text, "")
+	}
+	// What a nested block leaves behind, and Cursor's wrapper around the words
+	// a person typed: the tags go, the words stay.
+	text = orphanCloseRe.ReplaceAllString(text, "")
+	text = userQueryTagRe.ReplaceAllString(text, "")
+	return strings.TrimSpace(text)
 }
 
 // StripHarnessBlocks returns what is left of a prompt once the harness's own

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -68,9 +68,27 @@ var closedHarnessBlockREs = func() []*regexp.Regexp {
 	return out
 }()
 
-// closedUserQueryRe is Cursor's wrapper with both of its tags: the words
-// between them are the person's and stay.
-var closedUserQueryRe = regexp.MustCompile(`(?is)<user_query>(.*?)</user_query>`)
+// unwrapUserQuery removes Cursor's wrapper where both of its tags are there,
+// keeping the words between them. Each close pairs with the nearest open
+// before it: a regexp runs from the first open to the first close, so a turn
+// that opens one and never closes it, and closes a later one, kept the stray
+// tag inside what it handed back (review of #3323). An open with no close is
+// a person naming the tag, and is left where it is.
+func unwrapUserQuery(text string) string {
+	const open, close = "<user_query>", "</user_query>"
+	for {
+		end := strings.Index(text, close)
+		if end < 0 {
+			return text
+		}
+		start := strings.LastIndex(text[:end], open)
+		if start < 0 {
+			// A close with nothing open before it: the orphan rule owns that.
+			return text
+		}
+		text = text[:start] + text[start+len(open):end] + text[end+len(close):]
+	}
+}
 
 // StripClosedHarnessBlocks removes the envelopes a harness opened and closed
 // under one name, and leaves everything else as it stands. The prompt hook
@@ -90,7 +108,7 @@ func StripClosedHarnessBlocks(text string) string {
 	// naming the tag, and taking it out of their prose mangles the sentence
 	// (review of #3323).
 	text = orphanCloseRe.ReplaceAllString(text, "")
-	text = closedUserQueryRe.ReplaceAllString(text, "$1")
+	text = unwrapUserQuery(text)
 	return strings.TrimSpace(text)
 }
 

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -68,6 +68,10 @@ var closedHarnessBlockREs = func() []*regexp.Regexp {
 	return out
 }()
 
+// closedUserQueryRe is Cursor's wrapper with both of its tags: the words
+// between them are the person's and stay.
+var closedUserQueryRe = regexp.MustCompile(`(?is)<user_query>(.*?)</user_query>`)
+
 // StripClosedHarnessBlocks removes the envelopes a harness opened and closed
 // under one name, and leaves everything else as it stands. The prompt hook
 // wants the stricter rule — a truncated notification is still not the person —
@@ -81,9 +85,12 @@ func StripClosedHarnessBlocks(text string) string {
 		text = re.ReplaceAllString(text, "")
 	}
 	// What a nested block leaves behind, and Cursor's wrapper around the words
-	// a person typed: the tags go, the words stay.
+	// a person typed: the tags go, the words stay. The wrapper is unwrapped as
+	// a pair — a lone `<user_query>` in a sentence about Cursor is someone
+	// naming the tag, and taking it out of their prose mangles the sentence
+	// (review of #3323).
 	text = orphanCloseRe.ReplaceAllString(text, "")
-	text = userQueryTagRe.ReplaceAllString(text, "")
+	text = closedUserQueryRe.ReplaceAllString(text, "$1")
 	return strings.TrimSpace(text)
 }
 

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -55,6 +55,30 @@ var harnessBlockRe = func() *regexp.Regexp {
 	return regexp.MustCompile(`(?is)<(` + strings.Join(alts, "|") + `)(?:\s[^>]*)?>(?:.*?</\s*` + "(?:" + strings.Join(alts, "|") + `)\s*>|.*$)`)
 }()
 
+// closedHarnessBlockRe is harnessBlockRe without the run-to-the-end arm: only
+// a block that is closed. An unclosed tag is not always the host — a person
+// asking "why does <system-reminder> show up in my prompt?" opens one and
+// never closes it, and taking everything after it would take the question
+// (review of #3323).
+var closedHarnessBlockRe = func() *regexp.Regexp {
+	alts := make([]string, 0, len(harnessBlockTags))
+	for _, t := range harnessBlockTags {
+		alts = append(alts, regexp.QuoteMeta(t))
+	}
+	return regexp.MustCompile(`(?is)<(` + strings.Join(alts, "|") + `)(?:\s[^>]*)?>.*?</\s*(?:` + strings.Join(alts, "|") + `)\s*>`)
+}()
+
+// StripClosedHarnessBlocks removes the envelopes a harness closed and leaves
+// everything else as it stands. The prompt hook wants the stricter rule — a
+// truncated notification is still not the person — but a surface that prints
+// the turn back must not lose words to a tag somebody typed themselves.
+func StripClosedHarnessBlocks(text string) string {
+	if !strings.Contains(text, "<") {
+		return strings.TrimSpace(text)
+	}
+	return strings.TrimSpace(closedHarnessBlockRe.ReplaceAllString(text, ""))
+}
+
 // StripHarnessBlocks returns what is left of a prompt once the harness's own
 // envelopes are removed: the person's words, or "" when the turn was the host
 // alone. A task notification delivered as a user turn once made the prompt

--- a/internal/search/context_envelope_test.go
+++ b/internal/search/context_envelope_test.go
@@ -83,3 +83,27 @@ func TestContextKeepsTheQuestionUnderAnUnclosedTag(t *testing.T) {
 		t.Errorf("a question that names a tag lost its words:\n%s", got)
 	}
 }
+
+// Two different envelopes standing apart are two blocks, not one: the words
+// between them are a person's. And what a nested block leaves behind — an
+// orphan closing tag, Cursor's wrapper — does not reach the agent reading the
+// context (second review of #3323).
+func TestContextKeepsWordsBetweenTwoEnvelopes(t *testing.T) {
+	s := model.Session{Harness: "claude", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "<meta>\nsome session meta\n</meta>\nI wanted to also ask: why did the deploy fail last night?\n<deja-recall>\nan old block\n</deja-recall>"},
+		{Role: "user", Text: "<additional_data>\nsome file dump\n<attached_files>\nfile1.go\n</attached_files>\n</additional_data>\nplease review the retry loop off-by-one"},
+		{Role: "user", Text: "<user_query>\nwhy is the retry loop dropping the last attempt\n</user_query>"},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "deploy")
+	got := b.String()
+	if !strings.Contains(got, "why did the deploy fail last night?") {
+		t.Errorf("the sentence between two envelopes was eaten:\n%s", got)
+	}
+	if strings.Contains(got, "</additional_data>") || strings.Contains(got, "<user_query>") {
+		t.Errorf("a bare tag reached the context:\n%s", got)
+	}
+	if !strings.Contains(got, "why is the retry loop dropping the last attempt") {
+		t.Errorf("the words inside Cursor's wrapper are gone:\n%s", got)
+	}
+}

--- a/internal/search/context_envelope_test.go
+++ b/internal/search/context_envelope_test.go
@@ -1,0 +1,65 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Every user turn was kept whatever it held, so a session whose transcript
+// carries the harness talking to itself — Claude Code's teammate messages,
+// task notifications, idle-notification JSON — spent the context budget on
+// that and never reached the turns about the question. On this machine's
+// index, ten real questions came back 38% envelope, three of them 89% (#3323).
+func TestContextSkipsTurnsThatAreOnlyTheHostTalking(t *testing.T) {
+	long := strings.Repeat("Review of the damaged-index JSON fix, point four. ", 120)
+	s := model.Session{Harness: "claude", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "Another Claude session sent a message:\n<teammate-message teammate_id=\"rev354\">\n" + long + "\n</teammate-message>"},
+		{Role: "user", Text: "<teammate-message teammate_id=\"rev354\">\n{\"type\":\"idle_notification\",\"from\":\"rev354\"}\n</teammate-message>"},
+		{Role: "user", Text: "follow HERMES_HOME, the variable Hermes itself reads"},
+		{Role: "assistant", Text: "the hermes reader now takes HERMES_HOME before the profiles root"},
+	}}
+
+	var b bytes.Buffer
+	PrintContext(&b, s, "HERMES_HOME")
+	got := b.String()
+	if strings.Contains(got, "idle_notification") {
+		t.Errorf("an idle notification is in the context handed to another agent:\n%s", got)
+	}
+	if strings.Contains(got, "teammate_id") {
+		t.Errorf("a teammate envelope is in the context handed to another agent:\n%s", got)
+	}
+	if !strings.Contains(got, "HERMES_HOME") {
+		t.Errorf("the turns about the question never made it:\n%s", got)
+	}
+}
+
+// A turn that is the person's words with an envelope appended is the person's
+// turn and stays whole — the words are what the reader asked about.
+func TestContextKeepsATurnThatHasWordsBesideTheEnvelope(t *testing.T) {
+	s := model.Session{Harness: "claude", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "why does the retry loop drop the last attempt\n<system-reminder>the file was edited</system-reminder>"},
+		{Role: "assistant", Text: "because the counter is compared with < instead of <="},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "retry loop")
+	if !strings.Contains(b.String(), "why does the retry loop drop the last attempt") {
+		t.Errorf("the person's words went with the envelope:\n%s", b.String())
+	}
+}
+
+// The fallback overview, printed when no turn carries the whole query, is
+// context too: it must not be an agent's idle notifications either.
+func TestContextOverviewSkipsTheHostsOwnTurns(t *testing.T) {
+	s := model.Session{Harness: "claude", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "<task-notification>agent qa-zed2 finished</task-notification>"},
+		{Role: "user", Text: "index the copied Zed store and compare the counts"},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "a query that matches nothing at all here")
+	if strings.Contains(b.String(), "task-notification") {
+		t.Errorf("the overview is the host's own turn:\n%s", b.String())
+	}
+}

--- a/internal/search/context_envelope_test.go
+++ b/internal/search/context_envelope_test.go
@@ -107,3 +107,17 @@ func TestContextKeepsWordsBetweenTwoEnvelopes(t *testing.T) {
 		t.Errorf("the words inside Cursor's wrapper are gone:\n%s", got)
 	}
 }
+
+// Naming a tag is not writing one: a sentence that quotes Cursor's wrapper
+// keeps its words, where a global strip of the bare tag gutted it (third
+// review of #3323).
+func TestContextKeepsASentenceThatNamesTheWrapper(t *testing.T) {
+	s := model.Session{Harness: "claude", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "the three things Cursor wraps around a user message: `<user_query>`, `<additional_data>`, `<attached_files>`"},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "cursor wraps")
+	if !strings.Contains(b.String(), "`<user_query>`") {
+		t.Errorf("the sentence lost the tag it was naming:\n%s", b.String())
+	}
+}

--- a/internal/search/context_envelope_test.go
+++ b/internal/search/context_envelope_test.go
@@ -121,3 +121,31 @@ func TestContextKeepsASentenceThatNamesTheWrapper(t *testing.T) {
 		t.Errorf("the sentence lost the tag it was naming:\n%s", b.String())
 	}
 }
+
+// Each close pairs with the nearest open before it. A turn that opens one
+// wrapper and never closes it, then closes a later one, used to hand the stray
+// tag back inside the text (third review of #3323).
+func TestContextPairsEachWrapperWithTheNearestOpen(t *testing.T) {
+	s := model.Session{Harness: "cursor", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "<user_query>open one never closed about the retry loop, then <user_query>why does it drop the last attempt</user_query> after it"},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "retry loop")
+	got := b.String()
+	if strings.Contains(got, "</user_query>") {
+		t.Errorf("a closing tag was left where its pair was unwrapped:\n%s", got)
+	}
+	if !strings.Contains(got, "why does it drop the last attempt") {
+		t.Errorf("the question inside the closed wrapper is gone:\n%s", got)
+	}
+	// The open with no close is the person naming the tag, and stays where it
+	// is — the same rule every other tag gets here.
+	if strings.Count(got, "<user_query>") != 1 {
+		t.Errorf("the unclosed tag a person typed was taken out:\n%s", got)
+	}
+	// And it is the one they left open, at the head — not the wrapper's own,
+	// which the close paired with.
+	if !strings.Contains(got, "then why does it drop the last attempt") {
+		t.Errorf("the close paired with the wrong open, so the tag sits against the question:\n%s", got)
+	}
+}

--- a/internal/search/context_envelope_test.go
+++ b/internal/search/context_envelope_test.go
@@ -63,3 +63,23 @@ func TestContextOverviewSkipsTheHostsOwnTurns(t *testing.T) {
 		t.Errorf("the overview is the host's own turn:\n%s", b.String())
 	}
 }
+
+// The strip must not take a person's words with it. An unclosed tag runs to
+// the end of the text under the prompt hook's rule, and a person who quotes a
+// tag name in a question opens one without closing it — the review of #3323
+// found both, on the shapes Codex and Copilot write.
+func TestContextKeepsTheQuestionUnderAnUnclosedTag(t *testing.T) {
+	s := model.Session{Harness: "codex", Project: "p", ID: "id", Messages: []model.Message{
+		{Role: "user", Text: "<environment_context>\n  <cwd>/repo</cwd>\nCan you fix the failing test in parser_test.go?"},
+		{Role: "user", Text: "why does <system-reminder> show up in my prompt when I did not add it?"},
+	}}
+	var b bytes.Buffer
+	PrintContext(&b, s, "parser_test.go")
+	got := b.String()
+	if !strings.Contains(got, "Can you fix the failing test in parser_test.go?") {
+		t.Errorf("the question under an unclosed tag was cut:\n%s", got)
+	}
+	if !strings.Contains(got, "show up in my prompt when I did not add it?") {
+		t.Errorf("a question that names a tag lost its words:\n%s", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1499,12 +1499,14 @@ const ContextBudget = 8000
 // ten real questions on this machine's index came back 38% envelope, three of
 // them 89%, one of them twelve idle notifications (#3323). A turn that was
 // nothing but the envelope is not context and goes; a turn with the person's
-// words beside it keeps the words.
+// words beside it keeps the words. Only a closed block goes: an unclosed tag
+// is as often a person quoting one as a host truncating one, and this surface
+// prints the turn back.
 func withoutHarnessEnvelopes(s model.Session) model.Session {
 	msgs := make([]model.Message, 0, len(s.Messages))
 	for _, m := range s.Messages {
 		if m.Role == "user" && strings.Contains(m.Text, "<") {
-			left := digest.StripHarnessBlocks(m.Text)
+			left := digest.StripClosedHarnessBlocks(m.Text)
 			if left == "" {
 				continue
 			}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1492,6 +1492,30 @@ func isWorkRecord(role string) bool {
 // recall_context away when an agent genuinely needs it.
 const ContextBudget = 8000
 
+// withoutHarnessEnvelopes takes the host's own blocks off the user turns
+// before the window is chosen: teammate messages, task notifications, system
+// reminders, deja's own recall coming back. Every user turn was kept whatever
+// it held, so a session that carries a few of these spent the budget on them —
+// ten real questions on this machine's index came back 38% envelope, three of
+// them 89%, one of them twelve idle notifications (#3323). A turn that was
+// nothing but the envelope is not context and goes; a turn with the person's
+// words beside it keeps the words.
+func withoutHarnessEnvelopes(s model.Session) model.Session {
+	msgs := make([]model.Message, 0, len(s.Messages))
+	for _, m := range s.Messages {
+		if m.Role == "user" && strings.Contains(m.Text, "<") {
+			left := digest.StripHarnessBlocks(m.Text)
+			if left == "" {
+				continue
+			}
+			m.Text = left
+		}
+		msgs = append(msgs, m)
+	}
+	s.Messages = msgs
+	return s
+}
+
 func PrintContext(w io.Writer, s model.Session, query string) {
 	// Project and id are transcript text a harness wrote, and this is one line:
 	// an escape byte in either recolours the header and a carriage return
@@ -1512,6 +1536,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 		fmt.Fprintf(w, " · updated %s", s.Updated.Local().Format("2006-01-02"))
 	}
 	fmt.Fprintln(w)
+	s = withoutHarnessEnvelopes(s)
 	qlow := strings.ToLower(query)
 	terms, phrases := QueryParts(query)
 	budget := ContextBudget


### PR DESCRIPTION
Closes #3323.

`withoutHarnessEnvelopes` takes the host's blocks off the user turns before the window is chosen, using the same list the prompt hook has used since #3156. A turn that was nothing but the envelope is dropped; a turn with the person's words beside it keeps the words, and the window then scores against what was said rather than against the envelope's field names.

Fail-before test: `TestContextSkipsTurnsThatAreOnlyTheHostTalking` and `TestContextOverviewSkipsTheHostsOwnTurns` (internal/search), on the collector: an idle notification and a teammate envelope come back in the context handed to another agent. `TestContextKeepsATurnThatHasWordsBesideTheEnvelope` passes before and after and holds the other side.

On a read-only copy of this machine's index, the ten questions from the issue:

```
before:  67649 bytes served, 26360 in envelopes (38%), 12 idle notifications
after:   69608 bytes served,     0 in envelopes  (0%),  0
```

The output grows slightly because the budget now buys transcript instead of envelopes.

Only user turns are stripped. An assistant turn or a tool record quoting one of these tags keeps it, since there the tag is something being discussed rather than the host talking.
