### PR TITLE
fix(antigravity): approving a plan is the IDE's record, not something the person said

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -124,7 +124,9 @@ import (
 // (#3281), Grok's tool input (#3285), Antigravity's edits (#3279), Zed's
 // tool results (#3291), Gemini's toolCalls (#3293), Roo and legacy Cline's
 // tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
-// (#3301), Copilot's injected skills (#3305). A store
+// (#3301), Copilot's injected skills (#3305), aider's banner and its
+// continuation lines (#3311), opencode's own session titles (#3315),
+// Antigravity's plan approvals (#3326). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/sources/antigravity.go
+++ b/internal/sources/antigravity.go
@@ -12,9 +12,11 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-const (
-	antigravityRequestOpen  = "<USER_REQUEST>"
-	antigravityRequestClose = "</USER_REQUEST>"
+var (
+	antigravityRequestTagRE = regexp.MustCompile(`[ \t]*\n?\s*</?USER_REQUEST>\s*`)
+	// "Comments on artifact URI: file:///…/implementation_plan.md" and the
+	// sentence under it, which is the IDE recording what the person clicked.
+	antigravityArtifactCommentRE = regexp.MustCompile(`(?m)^Comments on artifact URI:.*$|^The user has (?:approved|rejected) this document\.$`)
 )
 
 var antigravityUserBlockREs = []*regexp.Regexp{
@@ -113,22 +115,17 @@ func antigravitySessionID(path string) string {
 }
 
 func cleanAntigravityUserContent(text string) string {
-	// What is inside the request tag is the person's turn, wherever the tag
-	// stands. Approving a plan writes the IDE's own comment above an empty
-	// one — "Comments on artifact URI: … The user has approved this document."
-	// — and taking the tag off only when it opened the content indexed that
-	// comment as their words (#3326). deja's own antigravity hook has read the
-	// tag this way since it was written.
-	if open := strings.Index(text, antigravityRequestOpen); open >= 0 {
-		text = text[open+len(antigravityRequestOpen):]
-		if close := strings.Index(text, antigravityRequestClose); close >= 0 {
-			text = text[:close]
-		}
-	}
 	// The IDE's own blocks can sit inside the request tag as well as beside it.
 	for _, re := range antigravityUserBlockREs {
 		text = re.ReplaceAllString(text, "")
 	}
+	// The comment the IDE writes when a document is approved or rejected: it
+	// stands above an empty <USER_REQUEST>, and taking the tag off only when it
+	// opened the content indexed that comment as the person's words (#3326).
+	text = antigravityArtifactCommentRE.ReplaceAllString(text, "")
+	// The tags come off wherever they stand and whatever is around them stays:
+	// a person can write above the tag, and a turn can carry two of them.
+	text = antigravityRequestTagRE.ReplaceAllString(text, "\n")
 	return strings.TrimSpace(text)
 }
 

--- a/internal/sources/antigravity.go
+++ b/internal/sources/antigravity.go
@@ -12,9 +12,9 @@ import (
 	"github.com/vshulcz/deja-vu/internal/model"
 )
 
-var (
-	antigravityRequestOpenRE  = regexp.MustCompile(`^\s*<USER_REQUEST>\s*`)
-	antigravityRequestCloseRE = regexp.MustCompile(`\s*</USER_REQUEST>\s*$`)
+const (
+	antigravityRequestOpen  = "<USER_REQUEST>"
+	antigravityRequestClose = "</USER_REQUEST>"
 )
 
 var antigravityUserBlockREs = []*regexp.Regexp{
@@ -113,11 +113,22 @@ func antigravitySessionID(path string) string {
 }
 
 func cleanAntigravityUserContent(text string) string {
+	// What is inside the request tag is the person's turn, wherever the tag
+	// stands. Approving a plan writes the IDE's own comment above an empty
+	// one — "Comments on artifact URI: … The user has approved this document."
+	// — and taking the tag off only when it opened the content indexed that
+	// comment as their words (#3326). deja's own antigravity hook has read the
+	// tag this way since it was written.
+	if open := strings.Index(text, antigravityRequestOpen); open >= 0 {
+		text = text[open+len(antigravityRequestOpen):]
+		if close := strings.Index(text, antigravityRequestClose); close >= 0 {
+			text = text[:close]
+		}
+	}
+	// The IDE's own blocks can sit inside the request tag as well as beside it.
 	for _, re := range antigravityUserBlockREs {
 		text = re.ReplaceAllString(text, "")
 	}
-	text = antigravityRequestOpenRE.ReplaceAllString(text, "")
-	text = antigravityRequestCloseRE.ReplaceAllString(text, "")
 	return strings.TrimSpace(text)
 }
 

--- a/internal/sources/antigravity_approval_test.go
+++ b/internal/sources/antigravity_approval_test.go
@@ -53,3 +53,18 @@ func TestAntigravitySkipsAPlanApprovalWithNoRequestInIt(t *testing.T) {
 		t.Errorf("second turn = %q, want the words inside the request tag", users[1])
 	}
 }
+
+// Whatever the person wrote around the tag stays: a line above it, and a turn
+// that carries two request blocks with words between them (review of #3326).
+func TestAntigravityKeepsWhatIsWrittenAroundTheRequestTag(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"also note: <USER_REQUEST>\nplease fix the bug\n</USER_REQUEST>", "also note:\nplease fix the bug"},
+		{"<USER_REQUEST>first</USER_REQUEST> and also <USER_REQUEST>second</USER_REQUEST>", "first\nand also\nsecond"},
+		{"Comments on artifact URI: file:///w/api/implementation_plan.md\n\nThe user has approved this document.\n\n\n<USER_REQUEST>\n\n</USER_REQUEST>", ""},
+	}
+	for _, c := range cases {
+		if got := cleanAntigravityUserContent(c.in); got != c.want {
+			t.Errorf("cleanAntigravityUserContent(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/sources/antigravity_approval_test.go
+++ b/internal/sources/antigravity_approval_test.go
@@ -1,0 +1,55 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Approving a plan writes a USER_INPUT step whose <USER_REQUEST> is empty: the
+// IDE's own comment about the document, with the person contributing nothing.
+// deja indexed the comment as their words, opening tag and absolute path
+// included — two of the 67 real user records on this machine (#3326).
+func TestAntigravitySkipsAPlanApprovalWithNoRequestInIt(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "brain", "f017fad5-095f-47ee-abf7-c13b7ce6844a", ".system_generated", "logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "transcript.jsonl")
+	lines := []string{
+		`{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-07-08T14:18:27Z","content":"<USER_REQUEST>\nwhy does the retry loop drop the last attempt\n</USER_REQUEST>"}`,
+		`{"step_index":13,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-07-08T14:45:28Z","content":"Comments on artifact URI: file:///w/api/implementation_plan.md\n\nThe user has approved this document.\n\n\n<USER_REQUEST>\n\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-07-08T17:45:28+03:00.\n</ADDITIONAL_METADATA>"}`,
+		`{"step_index":14,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-07-08T14:47:00Z","content":"Comments on artifact URI: file:///w/api/implementation_plan.md\n\n<USER_REQUEST>\ncap the retries at three\n</USER_REQUEST>"}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ParseAntigravityFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(got))
+	}
+	var users []string
+	for _, m := range got[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	if len(users) != 2 {
+		t.Fatalf("user turns = %d, want 2 — the approval is the IDE's own record: %q", len(users), users)
+	}
+	for _, u := range users {
+		if strings.Contains(u, "has approved this document") || strings.Contains(u, "USER_REQUEST") ||
+			strings.Contains(u, "artifact URI") {
+			t.Errorf("a user turn carries the IDE's own text: %q", u)
+		}
+	}
+	if users[1] != "cap the retries at three" {
+		t.Errorf("second turn = %q, want the words inside the request tag", users[1])
+	}
+}


### PR DESCRIPTION
Closes #3326.

`cleanAntigravityUserContent` now takes what is inside `<USER_REQUEST>` wherever the tag stands, instead of only when it opens the content, and then removes the IDE's blocks — they appear both inside the tag and beside it, which the existing fixture covers. An approval whose request is empty leaves nothing and the caller already drops such a turn.

This is the rule deja's own Antigravity hook has always used (`userRequestText`, cmd/deja/hook_antigravity_prompt.go), which is why the hook never answered an approval turn while the index held it as a question.

Fail-before test: `TestAntigravitySkipsAPlanApprovalWithNoRequestInIt` (internal/sources), on the collector: `user turns = 3, want 2`, with the second turn being `Comments on artifact URI: … The user has approved this document. <USER_REQUEST>`.

Real store, hermetic copy, `deja index --rebuild`:

```
before: antigravity: 8 sessions, 580 messages   deja "approved this document" → two sessions whose top snippet is the IDE's comment
after:  antigravity: 8 sessions, 578 messages   → the only hit left is the agent's own sentence about the plan
```

The index version note names this reader change (and the two merged before it on this branch, #3311 and #3315); the version itself is already 35 on the collector, so the store is re-read once either way.
