### PR TITLE
fix(prompt): read the question before the paste above it

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -221,6 +221,24 @@ type promptReport struct {
 	// the whole corpus turned against itself, and it grows whenever a chain is
 	// added.
 	CrossPaired promptArmReport `json:"cross_paired"`
+	// Every question of the corpus asked at home with a paste above it — a repo
+	// listing, a set of @file mentions, a stack trace. The six terms are spent
+	// before the question is reached unless the extractor reads the question
+	// first, and a person pasting context then asking about it is the shape the
+	// hook meets most (#3183).
+	Pasted promptArmReport `json:"pasted_preamble"`
+}
+
+// pastedPreambles are what sits above a question in a real prompt: a repo
+// listing, Amp's @file mentions, a stack trace. Each carries at least six
+// identifier-shaped tokens, which is the whole term budget, and none of them
+// name anything the corpus holds.
+func pastedPreambles() []string {
+	return []string{
+		"cmd/quokkabloom main.go install.go index.go search.go docs/registry Makefile go.mod",
+		"@quokkabloom/fetch.go @quokkabloom/fetch_test.go @quokkabloom/client.go @quokkabloom/retry.go @quokkabloom/dial.go",
+		"panic: runtime error: index out of range [7]\n\tgoroutine 41 [running]:\n\tquokkabloom/retry.dialLoop(0xc000123456)",
+	}
 }
 
 // awayFor picks where a chain's question is asked: forward to the first chain
@@ -561,6 +579,19 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 	}
 	finishPromptArm(&report.CrossPaired, nil)
+	// The same questions asked at home, each under a paste. The answer is
+	// there and the question is the one that fires without the paste, so
+	// anything below that rate is the term budget going to someone else's
+	// file names.
+	for i, c := range crossed {
+		pre := pastedPreambles()[i%len(pastedPreambles())]
+		report.Pasted.Cases++
+		if fired, _ := promptBenchProbe(indexDir, c.Project, c.ID, prompt.Terms(pre+"\n"+c.Question)); fired {
+			report.Pasted.Fired++
+			report.Pasted.Correct++
+		}
+	}
+	finishPromptArm(&report.Pasted, nil)
 	finishPromptArm(&report.Real, realTerms)
 	finishPromptArm(&report.Negative, negTerms)
 	finishPromptArm(&report.Marathon, nil)

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -23,11 +23,6 @@ func relevanceTerms(q string) []string { return query.RelevanceTerms(q) }
 // prompt: stop words and short fragments dropped, capped so the query stays
 // specific.
 func Terms(prompt string) []string {
-	fields := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
-		wordy := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
-			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
-		return !wordy
-	})
 	var out []string
 	seen := map[string]bool{}
 	add := func(f string) bool {
@@ -38,6 +33,30 @@ func Terms(prompt string) []string {
 		out = append(out, f)
 		return len(out) == 6
 	}
+	// Six terms is the whole budget and a paste spends it before the question is
+	// reached: a repo listing, a set of @file mentions or a stack trace above
+	// "why does the fetcher time out?" left the question out of the query and
+	// auto-recall answered nothing (#3183). The ask is read first, the rest of
+	// the prompt fills what is left — the term rules themselves are untouched,
+	// and a one-line prompt takes the same path it always did.
+	ask, rest := splitAsk(prompt)
+	if ask != "" {
+		if termsFrom(ask, seen, add) {
+			return out
+		}
+	}
+	termsFrom(rest, seen, add)
+	return out
+}
+
+// termsFrom runs the three passes — identifiers, CJK bigrams, Cyrillic words —
+// over one part of the prompt, and reports whether the budget filled.
+func termsFrom(prompt string, seen map[string]bool, add func(string) bool) bool {
+	fields := strings.FieldsFunc(strings.ToLower(prompt), func(r rune) bool {
+		wordy := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') ||
+			r == '-' || r == '_' || r == '.' || r == '/' || r >= 0x400
+		return !wordy
+	})
 	for _, f := range fields {
 		// A word at the end of a sentence arrives with its full stop attached,
 		// and the dot then does two things at once: it marks the token as an
@@ -53,7 +72,7 @@ func Terms(prompt string) []string {
 			continue
 		}
 		if add(f) {
-			return out
+			return true
 		}
 	}
 	// CJK carries no spaces, so FieldsFunc hands back a whole phrase as one
@@ -75,7 +94,7 @@ func Terms(prompt string) []string {
 				continue
 			}
 			if add(t) {
-				break
+				return true
 			}
 		}
 	}
@@ -89,10 +108,59 @@ func Terms(prompt string) []string {
 			continue
 		}
 		if add(f) {
-			break
+			return true
 		}
 	}
-	return out
+	return false
+}
+
+// splitAsk separates the line the person is asking on from the rest of the
+// prompt. The ask is the last line that ends in a question mark, and where
+// there is none, the last line carrying any word at all — which is where an ask
+// under a paste sits. A single-line prompt has no split: it comes back whole as
+// the rest, and reads exactly as it did before.
+//
+// Measured on the bench's pasted-preamble arm — every question of the corpus
+// asked at home under a paste — this carried 9 of 47 to 45, against 46 for the
+// same questions with no paste at all. No other arm moved.
+func splitAsk(prompt string) (ask, rest string) {
+	if !strings.Contains(prompt, "\n") {
+		return "", prompt
+	}
+	lines := strings.Split(prompt, "\n")
+	// The last question is the live one: people paste, ask, paste again, ask.
+	q := -1
+	for i, l := range lines {
+		if strings.HasSuffix(strings.TrimRight(l, " \t"), "?") && hasWordRune(l) {
+			q = i
+		}
+	}
+	if q < 0 {
+		for i := len(lines) - 1; i >= 0; i-- {
+			if hasWordRune(lines[i]) {
+				q = i
+				break
+			}
+		}
+	}
+	if q < 0 {
+		return "", prompt
+	}
+	others := make([]string, 0, len(lines)-1)
+	others = append(others, lines[:q]...)
+	others = append(others, lines[q+1:]...)
+	return lines[q], strings.Join(others, "\n")
+}
+
+// hasWordRune reports whether a line carries anything a term could come from. A
+// line of punctuation — a lone "?", a rule of dashes — is nobody's question.
+func hasWordRune(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // cyrPromptTerm reports whether a field is a Cyrillic word specific enough to

--- a/internal/prompt/question_first_test.go
+++ b/internal/prompt/question_first_test.go
@@ -1,0 +1,92 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+)
+
+func has(terms []string, want string) bool {
+	for _, t := range terms {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Six terms is the whole budget, and a paste above the question spends it on
+// file names: the question never reached the query and auto-recall answered
+// nothing (#3183).
+func TestTheQuestionUnderAPasteIsWhatIsSearched(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{
+			"repo listing above the question",
+			"cmd/deja main.go install.go index.go search.go docs/registry Makefile go.mod\nwhy does the zebraquux fetcher time out?",
+			"zebraquux",
+		},
+		{
+			"file mentions above the question",
+			"@zebraquux/fetch.go @zebraquux/client.go @zebraquux/retry.go @zebraquux/dial.go @zebraquux/config.go\nwhat did we decide about the quokkabloom retry budget?",
+			"quokkabloom",
+		},
+		{
+			"no question mark: the ask is the last line",
+			"panic: index out of range [7]\n\tgoroutine 41 [running]:\n\tretry.dialLoop(0xc000123456)\nfix the quokkabloom dial timeout",
+			"quokkabloom",
+		},
+		{
+			"a paste under the question still works",
+			"why does the zebraquux fetcher time out?\ncmd/deja main.go install.go index.go search.go docs/registry Makefile",
+			"zebraquux",
+		},
+		{
+			"russian question under a paste",
+			"cmd/deja main.go install.go index.go search.go docs/registry Makefile go.mod\nпочему хендлер квоккаблум падает по таймауту?",
+			"квоккаблум",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Terms(c.prompt)
+			if !has(got, c.want) {
+				t.Errorf("terms %q carry nothing from the ask (%q)", got, c.want)
+			}
+		})
+	}
+}
+
+// A one-line prompt has no ask to lift out: it reads exactly as before.
+func TestASingleLinePromptIsNotSplit(t *testing.T) {
+	for _, p := range []string{
+		"why does the zebraquux fetcher time out?",
+		"почему квоккаблум падает?",
+		"",
+	} {
+		ask, rest := splitAsk(p)
+		if ask != "" || rest != p {
+			t.Errorf("splitAsk(%q) = (%q, %q), want the whole prompt as the rest", p, ask, rest)
+		}
+	}
+}
+
+// A question mark inside a pasted line is not the ask. The last line that ends
+// in one is, and a line of punctuation is nobody's question.
+func TestWhichLineCountsAsTheAsk(t *testing.T) {
+	ask, rest := splitAsk("is this thing on?\nhere is the paste\nwhy does the zebraquux fetcher time out?\ntrailing note")
+	if ask != "why does the zebraquux fetcher time out?" {
+		t.Errorf("ask = %q, want the last question", ask)
+	}
+	if len(strings.Split(rest, "\n")) != 3 {
+		t.Errorf("the rest lost or gained a line: %q", rest)
+	}
+	if ask, _ := splitAsk("here is the paste\n?"); ask == "?" {
+		t.Error("a lone question mark was taken for the ask")
+	}
+	if ask, _ := splitAsk("fix the quokkabloom dial timeout\n\n"); ask != "fix the quokkabloom dial timeout" {
+		t.Errorf("trailing blank lines hid the ask: %q", ask)
+	}
+}


### PR DESCRIPTION
`prompt.Terms` kept the first six identifying tokens and stopped, so a repo listing, a set of @file mentions or a pasted stack trace above the question spent the whole budget and auto-recall answered nothing.

The ask — the last line ending in `?`, or the last line carrying a word where there is none — is read first, then the rest of the prompt fills what is left. The term rules are untouched and a single-line prompt takes the same path it always did.

Measured with a new bench arm (`pasted_preamble`: every question of the corpus asked at home under a paste): 9 of 47 before, 45 after, against 46 for the same questions with no paste. No other arm moved, `bench recall` and `bench context` unchanged. On this machine's own history, 599 of 1,516 prompts are multi-line; the query changes on 571 of them and 568 gain a term from the line the ask is on, none lose one without gaining.

Closes #3183