### PR TITLE
fix(doctor): the cline row says when a transcript went unread

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -734,13 +734,19 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// disagree with `deja sources` by one; counted as unread, it made every
 	// store report a file deja could not read (#3297). So it is neither: the
 	// count is the transcripts, and the note leaves the list alone.
-	printFilesBeside := func(name, path string, present bool, seen []string, beside ...string) {
+	// printFilesBesideIn is printFilesBeside for a row whose printed location is
+	// not one directory: cline names its modern store and its legacy roots on
+	// the same line, and that string cannot be walked (#3360).
+	printFilesBesideIn := func(name, loc, walk string, present bool, seen []string, beside ...string) {
 		detail := doctorCount(len(seen), "file")
 		placed := append(append([]string{}, seen...), beside...)
-		if unread, _ := unplacedFiles(path, placed, nil); unread > 0 {
+		if unread, _ := unplacedFiles(walk, placed, nil); unread > 0 {
 			detail += fmt.Sprintf(", %d not recognised here", unread)
 		}
-		printRow(name, path, present, detail)
+		printRow(name, loc, present, detail)
+	}
+	printFilesBeside := func(name, path string, present bool, seen []string, beside ...string) {
+		printFilesBesideIn(name, path, path, present, seen, beside...)
 	}
 
 	claudeRoot := sources.ClaudeRoot()
@@ -783,7 +789,8 @@ func doctorHarnesses(w io.Writer, dir string) {
 	if legacy := sources.ClineLegacyRoots(); len(legacy) > 0 {
 		clineLoc += ", " + strings.Join(legacy, string(os.PathListSeparator))
 	}
-	printRow("cline", clineLoc, clineFiles > 0 || doctorExists(clineModern), doctorCount(clineFiles, "file"))
+	printFilesBesideIn("cline", clineLoc, clineModern, clineFiles > 0 || doctorExists(clineModern),
+		sources.ClineSessionFiles(), sources.ClineSidecarFiles()...)
 
 	rooFiles := len(sources.RooTaskFiles())
 	rooLoc := "VS Code globalStorage rooveterinaryinc.roo-cline"

--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -737,16 +737,21 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// printFilesBesideIn is printFilesBeside for a row whose printed location is
 	// not one directory: cline names its modern store and its legacy roots on
 	// the same line, and that string cannot be walked (#3360).
-	printFilesBesideIn := func(name, loc, walk string, present bool, seen []string, beside ...string) {
+	printFilesBesideIn := func(name, loc string, walks []string, present bool, seen []string, beside ...string) {
 		detail := doctorCount(len(seen), "file")
 		placed := append(append([]string{}, seen...), beside...)
-		if unread, _ := unplacedFiles(walk, placed, nil); unread > 0 {
+		unread := 0
+		for _, walk := range walks {
+			u, _ := unplacedFiles(walk, placed, nil)
+			unread += u
+		}
+		if unread > 0 {
 			detail += fmt.Sprintf(", %d not recognised here", unread)
 		}
 		printRow(name, loc, present, detail)
 	}
 	printFilesBeside := func(name, path string, present bool, seen []string, beside ...string) {
-		printFilesBesideIn(name, path, path, present, seen, beside...)
+		printFilesBesideIn(name, path, []string{path}, present, seen, beside...)
 	}
 
 	claudeRoot := sources.ClaudeRoot()
@@ -789,7 +794,14 @@ func doctorHarnesses(w io.Writer, dir string) {
 	if legacy := sources.ClineLegacyRoots(); len(legacy) > 0 {
 		clineLoc += ", " + strings.Join(legacy, string(os.PathListSeparator))
 	}
-	printFilesBesideIn("cline", clineLoc, clineModern, clineFiles > 0 || doctorExists(clineModern),
+	// Every root the line names is walked, or the count would promise coverage
+	// the row does not have: a stray file under a legacy tasks tree was
+	// invisible while the line advertised that root (review of #3360).
+	clineWalks := []string{clineModern}
+	for _, root := range sources.ClineLegacyRoots() {
+		clineWalks = append(clineWalks, filepath.Join(root, "tasks"))
+	}
+	printFilesBesideIn("cline", clineLoc, clineWalks, clineFiles > 0 || doctorExists(clineModern),
 		sources.ClineSessionFiles(), sources.ClineSidecarFiles()...)
 
 	rooFiles := len(sources.RooTaskFiles())

--- a/cmd/deja/doctor_cline_files_test.go
+++ b/cmd/deja/doctor_cline_files_test.go
@@ -53,3 +53,37 @@ func TestDoctorNamesAnUnreadClineTranscriptButNotItsManifest(t *testing.T) {
 		t.Errorf("row = %q, want it to name the transcript deja did not read", got)
 	}
 }
+
+// The row names the legacy VS Code roots on the same line, so they are walked
+// too: a stray file under a legacy task was invisible while the line said the
+// root was covered (review of #3360).
+func TestDoctorCountsAStrayFileUnderAClineLegacyRoot(t *testing.T) {
+	tmp := hermeticEnv(t)
+	legacy := filepath.Join(tmp, "vscode", "globalStorage", "saoudrizwan.claude-dev")
+	task := filepath.Join(legacy, "tasks", "1757000000")
+	if err := os.MkdirAll(task, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOTS", legacy)
+	t.Setenv("DEJA_CLINE_ROOT", filepath.Join(tmp, "cline", "data", "sessions"))
+
+	if err := os.WriteFile(filepath.Join(task, "api_conversation_history.json"),
+		[]byte(`[{"role":"user","content":[{"type":"text","text":"why does the retry loop drop the last attempt"}]}]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(task, "ui_messages.json"), []byte(`[]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	doctorHarnesses(&buf, t.TempDir())
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "cline") && strings.Contains(l, "file") {
+			if !strings.Contains(l, "1 not recognised here") {
+				t.Errorf("row = %q, want the stray file under the legacy root counted", l)
+			}
+			return
+		}
+	}
+	t.Fatal("no cline file row in the report at all")
+}

--- a/cmd/deja/doctor_cline_files_test.go
+++ b/cmd/deja/doctor_cline_files_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The cline row printed a count and nothing else, so a transcript deja could
+// not read was invisible there while every other file-listing harness named it
+// (#3360). A session directory keeps `<id>.json` beside `<id>.messages.json` —
+// the manifest the reader opens itself for the title, the working directory
+// and the timestamps — and that is not a failure either.
+func TestDoctorNamesAnUnreadClineTranscriptButNotItsManifest(t *testing.T) {
+	tmp := hermeticEnv(t)
+	sessions := filepath.Join(tmp, "cline", "data", "sessions")
+	dir := filepath.Join(sessions, "1757000000_ab12c")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOT", sessions)
+
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("1757000000_ab12c.messages.json", `[{"role":"user","content":[{"type":"text","text":"why does the retry loop drop the last attempt"}]}]`)
+	write("1757000000_ab12c.json", `{"session_id":"1757000000_ab12c","cwd":"/w/api","metadata":{"title":"retry loop"}}`)
+
+	row := func() string {
+		t.Helper()
+		var buf bytes.Buffer
+		doctorHarnesses(&buf, t.TempDir())
+		for _, l := range strings.Split(buf.String(), "\n") {
+			if strings.Contains(l, "cline") && strings.Contains(l, "file") {
+				return l
+			}
+		}
+		t.Fatal("no cline file row in the report at all")
+		return ""
+	}
+	if got := row(); strings.Contains(got, "not recognised") {
+		t.Errorf("row = %q, want no such note — the manifest is the reader's own", got)
+	}
+	// And the note is there for the thing it exists for: a transcript under a
+	// name the reader does not take, which is what a format change looks like.
+	write("conversation.json", `[{"role":"user","content":[{"type":"text","text":"anything"}]}]`)
+	if got := row(); !strings.Contains(got, "1 not recognised here") {
+		t.Errorf("row = %q, want it to name the transcript deja did not read", got)
+	}
+}

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -123,6 +123,18 @@ func ClineSessionFiles() []string {
 	return files
 }
 
+// ClineSidecarFiles lists the per-session manifest the reader opens itself for
+// the title, the working directory and the timestamps. doctor counted one per
+// session as a transcript it could not read, the same shape as #3297 (#3360).
+func ClineSidecarFiles() []string {
+	return walkFiles(ClineSessionsDir(), func(p string) bool {
+		// The manifest is named after the directory it sits in, which is what
+		// the reader opens; anything else under a session is a file deja has
+		// no account of and the row should say so.
+		return filepath.Base(p) == filepath.Base(filepath.Dir(p))+".json"
+	})
+}
+
 func LoadCline() []model.Session {
 	return parseFiles(ClineSessionFiles(), ParseClineFile)
 }


### PR DESCRIPTION
Closes #3360.

The cline row moves to `printFilesBeside`, the pattern Continue (#3297), Copilot (#3303), Kimi (#3309), OpenClaw (#3317), Grok (#3319) and Codex (#3321) already use. `ClineSidecarFiles` names the per-session manifest — the file named after its own directory, which the reader opens for the title, the working directory and the timestamps — and nothing else, so a transcript under an unexpected name is still counted.

The row prints its modern store and its legacy roots on one line, and that string is not a directory, so `printFilesBesideIn` takes the walked path separately. Every other caller goes through the old signature unchanged.

Fail-before test: `TestDoctorNamesAnUnreadClineTranscriptButNotItsManifest` (cmd/deja), on the collector: `(1 file)`, want it to name the transcript deja did not read.

Real store, hermetic copy of 15 sessions, with one transcript copied to `conversation.json`:

```
before:  cline  found  ~/.cline/data/sessions  (15 files)
after:   cline  found  ~/.cline/data/sessions  (15 files, 1 not recognised here)
clean:   cline  found  ~/.cline/data/sessions  (15 files)
```

The bare-count shape is still on aider, antigravity, roo and copilot-chat; they are queued one at a time.
