### PR TITLE
bench(prompt): an arm for the long session that also decides things

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -221,6 +221,10 @@ type promptReport struct {
 	// the whole corpus turned against itself, and it grows whenever a chain is
 	// added.
 	CrossPaired promptArmReport `json:"cross_paired"`
+	// The marathon that also decides things, in the project it shares with the
+	// sessions that settled what is being asked. Correct is the short session;
+	// a fire on the long one is the shape #3214 measured on a real index.
+	SpecificVsMarathon promptArmReport `json:"specific_vs_marathon"`
 	// Every question of the corpus asked at home with a paste above it — a repo
 	// listing, a set of @file mentions, a stack trace. The six terms are spent
 	// before the question is reached unless the extractor reads the question
@@ -329,7 +333,8 @@ func measurePrompt(seed int64) (promptReport, error) {
 		}
 		// Filler that only exists to fill the bucket has no question of its
 		// own; it is asked about through the bucket-answer chain below.
-		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" || chain.Kind == "concluded-noise" || chain.Kind == "background" {
+		if chain.Kind == "bucket" || chain.Kind == "haystack-noise" || chain.Kind == "concluded-noise" || chain.Kind == "marathon-vs-noise" ||
+			chain.Kind == "background" {
 			continue
 		}
 		terms := prompt.Terms(chain.Question)
@@ -377,6 +382,11 @@ func measurePrompt(seed int64) (promptReport, error) {
 				report.Decision.Fired++
 				report.Decision.Correct++
 			}
+		case "marathon-vs":
+			// Which session is served, not whether the words are in the block:
+			// the long one holds the topic too, so a text test cannot tell the
+			// two apart. Correct is the chain's own session ranking first.
+			arm = &report.SpecificVsMarathon
 		case "concluded":
 			arm = &report.Concluded
 			arm.Cases++
@@ -523,6 +533,12 @@ func measurePrompt(seed int64) (promptReport, error) {
 			if chain.Kind == "bucket-answer" {
 				arm.FalseFires++
 			}
+			// The long session in the same project is not an answer either:
+			// the arm exists to count the times it takes the place of the one
+			// that settled the question (#3214).
+			if chain.Kind == "marathon-vs" && !correct {
+				arm.FalseFires++
+			}
 		}
 		if correct {
 			arm.Correct++
@@ -622,6 +638,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Decision, nil)
 	finishPromptArm(&report.DecisionInline, nil)
 	finishPromptArm(&report.Concluded, nil)
+	finishPromptArm(&report.SpecificVsMarathon, nil)
 	finishPromptArm(&report.ShortSubject, nil)
 	finishPromptArm(&report.Echo, nil)
 	finishPromptArm(&report.Compound, nil)

--- a/cmd/deja/bench_prompt_test.go
+++ b/cmd/deja/bench_prompt_test.go
@@ -29,7 +29,8 @@ func TestPromptBenchCorpusIsMeasurable(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" || c.Kind == "background" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" ||
+			c.Kind == "marathon-vs-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -548,6 +548,77 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			}},
 		})
 	}
+	// The marathon that also decides things. The haystack above only mentions
+	// its topics in passing, which is the easy half; on a real index the
+	// sessions that win are the long ones that discussed the same subjects and
+	// settled things about them — on ten questions phrased from last week's PR
+	// titles, two were topped by one of the three biggest sessions rather than
+	// by the session that did the work (#3214).
+	//
+	// One project, so project scope cannot separate them: one long session that
+	// says every topic over and over and concludes something adjacent about
+	// each, against four short sessions that each settled the thing being
+	// asked about. Correct is the short one.
+	// paraphrase carries the noun the question uses beside the subject, so the
+	// long session below can repeat both.
+	marathonTopics := []promptTopic{
+		{"wheatear", "wheatear retries stop after the second timeout",
+			"what did we decide about wheatear retries", "retries"},
+		{"samphire", "samphire uploads are chunked at eight megabytes",
+			"what did we decide about samphire uploads", "uploads"},
+		{"brambling", "brambling reads come from the follower now",
+			"what did we decide about brambling reads", "reads"},
+		{"chicory", "chicory tokens are rotated every sunday",
+			"what did we decide about chicory tokens", "tokens"},
+	}
+	const marathonProject = "promptbenchmarathonvs"
+	marathonStart := base.Add(3300 * time.Minute)
+	var longSession []model.Message
+	for k := 0; k < 90; k++ {
+		at := marathonStart.Add(time.Duration(k) * time.Minute)
+		longSession = append(longSession,
+			model.Message{Role: "user", Text: fillerText(rng, "another pass over the same branch"), Time: at},
+			model.Message{Role: "assistant", Text: fillerText(rng, "tweaked it and ran the suite again"), Time: at.Add(time.Second)})
+		for _, m := range marathonTopics {
+			// It settles something — just not the thing the question asks
+			// about, which is what makes it a competitor rather than an answer.
+			// The same words the question uses, over and over: the subject and
+			// the noun beside it. On a real index that is what the giants have
+			// — hundreds of turns sharing the vocabulary of the question —
+			// while the decision itself lives in the short session.
+			longSession = append(longSession,
+				model.Message{Role: "user",
+					Text: "where are we on " + m.word + " " + m.paraphrase,
+					Time: at.Add(2 * time.Second)},
+				model.Message{Role: "assistant",
+					Text: "we settled the " + m.word + " " + m.paraphrase + " log format today, and looked at " +
+						m.word + " again after",
+					Time: at.Add(3 * time.Second)})
+		}
+	}
+	chains = append(chains, PromptChain{
+		ID: "prompt-marathonvs-noise", Project: marathonProject, Kind: "marathon-vs-noise",
+		Sessions: []model.Session{{
+			ID: "prompt-marathonvs-noise-session", Harness: "claude", Project: marathonProject,
+			Started: marathonStart, Updated: marathonStart.Add(90 * time.Minute), Messages: longSession,
+		}},
+	})
+	for i, m := range marathonTopics {
+		id := fmt.Sprintf("prompt-marathonvs-%02d", i)
+		at := marathonStart.Add(time.Duration(-100-i*10) * time.Minute)
+		chains = append(chains, PromptChain{
+			ID: id, Project: marathonProject, Kind: "marathon-vs",
+			Topic: m.word, Question: m.question, Fact: m.fact,
+			Sessions: []model.Session{{
+				ID: id + "-session", Harness: "claude", Project: marathonProject,
+				Started: at, Updated: at.Add(4 * time.Minute),
+				Messages: []model.Message{
+					{Role: "user", Text: "what should we do about " + m.word, Time: at},
+					{Role: "assistant", Text: "the fix: " + m.fact, Time: at.Add(time.Minute)},
+				},
+			}},
+		})
+	}
 	// The short subject. Measured on a real store over the questions the user
 	// actually typed: five of the nine that recalled nothing named their
 	// subject in two characters — "как там pr, смержился?", "ну что там v3

--- a/internal/bench/prompt_test.go
+++ b/internal/bench/prompt_test.go
@@ -25,8 +25,12 @@ func TestGeneratePromptShape(t *testing.T) {
 		// The concluded pair shares a project on purpose too: the whole case is
 		// that two sessions of the same project hold the subject and only one
 		// of them settled it.
+		// The marathon pair shares one on purpose as well: the case is a long
+		// session and the short ones that settled the questions, competing
+		// inside the project scope so scope cannot separate them.
 		if c.Kind != "bucket" && c.Kind != "haystack" && c.Kind != "haystack-noise" && c.Kind != "russian" &&
-			c.Kind != "concluded" && c.Kind != "concluded-noise" {
+			c.Kind != "concluded" && c.Kind != "concluded-noise" &&
+			c.Kind != "marathon-vs" && c.Kind != "marathon-vs-noise" {
 			if projects[c.Project] {
 				t.Fatalf("project %q shared by two chains; a query would match both", c.Project)
 			}
@@ -46,7 +50,8 @@ func TestGeneratePromptShape(t *testing.T) {
 		// asked about through the bucket-answer chain, whose question is the
 		// one that must go unanswered. A chain nobody asks about still has to
 		// earn its place, and this one earns it by being the wrong answer.
-		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" || c.Kind == "background" {
+		if c.Kind == "bucket" || c.Kind == "haystack-noise" || c.Kind == "concluded-noise" ||
+			c.Kind == "marathon-vs-noise" || c.Kind == "background" {
 			continue
 		}
 		if topics[c.Topic] {


### PR DESCRIPTION
#3214 has no instrument: the haystack arm's long session only mentions its topics in passing and scores 3/3, while the sessions that actually win on a real index are the ones that discussed the same subjects and settled things about them.

New `specific_vs_marathon` arm — one 90-round session repeating each subject with the noun the question uses and settling something adjacent, against four short sessions that each settled the thing being asked, all in one project so scope cannot separate them. **2 of 4 go to the long session today**, which is the ratio #3214 measured on the real index (2 of 10).

No ranking change here. This is the number to move, and to move it without trading away `real_questions` or `concluded_session`.

The two corpus-wide arms grow by the four new questions (`cross_paired` 47→51 cases with one more false fire, `pasted_preamble` 47→51 with four more correct); every other arm is unchanged.