### PR TITLE
fix(index): the indexing phase counts messages as they are indexed

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -513,7 +513,11 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	}
 	preRedactSessions(&m, ss)
 	seenMsgs := msgSeen{}
-	reportPhase("indexing messages", len(ss))
+	// Counted in messages and reported when a batch has actually been
+	// indexed, not when it was handed to the spiller: reporting per session
+	// pushed sent the bar from 1% to 99% in one step and then held it at 99%
+	// while the workers drained — a third of the phase (#3372).
+	reportPhase("indexing messages", countMessages(ss))
 	wrote := map[string]bool{}
 	var wroteMu sync.Mutex
 	sp, err := newSpiller(tmp)
@@ -524,7 +528,6 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	defer sp.cleanup()
 	err = sp.run(func(push func(tokenJob)) error {
 		for _, s := range ss {
-			reportAdvance(1)
 			key := s.Harness + ":" + s.ID
 			ord := uint32(0)
 			if old, ok := m.Sessions[key]; ok {
@@ -683,6 +686,17 @@ func safeLoad(name string, load func() []model.Session, progress io.Writer) (ss 
 		}
 	}()
 	return load()
+}
+
+// countMessages is the unit the indexing phase works through. A message that
+// strips to nothing is skipped by the loop, so the count is an upper bound and
+// the bar finishes a little short rather than sitting at 99%.
+func countMessages(ss []model.Session) int {
+	n := 0
+	for _, s := range ss {
+		n += len(s.Messages)
+	}
+	return n
 }
 
 // progressWeights is how many files each store contributes, set by the caller
@@ -1044,7 +1058,11 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	// secrets straight out of the unredacted commands.
 	preRedactSessions(&m, ss)
 	seenMsgs := msgSeen{}
-	reportPhase("indexing messages", len(ss))
+	// Counted in messages and reported when a batch has actually been
+	// indexed, not when it was handed to the spiller: reporting per session
+	// pushed sent the bar from 1% to 99% in one step and then held it at 99%
+	// while the workers drained — a third of the phase (#3372).
+	reportPhase("indexing messages", countMessages(ss))
 	wrote := map[string]bool{}
 	var wroteMu sync.Mutex
 	sp, err := newSpiller(tmp)
@@ -1055,7 +1073,6 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	defer sp.cleanup()
 	err = sp.run(func(push func(tokenJob)) error {
 		for _, s := range ss {
-			reportAdvance(1)
 			key := s.Harness + ":" + s.ID
 			ord := uint32(0)
 			if old, ok := m.Sessions[key]; ok {

--- a/internal/index/read_progress_test.go
+++ b/internal/index/read_progress_test.go
@@ -57,9 +57,9 @@ func TestTheReadPhaseMovesPerFile(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		line := fmt.Sprintf(`{"type":"user","sessionId":"s%d","timestamp":%q,`+
+		line := fmt.Sprintf(`{"type":"user","sessionId":"quokkabloom-%d","timestamp":%q,`+
 			`"message":{"role":"user","content":"the quokkabloom exporter drops spans"}}`, i, at)
-		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("s%d.jsonl", i)), []byte(line+"\n"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("quokkabloom-%d.jsonl", i)), []byte(line+"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -85,5 +85,52 @@ func TestTheReadPhaseMovesPerFile(t *testing.T) {
 	}
 	if total := rec.totals["reading sessions"]; sum != total {
 		t.Errorf("the read phase advanced %d of %d units — a store counted twice or not at all", sum, total)
+	}
+}
+
+// The indexing phase counted sessions the moment they were handed to the
+// spiller, so the bar read 1% and then 99% while the workers still had a third
+// of the corpus to go. It counts messages now, reported as each batch is
+// actually indexed (#3372).
+func TestTheIndexingPhaseCountsMessagesAsTheyAreIndexed(t *testing.T) {
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude", "proj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	const sessions, msgs = 3, 40
+	for i := 0; i < sessions; i++ {
+		var lines []byte
+		for k := 0; k < msgs; k++ {
+			lines = append(lines, []byte(fmt.Sprintf(
+				`{"type":"user","sessionId":"quokkabloom-%d","timestamp":%q,`+
+					`"message":{"role":"user","content":"quokkabloom span %d of session %d"}}`+"\n",
+				i, at, k, i))...)
+		}
+		if err := os.WriteFile(filepath.Join(claude, fmt.Sprintf("quokkabloom-%d.jsonl", i)), lines, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	rec := newPerFileProgress()
+	SetProgress(rec)
+	defer SetProgress(nil)
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if total := rec.totals["indexing messages"]; total < sessions*msgs {
+		t.Errorf("the phase counts %d units for %d messages — still counting sessions", total, sessions*msgs)
+	}
+	sum := 0
+	for _, n := range rec.advances("indexing messages") {
+		sum += n
+	}
+	if sum < sessions*msgs {
+		t.Errorf("the phase advanced %d of %d messages", sum, sessions*msgs)
 	}
 }

--- a/internal/index/spill.go
+++ b/internal/index/spill.go
@@ -151,6 +151,11 @@ func (s *spiller) run(feed func(push func(tokenJob)) error) error {
 					}
 					bufs[sh] = buf[:0]
 				}
+				// Work done, not work handed over: the phase that feeds this
+				// pool used to report a session the moment it was pushed, so
+				// the bar read 99% while the workers still had a third of the
+				// corpus to go (#3372).
+				reportAdvance(len(batch))
 			}
 			s.noteBuckets(seen)
 		}()


### PR DESCRIPTION
The other half of #3372. "indexing messages" counted a session the moment it was pushed to the spiller, so the bar went 1% → 99% in one step and then stood at 99% while the workers drained. It counts messages now, reported as each batch is actually indexed.

Same store as the first half (1311 Claude sessions, 2.1 GB):

```
before   16s indexing messages 1%   18s 99%   20s 99%   …   28s writing index
after    14s indexing messages 57%  16s 96%   …            24s writing index, digest arrives
```

The count is an upper bound — a message that strips to nothing is skipped — so the phase finishes a little short rather than sitting at 99%.

Closes #3372