### PR TITLE
fix(roo, cline): index what a turn did, not only what it said

### DIFF
--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -291,12 +291,21 @@ func parseClineLegacyTask(path string) ([]model.Session, error) {
 		if m.Role == "user" {
 			text = unwrapClineTask(text)
 		}
-		if text == "" {
+		ts := base.Add(time.Duration(ti) * time.Second)
+		// The legacy VS Code store speaks Roo's vocabulary, not the modern
+		// CLI's — the extension the two share is where both came from — so the
+		// same records come out through the same dialect. Taken before the
+		// empty-text check: a turn that only made a call carries no text, and
+		// skipping it on that alone is what left the work unindexed (#3295).
+		records := rooWorkRecords(m.Content, ts)
+		if text == "" && len(records) == 0 {
 			continue
 		}
-		ts := base.Add(time.Duration(ti) * time.Second)
 		s.Touch(ts)
-		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+		if text != "" {
+			s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+		}
+		s.Messages = append(s.Messages, records...)
 	}
 	if len(s.Messages) == 0 {
 		return nil, nil

--- a/internal/sources/roo.go
+++ b/internal/sources/roo.go
@@ -318,15 +318,71 @@ func ParseRooTask(path string) ([]model.Session, error) {
 		if m.Role == "user" {
 			text = unwrapClineTask(text)
 		}
-		if text == "" {
+		ts := base.Add(time.Duration(ti) * time.Second)
+		// The records first: a turn that only made a call carries no text, and
+		// skipping it on that alone is what left the work unindexed.
+		records := rooWorkRecords(m.Content, ts)
+		if text == "" && len(records) == 0 {
 			continue
 		}
-		ts := base.Add(time.Duration(ti) * time.Second)
 		s.Touch(ts)
-		s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+		if text != "" {
+			s.Messages = append(s.Messages, model.Message{Role: m.Role, Text: text, Time: ts})
+		}
+		s.Messages = append(s.Messages, records...)
 	}
 	if len(s.Messages) == 0 {
 		return nil, nil
 	}
 	return []model.Session{s}, nil
+}
+
+// rooDialect is Roo Code's tool vocabulary, from its own Task.ts: the shell
+// tool is `execute_command` with the command under `command`, and the file
+// tools take `path`. The modern Cline CLI names all three differently, which
+// is why this is a dialect of its own rather than clineDialect reused.
+var rooDialect = toolDialect{
+	pathKey: "path",
+	pathTools: map[string]bool{
+		"read_file": true, "write_to_file": true, "apply_diff": true,
+		"insert_content": true, "search_and_replace": true,
+	},
+	shellTool: "execute_command",
+	editTools: map[string]bool{"apply_diff": true, "search_and_replace": true},
+}
+
+// rooWorkRecords is what a Roo turn did, as the records `how`, `files`, `blame`
+// and the fix-pair miner read.
+//
+// The reader indexed the words of a turn and nothing it did, so a Roo session
+// yielded no command record and no files record at all — those four surfaces
+// were blind to the harness while the modern Cline reader emitted all of them
+// (#3295).
+func rooWorkRecords(raw json.RawMessage, ts time.Time) []model.Message {
+	var blocks []any
+	if json.Unmarshal(raw, &blocks) != nil {
+		return nil
+	}
+	var out []model.Message
+	if IndexToolPaths() {
+		if p := toolPathsIn(blocks, rooDialect); p != "" {
+			out = append(out, model.Message{Role: RoleFiles, Text: p, Time: ts})
+		}
+	}
+	if IndexEdits() {
+		for _, span := range editSpansIn(blocks, rooDialect) {
+			out = append(out, model.Message{Role: RoleEdit, Text: span, Time: ts})
+		}
+	}
+	if IndexCommands() {
+		for _, cmd := range commandsIn(blocks, rooDialect) {
+			out = append(out, model.Message{Role: RoleCommand, Text: cmd, Time: ts})
+		}
+	}
+	if IndexToolOutput() {
+		for _, body := range clineToolResults(blocks) {
+			out = append(out, model.Message{Role: RoleToolOutput, Text: body, Time: ts})
+		}
+	}
+	return out
 }

--- a/internal/sources/roo_work_records_test.go
+++ b/internal/sources/roo_work_records_test.go
@@ -1,0 +1,100 @@
+package sources
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The Roo and legacy Cline readers indexed the words of a turn and nothing it
+// did, so those sessions carried no command record and no files record at all:
+// `how`, `files`, `blame` and the fix-pair miner were blind to two harnesses
+// while the modern Cline reader emitted all of them (#3295).
+func TestRooTaskYieldsTheWorkItDid(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks", "1767225700000")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	turns := []map[string]any{
+		{"role": "user", "content": "the build fails on the widget parser"},
+		{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "execute_command",
+				"input": map[string]any{"command": "go test ./..."}},
+		}},
+		{"role": "user", "content": []any{
+			map[string]any{"type": "tool_result",
+				"content": "pkg/parser.go:42:9: undefined: frobnicateWidget\nExit code: 1"},
+		}},
+		{"role": "assistant", "content": []any{
+			map[string]any{"type": "tool_use", "name": "apply_diff",
+				"input": map[string]any{"path": "pkg/parser.go", "diff": "<<<<<<< SEARCH"}},
+		}},
+	}
+	b, err := json.Marshal(turns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "api_conversation_history.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The legacy Cline store is the same file in the same shape — the two
+	// harnesses share the extension both came from — so both readers are asked
+	// the same question.
+	for _, tc := range []struct {
+		name  string
+		parse func(string) ([]model.Session, error)
+	}{
+		{"roo", ParseRooTask},
+		{"cline (legacy)", ParseClineFile},
+	} {
+		t.Run(tc.name, func(t *testing.T) { assertRooWorkRecords(t, tc.parse, path) })
+	}
+}
+
+func assertRooWorkRecords(t *testing.T, parse func(string) ([]model.Session, error), path string) {
+	t.Helper()
+	ss, err := parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	got := map[string][]string{}
+	for _, m := range ss[0].Messages {
+		got[m.Role] = append(got[m.Role], m.Text)
+	}
+	for _, want := range []struct{ role, text string }{
+		// The `$ ` is deja's own marker on a command record, the same one the
+		// Claude and Cline readers write.
+		{RoleCommand, "$ go test ./..."},
+		{RoleFiles, "pkg/parser.go"},
+	} {
+		found := false
+		for _, have := range got[want.role] {
+			if have == want.text {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no %s record for %q; got %v", want.role, want.text, got[want.role])
+		}
+	}
+	// The error a command hit is what a later search reaches for, and the
+	// fix-pair miner pairs it with what ran next.
+	found := false
+	for _, have := range got[RoleToolOutput] {
+		if strings.Contains(have, "frobnicateWidget") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no tool output record carrying the error: %v", got[RoleToolOutput])
+	}
+}


### PR DESCRIPTION
Both readers indexed the words of a turn and nothing it did, so a Roo or legacy Cline session carried no command record and no files record at all — `how`, `files`, `blame` and the fix-pair miner were blind to two harnesses while the modern Cline reader emitted all of them.

Two things were wrong. Roo's vocabulary is its own — `execute_command` with the command under `command`, `path` on the file tools — where the modern CLI names all three differently, so it gets a dialect rather than `clineDialect` reused. And a turn that only made a call carries no text: the loop skipped it on the empty text before any record could be taken, which is why adding the extraction alone changed nothing.

The legacy VS Code store speaks the same vocabulary — the extension both harnesses came from — so it goes through the same dialect, and the test asks both readers the same question:

```
--- PASS: TestRooTaskYieldsTheWorkItDid/roo
--- PASS: TestRooTaskYieldsTheWorkItDid/cline_(legacy)
```

Five mutations, all red — including the one that caught the legacy reader being untested the first time round.

Closes #3295.
