### PR TITLE
fix(uninstall): take back a snapshot that holds only deja's own block

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1041,6 +1041,29 @@ func isRealDir(p string) bool {
 	return err == nil && fi.IsDir()
 }
 
+// dropOurOwnBackup removes the snapshot beside path when it holds deja's
+// wiring: that copy is deja's own and nothing the user asked to keep, and
+// leaving it puts a file naming a binary they just removed back in their
+// config directory. Ownership is read from the content rather than from who
+// wrote it — installing a harness whose config deja edits twice takes the
+// snapshot on the second write, so the uninstall that meets it did not create
+// it and would otherwise leave it (goose).
+//
+// A snapshot of the reader's config stays even when the live file has come
+// back to exactly it: that copy is theirs, and
+// TestUninstallLeavesNoFileOrDirItCreated has said so since #840 — "the user's
+// own config and its snapshot are not ours to delete" (#2604).
+func dropOurOwnBackup(path string) {
+	bak := path + ".bak"
+	b, err := os.ReadFile(bak)
+	if err != nil {
+		return
+	}
+	if mentionsDeja(b) {
+		_ = os.Remove(bak)
+	}
+}
+
 // backupOnce reports whether it created the snapshot, so an uninstall can take
 // its own back out afterwards without touching one the user made.
 func backupOnce(path string) (bool, error) {
@@ -1264,6 +1287,12 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				return "", err
 			}
+			// A snapshot left by an earlier write of the same file is deja's
+			// too, and this path returns before the defer below is registered:
+			// `deja uninstall deepseek-auto` left a .bak holding nothing but
+			// deja's own block and called it a config the reader already had
+			// (#3340).
+			dropOurOwnBackup(path)
 			return "removed", nil
 		}
 		// The same rule for the structured writers, which never reach zero
@@ -1279,6 +1308,7 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 			if dir := filepath.Dir(path); isRealDir(dir) {
 				_ = os.Remove(dir)
 			}
+			dropOurOwnBackup(path)
 			return "removed", nil
 		}
 	}
@@ -1303,29 +1333,8 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 	if _, err := backupOnce(path); err != nil {
 		return "", err
 	}
-	// On the way out, a snapshot that itself contains deja's wiring is deja's
-	// own and nothing the user asked to keep: leaving it puts a file naming a
-	// binary they just removed back in their config directory. Ownership is
-	// read from the content rather than from who wrote it — installing a
-	// harness whose config deja edits twice takes the snapshot on the second
-	// write, so the uninstall that meets it did not create it and would
-	// otherwise leave it (goose). A backup with no deja in it is the user's.
 	if removingWiring {
-		defer func() {
-			bak := path + ".bak"
-			b, err := os.ReadFile(bak)
-			if err != nil {
-				return
-			}
-			// Only deja's own. A snapshot of the reader's config stays even
-			// when the live file has come back to exactly it: that copy is
-			// theirs, and TestUninstallLeavesNoFileOrDirItCreated has said so
-			// since #840 — "the user's own config and its snapshot are not
-			// ours to delete" (#2604).
-			if mentionsDeja(b) {
-				_ = os.Remove(bak)
-			}
-		}()
+		defer func() { dropOurOwnBackup(path) }()
 	}
 	tmp, terr := os.CreateTemp(filepath.Dir(path), ".deja-tmp-")
 	if terr != nil {

--- a/cmd/deja/install_own_backup_test.go
+++ b/cmd/deja/install_own_backup_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// A config deja wrote whole and then edited again leaves a snapshot on the
+// second write. Removing the wiring empties the file, which is the path that
+// deletes it — and it returned before the snapshot rule ran, so uninstall left
+// a .bak holding nothing but deja's own block and called it a config the
+// reader already had (#3340).
+func TestUninstallTakesItsOwnSnapshotWithIt(t *testing.T) {
+	hermeticEnv(t)
+	if _, err := installDeepSeekMCP("/bin/deja", false); err != nil {
+		t.Fatalf("install deepseek: %v", err)
+	}
+	// The second write is what snapshots the file deja itself created.
+	if _, err := installDeepSeekAuto("/bin/deja", false); err != nil {
+		t.Fatalf("install deepseek-auto: %v", err)
+	}
+	patch := filepath.Join(sources.DSHHome(), "cordis.patch.yml")
+	if _, err := os.Stat(patch + ".bak"); err != nil {
+		t.Skipf("this install left no snapshot to take back: %v", err)
+	}
+
+	removingWiring = true
+	defer func() { removingWiring = false }()
+	if _, err := installDeepSeekAuto("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall deepseek-auto: %v", err)
+	}
+	if _, err := installDeepSeekMCP("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall deepseek: %v", err)
+	}
+	if b, err := os.ReadFile(patch + ".bak"); err == nil {
+		t.Errorf("uninstall kept a snapshot of deja's own block:\n%s", b)
+	}
+}
+
+// The other half of the same rule: a config the reader already had keeps its
+// snapshot, whatever deja did to the live file.
+func TestUninstallKeepsASnapshotOfTheirOwnConfig(t *testing.T) {
+	hermeticEnv(t)
+	dir := sources.DSHHome()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	patch := filepath.Join(dir, "cordis.patch.yml")
+	theirs := "- insert:\n    - id: my-plugin\n      name: \"my-plugin.js\"\n"
+	if err := os.WriteFile(patch, []byte(theirs), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installDeepSeekMCP("/bin/deja", false); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	removingWiring = true
+	defer func() { removingWiring = false }()
+	if _, err := installDeepSeekMCP("/bin/deja", true); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	b, err := os.ReadFile(patch + ".bak")
+	if err != nil {
+		t.Fatalf("uninstall took the snapshot of a config they already had: %v", err)
+	}
+	if string(b) != theirs {
+		t.Errorf("their snapshot changed:\n%s", b)
+	}
+}

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -215,3 +215,8 @@ unchanged.
 modification. Backups and newly created configs are written owner-only
 (0600) because these files can carry MCP server credentials; the mode of an
 existing live config is preserved on update.
+
+`deja uninstall` takes back a snapshot whose content is deja's own wiring,
+including the one left behind when a config deja wrote whole is removed
+outright. A snapshot of a config that was already there stays, and is reported
+as yours to remove.


### PR DESCRIPTION
`writeIfChanged` already deletes a `.bak` whose content is deja's own, but the two fast paths that delete a config deja wrote whole return before that runs — which is exactly the path a config deja created and then edited twice takes. `deja uninstall deepseek-auto` left a `.bak` containing nothing but deja's block and printed "kept 1 snapshot of configs you already had".

The rule is now one helper called from all three places. A snapshot of a config that was already there still stays (#2604), with a test for each half.

Closes #3340