### PR TITLE
fix(site): the home grid shows all 25 agents its heading counts

### DIFF
--- a/cmd/deja/home_grid_test.go
+++ b/cmd/deja/home_grid_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The grid under "Works with 25" listed twenty names: Amp, Continue, Copilot
+// Chat, prime-agent and Crush landed and never reached it, so the heading
+// counted five agents the grid did not show. It is the list a reader scans for
+// their own agent before installing anything.
+func TestTheHomeGridShowsEveryHarnessItCounts(t *testing.T) {
+	root := filepath.Join("..", "..")
+	page, err := os.ReadFile(filepath.Join(root, "docs", "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grid := regexp.MustCompile(`(?s)<div class="agents".*?</div>`).Find(page)
+	if grid == nil {
+		t.Fatal("the home page has no agent grid to check")
+	}
+	shown := 0
+	for _, m := range regexp.MustCompile(`<span>([^<]+)</span>`).FindAllSubmatch(grid, -1) {
+		if strings.TrimSpace(string(m[1])) != "" {
+			shown++
+		}
+	}
+	if n := registryHarnessCount(t, root); shown != n {
+		t.Errorf("the grid shows %d agents under a heading that counts %d", shown, n)
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -411,6 +411,8 @@ footer a:hover{color:var(--ph-hi)}
     <span>aider</span><span>Goose</span><span>Qwen Code</span><span>Kimi Code</span>
     <span>Antigravity</span><span>Grok Build</span><span>OpenClaw</span><span>pi</span>
     <span>omp</span><span>DeepSeek Harness</span><span>Hermes</span><span>Zed</span>
+    <span>Amp</span><span>Continue</span><span>Copilot Chat</span><span>prime-agent</span>
+    <span>Crush</span>
     <span class="more">one memory, all of them</span>
   </div>
 </section>


### PR DESCRIPTION
The grid under "Works with 25" listed twenty names — Amp, Continue, Copilot Chat, prime-agent and Crush landed and never reached it. Names added and a test ties the grid to the registry count.

The "one memory, all of them" tail stays; if the fuller grid reads too heavy on the page, the trim is a design call and I will take whatever you prefer.