### PR TITLE
fix(handoff): carry what the compaction dropped, named as the harness's own

### DIFF
--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -669,6 +669,71 @@ func IsAgentArtifact(text string) bool {
 	return false
 }
 
+// compactedHalf returns what the harness said the session was about before the
+// compaction, when its summary is the first thing in the session — the shape a
+// resumed session has, and the only place the earlier half survives. Empty for
+// every other session, including one whose summary sits after turns of its own:
+// there the person has already said what the work is.
+//
+// Bounded to the intent the summary opens with. The whole block runs to
+// kilobytes and the handoff has a budget to spend on what was actually said.
+func compactedHalf(s model.Session) string {
+	for _, m := range s.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		trimmed := strings.TrimSpace(m.Text)
+		if !isCompactionSummary(trimmed) {
+			return ""
+		}
+		return compactionIntent(trimmed)
+	}
+	return ""
+}
+
+// compactionIntent is the "Primary Request and Intent" section of a compaction
+// summary, cut to the first few lines of it.
+func compactionIntent(summary string) string {
+	const heading = "1. Primary Request and Intent"
+	i := strings.Index(summary, heading)
+	if i < 0 {
+		return ""
+	}
+	rest := summary[i+len(heading):]
+	rest = strings.TrimLeft(rest, ":* \n")
+	// The next numbered heading ends it; a summary that has none is cut by the
+	// line budget below.
+	if j := strings.Index(rest, "\n2. "); j > 0 {
+		rest = rest[:j]
+	}
+	var kept []string
+	for _, line := range strings.Split(rest, "\n") {
+		line = strings.TrimRight(line, " \t")
+		if strings.TrimSpace(line) == "" {
+			if len(kept) == 0 {
+				continue
+			}
+			break
+		}
+		kept = append(kept, line)
+		if len(kept) == compactionIntentLines {
+			break
+		}
+	}
+	out := strings.TrimSpace(strings.Join(kept, "\n"))
+	if len(out) > compactionIntentBytes {
+		out = strings.TrimSpace(out[:compactionIntentBytes]) + cutMark
+	}
+	return out
+}
+
+// How much of the summary the handoff carries: enough to say what the work was,
+// far short of the kilobytes the whole block runs to.
+const (
+	compactionIntentLines = 6
+	compactionIntentBytes = 700
+)
+
 // cleanSession drops agent artifacts and exact repeats so the digest carries
 // conversation, not tool output replayed under a user role.
 func cleanSession(s model.Session) model.Session {
@@ -701,6 +766,7 @@ const (
 )
 
 func Handoff(s model.Session, budget int) string {
+	earlier := compactedHalf(s)
 	s = cleanSession(s)
 	var b strings.Builder
 	date := "unknown"
@@ -723,6 +789,17 @@ func Handoff(s model.Session, budget int) string {
 	// Drop the share header line; the framing above replaces it.
 	if i := strings.Index(body, "\n"); i > 0 && strings.HasPrefix(body, "# deja share:") {
 		body = strings.TrimSpace(body[i:])
+	}
+	// A session resumed after a compaction opens on the harness's summary of
+	// the half it dropped, and that summary is the only record of what the
+	// work was: without it the handoff's problem statement is whatever the
+	// person typed after the resume — "продолжай" (#3266). It is the
+	// harness's text rather than theirs, so it is named as such and kept
+	// short, and it is taken only when it opens the session: a summary with
+	// the person's own turns above it adds nothing they did not already say.
+	if earlier != "" {
+		body = "## Earlier, from the harness's summary of the compacted half\n\n" +
+			earlier + "\n\n" + body
 	}
 	// The marker says the passage before it was cut and that the block ends
 	// there — that is the rule Share and the tail each keep on their own. The

--- a/internal/digest/handoff_compacted_test.go
+++ b/internal/digest/handoff_compacted_test.go
@@ -1,0 +1,108 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+const compactSummary = `This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.
+
+Summary:
+1. Primary Request and Intent:
+   Review PR 1159 strictly, improve what can be improved, test it and measure the effect.
+   The measurement has to be reproducible from the repository.
+
+2. Key Technical Concepts:
+   - the ranking's gaveUpPenalty
+   - the recall bench
+`
+
+// A session resumed after a compaction opens on the harness's summary of the
+// half it dropped. The summary is dropped as an artifact, so the handoff's
+// problem statement became whatever the person typed after the resume —
+// "продолжай" — and what the work actually was survived nowhere (#3266).
+func TestHandoffCarriesWhatTheCompactionDropped(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "claude", Project: "deja-vu", ID: "780c3bd3", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: compactSummary, Time: at},
+			{Role: "user", Text: "продолжай", Time: at.Add(time.Minute)},
+			{Role: "assistant", Text: "Merged it and started the bug hunt.", Time: at.Add(2 * time.Minute)},
+		},
+	}
+	got := Handoff(s, 4000)
+	if !strings.Contains(got, "Review PR 1159 strictly") {
+		t.Errorf("the handoff lost the only record of what the session was about:\n%s", got)
+	}
+	if !strings.Contains(got, "harness's summary") {
+		t.Errorf("the summary is not named as the harness's own text:\n%s", got)
+	}
+	// The rest of the block stays out: it runs to kilobytes and the budget is
+	// for what was said.
+	if strings.Contains(got, "Key Technical Concepts") {
+		t.Errorf("the whole summary went in, not the intent:\n%s", got)
+	}
+}
+
+// The next numbered heading ends the intent even when no blank line does —
+// harnesses write the block both ways.
+func TestTheIntentStopsAtTheNextHeading(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	tight := "Summary:\n1. Primary Request and Intent:\n" +
+		"   Review PR 1159 strictly and measure the effect.\n" +
+		"2. Key Technical Concepts:\n   - the ranking's gaveUpPenalty\n"
+	s := model.Session{
+		Harness: "claude", Project: "deja-vu", ID: "tight", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: tight, Time: at},
+			{Role: "user", Text: "продолжай", Time: at.Add(time.Minute)},
+		},
+	}
+	got := Handoff(s, 4000)
+	if !strings.Contains(got, "Review PR 1159 strictly") {
+		t.Fatalf("the intent is missing, so this measures nothing:\n%s", got)
+	}
+	if strings.Contains(got, "gaveUpPenalty") {
+		t.Errorf("the intent ran into the next section:\n%s", got)
+	}
+}
+
+// Only when the summary opens the session. With the person's own turns above
+// it, they have already said what the work is.
+func TestASummaryUnderTheirOwnTurnsIsNotTheProblemStatement(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "claude", Project: "deja-vu", ID: "abc", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: "the exporter drops spans over 4 KB, find out why", Time: at},
+			{Role: "assistant", Text: "Looking at the batcher.", Time: at.Add(time.Minute)},
+			{Role: "user", Text: compactSummary, Time: at.Add(2 * time.Minute)},
+		},
+	}
+	got := Handoff(s, 4000)
+	if strings.Contains(got, "harness's summary") {
+		t.Errorf("a summary under their own turns was promoted anyway:\n%s", got)
+	}
+	if !strings.Contains(got, "exporter drops spans") {
+		t.Errorf("the person's own problem statement is missing:\n%s", got)
+	}
+}
+
+// A session that was never compacted reads exactly as before.
+func TestAnUncompactedSessionHandsOffUnchanged(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "claude", Project: "deja-vu", ID: "abc", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: "the exporter drops spans over 4 KB, find out why", Time: at},
+			{Role: "assistant", Text: "The batcher caps the payload at 4 KB.", Time: at.Add(time.Minute)},
+		},
+	}
+	if got := Handoff(s, 4000); strings.Contains(got, "Earlier, from the harness") {
+		t.Errorf("a section appeared on a session with no compaction:\n%s", got)
+	}
+}


### PR DESCRIPTION
Option 3 from the issue, with the label from option 1: when a compaction summary is the **first** thing in the session — the shape a resumed session has, and the only place the earlier half survives — the handoff opens with its "Primary Request and Intent", bounded to six lines and 700 bytes, under a heading that says it is the harness's text and not the person's. A summary sitting under the person's own turns changes nothing: there they have already said what the work is.

Measured on one real transcript of 485 messages (hermetic copy, read-only): before, the handoff's problem statement was the one-word continuation typed after the resume and 5542 B; after, 6308 B opening on the task the compacted half had been about, under the new heading.

The `/fork` notice the issue mentions at the end is gone separately: it is an `isMeta` record, dropped since #3267.

Closes #3266