### PR TITLE
fix(index): the read phase moves per file, not per store

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -692,6 +692,30 @@ var progressWeights = map[string]int{}
 // loadProgress narrates a full rebuild per harness: a cold pass over a large
 // corpus takes seconds and used to look hung.
 func loadProgress(h string, progress io.Writer) []model.Session {
+	// Per file while the stores parse, and the remainder of each store's
+	// weight when it lands. Advancing only per store left the bar at 0% for as
+	// long as the largest one took — on a machine where Claude Code holds most
+	// of the corpus, ten seconds of a thirty-second rebuild (#3372). A store
+	// that parses no files through the pool (the SQLite ones) is unchanged: it
+	// counts nothing here and its whole weight arrives at the end.
+	var readMu sync.Mutex
+	readPerHarness := map[string]int{}
+	restore := sources.SetFileProgress(func(path string) {
+		name := harnessForPath(path)
+		if store := sources.HarnessForKind(name); store != "" {
+			name = store
+		}
+		readMu.Lock()
+		counted := readPerHarness[name] < progressWeights[name]
+		if counted {
+			readPerHarness[name]++
+		}
+		readMu.Unlock()
+		if counted {
+			reportAdvance(1)
+		}
+	})
+	defer restore()
 	// Harness stores are independent files owned by different tools; parsing
 	// them is CPU-bound JSON/regex work with no shared state, so the cold
 	// build parses all stores concurrently. Results keep registry order so a
@@ -719,7 +743,15 @@ func loadProgress(h string, progress io.Writer) []model.Session {
 				msgs += len(x.Messages)
 			}
 			reportHarness(name, len(ss), msgs)
-			reportAdvance(progressWeights[name])
+			// Only what the per-file reports did not already cover, so a store
+			// counts its weight once.
+			readMu.Lock()
+			rest := progressWeights[name] - readPerHarness[name]
+			readPerHarness[name] = progressWeights[name]
+			readMu.Unlock()
+			if rest > 0 {
+				reportAdvance(rest)
+			}
 		}(i, hr.Name, hr.Load)
 	}
 	wg.Wait()

--- a/internal/index/read_progress_test.go
+++ b/internal/index/read_progress_test.go
@@ -1,0 +1,89 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// perFileProgress keeps what a build reported, so a test can ask when the
+// bar moved rather than only where it ended.
+type perFileProgress struct {
+	mu     sync.Mutex
+	phase  string
+	steps  map[string][]int // phase -> the advances it received
+	totals map[string]int
+}
+
+func newPerFileProgress() *perFileProgress {
+	return &perFileProgress{steps: map[string][]int{}, totals: map[string]int{}}
+}
+
+func (r *perFileProgress) Phase(name string, total int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.phase = name
+	r.totals[name] = total
+}
+
+func (r *perFileProgress) Advance(units int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps[r.phase] = append(r.steps[r.phase], units)
+}
+
+func (r *perFileProgress) Harness(string, int, int) {}
+
+func (r *perFileProgress) advances(phase string) []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int(nil), r.steps[phase]...)
+}
+
+// The read phase advanced once per store, so a machine whose corpus is mostly
+// one harness watched "reading sessions 0%" until that harness finished — ten
+// seconds of a thirty-second rebuild on a real store (#3372). It moves per
+// file now, and a store still counts its weight exactly once.
+func TestTheReadPhaseMovesPerFile(t *testing.T) {
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude")
+	at := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	const files = 6
+	for i := 0; i < files; i++ {
+		dir := filepath.Join(claude, "proj")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		line := fmt.Sprintf(`{"type":"user","sessionId":"s%d","timestamp":%q,`+
+			`"message":{"role":"user","content":"the quokkabloom exporter drops spans"}}`, i, at)
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("s%d.jsonl", i)), []byte(line+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	rec := newPerFileProgress()
+	SetProgress(rec)
+	defer SetProgress(nil)
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got := rec.advances("reading sessions")
+	if len(got) < files {
+		t.Errorf("the read phase reported %d advances for %d files: %v", len(got), files, got)
+	}
+	sum := 0
+	for _, n := range got {
+		sum += n
+	}
+	if total := rec.totals["reading sessions"]; sum != total {
+		t.Errorf("the read phase advanced %d of %d units — a store counted twice or not at all", sum, total)
+	}
+}

--- a/internal/sources/util.go
+++ b/internal/sources/util.go
@@ -432,6 +432,43 @@ func safeParse(path string, parse func(string) ([]model.Session, error)) (ss []m
 	return parse(path)
 }
 
+// OnFileParsed is called with each transcript path as it finishes parsing, so
+// a caller drawing progress can move per file rather than per store. The index
+// sets it for a cold rebuild: every file-based store parses through the pool
+// below, and one store holding most of the corpus used to leave the bar at 0%
+// until it finished — measured, ten seconds of a thirty-second rebuild (#3372).
+//
+// Set before the parse and cleared after; nil means nobody is watching. It is
+// called from the pool's workers, so an implementation has to be safe to call
+// from several goroutines at once.
+var OnFileParsed func(path string)
+
+// SetFileProgress installs the callback and returns a function that restores
+// what was there. The mutex covers the swap, not the call: parsing runs long
+// after this returns.
+func SetFileProgress(fn func(path string)) func() {
+	fileProgressMu.Lock()
+	prev := OnFileParsed
+	OnFileParsed = fn
+	fileProgressMu.Unlock()
+	return func() {
+		fileProgressMu.Lock()
+		OnFileParsed = prev
+		fileProgressMu.Unlock()
+	}
+}
+
+var fileProgressMu sync.Mutex
+
+func fileParsed(path string) {
+	fileProgressMu.Lock()
+	fn := OnFileParsed
+	fileProgressMu.Unlock()
+	if fn != nil {
+		fn(path)
+	}
+}
+
 func parseFiles(files []string, parse func(string) ([]model.Session, error)) []model.Session {
 	files = append([]string(nil), files...)
 	sort.Strings(files)
@@ -459,6 +496,7 @@ func parseFiles(files []string, parse func(string) ([]model.Session, error)) []m
 			for j := range jobs {
 				ss, err := safeParse(j.p, parse)
 				diagFileError(j.p, err)
+				fileParsed(j.p)
 				outs <- struct {
 					i  int
 					ss []model.Session


### PR DESCRIPTION
The read phase advanced once per harness, so on a machine whose corpus is mostly one store the line every upgrading user sees stood still until that store finished. Measured on this machine (1311 Claude sessions, 2.1 GB, everything else pointed at an empty directory):

```
before   6s reading sessions 0%   8s 0%   10s 0%   12s 0%   14s 0%   16s indexing messages 1%
after    6s reading sessions 21%  8s 79%  10s 99%  12s 99%  14s 100%  16s indexing messages 1%
```

The file-based parsers all go through one pool, so a callback there reports each transcript as it lands; a store still counts its weight exactly once (the per-store report now advances only the remainder), and the SQLite-backed stores, which parse no files through the pool, are unchanged.

Part of #3372. The other half of that issue — "indexing messages" going 1% → 99% in one step and then standing at 99% while the spiller works — is untouched here: that phase counts sessions pushed rather than work done, and fixing it is a change to the spiller's accounting.