### PR TITLE
fix(claude): a record Claude Code wrote itself is not the person talking

### DIFF
--- a/docs/registry/claude-code.html
+++ b/docs/registry/claude-code.html
@@ -53,6 +53,7 @@
 <p>Message records have <code>type</code>, <code>sessionId</code>, <code>timestamp</code>, and a <code>message</code> object. <code>message.content</code> is either a string or an array whose useful parts have <code>text</code> or <code>content</code>.</p>
 <pre><code class="language-json">{&#34;type&#34;:&#34;assistant&#34;,&#34;sessionId&#34;:&#34;session-7&#34;,&#34;timestamp&#34;:&#34;2026-07-17T09:00:01Z&#34;,&#34;message&#34;:{&#34;role&#34;:&#34;assistant&#34;,&#34;content&#34;:[{&#34;type&#34;:&#34;text&#34;,&#34;text&#34;:&#34;The failing check is in parser.go.&#34;}]}}</code></pre>
 <p><code>type: &#34;user&#34;</code> maps to <code>user</code> and <code>type: &#34;assistant&#34;</code> maps to <code>assistant</code>; a non-empty <code>message.role</code> takes precedence. Timestamps are RFC 3339 strings in observed files. deja also accepts numeric Unix seconds or milliseconds.</p>
+<p><code>isMeta: true</code> marks a user record Claude Code wrote itself — the body of a skill it loaded, a prompt a cron job re-fired, the <code>/fork</code> notice, an <code>[Image: …]</code> placeholder, the local-command caveat. Its text is not a turn and is dropped; the record&#39;s tool calls, if it ever carries any, are read as usual. On this machine that is 779 records, none on an assistant record and none carrying a tool call.</p>
 <h2 id="known-quirks-and-drift">Known quirks and drift</h2>
 <ul>
 <li>JSONL can end in a partial line while Claude is writing. Malformed lines are skipped; a later indexing pass reads the completed tail.</li>

--- a/docs/registry/claude-code.md
+++ b/docs/registry/claude-code.md
@@ -26,6 +26,8 @@ Message records have `type`, `sessionId`, `timestamp`, and a `message` object. `
 
 `type: "user"` maps to `user` and `type: "assistant"` maps to `assistant`; a non-empty `message.role` takes precedence. Timestamps are RFC 3339 strings in observed files. deja also accepts numeric Unix seconds or milliseconds.
 
+`isMeta: true` marks a user record Claude Code wrote itself — the body of a skill it loaded, a prompt a cron job re-fired, the `/fork` notice, an `[Image: …]` placeholder, the local-command caveat. Its text is not a turn and is dropped; the record's tool calls, if it ever carries any, are read as usual. On this machine that is 779 records, none on an assistant record and none carrying a tool call.
+
 ## Known quirks and drift
 
 - JSONL can end in a partial line while Claude is writing. Malformed lines are skipped; a later indexing pass reads the completed tail.

--- a/internal/sources/claude.go
+++ b/internal/sources/claude.go
@@ -218,6 +218,11 @@ func parseClaudeGenericFromOffset(path string, offset int64) ([]model.Session, e
 				role = RoleToolOutput
 			}
 		}
+		// The same cut the typed parser makes on a record Claude Code wrote
+		// itself (#3267).
+		if meta, _ := m["isMeta"].(bool); meta && role == "user" {
+			txt = ""
+		}
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})
 		}

--- a/internal/sources/claude_decode.go
+++ b/internal/sources/claude_decode.go
@@ -41,6 +41,12 @@ type claudeLine struct {
 	IsSidechain      bool   `json:"isSidechain"`
 	AgentID          string `json:"agentId"`
 	AttributionAgent string `json:"attributionAgent"`
+	// isMeta marks a user record Claude Code wrote itself: the body of a skill
+	// it loaded, a prompt a cron job re-fired, the /fork notice, an [Image: …]
+	// placeholder, the local-command caveat. 779 of them on this machine, none
+	// on an assistant record and none carrying a tool call, so a meta record is
+	// the harness talking and nothing else (#3267).
+	IsMeta bool `json:"isMeta"`
 }
 
 type claudeMessage struct {
@@ -89,6 +95,14 @@ func parseClaudeTypedFromOffset(path string, offset int64) ([]model.Session, err
 			if toolOut {
 				role = RoleToolOutput
 			}
+		}
+		// A meta record's text is the harness's, not the person's, so it is not
+		// a turn — dropped here rather than by a text rule, because no text rule
+		// names a skill body or a re-fired prompt. Only the text goes: the work
+		// records below still run, so a meta record that ever carries a tool
+		// call keeps it.
+		if v.IsMeta && role == "user" {
+			txt = ""
 		}
 		if txt != "" {
 			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: t})

--- a/internal/sources/claude_ismeta_test.go
+++ b/internal/sources/claude_ismeta_test.go
@@ -1,0 +1,67 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Claude Code marks the user records it writes itself with isMeta: a skill body
+// it loaded, a prompt a cron re-fired, the /fork notice. Indexed as the person's
+// words they feed terms, titles and "asked by a person" — 779 of them on this
+// machine, none carrying a tool call (#3267).
+func TestClaudeMetaRecordsAreNotTheirWords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "s1.jsonl")
+	lines := strings.Join([]string{
+		`{"type":"user","sessionId":"s1","timestamp":"2026-09-08T10:00:00Z","message":{"role":"user","content":"why does the index rebuild twice?"}}`,
+		`{"type":"user","isMeta":true,"sessionId":"s1","timestamp":"2026-09-08T10:00:01Z","message":{"role":"user","content":"# /loop — schedule a recurring prompt. Parse the input below."}}`,
+		`{"type":"user","isMeta":true,"sessionId":"s1","timestamp":"2026-09-08T10:00:02Z","message":{"role":"user","content":"[Image: source: /var/folders/x/Screenshot.png]"}}`,
+		`{"type":"assistant","sessionId":"s1","timestamp":"2026-09-08T10:00:03Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./internal/index"}}]}}`,
+		// A meta record still gives up the work it names, if it ever carries any.
+		`{"type":"user","isMeta":true,"sessionId":"s1","timestamp":"2026-09-08T10:00:04Z","message":{"role":"user","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/repo/internal/index/index.go"}}]}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(name string, ss []model.Session, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if len(ss) != 1 {
+			t.Fatalf("%s: sessions = %d", name, len(ss))
+		}
+		var user, files, commands int
+		for _, m := range ss[0].Messages {
+			switch m.Role {
+			case "user":
+				user++
+				if !strings.Contains(m.Text, "rebuild twice") {
+					t.Errorf("%s: a record the harness wrote is indexed as the person: %q", name, m.Text)
+				}
+			case RoleFiles:
+				files++
+			case RoleCommand:
+				commands++
+			}
+		}
+		if user != 1 {
+			t.Errorf("%s: user turns = %d, want the one the person typed", name, user)
+		}
+		if commands != 1 {
+			t.Errorf("%s: command records = %d, want the one the assistant ran", name, commands)
+		}
+		if files != 1 {
+			t.Errorf("%s: files records = %d — a meta record's work went with its text", name, files)
+		}
+	}
+
+	typed, err := parseClaudeTypedFromOffset(path, 0)
+	check("typed", typed, err)
+	generic, err := parseClaudeGenericFromOffset(path, 0)
+	check("generic", generic, err)
+}


### PR DESCRIPTION
Claude Code flags the user records it writes itself with `isMeta`: a skill body it loaded, a prompt a cron job re-fired, the `/fork` notice, an `[Image: …]` placeholder. The reader ignored the flag, so all of it was indexed as the person's words — 779 records on my store, none on an assistant record and none carrying a tool call.

Their text is dropped in both the typed reader and the generic one it is proved against; the work records still run, so a meta record that ever carries a tool call keeps it. Registry doc updated.

Closes #3267