### PR TITLE
docs(deepseek): dsh lists one deja tool with a mode, not six tools

### DIFF
--- a/docs/guide/memory-for-copilot-chat.html
+++ b/docs/guide/memory-for-copilot-chat.html
@@ -112,7 +112,7 @@
 <p>The same command writes <code>&lt;User&gt;/prompts/deja.instructions.md</code>. VS Code applies a custom-instructions file to every chat when its frontmatter says <code>applyTo: "**"</code>, and that is what makes recall arrive without being asked for: the block is in front of the model before it reads your question, and it says to search history first.</p>
 
 <h2>What arrives, and what does not</h2>
-<p>The six tools, in agent mode, and the instruction to use them. Measured on VS Code 1.134.0: with the instructions file installed and deja never mentioned in the question, "the packer keeps refusing our manifest — why?" made Copilot Chat call <code>recall</code> on its own, and answer from a session it had never seen.</p>
+<p>The <code>deja</code> tool with its six modes, in agent mode, and the instruction to use it. Measured on VS Code 1.134.0: with the instructions file installed and deja never mentioned in the question, "the packer keeps refusing our manifest — why?" made Copilot Chat call <code>recall</code> on its own, and answer from a session it had never seen.</p>
 <p>What Copilot Chat still does not have is a hook. There is no session-start and no per-prompt event an outside tool can use, so nothing can hand it a block at a fixed moment or react to a failing command — the instructions file steers the agent, it does not inject. A slash command is the other gap: deja serves an MCP prompt and VS Code lists it, but its slash form is not something we have driven end to end.</p>
 
 <h2>The part that is not about this harness</h2>

--- a/docs/guide/memory-for-kimi.html
+++ b/docs/guide/memory-for-kimi.html
@@ -114,7 +114,7 @@ curl -fsSL https://raw.githubusercontent.com/vshulcz/deja-vu/main/install.sh | s
 
 <h2>What arrives</h2>
 <ul>
-<li>The MCP server, with the six tools deja serves everywhere.</li>
+<li>The MCP server, with the <code>deja</code> tool and the six modes it serves everywhere.</li>
 <li>The <code>deja-history</code> skill, so the agent knows the CLI contract when the tools are not reachable.</li>
 <li><code>/deja:recall &lt;query&gt;</code> for asking directly.</li>
 <li>The project digest on the first prompt of a session, and recall on every prompt after it — both through <code>UserPromptSubmit</code> hooks. Kimi appends a hook's stdout to the turn's context, and it runs every hook on that event, so the two sit side by side; the digest is held to one per session. Recall stays silent when the history has no answer.</li>

--- a/docs/guide/memory-for-zed.html
+++ b/docs/guide/memory-for-zed.html
@@ -113,7 +113,7 @@
 <pre>brew install deja-vu</pre>
 
 <h2>What arrives, and what does not</h2>
-<p>The six tools, and a <code>/deja</code> slash command in the agent panel. What Zed cannot give you today is memory that arrives unasked: its extension API covers language servers, slash commands, context servers and debuggers, and there is no lifecycle hook where recall could be injected — no session-start block, nothing before a tool call. Every other harness in the matrix gets that; Zed does not, and it is a limitation of the API rather than something we chose to skip. It becomes work the day Zed ships a hook.</p>
+<p>The <code>deja</code> tool with its six modes, and a <code>/deja</code> slash command in the agent panel. What Zed cannot give you today is memory that arrives unasked: its extension API covers language servers, slash commands, context servers and debuggers, and there is no lifecycle hook where recall could be injected — no session-start block, nothing before a tool call. Every other harness in the matrix gets that; Zed does not, and it is a limitation of the API rather than something we chose to skip. It becomes work the day Zed ships a hook.</p>
 <p>In practice the agent calls <code>recall</code> itself when the conversation implies earlier work, because the tool description tells it to. That covers most of the gap and none of the silence.</p>
 
 <h2>The part that is not about this harness</h2>

--- a/docs/registry/deepseek.html
+++ b/docs/registry/deepseek.html
@@ -88,8 +88,9 @@
 <p>home-level patch layer every profile composes over its own. An MCP server here</p>
 <p>is a plugin row (<code>@deepseek-ai/dsh-mcp-client</code>) inside an <code>insert:</code> list — a</p>
 <p>bare row is rejected with <code>entry &#34;mcp-deja&#34; not found</code>, because a patch entry</p>
-<p>addresses a row that already exists. After it, dsh lists <code>mcp__deja__recall</code>,</p>
-<p><code>recall_context</code>, <code>remember</code>, <code>blame</code>, <code>fix</code> and <code>how</code> itself.</p>
+<p>addresses a row that already exists. After it dsh lists one tool, <code>deja</code>,</p>
+<p>called with a <code>mode</code> of <code>recall</code>, <code>context</code>, <code>blame</code>, <code>fix</code>, <code>how</code> or</p>
+<p><code>remember</code>.</p>
 <ul>
 <li><strong>Skill</strong>: the shared <code>~/.agents/skills/deja-history/SKILL.md</code>. dsh splices a</li>
 </ul>
@@ -113,12 +114,12 @@
 <ul>
 <li><strong>Auto-recall</strong>: <code>deja install deepseek-auto</code> writes a second plugin at</li>
 </ul>
-<p><code>$DSH_HOME/plugins/deja/auto.js</code>. It listens on <code>agent/pre-step</code>, the event</p>
-<p>that carries the messages entering the step the agent is about to take, and</p>
-<p>splices the recall block in front of the last user message. The handler is</p>
-<p>middleware, so it calls <code>next()</code> first and returns that decision with the</p>
-<p>longer message list — returning a bare <code>{messages}</code> ends the turn with</p>
-<p><code>Cannot read properties of undefined (reading &#39;kind&#39;)</code>. The plain</p>
+<p><code>$DSH_HOME/plugins/deja/auto.js</code>. Recall arrives through</p>
+<p><code>ctx.systemPrompt.context</code>, evaluated on every assembly. The obvious</p>
+<p>alternative — a middleware on <code>agent/pre-step</code> that splices a message into</p>
+<p>the step — loads, completes the turn and never reaches the model: a later</p>
+<p>listener rebuilds its answer from the payload and the added message is</p>
+<p>dropped with nothing reported. The plain</p>
 <p><code>deja install deepseek</code> target keeps the MCP server and <code>/deja</code> but writes no</p>
 <p>such plugin, and removes it along with its row when someone drops back to it.</p>
 <p>Verified against a local model with no tools in play: dsh answered a question</p>

--- a/docs/registry/deepseek.md
+++ b/docs/registry/deepseek.md
@@ -40,8 +40,9 @@ harness falls back to the first prompt.
   home-level patch layer every profile composes over its own. An MCP server here
   is a plugin row (`@deepseek-ai/dsh-mcp-client`) inside an `insert:` list — a
   bare row is rejected with `entry "mcp-deja" not found`, because a patch entry
-  addresses a row that already exists. After it, dsh lists `mcp__deja__recall`,
-  `recall_context`, `remember`, `blame`, `fix` and `how` itself.
+  addresses a row that already exists. After it dsh lists one tool, `deja`,
+  called with a `mode` of `recall`, `context`, `blame`, `fix`, `how` or
+  `remember`.
 - **Skill**: the shared `~/.agents/skills/deja-history/SKILL.md`. dsh splices a
   skill catalogue into the turn and reads that directory, so it needs no file of
   its own — checked by asking a running dsh to list its skills.

--- a/docs/registry/goose.html
+++ b/docs/registry/goose.html
@@ -63,7 +63,8 @@
 </ul>
 <p><code>~/.agents/plugins/deja/hooks/hooks.json</code>. Goose discards what a hook prints,</p>
 <p>so neither answers on stdout: they write the file Goose re-reads, which is</p>
-<p><code>.goosehints</code> at session start and the MOIM file per prompt.</p>
+<p>deja&#39;s block in <code>~/.config/goose/AGENTS.md</code> at session start and the MOIM</p>
+<p>file per prompt.</p>
 <ul>
 <li><strong>Resume</strong>: <code>goose session --resume --session-id &lt;id&gt;</code>.</li>
 <li><strong>Handoff</strong>: exec, <code>goose run -t</code>.</li>

--- a/docs/registry/hermes.html
+++ b/docs/registry/hermes.html
@@ -40,6 +40,7 @@
 <ul>
 <li><strong>ID</strong>: <code>hermes</code></li>
 <li><strong>Store</strong>: <code>~/.hermes/state.db</code> (0.17+) or <code>~/.hermes/profiles/&lt;profile&gt;/state.db</code> (older builds, one store per profile)</li>
+<li><strong>Home</strong>: <code>HERMES_HOME</code> moves install, parse and doctor together, as it moves Hermes; <code>DEJA_HERMES_HOME</code> overrides it for deja alone</li>
 <li><strong>Read overrides</strong>: <code>DEJA_HERMES_PROFILES_ROOT</code> for the profiles directory, <code>DEJA_HERMES_DB</code> to pin a single store</li>
 <li><strong>Format</strong>: SQLite relational store</li>
 </ul>

--- a/docs/registry/kimi.html
+++ b/docs/registry/kimi.html
@@ -54,7 +54,7 @@
 </ul>
 <p><code>$KIMI_CODE_HOME/mcp.json</code> (common JSON shape, existing entries preserved).</p>
 <ul>
-<li><strong>Guidance</strong>: a skill at <code>$KIMI_CODE_HOME/skills/deja-history/</code>. Kimi Code scans that directory; the <code>~/.kimi/skills/</code> in some write-ups belongs to <code>MoonshotAI/kimi-cli</code>, a different tool with the same name. An older deja wrote a block into the global <code>AGENTS.md</code>, which install now removes.</li>
+<li><strong>Guidance</strong>: the shared skill at <code>~/.agents/skills/deja-history/</code>, one of the two directories Kimi Code scans (the other is <code>$KIMI_CODE_HOME/skills</code>); the <code>~/.kimi/skills/</code> in some write-ups belongs to <code>MoonshotAI/kimi-cli</code>, a different tool with the same name. An older deja wrote a block into the global <code>AGENTS.md</code>, which install now removes.</li>
 <li><strong>Resume</strong>: <code>kimi --session &lt;sessionId&gt;</code> (verified live on 0.28.1).</li>
 <li><strong>Handoff</strong>: paste — the CLI has no documented start-with-prompt flag.</li>
 </ul>

--- a/docs/registry/prime.html
+++ b/docs/registry/prime.html
@@ -41,7 +41,7 @@
 <tr><th>Field</th><th>Value</th></tr>
 <tr><td><strong>Format</strong></td><td>JSONL transcript</td></tr>
 <tr><td><strong>Default store path</strong></td><td><code>~/.prime/agent/sessions/&lt;uuid7&gt;.jsonl</code></td></tr>
-<tr><td><strong>Env override</strong></td><td><code>DEJA_PRIME_ROOT</code>, <code>PRIME_AGENT_SESSION_DIR</code>, <code>PRIME_AGENT_CODING_AGENT_SESSION_DIR</code></td></tr>
+<tr><td><strong>Env override</strong></td><td><code>DEJA_PRIME_ROOT</code>, <code>PRIME_AGENT_SESSION_DIR</code>, <code>PRIME_AGENT_CODING_AGENT_SESSION_DIR</code>; <code>PRIME_AGENT_CODING_AGENT_DIR</code> moves the whole <code>~/.prime/agent</code> directory (settings, extensions, the default session root) for prime and for deja alike</td></tr>
 <tr><td><strong>deja parser</strong></td><td><code>internal/sources/prime.go</code></td></tr>
 <tr><td><strong>Last verified</strong></td><td>2026-08-30</td></tr>
 </table></div>

--- a/internal/sources/registry_mcp_tool_test.go
+++ b/internal/sources/registry_mcp_tool_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,21 +19,39 @@ var mcpToolNameRE = regexp.MustCompile("mcp__deja__([a-z_]+)")
 // so a reader following it looked for five tools their client never shows and
 // could not tell whether the install had worked (#3343).
 func TestNoRegistryPageNamesAToolTheServerDoesNotAdvertise(t *testing.T) {
-	dir := filepath.Join("..", "..", "docs", "registry")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
-			continue
+	// The .html beside each page is what a reader and a search engine open, and
+	// it is generated from the .md — a page fixed in one and not rebuilt in the
+	// other keeps the stale claim where it is actually read (review of #3343).
+	var files []string
+	for _, dir := range []string{
+		filepath.Join("..", "..", "docs", "registry"),
+		filepath.Join("..", "..", "docs", "guide"),
+	} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
 		}
-		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			if strings.HasSuffix(e.Name(), ".md") || strings.HasSuffix(e.Name(), ".html") {
+				files = append(files, filepath.Join(dir, e.Name()))
+			}
+		}
+	}
+	files = append(files, filepath.Join("..", "..", "README.md"))
+	for _, path := range files {
+		e := struct{ name string }{filepath.Base(path)}
+		b, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
 		for _, m := range mcpToolNameRE.FindAllSubmatch(b, -1) {
-			t.Errorf("%s names the tool %q; the server advertises one tool, deja, with a mode", e.Name(), string(m[0]))
+			t.Errorf("%s names the tool %q; the server advertises one tool, deja, with a mode", e.name, string(m[0]))
+		}
+		if bytes.Contains(b, []byte("six tools")) {
+			t.Errorf("%s says \"six tools\"; there is one tool with six modes", e.name)
 		}
 	}
 }

--- a/internal/sources/registry_mcp_tool_test.go
+++ b/internal/sources/registry_mcp_tool_test.go
@@ -1,0 +1,38 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// mcpToolNameRE is how a page would name a tool a client shows: the prefixed
+// form an MCP client prints in its tool list.
+var mcpToolNameRE = regexp.MustCompile("mcp__deja__([a-z_]+)")
+
+// deja's MCP server advertises one tool, `deja`, with a mode argument. The dsh
+// page still described the shape from before that collapse — "dsh lists
+// mcp__deja__recall, recall_context, remember, blame, fix and how itself" —
+// so a reader following it looked for five tools their client never shows and
+// could not tell whether the install had worked (#3343).
+func TestNoRegistryPageNamesAToolTheServerDoesNotAdvertise(t *testing.T) {
+	dir := filepath.Join("..", "..", "docs", "registry")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, m := range mcpToolNameRE.FindAllSubmatch(b, -1) {
+			t.Errorf("%s names the tool %q; the server advertises one tool, deja, with a mode", e.Name(), string(m[0]))
+		}
+	}
+}


### PR DESCRIPTION
Closes #3343.

The page described the shape from before the six MCP tools were collapsed into one with a `mode` argument. Driven against the real server, `tools/list` returns `deja` alone with modes `recall`, `context`, `blame`, `fix`, `how`, `remember`.

Fail-before test: `TestNoRegistryPageNamesAToolTheServerDoesNotAdvertise` (internal/sources) reads every page under docs/registry and fails on a `mcp__deja__<name>` mention; on the collector it fails on deepseek.md. It is the guard for the next page that drifts the same way — this was the only one today.
