### PR TITLE
fix(friction): the go module and sqlite walls read as errors

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -377,6 +377,12 @@ func isFriction(l string) bool {
 		"failed to connect to", "cannot import name", "symbol(s) not found",
 		"failed to push some refs", "acquiring the state lock",
 		"no space left on device",
+		// Three this machine hits that nothing above reached: the two ways the
+		// go toolchain says there is no module here, counted 17 and 12 times
+		// in the real stores, and sqlite saying a table is missing, 4 times.
+		// "no such file or directory" was already here; its sibling was not
+		// (#3373).
+		"go.mod file not found", "does not contain main module", "no such table",
 	} {
 		if strings.Contains(low, p) {
 			return true

--- a/internal/index/friction_go_test.go
+++ b/internal/index/friction_go_test.go
@@ -1,0 +1,33 @@
+package index
+
+import "testing"
+
+// Three walls this machine hits that no phrase recognised: the two ways the go
+// toolchain says there is no module here, and sqlite saying a table is not
+// there. Counted in the real stores: the go.mod line 17 times, the pattern
+// line 12, the sqlite one 4 — and none of them was ever mined, so `deja fix`
+// answered nothing for the sessions that hit them (#3373).
+func TestFrictionReadsTheGoModuleAndSqliteWalls(t *testing.T) {
+	walls := []string{
+		"go: go.mod file not found in current directory or any parent directory; see 'go help modules'",
+		"pattern ./...: directory prefix . does not contain main module or its selected dependencies",
+		"Error: in prepare, no such table: part",
+	}
+	for _, w := range walls {
+		if _, ok := FrictionLine(w); !ok {
+			t.Errorf("not read as friction: %q", w)
+		}
+	}
+	// And the source that talks about them is not a wall: a test asserting on
+	// the text, a comment, a line of Go quoting it.
+	notWalls := []string{
+		`	if !strings.Contains(got[0], "does not contain main module") {`,
+		`// go.mod file not found is what the toolchain says when there is no module`,
+		`echo "no such table: part"`,
+	}
+	for _, s := range notWalls {
+		if _, ok := FrictionLine(s); ok {
+			t.Errorf("source read as friction: %q", s)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3373.

Three phrases join the list, each carrying the tool's own wording: `go.mod file not found`, `does not contain main module`, `no such table`. `no such file or directory` was already there; its siblings were not.

Fail-before test: `TestFrictionReadsTheGoModuleAndSqliteWalls` (internal/index), on the collector all three lines come back unrecognised. The same test holds the other side — a test asserting on the text, a comment about it and an `echo` of it are still not walls, which the source-shape rules above the list already handle.

Counted in the real stores under `~/.claude/projects`, `~/.codex/sessions`, `~/.copilot` and the opencode database: 23 transcripts hit one of the three, the go.mod line 17 times and the module-prefix line 12. None of it was mined.

What this does not do, checked on the real Copilot session that started this: `deja fix` still answers nothing there. The line is now read as a wall, and the miner does produce the pair — `fixPairsIn` returns error `pattern ./...: directory prefix …` with `go mod init coprobe && go vet ./...` next — but `buildFixes` keeps a pair only when the remedy names something the error named or the same remedy followed the same error in another session, and this single sighting has neither. That rule is deliberate (#1301) and unchanged here.
