### PR TITLE
docs: llms.txt says nineteen more agents, not fifteen

### DIFF
--- a/cmd/deja/page_titles_count_test.go
+++ b/cmd/deja/page_titles_count_test.go
@@ -74,6 +74,18 @@ func TestPageTitlesCountTheRestOfTheHarnesses(t *testing.T) {
 	if pages != n {
 		t.Errorf("%d registry pages for %d harnesses", pages, n)
 	}
+
+	// And llms.txt, which is the summary an agent reads instead of the site. It
+	// names six harnesses and spells the rest, and had stood at fifteen through
+	// four landing.
+	llms, err := os.ReadFile(filepath.Join(root, "docs", "llms.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	named := strings.Count("Claude Code, Codex, Cursor, opencode, Gemini CLI, Zed", ",") + 1
+	if want := fmt.Sprintf("Zed and %s more agents", countWordForTest(n-named)); !strings.Contains(string(llms), want) {
+		t.Errorf("docs/llms.txt does not say %q — the registry has %d harnesses", want, n)
+	}
 }
 
 // countWordForTest spells the number the generator's template spells.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # deja-vu
 
-> Local memory for coding agents, built from the session transcripts they already write to disk. deja indexes what Claude Code, Codex, Cursor, opencode, Gemini CLI, Zed and fifteen more agents wrote on this machine — including the months before it was installed — and answers from them over MCP or the command line. BM25 over the transcripts: no model, no embeddings, nothing leaves the machine.
+> Local memory for coding agents, built from the session transcripts they already write to disk. deja indexes what Claude Code, Codex, Cursor, opencode, Gemini CLI, Zed and nineteen more agents wrote on this machine — including the months before it was installed — and answers from them over MCP or the command line. BM25 over the transcripts: no model, no embeddings, nothing leaves the machine.
 
 Two things distinguish it from memory tools that record forward: it starts full, because the history is already on disk, and recall arrives without being asked — at session start, on each prompt, before an edit or a command, and after a command fails. Credentials are stripped as the index is built.
 


### PR DESCRIPTION
The summary agents read named six harnesses and put the rest at fifteen — that was true four harnesses ago. The existing count test now covers llms.txt alongside the two pages it already checks.