### PR TITLE
fix(zed): a thread's own order is its clock, so two identical turns both survive

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -126,7 +126,7 @@ import (
 // tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
 // (#3301), Copilot's injected skills (#3305), aider's banner and its
 // continuation lines (#3311), opencode's own session titles (#3315),
-// Antigravity's plan approvals (#3326). A store
+// Antigravity's plan approvals (#3326), Zed's per-message stamps (#3333). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -302,15 +302,27 @@ func zedSession(db string, r zedRow) (model.Session, bool) {
 		Started: started,
 		Updated: updated,
 	}
-	// Zed stores no per-message timestamp in either thread format, so every
-	// message inherits the thread's start the way aider's do. Order is carried
-	// by the array itself, which is what recall actually reads.
+	// Zed stores no per-message timestamp in either thread format, so the place
+	// in the array is the only clock there is, and it becomes one: the thread's
+	// start plus a millisecond per record. Sharing one stamp made two turns
+	// that say the same thing — the same file read twice, the same command run
+	// twice — indistinguishable to the ingest's duplicate check, which dropped
+	// 1385 of this machine's 6767 Zed messages (#3333).
+	at := started
+	tick := func() time.Time {
+		t := at
+		at = at.Add(time.Millisecond)
+		return t
+	}
 	for _, raw := range th.Messages {
 		role, text := zedMessage(raw)
 		if text != "" && !HarnessAuthored(role) {
-			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: started})
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: text, Time: tick()})
 		}
-		s.Messages = append(s.Messages, zedWork(raw, started)...)
+		for _, w := range zedWork(raw, started) {
+			w.Time = tick()
+			s.Messages = append(s.Messages, w)
+		}
 	}
 	if len(s.Messages) == 0 {
 		return model.Session{}, false

--- a/internal/sources/zed_clock_test.go
+++ b/internal/sources/zed_clock_test.go
@@ -1,0 +1,60 @@
+package sources
+
+import (
+	"fmt"
+	"testing"
+)
+
+// A thread that reads the same file twice and runs the same command twice —
+// ordinary work, and what a real Zed thread does all day. Every message
+// carried the thread's start, so the ingest's duplicate check saw one turn
+// where there were two: 1385 of 6767 messages from the 30 real threads on
+// this machine never reached the index (#3333).
+const zedRepeatBody = `{"version":"0.3.0","title":"repeated work","updated_at":"2026-07-19T09:00:02Z","messages":[
+{"User":{"id":"u1","content":[{"Text":"the retry queue stalls on staging"}]}},
+{"Agent":{"content":[
+ {"ToolUse":{"id":"c1","name":"read_file","input":{"path":"/w/app/queue/retry.go","start_line":1,"end_line":80}}},
+ {"ToolUse":{"id":"c2","name":"terminal","input":{"command":"go test ./queue/...","cd":"/w/app"}}}
+],"tool_results":{},"reasoning_details":null}},
+{"Agent":{"content":[
+ {"ToolUse":{"id":"c3","name":"read_file","input":{"path":"/w/app/queue/retry.go","start_line":1,"end_line":80}}},
+ {"ToolUse":{"id":"c4","name":"terminal","input":{"command":"go test ./queue/...","cd":"/w/app"}}}
+],"tool_results":{},"reasoning_details":null}}
+]}`
+
+func TestZedTellsTwoIdenticalTurnsApartByTheirPlace(t *testing.T) {
+	zedHome(t)
+	hex := zedZstdHex(t, zedRepeatBody)
+	sql := fmt.Sprintf("%s\ninsert into threads (id, summary, updated_at, data_type, data, folder_paths, created_at) values ('r1', 'repeated work', '2026-07-19T09:00:02Z', 'zstd', x'%s', '[\"/w/app\"]', '2026-07-19T08:00:00Z');", zedSchema, hex)
+	db := zedTestDB(t, sql)
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	ss, err := ParseZedDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(ss))
+	}
+	seen := map[string]int{}
+	for _, m := range ss[0].Messages {
+		seen[m.Role+"\x00"+m.Text+"\x00"+m.Time.Format("2006-01-02T15:04:05.000000000Z07:00")]++
+	}
+	for k, n := range seen {
+		if n > 1 {
+			t.Errorf("%d messages share role, text and stamp — the ingest stores one of them: %q", n, k)
+		}
+	}
+	// The stamps stay inside the thread's own span and keep the array's order.
+	prev := ss[0].Messages[0].Time
+	for _, m := range ss[0].Messages[1:] {
+		if m.Time.Before(prev) {
+			t.Errorf("message stamped before the one ahead of it: %v < %v", m.Time, prev)
+		}
+		prev = m.Time
+	}
+	if last := ss[0].Messages[len(ss[0].Messages)-1].Time; last.After(ss[0].Updated) {
+		t.Errorf("last message stamped %v, after the thread's own update %v", last, ss[0].Updated)
+	}
+}

--- a/internal/sources/zed_test.go
+++ b/internal/sources/zed_test.go
@@ -133,8 +133,11 @@ func TestParseZedDBReadsBothStorageEncodings(t *testing.T) {
 			if got.Messages[j].Role != role || got.Messages[j].Text != text {
 				t.Fatalf("session %d message %d = %#v, want %s/%q", i, j, got.Messages[j], role, text)
 			}
-			if !got.Messages[j].Time.Equal(got.Started) {
-				t.Fatalf("session %d message %d time = %v, want the thread start %v", i, j, got.Messages[j].Time, got.Started)
+			// The thread has no clock of its own, so the place in the array
+			// is one: the start plus a millisecond per record, which is what
+			// tells two identical turns apart (#3333).
+			if want := got.Started.Add(time.Duration(j) * time.Millisecond); !got.Messages[j].Time.Equal(want) {
+				t.Fatalf("session %d message %d time = %v, want %v", i, j, got.Messages[j].Time, want)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #3333.

A Zed thread carries no per-message clock, so every record took the thread's start and the ingest's duplicate check — session, role, timestamp, text — could not tell a repeated turn from the same session parsed twice. The place in the array is the only clock there is, so it becomes one: the start plus a millisecond per record, which keeps the order Zed recorded and stays inside the thread's own span.

Fail-before test: `TestZedTellsTwoIdenticalTurnsApartByTheirPlace` (internal/sources), on the collector: two file records and two command records share role, text and stamp, so the index stores one of each. `TestParseZedDBReadsBothStorageEncodings` asserted the old behaviour and now asserts the new stamps.

Real store, hermetic copy of `threads.db`, 30 threads:

```
before: parsed 6767, stored 5382   (the gap is mostly work records — the same file read twice in a thread)
after:  parsed 6767, stored 6767
```

The index version note names the reader change; the version is already 35 on this branch.

The comment this replaces said aider shares the shape. It does, and it is filed separately once measured — aider has six sessions here, so the loss there is small and the fix is not the same one line.
