### PR TITLE
fix(site): the sources list names 25 harnesses, not 24

### DIFF
--- a/cmd/deja/site_sources_list_test.go
+++ b/cmd/deja/site_sources_list_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The home page's `sources` command prints the harness names one by one and
+// then a count. Crush landed as the 25th, every count on the site moved with
+// it, and this list did not: it said 25 while naming 24. A list of names goes
+// stale the same way a number does, and it is the one place a reader checks
+// for their own agent.
+func TestTheHomePageNamesEveryHarnessItCounts(t *testing.T) {
+	root := filepath.Join("..", "..")
+	page, err := os.ReadFile(filepath.Join(root, "docs", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := regexp.MustCompile(`'sources':'<p class="none">(.*?)\\n(\d+) harnesses`).FindSubmatch(page)
+	if line == nil {
+		t.Fatal("the home page has no `sources` line to check")
+	}
+	named := map[string]bool{}
+	for _, n := range strings.Fields(strings.ReplaceAll(string(line[1]), "&nbsp;", " ")) {
+		named[n] = true
+	}
+
+	b, err := os.ReadFile(filepath.Join(root, "docs", "registry", "registry.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reg struct {
+		Harnesses []struct {
+			ID string `json:"id"`
+		} `json:"harnesses"`
+	}
+	if err := json.Unmarshal(b, &reg); err != nil {
+		t.Fatal(err)
+	}
+	// The registry ids are the doc page names; the line prints what `deja
+	// sources` calls each harness, and the two differ for a handful.
+	alias := map[string]string{
+		"claude-code": "claude",
+		"continue":    "continue",
+		"copilot-cli": "copilot",
+	}
+	missing := []string{}
+	count := 0
+	for _, h := range reg.Harnesses {
+		if h.ID == "deja" {
+			continue
+		}
+		count++
+		name := h.ID
+		if a, ok := alias[h.ID]; ok {
+			name = a
+		}
+		if !named[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("the home page counts %d harnesses and names neither of %v", count, missing)
+	}
+	if len(named) != count {
+		t.Errorf("the home page names %d harnesses and says %d", len(named), count)
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -654,7 +654,7 @@ document.querySelectorAll('.reveal').forEach(function(el){io.observe(el)});
   }
   var COMMANDS={
     'help':'<p class="none">this input is a tiny deja: type words to search 16 demo sessions.\ncommands: <span class="t">sources</span> · <span class="t">stats</span> · <span class="t">version</span> · <span class="t">clear</span>\nthe real CLI does far more — see <a href="guide/commands.html">cli reference</a></p>',
-    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;omp&nbsp;&nbsp;openclaw&nbsp;&nbsp;goose&nbsp;&nbsp;copilot&nbsp;&nbsp;copilot-chat&nbsp;&nbsp;deepseek&nbsp;&nbsp;zed&nbsp;&nbsp;hermes&nbsp;&nbsp;prime&nbsp;&nbsp;amp&nbsp;&nbsp;continue\n25 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
+    'sources':'<p class="none">claude&nbsp;&nbsp;codex&nbsp;&nbsp;opencode&nbsp;&nbsp;cursor&nbsp;&nbsp;gemini&nbsp;&nbsp;aider&nbsp;&nbsp;antigravity&nbsp;&nbsp;grok&nbsp;&nbsp;qwen&nbsp;&nbsp;kimi&nbsp;&nbsp;cline&nbsp;&nbsp;roo&nbsp;&nbsp;pi&nbsp;&nbsp;omp&nbsp;&nbsp;openclaw&nbsp;&nbsp;goose&nbsp;&nbsp;copilot&nbsp;&nbsp;copilot-chat&nbsp;&nbsp;deepseek&nbsp;&nbsp;crush&nbsp;&nbsp;zed&nbsp;&nbsp;hermes&nbsp;&nbsp;prime&nbsp;&nbsp;amp&nbsp;&nbsp;continue\n25 harnesses, one index — real paths in the <a href="#proof">matrix below</a></p>',
     'stats':'<p class="none">sessions 16 · messages 412 · top project api-gateway\nlast 12 months&nbsp;&nbsp;▁▁▂▃▂▅▆▄▇█▆▇\n(demo numbers — <span class="t">deja stats</span> wraps your real year)</p>',
     'version':'<p class="none">deja 0.19.4</p>',
     'clear':''


### PR DESCRIPTION
The home page's `sources` command printed 24 names above the line "25 harnesses, one index" — crush landed and every count moved with it except this list, which is the one place a reader looks for their own agent.

Added the name and a test comparing the list against the registry, so the next harness cannot land half-listed.