### PR TITLE
fix(digest): a subagent's own transcript is not this project's history

### DIFF
--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -140,6 +140,20 @@ func runHookPrecompact(dir string) {
 	requestWarmup(dir)
 }
 
+// withoutSubagentRuns drops the sessions a parent spawned. The caller keeps
+// the original pool when this leaves nothing, so a project whose only history
+// is subagent runs still gets a digest.
+func withoutSubagentRuns(ss []model.Session) []model.Session {
+	out := make([]model.Session, 0, len(ss))
+	for _, s := range ss {
+		if s.Kind == "sidechain" {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
 // sessionHadDigest reports whether this session has already had its one
 // session-start attempt, for a host that fires that event every turn. Antigravity
 // keeps the same record under a key of its own; this one is for hosts that come
@@ -1014,6 +1028,16 @@ func hookDigestResultFor(dir, fromPayload string) (string, int, int64, []string,
 		}
 	}
 	mark("load-sessions")
+	// A subagent run is the parent's work seen from inside, and what it says
+	// on its own is the process talk a spawned agent produces — "Sending
+	// verdict", "Worktrees cleaned up". Indexing already treats these runs as
+	// secondary (#3009 keeps only the task and the answer); the digest picked
+	// them like any other session and let one lead the block ahead of the
+	// session that settled the work (#3368). Kept only when the project has
+	// nothing else: a subagent's transcript still beats an empty digest.
+	if kept := withoutSubagentRuns(ss); len(kept) > 0 {
+		ss = kept
+	}
 	if len(ss) == 0 {
 		// A project can have settled decisions and no recent session left to
 		// show them (the transcript was forgotten, or aged past the window).

--- a/cmd/deja/hook_context_subagent_test.go
+++ b/cmd/deja/hook_context_subagent_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A subagent run is indexed under its own agent id, and the session-start
+// digest picked it like any other session — so a reviewer's process talk
+// ("Sending verdict", "Worktrees cleaned up") led the block ahead of the
+// session that settled the work (#3368).
+func TestTheSessionStartDigestPrefersSessionsSomebodyWorkedIn(t *testing.T) {
+	claudeRoot := hookDigestFixture(t, true)
+	_ = claudeRoot
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := hookDigest(index.DefaultDir())
+	if !strings.Contains(got, "quokkabloom batcher") {
+		t.Fatalf("the session that settled the work is missing, so this measures nothing:\n%s", got)
+	}
+	if strings.Contains(got, "Sending verdict") {
+		t.Errorf("the subagent run is quoted in the session-start digest:\n%s", got)
+	}
+}
+
+// Unless the project has nothing else: a subagent's transcript still beats an
+// empty digest.
+func TestAProjectOfOnlySubagentRunsStillGetsADigest(t *testing.T) {
+	hookDigestFixture(t, false)
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := hookDigest(index.DefaultDir()); !strings.Contains(got, "Sending verdict") {
+		t.Errorf("a project whose only history is subagent runs got nothing:\n%s", got)
+	}
+}
+
+// hookDigestFixture writes one subagent run and, when withParent, the session
+// that spawned it, then puts the test in that project's directory.
+func hookDigestFixture(t *testing.T, withParent bool) string {
+	// A project of its own: withStatsStores seeds beta, gamma and the rest,
+	// and the fallback case needs a project that holds nothing else.
+	project := "beta"
+	if !withParent {
+		project = "quokkaonly"
+	}
+	t.Helper()
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	recent := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	older := time.Now().Add(-5 * time.Hour).UTC().Format(time.RFC3339)
+	if withParent {
+		writeClaudeFixture(t, filepath.Join(claudeRoot, project, "parent.jsonl"), "parent-1", []string{
+			`{"type":"user","sessionId":"parent-1","timestamp":"` + older +
+				`","message":{"role":"user","content":"the quokkabloom exporter drops spans over 4 KB"}}`,
+			`{"type":"assistant","sessionId":"parent-1","timestamp":"` + older +
+				`","message":{"role":"assistant","content":"the fix: the quokkabloom batcher caps the payload at 4 KB, raised to 64 KB"}}`,
+		})
+	}
+	writeClaudeFixture(t, filepath.Join(claudeRoot, project, "review.jsonl"), "arev-quokka-review-9f1", []string{
+		`{"type":"assistant","sessionId":"parent-1","isSidechain":true,"agentId":"arev-quokka-review-9f1",` +
+			`"attributionAgent":"reviewer","timestamp":"` + recent +
+			`","message":{"role":"assistant","content":"Reviewing the quokkabloom diff now."}}`,
+		`{"type":"assistant","sessionId":"parent-1","isSidechain":true,"agentId":"arev-quokka-review-9f1",` +
+			`"attributionAgent":"reviewer","timestamp":"` + recent +
+			`","message":{"role":"assistant","content":"Sending verdict."}}`,
+	})
+	cwd := filepath.Join(t.TempDir(), "tmp", project)
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+	return claudeRoot
+}


### PR DESCRIPTION
A spawned run is indexed under its own agent id, and the session-start digest treated it as an ordinary session — so on a hermetic stand with one real session and one reviewer subagent, the block opened on "Sending verdict" and "Worktrees cleaned up" while the session that settled the work came second. The same shape is on this machine's real index, where a reviewer subagent is one of the six sessions the deja-vu digest quotes.

Indexing already treats those runs as secondary (#3009 keeps the task and the answer only), so the digest now prefers sessions somebody worked in, and falls back to subagent runs when the project holds nothing else — with a test for each half.

Closes #3368