### PR TITLE
fix(search): --limit binds the ranked and error tiers too

### DIFF
--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -1243,10 +1243,15 @@ func runBareSearch(dir string, args []string, sourceInstance string) error {
 // keep the window they have always served, which the JSON envelope's own test
 // pins; only what the reader asked for binds them.
 func capTierHits(hits []search.Hit, o search.Options) ([]search.Hit, bool) {
-	if o.Limit == 0 || o.All {
+	if o.Limit == 0 {
 		return hits, false
 	}
-	return search.CapHits(hits, o.Limit, o.All)
+	// A limit the reader typed binds even beside --all, which is how the exact
+	// tier has always read the pair: --all lifts the default, and the number
+	// asked for is still the number wanted. Letting --all win here made the
+	// same two flags mean opposite things depending on which tier answered
+	// (review of #3345).
+	return search.CapHits(hits, o.Limit, false)
 }
 
 func runSearch(dir string, args []string, sourceInstance string) error {

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -951,10 +951,13 @@ func cmdCtx(dir string, rest []string) error {
 	var hits []search.Hit
 	if result.Tier == search.TierError {
 		fmt.Fprintln(os.Stderr, "deja: matched by error signature; showing the sessions that hit it")
-		hits = search.ErrorHits(ss)
+		// Both tiers below build their own hits and never went through the cap
+		// in RunDetailed, so `--limit 3` printed the whole window — fifty
+		// sessions — and so did a query with no flag (#3345).
+		hits, _ = capTierHits(search.ErrorHits(ss), o)
 	} else if result.Tier == search.TierRelevance {
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
-		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(o.Query), result.TermIDF)
+		hits, _ = capTierHits(search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(o.Query), result.TermIDF), o)
 	} else if hits, err = search.Run(ss, o); err != nil {
 		return err
 	}
@@ -1233,6 +1236,19 @@ func runBareSearch(dir string, args []string, sourceInstance string) error {
 	return searchWithOptions(dir, args, sourceInstance, true)
 }
 
+// capTierHits bounds the two tiers that build their own hits — the ranked
+// relevance list and the error signature — which never went through the cap in
+// RunDetailed: `--limit 3` printed the whole retrieval window of fifty
+// sessions there while the exact tier printed three (#3345). With no flag they
+// keep the window they have always served, which the JSON envelope's own test
+// pins; only what the reader asked for binds them.
+func capTierHits(hits []search.Hit, o search.Options) ([]search.Hit, bool) {
+	if o.Limit == 0 || o.All {
+		return hits, false
+	}
+	return search.CapHits(hits, o.Limit, o.All)
+}
+
 func runSearch(dir string, args []string, sourceInstance string) error {
 	return searchWithOptions(dir, args, sourceInstance, false)
 }
@@ -1310,6 +1326,11 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 		if o.Total < len(hits) {
 			o.Total = len(hits)
 		}
+		// The cap the exact path gets from RunDetailed: without it `--json
+		// --limit 1` handed a consumer the whole window (#3345).
+		var capped bool
+		hits, capped = capTierHits(hits, o)
+		o.Capped = o.Capped || capped
 	case search.TierRelevance:
 		fmt.Fprintln(os.Stderr, "deja: no exact match; showing sessions ranked by relevance to the whole query")
 		hits = search.RelevanceHitsWeighted(ss, index.RelevanceMatchTerms(o.Query), result.TermIDF)
@@ -1325,6 +1346,9 @@ func searchWithOptions(dir string, args []string, sourceInstance string, bare bo
 		if o.Total < len(hits) {
 			o.Total = len(hits)
 		}
+		var relCapped bool
+		hits, relCapped = capTierHits(hits, o)
+		o.Capped = o.Capped || relCapped
 	default:
 		// RunDetailed rather than Run: the JSON envelope reports how many
 		// sessions matched before the cap, and that is not recoverable from a

--- a/cmd/deja/relevance_envelope_test.go
+++ b/cmd/deja/relevance_envelope_test.go
@@ -103,3 +103,36 @@ func TestRelevanceEnvelopeReportsThePreCapTotal(t *testing.T) {
 		t.Fatalf("empty: total = %d capped = %v hits = %d\n%s", env.Total, env.Capped, len(env.Hits), out)
 	}
 }
+
+// `--limit n` binds every tier. It did not bind these two, which build their
+// own hits and never went through RunDetailed's cap: the same flag that gave
+// three sessions on the exact tier gave the whole window of fifty here
+// (#3345).
+func TestLimitBindsTheRankedTier(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 60; i++ {
+		id := fmt.Sprintf("lim%02d", i)
+		writeClaudeFixture(t, filepath.Join(root, "relevance", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"kubernetes autoscaler telemetry notes ` + id + `"}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "relevance", "dash.jsonl"), "dash", []string{
+		`{"type":"user","sessionId":"dash","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"dashboards"}}`,
+	})
+
+	out, err := captureRun(t, "--json", "--no-embed", "--limit", "3", "kubernetes autoscaler telemetry dashboards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := decodeEnvelope(t, out)
+	if env.Tier != "relevance" {
+		t.Fatalf("tier = %q, want relevance — the fixture stopped exercising the path", env.Tier)
+	}
+	if len(env.Hits) != 3 {
+		t.Errorf("hits = %d, want the 3 the reader asked for", len(env.Hits))
+	}
+	if env.Total != 61 || !env.Capped {
+		t.Errorf("total = %d capped = %v, want 61 and true", env.Total, env.Capped)
+	}
+}

--- a/cmd/deja/relevance_envelope_test.go
+++ b/cmd/deja/relevance_envelope_test.go
@@ -136,3 +136,30 @@ func TestLimitBindsTheRankedTier(t *testing.T) {
 		t.Errorf("total = %d capped = %v, want 61 and true", env.Total, env.Capped)
 	}
 }
+
+// And the same pair on the ranked tier: `--all --limit 3` gives three, not the
+// window, so the flags do not change meaning with the tier (review of #3345).
+func TestAllWithALimitStillBindsTheRankedTier(t *testing.T) {
+	hermeticEnv(t)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := 0; i < 60; i++ {
+		id := fmt.Sprintf("alim%02d", i)
+		writeClaudeFixture(t, filepath.Join(root, "relevance", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"kubernetes autoscaler telemetry notes ` + id + `"}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(root, "relevance", "dash.jsonl"), "dash", []string{
+		`{"type":"user","sessionId":"dash","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"dashboards"}}`,
+	})
+	out, err := captureRun(t, "--json", "--no-embed", "--all", "--limit", "3", "kubernetes autoscaler telemetry dashboards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := decodeEnvelope(t, out)
+	if env.Tier != "relevance" {
+		t.Fatalf("tier = %q, want relevance", env.Tier)
+	}
+	if len(env.Hits) != 3 {
+		t.Errorf("hits = %d, want the 3 the reader asked for", len(env.Hits))
+	}
+}

--- a/internal/search/cap_hits_test.go
+++ b/internal/search/cap_hits_test.go
@@ -1,0 +1,39 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The cap lives in RunDetailed, which only the exact path goes through, so the
+// two tiers that build their own hits printed the whole retrieval window: 50
+// sessions for `--limit 3`, and 50 again for a query with no flag, where the
+// default is 15 (#3345).
+func TestCapHitsBoundsWhatEachTierHandsBack(t *testing.T) {
+	hits := make([]Hit, 50)
+	for i := range hits {
+		hits[i] = Hit{Session: model.Session{ID: string(rune('a' + i%26))}}
+	}
+	cases := []struct {
+		name    string
+		limit   int
+		all     bool
+		want    int
+		wantCap bool
+	}{
+		{"a limit is honoured", 3, false, 3, true},
+		{"no flag takes the default", 0, false, 15, true},
+		{"--all takes everything", 0, true, 50, false},
+		{"a limit past the end caps nothing", 100, false, 50, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, capped := CapHits(hits, c.limit, c.all)
+			if len(got) != c.want || capped != c.wantCap {
+				t.Errorf("CapHits(50 hits, limit %d, all %v) = %d hits capped %v, want %d capped %v",
+					c.limit, c.all, len(got), capped, c.want, c.wantCap)
+			}
+		})
+	}
+}

--- a/internal/search/cap_hits_test.go
+++ b/internal/search/cap_hits_test.go
@@ -37,3 +37,13 @@ func TestCapHitsBoundsWhatEachTierHandsBack(t *testing.T) {
 		})
 	}
 }
+
+// --all lifts the default, and a limit the reader typed still binds: the two
+// flags together must mean the same thing on every tier (review of #3345).
+func TestCapHitsHonoursALimitBesideAll(t *testing.T) {
+	hits := make([]Hit, 20)
+	got, capped := CapHits(hits, 5, true)
+	if len(got) != 5 || !capped {
+		t.Errorf("CapHits(20 hits, limit 5, all) = %d hits capped %v, want 5 and true", len(got), capped)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -414,15 +414,23 @@ func RunDetailed(ss []model.Session, o Options) (Results, error) {
 		return Results{}, err
 	}
 	r := Results{Hits: hits, Total: len(hits), Tier: setTier(o)}
-	limit := o.Limit
-	if limit == 0 && !o.All {
+	r.Hits, r.Capped = CapHits(hits, o.Limit, o.All)
+	return r, nil
+}
+
+// CapHits bounds what a search hands back, with the default a reader gets when
+// they pass no flag. It lives here rather than inside RunDetailed because the
+// tiers that build their own hits — relevance, error signature — never went
+// through that path and printed the whole retrieval window instead: fifty
+// sessions for `--limit 3`, and fifty for no flag at all (#3345).
+func CapHits(hits []Hit, limit int, all bool) ([]Hit, bool) {
+	if limit == 0 && !all {
 		limit = 15
 	}
 	if limit > 0 && len(hits) > limit {
-		r.Hits = hits[:limit]
-		r.Capped = true
+		return hits[:limit], true
 	}
-	return r, nil
+	return hits, false
 }
 
 func setTier(o Options) string {


### PR DESCRIPTION
Closes #3345.

The cap lives in `RunDetailed`, which only the exact path goes through. The ranked-relevance tier and the error-signature tier build their own hits, so `--limit` never reached them: on this machine's index, `--limit 3` printed 50 sessions where the same flag on the exact tier printed 3, and `--json --limit 1` handed a consumer 50 hits. `search.CapHits` is that cap as a function; `capTierHits` applies it to the two tiers.

Fail-before test: `TestLimitBindsTheRankedTier` (cmd/deja), on the collector: `hits = 50, want the 3 the reader asked for`. `TestCapHitsBoundsWhatEachTierHandsBack` (internal/search) pins the function itself.

Read-only copy of the real index:

```
before:  --limit 3 → 50 sessions      --json --limit 1 → 50 hits
after:   --limit 3 →  3 sessions      --json --limit 1 →  1 hit, total 973, capped true
```

A question rather than a change: with no flag at all these two tiers still print the whole window of 50, where every other tier defaults to 15. `TestRelevanceEnvelopeReportsThePreCapTotal` pins that 50 deliberately, so I left it — but 50 sessions is what a reader gets exactly when nothing matched their words, which is when they are least able to sift. Should the default be 15 there too?
