### PR TITLE
fix(cursor): a turn is dated by the stamp Cursor wrote into it

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -126,7 +126,7 @@ import (
 // tool calls (#3295), opencode's synthetic parts (#3299) and subagent parents
 // (#3301), Copilot's injected skills (#3305), aider's banner and its
 // continuation lines (#3311), opencode's own session titles (#3315),
-// Antigravity's plan approvals (#3326). A store
+// Antigravity's plan approvals (#3326), Cursor's per-turn stamps (#3349). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/sources/cursor.go
+++ b/internal/sources/cursor.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -338,10 +340,21 @@ var cursorDialect = toolDialect{
 func ParseCursorTranscript(path string) ([]model.Session, error) {
 	id := strings.TrimSuffix(filepath.Base(path), ".jsonl")
 	s := model.Session{Harness: "cursor", ID: id, Project: cursorTranscriptProject(path), Path: path}
+	// The file's own time is the fallback: a transcript with no stamp in it at
+	// all still needs a date, and so does one whose stamps deja cannot read.
+	// Where Cursor wrote the turn's own time, that wins — a copy or a restore
+	// moves the modification time and nothing else (#3349).
+	var fileTime time.Time
 	fi, err := os.Stat(path)
 	if err == nil {
-		s.Touch(fi.ModTime()) // transcripts carry no timestamps
+		fileTime = fi.ModTime()
 	}
+	// The stamp Cursor writes ahead of the question, carried forward: an
+	// assistant turn has none of its own and belongs to the question it
+	// answers. Every turn took the modification time before, so a transcript
+	// holding turns a month apart read as one day.
+	at := fileTime
+	stamped := false
 	err = scanJSONLFromOffset(path, 0, func(m map[string]any) {
 		role, _ := m["role"].(string)
 		if role != "user" && role != "assistant" {
@@ -351,32 +364,76 @@ func ParseCursorTranscript(path string) ([]model.Session, error) {
 		if msg == nil {
 			return
 		}
-		if txt := textFromContent(msg["content"]); txt != "" {
-			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: s.Updated})
+		txt := textFromContent(msg["content"])
+		if t, ok := cursorTurnTime(txt); ok {
+			at = t
+			s.Touch(t)
+			stamped = true
+		}
+		if txt != "" {
+			s.Messages = append(s.Messages, model.Message{Role: role, Text: txt, Time: at})
 		}
 		// A turn that only called tools has no text, so this cannot sit behind
 		// the text check: reading a file and running a build is exactly the
 		// turn that carries no prose.
 		if IndexToolPaths() {
 			if p := toolPathsIn(msg["content"], cursorDialect); p != "" {
-				s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: s.Updated})
+				s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: p, Time: at})
 			}
 		}
 		if IndexEdits() {
 			for _, e := range editSpansIn(msg["content"], cursorDialect) {
-				s.Messages = append(s.Messages, model.Message{Role: RoleEdit, Text: e, Time: s.Updated})
+				s.Messages = append(s.Messages, model.Message{Role: RoleEdit, Text: e, Time: at})
 			}
 		}
 		if IndexCommands() {
 			for _, cmd := range commandsIn(msg["content"], cursorDialect) {
-				s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: s.Updated})
+				s.Messages = append(s.Messages, model.Message{Role: RoleCommand, Text: cmd, Time: at})
 			}
 		}
 	})
+	if !stamped {
+		s.Touch(fileTime)
+	}
 	if len(s.Messages) == 0 {
 		return nil, err
 	}
 	return []model.Session{s}, err
+}
+
+// cursorTurnTimeRE is the block Cursor puts ahead of a person's words:
+// `<timestamp>Sunday, Jul 26, 2026, 1:06 PM (UTC+3)</timestamp>`. The zone is
+// an offset from UTC, spelled the way the shell prints it.
+var cursorTurnTimeRE = regexp.MustCompile(`<timestamp>\s*(?:[A-Za-z]+,\s*)?([A-Za-z]{3,}\s+\d{1,2},\s+\d{4},\s+\d{1,2}:\d{2}\s*(?:AM|PM))\s*(?:\(UTC([+-]\d{1,2})(?::(\d{2}))?\))?`)
+
+// cursorTurnTime reads that block. A transcript without one, or with a shape
+// this cannot parse, keeps the file's modification time.
+func cursorTurnTime(text string) (time.Time, bool) {
+	m := cursorTurnTimeRE.FindStringSubmatch(text)
+	if m == nil {
+		return time.Time{}, false
+	}
+	zone := time.UTC
+	if m[2] != "" {
+		h, err := strconv.Atoi(m[2])
+		if err != nil {
+			return time.Time{}, false
+		}
+		mins := 0
+		if m[3] != "" {
+			mins, _ = strconv.Atoi(m[3])
+			if h < 0 {
+				mins = -mins
+			}
+		}
+		zone = time.FixedZone("", h*3600+mins*60)
+	}
+	for _, layout := range []string{"Jan 2, 2006, 3:04 PM", "January 2, 2006, 3:04 PM"} {
+		if t, err := time.ParseInLocation(layout, m[1], zone); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // cursorTranscriptProject decodes ~/.cursor/projects/<Users-me-work-foo>/...

--- a/internal/sources/cursor_stamps_test.go
+++ b/internal/sources/cursor_stamps_test.go
@@ -61,3 +61,49 @@ func TestCursorTakesTheTimeFromTheTurnNotTheFile(t *testing.T) {
 		t.Errorf("third turn = %v, want %v", s.Messages[2].Time, august)
 	}
 }
+
+// The shapes the stamp can take, and the ones it cannot: a zone with minutes,
+// no zone at all, a month spelled in full, and three that do not parse — a
+// label other than UTC, seconds in the time, and a month name deja does not
+// know. Each of those falls back to the file's modification time, which is the
+// documented behaviour (#3349).
+func TestCursorTurnTimeReadsTheShapesCursorWrites(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want string
+	}{
+		{"<timestamp>Sunday, Jul 26, 2026, 1:06 PM (UTC+3)</timestamp>", "2026-07-26T13:06:00+03:00"},
+		{"<timestamp>Jul 26, 2026, 1:06 PM (UTC-3:30)</timestamp>", "2026-07-26T13:06:00-03:30"},
+		{"<timestamp>January 2, 2026, 9:05 AM</timestamp>", "2026-01-02T09:05:00Z"},
+	} {
+		got, ok := cursorTurnTime(c.in)
+		if !ok {
+			t.Errorf("cursorTurnTime(%q) did not parse", c.in)
+			continue
+		}
+		if got.Format(time.RFC3339) != c.want {
+			t.Errorf("cursorTurnTime(%q) = %s, want %s", c.in, got.Format(time.RFC3339), c.want)
+		}
+	}
+	for _, in := range []string{
+		"<timestamp>Sunday, Jul 26, 2026, 1:06:45 PM (UTC+3)</timestamp>",
+		"<timestamp>воскресенье, 26 июля 2026, 13:06</timestamp>",
+		"no stamp at all, just a question",
+	} {
+		if _, ok := cursorTurnTime(in); ok {
+			t.Errorf("cursorTurnTime(%q) parsed a shape it should have left to the file time", in)
+		}
+	}
+}
+
+// The encoded directory in the form the shared resolver walks: Cursor writes
+// it without the leading separator, so the exported helper adds it back.
+func TestCursorTranscriptProjectDirBase(t *testing.T) {
+	got := CursorTranscriptProjectDirBase(filepath.Join("root", "projects", "Users-me-work-app", "agent-transcripts", "s1", "s1.jsonl"))
+	if got != "-Users-me-work-app" {
+		t.Errorf("CursorTranscriptProjectDirBase = %q, want %q", got, "-Users-me-work-app")
+	}
+	if got := CursorTranscriptProjectDirBase(filepath.Join("agent-transcripts", "s1.jsonl")); got != "" {
+		t.Errorf("a path with no projects directory above it = %q, want empty", got)
+	}
+}

--- a/internal/sources/cursor_stamps_test.go
+++ b/internal/sources/cursor_stamps_test.go
@@ -1,0 +1,63 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Cursor writes the time of each turn into the turn, and the reader took the
+// file's modification time for all of them: one real transcript here holds
+// turns from July 26 and August 22 and every message was dated August 22, the
+// day the file was last written (#3349).
+func TestCursorTakesTheTimeFromTheTurnNotTheFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "projects", "Users-w-api", "agent-transcripts", "de875c53")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "de875c53.jsonl")
+	lines := `{"role":"user","message":{"role":"user","content":[{"type":"text","text":"<timestamp>Sunday, Jul 26, 2026, 1:06 PM (UTC+3)</timestamp>\n<user_query>\nwhy does the retry loop drop the last attempt\n</user_query>"}]}}
+{"role":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"because the counter compares with < instead of <="}]}}
+{"role":"user","message":{"role":"user","content":[{"type":"text","text":"<timestamp>Saturday, Aug 22, 2026, 9:35 AM (UTC+3)</timestamp>\n<user_query>\ncap the retries at three\n</user_query>"}]}}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The file's own mtime is a third date, and must not be what any turn says.
+	mtime := time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CURSOR_CLI_ROOT", root)
+
+	ss, err := ParseCursorTranscript(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(ss))
+	}
+	s := ss[0]
+	july := time.Date(2026, 7, 26, 13, 6, 0, 0, time.FixedZone("", 3*3600))
+	august := time.Date(2026, 8, 22, 9, 35, 0, 0, time.FixedZone("", 3*3600))
+	if !s.Started.Equal(july) {
+		t.Errorf("started = %v, want the first turn's own stamp %v", s.Started, july)
+	}
+	if !s.Updated.Equal(august) {
+		t.Errorf("updated = %v, want the last turn's own stamp %v", s.Updated, august)
+	}
+	if len(s.Messages) < 3 {
+		t.Fatalf("messages = %d, want at least 3", len(s.Messages))
+	}
+	if !s.Messages[0].Time.Equal(july) {
+		t.Errorf("first turn = %v, want %v", s.Messages[0].Time, july)
+	}
+	if !s.Messages[1].Time.Equal(july) {
+		t.Errorf("the reply carries the question's time: %v, want %v", s.Messages[1].Time, july)
+	}
+	if !s.Messages[2].Time.Equal(august) {
+		t.Errorf("third turn = %v, want %v", s.Messages[2].Time, august)
+	}
+}


### PR DESCRIPTION
Closes #3349.

Cursor writes `<timestamp>Sunday, Jul 26, 2026, 1:06 PM (UTC+3)</timestamp>` ahead of the person's words, in the same block the reader already strips before indexing. `cursorTurnTime` reads it, each turn carries it, and an assistant turn takes the question's stamp because it has none of its own. The file's modification time is the fallback for a transcript with no stamp deja can read — a copy or a restore moves that time and nothing else.

Fail-before test: `TestCursorTakesTheTimeFromTheTurnNotTheFile` (internal/sources), on the collector: `started = 2026-09-08 …, want the first turn's own stamp 2026-07-26 13:06`.

Real store, hermetic copy, one transcript:

```
before:  2026-08-22 09:35 user / assistant / user / assistant
after:   2026-07-26 13:06 user / assistant
         2026-08-22 09:35 user / assistant
```

The index version note names the reader change; the version is already 35 on this branch.
