### PR TITLE
fix(zed): the editor's summary of a mentioned thread is not what the person said

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -126,7 +126,7 @@ import (
 // tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
 // (#3301), Copilot's injected skills (#3305), aider's banner and its
 // continuation lines (#3311), opencode's own session titles (#3315),
-// Antigravity's plan approvals (#3326). A store
+// Antigravity's plan approvals (#3326), Zed's inlined thread mentions (#3336). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/sources/zed.go
+++ b/internal/sources/zed.go
@@ -609,9 +609,20 @@ func zedContentText(body json.RawMessage, keep ...string) string {
 			if err := json.Unmarshal(raw, &part); err != nil {
 				// Mention is a struct, not a string.
 				var m struct {
-					Content string `json:"content"`
+					URI     json.RawMessage `json:"uri"`
+					Content string          `json:"content"`
 				}
 				if err := json.Unmarshal(raw, &m); err != nil {
+					continue
+				}
+				var kind map[string]json.RawMessage
+				_ = json.Unmarshal(m.URI, &kind)
+				// A thread mention carries Zed's own summary of a conversation
+				// deja has already indexed under its own id, and it stood above
+				// the sentence the person typed: 48798 characters of it across
+				// the twelve mentions on a real store (#3336). Every other kind
+				// — a selection, a file — is what they attached on purpose.
+				if _, ok := kind["Thread"]; ok {
 					continue
 				}
 				part = m.Content

--- a/internal/sources/zed_mention_test.go
+++ b/internal/sources/zed_mention_test.go
@@ -1,0 +1,56 @@
+package sources
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// @-mentioning another thread inlines Zed's own generated summary of it into
+// the message. deja indexed that as the person's words — 48798 characters
+// across the 12 mentions on this machine's store, each standing above the
+// sentence someone actually typed (#3336). A selection mention is the other
+// kind and is theirs: code they attached on purpose.
+const zedMentionBody = `{"version":"0.3.0","title":"mention thread","updated_at":"2026-02-02T12:35:02Z","messages":[
+{"User":{"id":"u1","content":[
+ {"Mention":{"uri":{"Thread":{"id":"a6c02f18-ab43-4848-97a4-2a84f53ab927","name":"Deep Code Review Advertising Feature Branch"}},"content":"# Conversation Summary: Deep Code Review\n## 1. Overview\n- The user requested a deep review of the advertising branch."}},
+ {"Text":"\ncarry on with the errors listed in KNOWN_ISSUES.md"}]}},
+{"User":{"id":"u2","content":[
+ {"Mention":{"uri":{"Selection":{"abs_path":"/w/app/pool.go","line_range":{"start":12,"end":18}}},"content":"item := pool.Get()\npool.Put(item)"}},
+ {"Text":"\nwhy does this leak"}]}}
+]}`
+
+func TestZedDoesNotTakeTheSummaryOfAMentionedThreadAsSpeech(t *testing.T) {
+	zedHome(t)
+	hex := zedZstdHex(t, zedMentionBody)
+	sql := fmt.Sprintf("%s\ninsert into threads (id, summary, updated_at, data_type, data, folder_paths, created_at) values ('m1', 'mention thread', '2026-02-02T12:35:02Z', 'zstd', x'%s', '[\"/w/app\"]', '2026-02-02T12:35:00Z');", zedSchema, hex)
+	db := zedTestDB(t, sql)
+	if !ZstdAvailable() {
+		t.Skip("zstd not installed")
+	}
+	ss, err := ParseZedDB(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(ss))
+	}
+	var users []string
+	for _, m := range ss[0].Messages {
+		if m.Role == "user" {
+			users = append(users, m.Text)
+		}
+	}
+	if len(users) != 2 {
+		t.Fatalf("user turns = %d, want 2: %q", len(users), users)
+	}
+	if strings.Contains(users[0], "Conversation Summary") {
+		t.Errorf("the editor's summary of another thread is indexed as the person's words: %q", users[0])
+	}
+	if !strings.Contains(users[0], "carry on with the errors listed in KNOWN_ISSUES.md") {
+		t.Errorf("the person's own sentence went with it: %q", users[0])
+	}
+	if !strings.Contains(users[1], "pool.Put(item)") {
+		t.Errorf("a selection the person attached is theirs and must stay: %q", users[1])
+	}
+}


### PR DESCRIPTION
Closes #3336.

A `Mention` whose uri names a `Thread` carries Zed's own generated summary of a conversation deja has already indexed under its own id, and it stood above the sentence the person typed. `zedContentText` now skips that one kind; every other mention — the three `Selection` ones on this store, code someone attached on purpose — is kept as before.

Fail-before test: `TestZedDoesNotTakeTheSummaryOfAMentionedThreadAsSpeech` (internal/sources), on the collector: the user turn opens `# Conversation Summary: Deep Code Review…`. The same test holds the other side, a selection mention staying whole.

Real store, hermetic copy, `deja index --rebuild`:

```
before: user: # Conversation Summary: Deep Code Review & Refactoring of `feat/advertising`---## 1. Overview…
                продолжи чинить баги из apps/widgetd/KNOWN_ISSUES.md
after:  user: продолжи чинить баги из apps/widgetd/KNOWN_ISSUES.md
```

and `deja "Conversation Summary"` no longer answers with three threads whose top snippet is that block.

One thing to decide: the mention's name (`Deep Code Review Advertising Feature Branch`) goes with the body. Keeping it would say which thread was referenced, at the cost of putting the other thread's name into this one's opening turn. Left out for now.


