### PR TITLE
fix(hook): the same question gets one answer, not one session per tick

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -191,6 +191,20 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		requestWarmup(dir)
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
+	// The same question, from the same reader, was answered a moment ago. The
+	// cooldowns below are per session shown, so an identical prompt arriving
+	// every minute — a `/loop 1m …` sends the same text on each tick — walked
+	// one session further down the ranking each time: 25 blocks from 21
+	// different sessions in one evening, none of them the loop's subject
+	// (#3189). "You have been here" is about the question, not the tick.
+	//
+	// Not for a spawned agent: a fleet is many readers behind one key, and ten
+	// agents sent out on the same work each need the answer once rather than
+	// the first one taking it for all of them (#2534).
+	if !isSpawnedReader(input.SessionID) &&
+		askedRecently(dir, input.SessionID, askKey(terms), repeatAskWindow) {
+		return emitNudgeOnly(stdout, plain, nudge)
+	}
 	// The payload first, then the export, then where the process stands: the
 	// export is set once per process and will not change, so reading it alone
 	// answered a second payload with the first one's project (#2182).
@@ -474,6 +488,9 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	}
 	out := frameRecall(body)
 	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
+	// Stamped, because the question is answered again once the window passes,
+	// where a block fingerprint holds for the life of the session.
+	rememberInjectedIDsFor(dir, input.SessionID, "", []string{askKey(terms)})
 	rememberInjectedFor(dir, input.SessionID, projectKey, ss)
 	if unreadable {
 		usage.RecordDigestFromUnread(dir, usage.KindDejaVu, out, input.SessionID, len(ss), rawSize(ss),
@@ -821,6 +838,54 @@ func alreadyInjected(dir, sid string) map[string]bool {
 func blockFingerprint(body string) string {
 	sum := sha256.Sum256([]byte(strings.Join(strings.Fields(body), " ")))
 	return hex.EncodeToString(sum[:8])
+}
+
+// repeatAskWindow is how long one reader's question stays answered. An hour is
+// long enough to cover a loop that ticks every minute and short enough that
+// coming back to the same subject after real work is answered again — and what
+// the reader was shown is still on screen for that stretch, so a second copy
+// adds nothing.
+const repeatAskWindow = time.Hour
+
+// askKey identifies a question by the terms it searches on rather than by its
+// text: the same question typed twice with different filler is the same
+// question, and terms are what the ranking sees.
+func askKey(terms []string) string {
+	sorted := append([]string(nil), terms...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, " ")))
+	// The prefix keeps it out of the session-id space this file also holds.
+	return "ask:" + hex.EncodeToString(sum[:8])
+}
+
+// askedRecently reports whether this reader already had an answer to the same
+// question inside the window. Scanned from the end, like the cooldowns: the
+// file is append-only and the newest rows are the ones that matter.
+func askedRecently(dir, sid, key string, window time.Duration) bool {
+	if sid == "" || key == "" || window <= 0 {
+		return false
+	}
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		return false
+	}
+	want := hookseenKey(sid)
+	cutoff := time.Now().UTC().Add(-window)
+	lines := strings.Split(string(b), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		parts := strings.Fields(lines[i])
+		if len(parts) < 3 || parts[0] != want || parts[1] != key {
+			continue
+		}
+		// A row with an unreadable stamp is one this hook wrote in a shape it
+		// no longer writes; answering again is the safe way to be wrong.
+		t, err := time.Parse(time.RFC3339, parts[2])
+		if err != nil {
+			return false
+		}
+		return t.After(cutoff)
+	}
+	return false
 }
 
 // isSpawnedReader reports whether this recall is for an agent the parent just

--- a/cmd/deja/hook_prompt_ask_key_test.go
+++ b/cmd/deja/hook_prompt_ask_key_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A `/loop 1m …` sends the same text every minute, and the per-session
+// cooldowns are counted per session shown — so an identical prompt walked one
+// session further down the ranking on every tick: 25 blocks from 21 different
+// sessions in one evening, none of them the loop's subject (#3189).
+func TestTheSameQuestionIsAnsweredOnce(t *testing.T) {
+	dir := t.TempDir() + "/index"
+	terms := []string{"zebraquux", "fetcher", "timeout"}
+	key := askKey(terms)
+
+	if askedRecently(dir, "sess-1", key, repeatAskWindow) {
+		t.Fatal("nothing has been asked yet")
+	}
+	rememberInjectedIDsFor(dir, "sess-1", "", []string{key})
+	if !askedRecently(dir, "sess-1", key, repeatAskWindow) {
+		t.Error("the same question from the same reader is answered again")
+	}
+	// The order of the terms is the ranking's business, not the reader's.
+	if !askedRecently(dir, "sess-1", askKey([]string{"timeout", "zebraquux", "fetcher"}), repeatAskWindow) {
+		t.Error("the same terms in another order read as another question")
+	}
+	// Another question, and another reader, are not this one.
+	if askedRecently(dir, "sess-1", askKey([]string{"quokkabloom", "retry"}), repeatAskWindow) {
+		t.Error("a different question was taken for the one just answered")
+	}
+	if askedRecently(dir, "sess-2", key, repeatAskWindow) {
+		t.Error("one reader's answer silenced another reader")
+	}
+	// The window is what ends the silence: the same subject a day later is a
+	// question again.
+	if askedRecently(dir, "sess-1", key, time.Nanosecond) {
+		t.Error("the window is not honoured")
+	}
+}
+
+// The row has to carry a time, or the window cannot end.
+func TestTheAnsweredQuestionIsStamped(t *testing.T) {
+	dir := t.TempDir() + "/index"
+	rememberInjectedIDsFor(dir, "sess-1", "", []string{askKey([]string{"zebraquux"})})
+	b, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Fields(strings.TrimSpace(string(b)))
+	if len(parts) < 3 {
+		t.Fatalf("row has no timestamp: %q", b)
+	}
+	if _, err := time.Parse(time.RFC3339, parts[2]); err != nil {
+		t.Errorf("stamp %q does not parse: %v", parts[2], err)
+	}
+	if !strings.HasPrefix(parts[1], "ask:") {
+		t.Errorf("the question key %q could be taken for a session id", parts[1])
+	}
+	// Wide enough that two questions do not share a key: a narrow one silences
+	// a question nobody asked, which is the failure the reader cannot see.
+	if got := len(strings.TrimPrefix(parts[1], "ask:")); got != 16 {
+		t.Errorf("question key is %d hex digits, want 16", got)
+	}
+}
+
+// Compaction takes the block off the screen, so the question may be answered
+// again — the same rule the block fingerprint follows.
+func TestCompactionClearsTheAnsweredQuestion(t *testing.T) {
+	dir := t.TempDir() + "/index"
+	key := askKey([]string{"zebraquux", "fetcher"})
+	rememberInjectedIDsFor(dir, "sess-1", "", []string{key})
+	forgetInjected(dir, "sess-1")
+	if askedRecently(dir, "sess-1", key, repeatAskWindow) {
+		t.Error("the question stayed answered after the answer was compacted away")
+	}
+}

--- a/cmd/deja/hook_prompt_loop_test.go
+++ b/cmd/deja/hook_prompt_loop_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The prompt that arrives every minute. Each tick is a new call with the same
+// text, and the cooldowns are counted per session shown — so the hook worked
+// down the ranking, one session per tick, and answered a loop with sessions
+// that had nothing to do with it (#3189).
+func TestALoopedPromptIsAnsweredOnce(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	claude := filepath.Join(tmp, "claude", "proj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	at := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	// Several sessions that all carry the subject, which is what gives the
+	// ranking somewhere to walk to on the second tick.
+	answers := []struct{ subject, settled string }{
+		{"dial deadline", "the zebraquux fetcher timed out on a 200ms dial deadline; we raised it to 5s"},
+		{"retry budget", "the zebraquux retry budget was two, so the fetcher gave up early"},
+		{"dns", "zebraquux resolved slowly and the fetcher timed out waiting on DNS"},
+		{"connection pool", "the fetcher shares a pool with zebraquux, so one slow call times out the rest"},
+	}
+	for i, a := range answers {
+		line := fmt.Sprintf(`{"type":"user","sessionId":"zeb%d","timestamp":%q,`+
+			`"message":{"role":"user","content":"looking at the zebraquux %s again"}}`+"\n"+
+			`{"type":"assistant","sessionId":"zeb%d","timestamp":%q,`+
+			`"message":{"role":"assistant","content":[{"type":"text","text":%q}]}}`, i, at, a.subject, i, at, a.settled)
+		if err := os.WriteFile(filepath.Join(claude, fmt.Sprintf("zeb%d.jsonl", i)), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// And the session the question was actually asked in, which is what the
+	// first tick is answered with.
+	asked := fmt.Sprintf(`{"type":"user","sessionId":"zebmain","timestamp":%q,`+
+		`"message":{"role":"user","content":"why does the zebraquux fetcher time out?"}}`+"\n"+
+		`{"type":"assistant","sessionId":"zebmain","timestamp":%q,`+
+		`"message":{"role":"assistant","content":[{"type":"text","text":`+
+		`"we settled it: the zebraquux dial deadline goes to 5s and the retry budget to three"}]}}`, at, at)
+	if err := os.WriteFile(filepath.Join(claude, "zebmain.jsonl"), []byte(asked+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(tmp, "work", "proj")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	tick := func(prompt string) string {
+		t.Helper()
+		var out bytes.Buffer
+		payload := fmt.Sprintf(`{"session_id":"loop-1","cwd":%q,"prompt":%q}`, cwd, prompt)
+		if err := runHookPrompt(dir, strings.NewReader(payload), &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	const q = "why does the zebraquux fetcher time out?"
+	first := tick(q)
+	if !strings.Contains(first, "zebraquux") {
+		t.Fatalf("the first tick recalled nothing, so this measures nothing: %q", first)
+	}
+	for i := 2; i <= 4; i++ {
+		if got := tick(q); strings.Contains(got, "deja-recall") {
+			t.Errorf("tick %d answered the same question again: %q", i, got)
+		}
+	}
+	// A different question in the same reader is still a question.
+	if got := tick("what did we settle on for the zebraquux retry budget?"); !strings.Contains(got, "deja-recall") {
+		t.Errorf("the next question went unanswered: %q", got)
+	}
+}


### PR DESCRIPTION
The cooldowns are counted per session shown, so an identical prompt arriving every minute walked one session further down the ranking on each tick — 25 blocks from 21 different sessions in one evening, none of them the loop's subject. Option (1) from the issue: a question fingerprint per reader, taken from the search terms, held for an hour.

A spawned fleet is exempt: ten agents sent out on the same work are ten readers behind one key, and #2534 is about each of them being answered.

Measured on a hermetic stand, same prompt six times: 750 B then 404 B then silence before, 750 B then silence after. `bench prompt` unchanged on every arm.

Closes #3189