### PR TITLE
docs(site): the CLI reference lists index, mcp, share, handoff and check

### DIFF
--- a/cmd/deja/commands_page_test.go
+++ b/cmd/deja/commands_page_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The CLI reference page is subtitled "every command". It missed five —
+// index, mcp, share, handoff and check — and nothing noticed, because the page
+// is only checked for its title and its counts (#3356).
+//
+// Two commands are named differently on purpose: the page describes the bare
+// `deja` screen rather than `deja brief`, and `deja "query"` rather than the
+// `deja search` alias that exists so a query may start with a dash. Hidden
+// hooks are not commands a reader types.
+func TestTheCommandsPageNamesEveryCommand(t *testing.T) {
+	page, err := os.ReadFile(filepath.Join("..", "..", "docs", "guide", "commands.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	named := map[string]bool{}
+	for _, m := range regexp.MustCompile(`<code>deja ([a-z-]+)`).FindAllStringSubmatch(string(page), -1) {
+		named[m[1]] = true
+	}
+	if len(named) < 20 {
+		t.Fatalf("the page names %d commands, so this checks nothing", len(named))
+	}
+
+	spelledOtherwise := map[string]bool{"brief": true, "search": true}
+	var missing []string
+	for _, line := range strings.Split(usageText(), "\n") {
+		// A name, not a flag: the usage lists `deja --harness name` under the
+		// bare query as well.
+		m := regexp.MustCompile(`^\s+deja ([a-z][a-z-]*)`).FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		name := m[1]
+		if strings.HasPrefix(name, "hook-") || spelledOtherwise[name] || named[name] {
+			continue
+		}
+		missing = append(missing, name)
+	}
+	if len(missing) > 0 {
+		t.Errorf("docs/guide/commands.html says \"every command\" and has no row for %v", missing)
+	}
+}

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -129,6 +129,11 @@
 <tr><td><code>deja doctor</code></td><td>Diagnose stores, wiring, index and version. <code>--json</code>, <code>--offline</code>. <code>--deep</code> re-parses a sample of source files and resolves postings to prove the index against the sources; exits non-zero on drift.</td></tr>
 <tr><td><code>deja bench recall|context</code></td><td>Reproducible search-quality and context-readiness benchmarks.</td></tr>
 <tr><td><code>deja update</code></td><td>Update a standalone install (Homebrew/npm update via the package manager).</td></tr>
+<tr><td><code>deja index</code></td><td>Read what the agents on this machine have written since the last pass. <code>--rebuild</code> reads everything again, which is what a parser change needs.</td></tr>
+<tr><td><code>deja mcp</code></td><td>Run the MCP server on stdio. <code>deja install</code> wires this for you; run it by hand only to debug a client.</td></tr>
+<tr><td><code>deja share &lt;id-prefix&gt;</code></td><td>A redacted digest of one session, for pasting to someone else.</td></tr>
+<tr><td><code>deja handoff [id-prefix]</code></td><td>What the next agent needs to carry on: the problem, what was tried, what was settled, and where it stopped. <code>--to &lt;agent&gt;</code> phrases it for that agent and <code>--exec</code> opens it there.</td></tr>
+<tr><td><code>deja check -</code></td><td>Read a plan from stdin and print what this machine's history says about the things in it — what was decided, and what went wrong last time.</td></tr>
 </tbody></table>
 <div class="note">Bare <code>deja</code> on a terminal prints the living brief; piped or redirected it prints the usage summary, which <code>deja --help</code> also shows, and any command takes <code>--help</code> for its flags. Everything is offline except <code>update</code>, <code>sync ssh</code> and the <code>doctor</code> version check.</div>
 


### PR DESCRIPTION
The reference page is subtitled "every command" and had no row for `index`, `mcp`, `share`, `handoff` or `check` — the last two are documented on other guide pages, so a reader who lands on the reference is told the tool does not have them.

Rows added, and a test that compares the page against the usage text so the next command cannot land half-listed. `brief` and `search` stay spelled as the bare `deja` screen and `deja "query"`, which is what the page already calls them.

Closes #3356