### PR TITLE
fix(copilot): a command that exited non-zero says so

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -127,7 +127,7 @@ import (
 // (#3301), Copilot's injected skills (#3305), aider's banner and its
 // continuation lines (#3311), opencode's own session titles (#3315),
 // Antigravity's plan approvals (#3326), Zed's inlined thread mentions (#3336)
-// and its per-message stamps (#3333). A store
+// and its per-message stamps (#3333), Copilot's exit codes (#3369). A store
 // built before holds skill bodies as the person's words and none of the new
 // tool output, and nothing re-reads a source without the bump (#3289).
 const version = 35

--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -79,7 +80,7 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 	}
 	// Which message holds each shell command, by the call id the completion
 	// event repeats: Copilot files the command and its outcome as two records.
-	commandAt := map[string]int{}
+	commandAt := map[string][]int{}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		typ, _ := m["type"].(string)
 		data, _ := m["data"].(map[string]any)
@@ -139,10 +140,12 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 					records = append(records, model.Message{Role: RoleEdit, Text: span, Time: t})
 				}
 			}
-			cmdAt := -1
+			// Every command of the call, not the last one: a dialect that
+			// hands back an array would otherwise mark one of them.
+			var cmdAt []int
 			if IndexCommands() {
 				for _, cmd := range commandsIn(part, copilotDialect) {
-					cmdAt = len(records)
+					cmdAt = append(cmdAt, len(records))
 					records = append(records, model.Message{Role: RoleCommand, Text: cmd, Time: t})
 				}
 			}
@@ -150,8 +153,10 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 				return
 			}
 			s.Touch(t)
-			if id, _ := data["toolCallId"].(string); id != "" && cmdAt >= 0 {
-				commandAt[id] = len(s.Messages) + cmdAt
+			if id, _ := data["toolCallId"].(string); id != "" && len(cmdAt) > 0 {
+				for _, at := range cmdAt {
+					commandAt[id] = append(commandAt[id], len(s.Messages)+at)
+				}
 			}
 			s.Messages = append(s.Messages, records...)
 		case "tool.execution_complete":
@@ -169,8 +174,10 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 			// trailer inside the output (#3369).
 			if code := copilotExitCode(data, out); code > 0 {
 				if id, _ := data["toolCallId"].(string); id != "" {
-					if i, ok := commandAt[id]; ok && i < len(s.Messages) {
-						s.Messages[i].Text += fmt.Sprintf("  → exit %d", code)
+					for _, i := range commandAt[id] {
+						if i < len(s.Messages) {
+							s.Messages[i].Text += fmt.Sprintf("  → exit %d", code)
+						}
 					}
 				}
 			}
@@ -187,6 +194,24 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 	return []model.Session{s}, err
 }
 
+// jsonInt reads a number the scanner decoded with UseNumber, and the two other
+// shapes a store can hold it in.
+func jsonInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return int(i), true
+		}
+	case float64:
+		return int(n), true
+	case string:
+		if i, err := strconv.Atoi(n); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
 // copilotShellExitRe is the trailer Copilot writes under a shell run's output:
 // "<shellId: 0 completed with exit code 1>". The tool's own documentation
 // mentions the words "exit code" in prose, which is why this asks for the
@@ -199,8 +224,12 @@ var copilotShellExitRe = regexp.MustCompile(`<shellId:[^>]*completed with exit c
 func copilotExitCode(data map[string]any, out string) int {
 	if tel, ok := data["toolTelemetry"].(map[string]any); ok {
 		if metrics, ok := tel["metrics"].(map[string]any); ok {
-			if code, ok := metrics["exit_code"].(float64); ok {
-				return int(code)
+			// The scanner decodes with UseNumber, so a JSON number arrives as
+			// json.Number and never as float64: asserting the latter made this
+			// whole path dead code and left every marker to the trailer below
+			// (review of #3369).
+			if code, ok := jsonInt(metrics["exit_code"]); ok {
+				return code
 			}
 		}
 	}

--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -1,8 +1,10 @@
 package sources
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/vshulcz/deja-vu/internal/model"
@@ -75,6 +77,9 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 		ID:      filepath.Base(filepath.Dir(path)),
 		Path:    path,
 	}
+	// Which message holds each shell command, by the call id the completion
+	// event repeats: Copilot files the command and its outcome as two records.
+	commandAt := map[string]int{}
 	err := scanJSONLFromOffset(path, offset, func(m map[string]any) {
 		typ, _ := m["type"].(string)
 		data, _ := m["data"].(map[string]any)
@@ -134,8 +139,10 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 					records = append(records, model.Message{Role: RoleEdit, Text: span, Time: t})
 				}
 			}
+			cmdAt := -1
 			if IndexCommands() {
 				for _, cmd := range commandsIn(part, copilotDialect) {
+					cmdAt = len(records)
 					records = append(records, model.Message{Role: RoleCommand, Text: cmd, Time: t})
 				}
 			}
@@ -143,6 +150,9 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 				return
 			}
 			s.Touch(t)
+			if id, _ := data["toolCallId"].(string); id != "" && cmdAt >= 0 {
+				commandAt[id] = len(s.Messages) + cmdAt
+			}
 			s.Messages = append(s.Messages, records...)
 		case "tool.execution_complete":
 			// Kept whether or not the call succeeded: the error a command hit
@@ -153,6 +163,17 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 			}
 			result, _ := data["result"].(map[string]any)
 			out, _ := result["content"].(string)
+			// What the command did, which Copilot does not put in `success`:
+			// that field is true on every completion in a real store, failed
+			// runs included, and the code lives in the telemetry and in a
+			// trailer inside the output (#3369).
+			if code := copilotExitCode(data, out); code > 0 {
+				if id, _ := data["toolCallId"].(string); id != "" {
+					if i, ok := commandAt[id]; ok && i < len(s.Messages) {
+						s.Messages[i].Text += fmt.Sprintf("  → exit %d", code)
+					}
+				}
+			}
 			if out = strings.TrimSpace(out); out == "" {
 				return
 			}
@@ -164,6 +185,31 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 		return nil, err
 	}
 	return []model.Session{s}, err
+}
+
+// copilotShellExitRe is the trailer Copilot writes under a shell run's output:
+// "<shellId: 0 completed with exit code 1>". The tool's own documentation
+// mentions the words "exit code" in prose, which is why this asks for the
+// whole shape rather than the phrase.
+var copilotShellExitRe = regexp.MustCompile(`<shellId:[^>]*completed with exit code (\d+)>`)
+
+// copilotExitCode reads what a shell call actually did. The telemetry carries
+// the number when Copilot recorded one; the trailer under the output is the
+// fallback, and both are absent for a call that is not a shell run.
+func copilotExitCode(data map[string]any, out string) int {
+	if tel, ok := data["toolTelemetry"].(map[string]any); ok {
+		if metrics, ok := tel["metrics"].(map[string]any); ok {
+			if code, ok := metrics["exit_code"].(float64); ok {
+				return int(code)
+			}
+		}
+	}
+	if m := copilotShellExitRe.FindStringSubmatch(out); m != nil {
+		if code, err := strconv.Atoi(m[1]); err == nil {
+			return code
+		}
+	}
+	return 0
 }
 
 // copilotProjectName mirrors the codex convention: the last two path segments

--- a/internal/sources/copilot.go
+++ b/internal/sources/copilot.go
@@ -154,9 +154,15 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 			}
 			s.Touch(t)
 			if id, _ := data["toolCallId"].(string); id != "" && len(cmdAt) > 0 {
-				for _, at := range cmdAt {
-					commandAt[id] = append(commandAt[id], len(s.Messages)+at)
+				// Assigned, not appended: an id reused for a later call would
+				// otherwise carry the first call's commands too, and the second
+				// outcome would land on a run that had already finished
+				// (review of #3369).
+				at := make([]int, 0, len(cmdAt))
+				for _, i := range cmdAt {
+					at = append(at, len(s.Messages)+i)
 				}
+				commandAt[id] = at
 			}
 			s.Messages = append(s.Messages, records...)
 		case "tool.execution_complete":
@@ -179,6 +185,8 @@ func parseCopilotFileFromOffset(path string, offset int64) ([]model.Session, err
 							s.Messages[i].Text += fmt.Sprintf("  → exit %d", code)
 						}
 					}
+					// Consumed: one outcome belongs to one call.
+					delete(commandAt, id)
 				}
 			}
 			if out = strings.TrimSpace(out); out == "" {
@@ -201,6 +209,10 @@ func jsonInt(v any) (int, bool) {
 	case json.Number:
 		if i, err := n.Int64(); err == nil {
 			return int(i), true
+		}
+		// A store that wrote the code as 1.0 says the same thing.
+		if f, err := n.Float64(); err == nil && f == float64(int(f)) {
+			return int(f), true
 		}
 	case float64:
 		return int(n), true

--- a/internal/sources/copilot_exit_test.go
+++ b/internal/sources/copilot_exit_test.go
@@ -81,3 +81,32 @@ func TestCopilotFailedRunIsNotOfferedAsTheRemedy(t *testing.T) {
 		}
 	}
 }
+
+// The scanner decodes numbers with UseNumber, so the telemetry's exit code
+// arrives as json.Number. Asserting float64 made that path dead and left every
+// marker to the trailer, which a run without one never has (review of #3369).
+func TestCopilotReadsTheExitCodeFromTelemetryWithoutATrailer(t *testing.T) {
+	dir := t.TempDir()
+	sess := filepath.Join(dir, "s2")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sess, "events.jsonl")
+	lines := strings.Join([]string{
+		`{"type":"session.start","timestamp":"2026-09-05T10:00:00Z","data":{"sessionId":"s2","startTime":"2026-09-05T10:00:00Z","context":{"cwd":"/w/api"}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:01Z","data":{"toolName":"bash","toolCallId":"c1","arguments":{"command":"go test ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:02Z","data":{"toolCallId":"c1","success":true,"result":{"content":"--- FAIL: TestRetry (0.01s)\nFAIL\tqueue\t0.4s"},"toolTelemetry":{"metrics":{"exit_code":1}}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCopilotFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleCommand && !strings.HasSuffix(m.Text, "  → exit 1") {
+			t.Errorf("command = %q, want the outcome the telemetry recorded", m.Text)
+		}
+	}
+}

--- a/internal/sources/copilot_exit_test.go
+++ b/internal/sources/copilot_exit_test.go
@@ -1,0 +1,83 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Copilot records every completion with `"success": true`, failed runs
+// included, and puts the outcome in the telemetry and in a trailer under the
+// output. deja took the field at its word, so no command carried an outcome
+// and `deja fix` answered nothing for the harness (#3369).
+func TestCopilotMarksACommandThatExitedNonZero(t *testing.T) {
+	dir := t.TempDir()
+	sess := filepath.Join(dir, "7dad4ddc")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sess, "events.jsonl")
+	lines := strings.Join([]string{
+		`{"type":"session.start","timestamp":"2026-09-05T10:00:00Z","data":{"sessionId":"7dad4ddc","startTime":"2026-09-05T10:00:00Z","context":{"cwd":"/w/api"}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:01Z","data":{"toolName":"bash","toolCallId":"call-1","arguments":{"command":"go vet ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:02Z","data":{"toolCallId":"call-1","success":true,"result":{"content":"pattern ./...: directory prefix . does not contain main module\n<shellId: 0 completed with exit code 1>"},"toolTelemetry":{"metrics":{"commandTimeout":30000,"exit_code":1}}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:03Z","data":{"toolName":"bash","toolCallId":"call-2","arguments":{"command":"go mod init api && go vet ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:04Z","data":{"toolCallId":"call-2","success":true,"result":{"content":"ok\n<shellId: 0 completed with exit code 0>"},"toolTelemetry":{"metrics":{"commandTimeout":30000}}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseCopilotFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(ss))
+	}
+	var cmds []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleCommand {
+			cmds = append(cmds, m.Text)
+		}
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("commands = %d, want 2: %q", len(cmds), cmds)
+	}
+	if !strings.HasSuffix(cmds[0], "  → exit 1") {
+		t.Errorf("the failed run reads %q, want it to end in the exit marker", cmds[0])
+	}
+	if strings.Contains(cmds[1], "→ exit") {
+		t.Errorf("the run that succeeded carries an outcome it did not have: %q", cmds[1])
+	}
+}
+
+// And the outcome is what the fix pair reads: with it, the command that
+// followed a failed run is the remedy; without it the failed run itself could
+// be handed back as one (#3369).
+func TestCopilotFailedRunIsNotOfferedAsTheRemedy(t *testing.T) {
+	dir := t.TempDir()
+	sess := filepath.Join(dir, "s1")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sess, "events.jsonl")
+	lines := strings.Join([]string{
+		`{"type":"session.start","timestamp":"2026-09-05T10:00:00Z","data":{"sessionId":"s1","startTime":"2026-09-05T10:00:00Z","context":{"cwd":"/w/api"}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:01Z","data":{"toolName":"bash","toolCallId":"c1","arguments":{"command":"go build ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:02Z","data":{"toolCallId":"c1","success":true,"result":{"content":"queue/retry.go:12:2: undefined: backoffCap\n<shellId: 0 completed with exit code 1>"},"toolTelemetry":{"metrics":{"exit_code":1}}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCopilotFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleCommand && !strings.Contains(m.Text, "→ exit 1") {
+			t.Errorf("the only command in the session failed and reads %q", m.Text)
+		}
+	}
+}

--- a/internal/sources/copilot_exit_test.go
+++ b/internal/sources/copilot_exit_test.go
@@ -110,3 +110,43 @@ func TestCopilotReadsTheExitCodeFromTelemetryWithoutATrailer(t *testing.T) {
 		}
 	}
 }
+
+// One outcome belongs to one call: an id reused later must not put its exit
+// code on a run that already finished (second review of #3369).
+func TestCopilotDoesNotMarkAnEarlierRunWithALaterOutcome(t *testing.T) {
+	dir := t.TempDir()
+	sess := filepath.Join(dir, "s3")
+	if err := os.MkdirAll(sess, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sess, "events.jsonl")
+	lines := strings.Join([]string{
+		`{"type":"session.start","timestamp":"2026-09-05T10:00:00Z","data":{"sessionId":"s3","startTime":"2026-09-05T10:00:00Z","context":{"cwd":"/w/api"}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:01Z","data":{"toolName":"bash","toolCallId":"dup","arguments":{"command":"go build ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:02Z","data":{"toolCallId":"dup","success":true,"result":{"content":"ok"},"toolTelemetry":{"metrics":{"exit_code":0}}}}`,
+		`{"type":"tool.execution_start","timestamp":"2026-09-05T10:00:03Z","data":{"toolName":"bash","toolCallId":"dup","arguments":{"command":"go test ./..."}}}`,
+		`{"type":"tool.execution_complete","timestamp":"2026-09-05T10:00:04Z","data":{"toolCallId":"dup","success":true,"result":{"content":"--- FAIL: TestRetry"},"toolTelemetry":{"metrics":{"exit_code":1}}}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCopilotFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cmds []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleCommand {
+			cmds = append(cmds, m.Text)
+		}
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("commands = %d, want 2: %q", len(cmds), cmds)
+	}
+	if strings.Contains(cmds[0], "→ exit") {
+		t.Errorf("the run that succeeded wears a later failure: %q", cmds[0])
+	}
+	if !strings.HasSuffix(cmds[1], "  → exit 1") {
+		t.Errorf("the run that failed lost its outcome: %q", cmds[1])
+	}
+}


### PR DESCRIPTION
Closes #3369.

Copilot writes `"success": true` on every `tool.execution_complete`, failed runs included — all 13 on this machine's store — and puts the outcome in `toolTelemetry.metrics.exit_code` and in a `<shellId: N completed with exit code M>` trailer under the output. `copilotExitCode` reads the telemetry first and falls back to the trailer, and a non-zero code appends the `  → exit N` marker to the command it belongs to, matched by `toolCallId`. That is the marker `CommandExitOutcome` already reads for codex and opencode.

Fail-before test: `TestCopilotMarksACommandThatExitedNonZero` (internal/sources), on the collector: `the failed run reads "$ go vet ./...", want it to end in the exit marker`. It also holds the other side — a run that exited zero gains nothing.

Real store, hermetic copy:

```
before:  $ … && go vet ./...
after:   $ … && go vet ./...  → exit 1
```

One thing this does not fix, found while checking it: `deja fix` still answers nothing for that particular error, because `FrictionLine` does not recognise `pattern ./...: directory prefix . does not contain main module or its selected dependencies` as an error line at all — a Go compile error in the same store pairs fine. That is a separate shape and is queued rather than widened here.
