### PR TITLE
fix(index): a one-word name from the store gives way to the question under it

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1460,18 +1460,7 @@ func metaForSession(s model.Session) SessionMeta {
 		// which is deja's own listing format (#1090 covers the escape bytes;
 		// this is the line break). Derived titles have been collapsed and cut
 		// since they existed.
-		title = boundSourceTitle(s.Harness, title)
-		// A name too short to name anything gives way to the question, the way
-		// a derived title has since #790: dsh's title model answered "ok" and
-		// "47" for sessions whose user turn is a whole sentence — 39 of the 43
-		// on this machine's store (#3328). Notes name themselves.
-		if s.Harness != "deja" && thinTitle(title) {
-			if next := nextSubstantialTitle(s.Messages, title); next != "" {
-				next, _ = redact.Text(next)
-				title = truncateTitle(next, 60)
-				agentTitle = false
-			}
-		}
+		title = widenThinSourceTitle(s, boundSourceTitle(s.Harness, title))
 	}
 	// The import fields travel with the session, not with the transcript: a
 	// rebuild reloads imported sessions out of the index itself, and rebuilding
@@ -2203,7 +2192,31 @@ func earliestTitle(ms []model.Message, role string) string {
 // tests" — are not. A length rule rather than a vocabulary is the only version
 // of this that works in every language the store holds.
 func thinTitle(t string) bool {
-	return len(strings.Fields(t)) <= 2 && len([]rune(t)) <= 12
+	return titleWords(t) <= 2 && len([]rune(t)) <= 12
+}
+
+// titleWords counts what a reader would call words. Whitespace separates them
+// in most scripts and in none of the CJK ones, where a whole sentence is one
+// field and a rune-length rule alone called it a greeting: 为什么测试失败了 is
+// eight runes and says why the test failed (review of #3328). Thai is spaced
+// the same way, which is why Unspaced covers both.
+func titleWords(t string) int {
+	words, inWord := 0, false
+	for _, r := range t {
+		switch {
+		case cjkfold.Unspaced(r):
+			words++
+			inWord = false
+		case unicode.IsSpace(r):
+			inWord = false
+		default:
+			if !inWord {
+				words++
+				inWord = true
+			}
+		}
+	}
+	return words
 }
 
 // nextSubstantialTitle is the first later user turn that can name the session.
@@ -2240,6 +2253,22 @@ func titleWorthy(t string) bool {
 	return t != "" && !strings.HasPrefix(t, "<local-command") && !strings.HasPrefix(t, "<command-") &&
 		!strings.HasPrefix(t, "<task-notification") && !strings.HasPrefix(t, "<teammate-message") &&
 		!strings.HasPrefix(t, "Caveat:")
+}
+
+// widenThinSourceTitle gives a name too short to name anything way to the
+// question under it, the way a derived title has since #790: dsh's title model
+// answered "ok" and "47" for sessions whose user turn is a whole sentence — 39
+// of the 43 on this machine's store (#3328). Notes name themselves.
+func widenThinSourceTitle(s model.Session, title string) string {
+	if s.Harness == "deja" || !thinTitle(title) {
+		return title
+	}
+	next := nextSubstantialTitle(s.Messages, title)
+	if next == "" {
+		return title
+	}
+	next, _ = redact.Text(next)
+	return truncateTitle(next, 60)
 }
 
 // boundSourceTitle collapses and bounds a title the source authored, the way
@@ -3248,8 +3277,12 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 				// one-line surface — `deja last`, the digest, the citation the
 				// hook hands the agent to say aloud — reading "[accepted]"
 				// until an unrelated rebuild happened to run (#R11).
-				if t, _ := redact.Text(s.Title); boundSourceTitle(s.Harness, t) != meta.Title {
-					meta.Title, meta.AgentTitle = boundSourceTitle(s.Harness, t), s.AgentTitle
+				// The same widening the first naming does, or a session that
+				// gets its thin title later — dsh and opencode both retitle
+				// after the fact — would keep it until an unrelated rebuild.
+				if t, _ := redact.Text(s.Title); widenThinSourceTitle(s, boundSourceTitle(s.Harness, t)) != meta.Title {
+					meta.Title = widenThinSourceTitle(s, boundSourceTitle(s.Harness, t))
+					meta.AgentTitle = s.AgentTitle
 				}
 			}
 			// Only the session that owns this row. The full build writes these

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1719,6 +1719,18 @@ func wordsFromRecords(recs []Record) int {
 // candidate this produced was "The following tool was executed by the user",
 // spanning April to July.
 func notAsked(text string) bool {
+	// "no visible output" is a shell record's phrase and not an opening, so it
+	// is asked about the whole turn here; a title candidate asks only
+	// harnessPreamble, because a person can write those words in a question
+	// ("why does the button have no visible output when clicked?") and that
+	// question is a perfectly good name for a session (review of #3328).
+	return harnessPreamble(text) || strings.Contains(strings.TrimSpace(text), "no visible output")
+}
+
+// harnessPreamble reports whether a turn opens with something the harness
+// wrote: an envelope, an interruption notice, a resume preamble, the
+// compaction caveat.
+func harnessPreamble(text string) bool {
 	t := strings.TrimSpace(text)
 	for _, p := range []string{
 		"<local-command", "<command-", "<task-notification", "<teammate-message",
@@ -1730,7 +1742,7 @@ func notAsked(text string) bool {
 			return true
 		}
 	}
-	return strings.Contains(t, "no visible output")
+	return false
 }
 
 // looksLikeQuestion keeps this to things a person actually asked. Without it
@@ -2259,7 +2271,7 @@ func titleWorthy(t string) bool {
 	// renamed after a resume preamble — "This session is being continued from a
 	// previous conversation…" — which notAsked has rejected all along (review
 	// of #3328).
-	return strings.TrimSpace(t) != "" && !notAsked(t)
+	return strings.TrimSpace(t) != "" && !harnessPreamble(t)
 }
 
 // widenThinSourceTitle gives a name too short to name anything way to the

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -2204,7 +2204,11 @@ func titleWords(t string) int {
 	words, inWord := 0, false
 	for _, r := range t {
 		switch {
-		case cjkfold.Unspaced(r):
+		// Hangul is in cjkfold's CJK set because that is what folds, but Korean
+		// writes its words apart like Latin does: counting each syllable as a
+		// word made "고마워" — one word, three syllables — look substantial and
+		// left it as a session's name (review of #3328).
+		case cjkfold.Unspaced(r) && !unicode.Is(unicode.Hangul, r):
 			words++
 			inWord = false
 		case unicode.IsSpace(r):
@@ -2250,9 +2254,12 @@ func nextSubstantialTitle(ms []model.Message, skip string) string {
 // slash command's expansion, a task notification, the compaction caveat — and
 // naming a session after one of those is how the titles in #636 happened.
 func titleWorthy(t string) bool {
-	return t != "" && !strings.HasPrefix(t, "<local-command") && !strings.HasPrefix(t, "<command-") &&
-		!strings.HasPrefix(t, "<task-notification") && !strings.HasPrefix(t, "<teammate-message") &&
-		!strings.HasPrefix(t, "Caveat:")
+	// The same list the repeat-question counter rejects: the two were written
+	// apart and drifted, so a session whose store title was thin could be
+	// renamed after a resume preamble — "This session is being continued from a
+	// previous conversation…" — which notAsked has rejected all along (review
+	// of #3328).
+	return strings.TrimSpace(t) != "" && !notAsked(t)
 }
 
 // widenThinSourceTitle gives a name too short to name anything way to the

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1461,6 +1461,17 @@ func metaForSession(s model.Session) SessionMeta {
 		// this is the line break). Derived titles have been collapsed and cut
 		// since they existed.
 		title = boundSourceTitle(s.Harness, title)
+		// A name too short to name anything gives way to the question, the way
+		// a derived title has since #790: dsh's title model answered "ok" and
+		// "47" for sessions whose user turn is a whole sentence — 39 of the 43
+		// on this machine's store (#3328). Notes name themselves.
+		if s.Harness != "deja" && thinTitle(title) {
+			if next := nextSubstantialTitle(s.Messages, title); next != "" {
+				next, _ = redact.Text(next)
+				title = truncateTitle(next, 60)
+				agentTitle = false
+			}
+		}
 	}
 	// The import fields travel with the session, not with the transcript: a
 	// rebuild reloads imported sessions out of the index itself, and rebuilding

--- a/internal/index/source_thin_title_test.go
+++ b/internal/index/source_thin_title_test.go
@@ -119,3 +119,21 @@ func TestAWidenedTitleIsNeverTheHarnessOwnPreamble(t *testing.T) {
 		t.Errorf("title = %q, want the sentence under the preamble", got)
 	}
 }
+
+// The phrase a shell record uses is not a reason to reject a person's
+// question: notAsked looks for "no visible output" anywhere in a turn, which
+// is right for counting repeated plumbing and wrong for naming a session
+// (second review of #3328).
+func TestAQuestionThatSaysNoVisibleOutputCanStillNameTheSession(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "deepseek", Project: "api", ID: "nvo1", Title: "ok",
+		Messages: []model.Message{
+			{Role: "user", Text: "why does the button have no visible output when clicked, please debug", Time: at},
+		},
+	}
+	// Cut to sixty runes like every widened title.
+	if got := metaForSession(s).Title; got != "why does the button have no visible output when clicked, ple\u2026" {
+		t.Errorf("title = %q, want the question", got)
+	}
+}

--- a/internal/index/source_thin_title_test.go
+++ b/internal/index/source_thin_title_test.go
@@ -55,3 +55,25 @@ func TestAShortSourceTitleThatNamesTheWorkIsKept(t *testing.T) {
 		t.Errorf("title = %q, want the store's own name", got)
 	}
 }
+
+// A sentence in a script that does not space its words is not thin: eight
+// runes of Chinese say why the test failed, and a rune-length rule alone
+// replaced it with a longer, worse turn (review of #3328).
+func TestACJKTitleThatSaysSomethingIsNotThin(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "opencode", Project: "api", ID: "cjk1", Title: "为什么测试失败了",
+		Messages: []model.Message{
+			{Role: "user", Text: "please look into this in more detail and explain step by step what happened", Time: at},
+		},
+	}
+	if got := metaForSession(s).Title; got != "为什么测试失败了" {
+		t.Errorf("title = %q, want the store's own name", got)
+	}
+	// A greeting in the same script still is thin.
+	s.Title = "你好"
+	s.ID = "cjk2"
+	if got := metaForSession(s).Title; got == "你好" {
+		t.Errorf("title = %q, want the turn under a two-character greeting", got)
+	}
+}

--- a/internal/index/source_thin_title_test.go
+++ b/internal/index/source_thin_title_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -75,5 +76,46 @@ func TestACJKTitleThatSaysSomethingIsNotThin(t *testing.T) {
 	s.ID = "cjk2"
 	if got := metaForSession(s).Title; got == "你好" {
 		t.Errorf("title = %q, want the turn under a two-character greeting", got)
+	}
+}
+
+// Korean writes its words apart, so a one-word acknowledgement is thin the way
+// "ok" is, and a sentence in it is not (review of #3328).
+func TestKoreanIsCountedByItsWordsNotItsSyllables(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "opencode", Project: "api", ID: "ko1", Title: "고마워",
+		Messages: []model.Message{
+			{Role: "user", Text: "the checkout worker drops connections under load", Time: at},
+		},
+	}
+	if got := metaForSession(s).Title; got != "the checkout worker drops connections under load" {
+		t.Errorf("title = %q, want the question — a one-word thanks names nothing", got)
+	}
+	s.Title = "결제 워커가 연결을 끊는 이유"
+	s.ID = "ko2"
+	if got := metaForSession(s).Title; got != "결제 워커가 연결을 끊는 이유" {
+		t.Errorf("title = %q, want the store's own name — it is a whole sentence", got)
+	}
+}
+
+// The turn that takes over must be something a person said. A resume preamble
+// is the harness's, and notAsked has rejected it for the repeat counter all
+// along (review of #3328).
+func TestAWidenedTitleIsNeverTheHarnessOwnPreamble(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "deepseek", Project: "api", ID: "pre1", Title: "ok",
+		Messages: []model.Message{
+			{Role: "user", Text: "This session is being continued from a previous conversation that ran out of context. The conversation is summarized below:", Time: at},
+			{Role: "user", Text: "cap the retries at three and log the last attempt", Time: at.Add(time.Minute)},
+		},
+	}
+	got := metaForSession(s).Title
+	if strings.Contains(got, "This session is being continued") {
+		t.Errorf("title = %q, want the person's own turn", got)
+	}
+	if got != "cap the retries at three and log the last attempt" {
+		t.Errorf("title = %q, want the sentence under the preamble", got)
 	}
 }

--- a/internal/index/source_thin_title_test.go
+++ b/internal/index/source_thin_title_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A title the reader took from the store skipped the rule that a derived one
+// has had since #790, so a harness whose title model answered with the reply
+// left "ok" and "47" in every listing while the question sat one line below —
+// 43 of the 60 sessions from three real stores on this machine (#3328).
+func TestAThinSourceTitleGivesWayToTheQuestion(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "deepseek", Project: "dshproj", ID: "28341f5a", Title: "ok",
+		Messages: []model.Message{
+			{Role: "user", Text: "what did we settle about the checkout worker dropping connections", Time: at},
+			{Role: "assistant", Text: "ok", Time: at.Add(time.Second)},
+		},
+	}
+	// Cut to sixty runes like every derived title.
+	if got := metaForSession(s).Title; got != "what did we settle about the checkout worker dropping connec\u2026" {
+		t.Errorf("title = %q, want the person's question", got)
+	}
+}
+
+// And it stands as it is when the session holds nothing better: the goose row
+// titled "say ok" is honest, because "say ok" is the whole turn.
+func TestAThinSourceTitleStaysWhenTheTurnIsThinToo(t *testing.T) {
+	at := time.Date(2026, 7, 27, 18, 30, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "goose", Project: "deja-vu", ID: "20260727_2", Title: "say ok",
+		Messages: []model.Message{
+			{Role: "user", Text: "say ok", Time: at},
+			{Role: "assistant", Text: "ok", Time: at.Add(time.Second)},
+		},
+	}
+	if got := metaForSession(s).Title; got != "say ok" {
+		t.Errorf("title = %q, want the name the store gave it", got)
+	}
+}
+
+// A short title that names the work is not thin and is not touched.
+func TestAShortSourceTitleThatNamesTheWorkIsKept(t *testing.T) {
+	at := time.Date(2026, 9, 2, 20, 23, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "cline", Project: "api", ID: "c1", Title: "cap the retries",
+		Messages: []model.Message{
+			{Role: "user", Text: "the checkout worker drops connections under load, cap the retries", Time: at},
+		},
+	}
+	if got := metaForSession(s).Title; got != "cap the retries" {
+		t.Errorf("title = %q, want the store's own name", got)
+	}
+}


### PR DESCRIPTION
Closes #3328.

`metaForSession` now applies the thin-title rule to a title the reader took from the store, not only to a derived one: a name of two words or fewer and twelve runes or fewer gives way to the first user turn that can name the session, and stands as it is when there is none. Notes keep their own names, as they do for the bound above.

Fail-before test: `TestAThinSourceTitleGivesWayToTheQuestion` (internal/index), on the collector: `title = "ok", want the person's question`. Two more hold the other side — a session whose only turn is `say ok` keeps that name, and a short title that does name the work (`cap the retries`) is not touched.

Three real stores on this machine, hermetic copy, `deja index --rebuild`:

```
before: 43 of 60 titles two words or fewer — 23 "ok", 15 "47", 4 "say ok", "say hello", "say hi"
after:   8 of 60, and every one of those eight is a session whose user turn really is that short
```

The eight are the honest ones: `deja show` on each shows a single turn saying `say ok` or `47`.

This is the shape #3315 fixed inside one reader; the rule now lives where the derived titles already had it, so cline, roo, continue, goose and deepseek get it without their own change.
