### PR TITLE
fix(index): a stripped block leaves no blank line ahead of the question

### DIFF
--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -130,7 +130,12 @@ func stripSelfRecall(text string) string {
 		text = unwrapBlock(text, m[0], m[1])
 	}
 	text = stripInjectedPrefixes(text)
-	return stripInjectedLines(text)
+	text = stripInjectedLines(text)
+	// Removing a block or unwrapping a tag leaves the newline that separated it
+	// from the words: every Cursor turn was indexed with a blank line ahead of
+	// the question, because the stamp above it and the wrapper around it each
+	// left one (#3357). The paragraph breaks inside what a person wrote stay.
+	return strings.Trim(text, "\n")
 }
 
 // stripInjectedLines drops lines that are entirely a harness marker. The line

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -117,7 +117,6 @@ var unwrapBlocks = [][2]string{
 // to a real user turn, so dropping the whole message would lose the question
 // that prompted the session.
 func stripSelfRecall(text string) string {
-	original := text
 	for _, m := range selfRecallMarkers {
 		text = stripBetween(text, m[0], m[1])
 	}
@@ -131,18 +130,7 @@ func stripSelfRecall(text string) string {
 		text = unwrapBlock(text, m[0], m[1])
 	}
 	text = stripInjectedPrefixes(text)
-	text = stripInjectedLines(text)
-	if text == original {
-		// Nothing was taken out, so nothing here is an artefact of taking it:
-		// a message that opens or closes with a blank line on purpose — a code
-		// block, a pasted diff — keeps it (review of #3357).
-		return text
-	}
-	// Removing a block or unwrapping a tag leaves the newline that separated it
-	// from the words: every Cursor turn was indexed with a blank line ahead of
-	// the question, because the stamp above it and the wrapper around it each
-	// left one (#3357).
-	return strings.Trim(text, "\n")
+	return stripInjectedLines(text)
 }
 
 // stripInjectedLines drops lines that are entirely a harness marker. The line
@@ -171,7 +159,10 @@ func stripInjectedLines(text string) string {
 func stripInjectedPrefixes(text string) string {
 	for again := true; again; {
 		again = false
-		trimmed := strings.TrimSpace(text)
+		// Only the head is trimmed for the match. Trimming both ends here took
+		// the blank line an author left after their own paste, at the far end
+		// of a message whose head happened to carry a block (review of #3357).
+		trimmed := strings.TrimLeft(text, " \t\n")
 		if rest, ok := stripAgentsBlock(trimmed); ok {
 			text, again = rest, true
 			continue
@@ -184,7 +175,12 @@ func stripInjectedPrefixes(text string) string {
 			if !ok {
 				continue
 			}
-			text = trimmed[end:]
+			// The newline the block left behind goes with it, and only that
+			// one: every Cursor turn opened on a blank line because the stamp
+			// above the question left its own break (#3357). Trimming the
+			// whole message instead ate blank lines an author wrote at the
+			// far end, which is action at a distance (review of #3357).
+			text = strings.TrimLeft(trimmed[end:], "\n")
 			again = true
 			break
 		}
@@ -249,7 +245,10 @@ func unwrapBlock(text, open, close string) string {
 		if end < 0 {
 			return text
 		}
-		text = text[:start] + rest[:end] + rest[end+len(close):]
+		// A wrapper writes its own line breaks around what a person typed:
+		// Cursor's <user_query> puts the question on its own line. Those two
+		// belong to the tags, not to the words.
+		text = text[:start] + strings.Trim(rest[:end], "\n") + rest[end+len(close):]
 	}
 }
 

--- a/internal/index/selfrecall.go
+++ b/internal/index/selfrecall.go
@@ -117,6 +117,7 @@ var unwrapBlocks = [][2]string{
 // to a real user turn, so dropping the whole message would lose the question
 // that prompted the session.
 func stripSelfRecall(text string) string {
+	original := text
 	for _, m := range selfRecallMarkers {
 		text = stripBetween(text, m[0], m[1])
 	}
@@ -131,10 +132,16 @@ func stripSelfRecall(text string) string {
 	}
 	text = stripInjectedPrefixes(text)
 	text = stripInjectedLines(text)
+	if text == original {
+		// Nothing was taken out, so nothing here is an artefact of taking it:
+		// a message that opens or closes with a blank line on purpose — a code
+		// block, a pasted diff — keeps it (review of #3357).
+		return text
+	}
 	// Removing a block or unwrapping a tag leaves the newline that separated it
 	// from the words: every Cursor turn was indexed with a blank line ahead of
 	// the question, because the stamp above it and the wrapper around it each
-	// left one (#3357). The paragraph breaks inside what a person wrote stay.
+	// left one (#3357).
 	return strings.Trim(text, "\n")
 }
 

--- a/internal/index/selfrecall_blank_test.go
+++ b/internal/index/selfrecall_blank_test.go
@@ -18,3 +18,12 @@ func TestStripSelfRecallLeavesNoBlankLineWhereABlockWas(t *testing.T) {
 		t.Errorf("stripSelfRecall = %q — a stamp that is not the head of the message is prose", got)
 	}
 }
+
+// And nothing is trimmed from a message the cleaning did not touch: a code
+// block that opens and closes with a blank line keeps both (review of #3357).
+func TestStripSelfRecallLeavesAnUntouchedMessageAlone(t *testing.T) {
+	in := "\n\n```\n\nfunc foo() {}\n```\n\n"
+	if got := stripSelfRecall(in); got != in {
+		t.Errorf("stripSelfRecall = %q, want the message unchanged — nothing was stripped from it", got)
+	}
+}

--- a/internal/index/selfrecall_blank_test.go
+++ b/internal/index/selfrecall_blank_test.go
@@ -1,0 +1,20 @@
+package index
+
+import "testing"
+
+// Cursor writes `<timestamp>…</timestamp>` above `<user_query>…</user_query>`,
+// and removing the one and unwrapping the other each left the newline that
+// separated them, so every Cursor turn on this machine's store was indexed
+// with a blank line ahead of the question (#3357).
+func TestStripSelfRecallLeavesNoBlankLineWhereABlockWas(t *testing.T) {
+	in := "<timestamp>Sunday, Jul 26, 2026, 1:06 PM (UTC+3)</timestamp>\n<user_query>\nwhy does the retry loop drop the last attempt\n</user_query>"
+	if got := stripSelfRecall(in); got != "why does the retry loop drop the last attempt" {
+		t.Errorf("stripSelfRecall = %q, want the question with nothing around it", got)
+	}
+	// A block in the middle keeps the paragraph break around it, and the words
+	// on both sides stay whole.
+	mid := "first line\n\n<timestamp>Sunday, Jul 26, 2026, 1:06 PM</timestamp>\n\nsecond line"
+	if got := stripSelfRecall(mid); got != "first line\n\n<timestamp>Sunday, Jul 26, 2026, 1:06 PM</timestamp>\n\nsecond line" {
+		t.Errorf("stripSelfRecall = %q — a stamp that is not the head of the message is prose", got)
+	}
+}

--- a/internal/index/selfrecall_blank_test.go
+++ b/internal/index/selfrecall_blank_test.go
@@ -27,3 +27,25 @@ func TestStripSelfRecallLeavesAnUntouchedMessageAlone(t *testing.T) {
 		t.Errorf("stripSelfRecall = %q, want the message unchanged — nothing was stripped from it", got)
 	}
 }
+
+// The trim belongs where the removal happened. Trimming the whole message
+// instead ate what an author wrote at the far end — a blank line after their
+// pasted diff — and made a message's edges depend on whether a marker fired
+// somewhere else entirely (second review of #3357).
+func TestStripSelfRecallTrimsOnlyWhereItCut(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{
+			"<timestamp>Sunday, Jul 26, 2026, 1:06 PM</timestamp>\n\nhere is my diff:\n\n```\n+foo\n```\n\n",
+			"here is my diff:\n\n```\n+foo\n```\n\n",
+		},
+		{
+			"\n\nfirst paragraph\n\n<system-reminder>noise</system-reminder>\n\nsecond paragraph\n\n",
+			"\n\nfirst paragraph\n\n\n\nsecond paragraph\n\n",
+		},
+	}
+	for _, c := range cases {
+		if got := stripSelfRecall(c.in); got != c.want {
+			t.Errorf("stripSelfRecall(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3357.

`stripSelfRecall` trims the newlines at the ends of what it hands back, which `stripBetween` has done for deja's own recall since it was written. The two other paths — cutting a harness preamble, unwrapping a wrapper — each left the break that separated the block from the words, and Cursor's turns go through both.

Fail-before test: `TestStripSelfRecallLeavesNoBlankLineWhereABlockWas` (internal/index), on the collector: `"\n\nwhy does the retry loop drop the last attempt"`. Its second half holds the other side: a stamp in the middle of a message is prose, and the paragraph breaks around it stay.

Real store, hermetic copy, `deja index --rebuild`:

```
before: "\n\nDo not use any tool. Count how many separate blocks…"
after:  "Do not use any tool. Count how many separate blocks…"
```

19 Cursor sessions here, every turn of them.
