### PR TITLE
fix(precompact): forget every key the session filed memory under

### DIFF
--- a/cmd/deja/hook_precompact_keys_test.go
+++ b/cmd/deja/hook_precompact_keys_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// A compaction takes the session-start digest off the screen along with
+// everything else, and the seen list is what stops deja sending it again. The
+// per-prompt rows were forgotten and the two the session-start hook writes —
+// `start:<sid>` and the once mark — were not, so the next start refused to
+// send back exactly what the compaction had just lost. On Kimi, whose only
+// rows are those two, nothing was forgotten at all (#3307).
+func TestCompactionForgetsEverySeenKeyOfTheSession(t *testing.T) {
+	dir := t.TempDir() + "/index"
+	const sid = "session_3f1f"
+	rememberInjectedIDs(dir, sid, "block-fingerprint")
+	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+sid, "proj", []string{"other-session"})
+	rememberSessionDigest(dir, sid)
+	// Another session's rows, which this must leave alone.
+	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+"session_other", "proj", []string{"kept-session"})
+	rememberSessionDigest(dir, "session_other")
+
+	before, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{sid + " block-fingerprint", sessionStartKeyPrefix + sid, onceDigestKey(sid)} {
+		if !strings.Contains(string(before), want) {
+			t.Fatalf("the fixture never wrote %q, so this measures nothing:\n%s", want, before)
+		}
+	}
+
+	forgetInjected(dir, sid)
+
+	after, err := os.ReadFile(dir + ".hookseen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, gone := range []string{sid + " block-fingerprint", sessionStartKeyPrefix + sid + " ", onceDigestKey(sid) + " "} {
+		if strings.Contains(string(after), gone) {
+			t.Errorf("%q survived the compaction:\n%s", gone, after)
+		}
+	}
+	for _, kept := range []string{sessionStartKeyPrefix + "session_other", onceDigestKey("session_other")} {
+		if !strings.Contains(string(after), kept) {
+			t.Errorf("another session lost %q:\n%s", kept, after)
+		}
+	}
+}

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -979,13 +979,24 @@ func forgetInjected(dir, sid string) {
 	if err != nil {
 		return
 	}
-	key := hookseenKey(sid)
+	// Every key this session's memory is filed under, not only the one the
+	// per-prompt hook writes: the session-start rows are `start:<sid>` and the
+	// once mark is `once:<sid>`, so a compaction dropped the prompt rows and
+	// kept the two that say the digest has already been sent — leaving the
+	// next start refusing to send back exactly what the compaction lost. On a
+	// harness whose only rows are those two, nothing was forgotten at all
+	// (#3307).
+	keys := map[string]bool{
+		hookseenKey(sid):                         true,
+		hookseenKey(sessionStartKeyPrefix + sid): true,
+		hookseenKey(onceDigestKey(sid)):          true,
+	}
 	var kept []string
 	for _, line := range strings.Split(string(b), "\n") {
 		if line == "" {
 			continue
 		}
-		if parts := strings.Fields(line); len(parts) >= 2 && parts[0] == key {
+		if parts := strings.Fields(line); len(parts) >= 2 && keys[parts[0]] {
 			continue
 		}
 		kept = append(kept, line)


### PR DESCRIPTION
`forgetInjected` dropped only rows keyed on the bare session id, and the session-start hook writes `start:<sid>` while the once mark is `once:<sid>`. So a compaction left standing exactly the two rows that say the session-start digest has already been sent — and on a harness whose only rows are those two (Kimi), nothing was forgotten at all.

All three keys go now; another session's rows are untouched, with a test for both halves.

Closes #3307