### PR TITLE
fix(mcp): the harness filter names the registry, not nine harnesses from 2026

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -251,6 +251,28 @@ func jsonTypeName(k reflect.Kind) string {
 	}
 }
 
+// harnessFilterDescription names the filter's options without going stale.
+// The description used to carry nine hand-written names and stood while
+// sixteen more harnesses landed, so an agent reading the schema had no way to
+// know it could ask for zed, cline or hermes — the filter takes any of them
+// (#3382). A few names and a count cost a fraction of what listing them all
+// would, and the count comes from the registry.
+func harnessFilterDescription() string {
+	var names []string
+	for _, h := range sources.Registry() {
+		// The notes source is deja's own; it is not an agent that wrote a session.
+		if h.Name == "deja" {
+			continue
+		}
+		names = append(names, h.Name)
+	}
+	if len(names) <= 4 {
+		return "Optional filter: " + strings.Join(names, ", ") + "."
+	}
+	return fmt.Sprintf("Optional filter, the agent that wrote the session: %s and %d more — `deja sources` lists them.",
+		strings.Join(names[:4], ", "), len(names)-4)
+}
+
 // dejaTool is the whole surface as one tool with a mode.
 //
 // Six tools were six envelopes: the same query, harness, project and limit
@@ -285,7 +307,7 @@ func dejaTool() map[string]any {
 				"what":    map[string]any{"type": "string", "description": "how: tool or target, e.g. 'go test', 'docker compose', a script name."},
 				"text":    map[string]any{"type": "string", "description": "remember: one durable fact, decision or conclusion."},
 				"tags":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "remember: optional navigation tags, searchable as #tag."},
-				"harness": map[string]any{"type": "string", "description": "Optional filter: claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen."},
+				"harness": map[string]any{"type": "string", "description": harnessFilterDescription()},
 				"project": map[string]any{"type": "string", "description": "Optional project filter; for remember, where the note is filed (default notes)."},
 				"since":   map[string]any{"type": "string", "description": "blame: age such as 30d or 24h."},
 				"limit":   map[string]any{"type": "number", "description": "Max results."},

--- a/cmd/deja/mcp_harness_filter_test.go
+++ b/cmd/deja/mcp_harness_filter_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The harness filter's description is the only place an agent learns which
+// agents it can ask about. It carried nine hand-written names while sixteen
+// more harnesses landed (#3382), so the names and the count come from the
+// registry now — and this checks that the count is the same one the site and
+// the README are held to.
+func TestTheHarnessFilterCountsEveryHarness(t *testing.T) {
+	got := harnessFilterDescription()
+	n := registryHarnessCount(t, filepath.Join("..", ".."))
+	if want := fmt.Sprintf("and %d more", n-4); !strings.Contains(got, want) {
+		t.Errorf("the filter says %q; the registry has %d harnesses, so it should say %q", got, n, want)
+	}
+	// The names it does show have to be real ones, in the registry's order.
+	for _, name := range []string{"claude", "codex"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("the filter no longer names %q: %q", name, got)
+		}
+	}
+	// And it points somewhere for the rest rather than pretending to be a
+	// closed list.
+	if !strings.Contains(got, "deja sources") {
+		t.Errorf("the filter does not say where the rest are listed: %q", got)
+	}
+}


### PR DESCRIPTION
The `harness` argument's description — the only place an agent learns which agents it may filter by — read "claude, codex, opencode, aider, gemini, cursor, antigravity, grok or qwen" while deja reads twenty-five. The filter itself accepts any of them; asking for `zed` works and always did.

It now names the first four from the registry and counts the rest, with `deja sources` as where to see them, so it cannot go stale again:

```
Optional filter, the agent that wrote the session: claude, codex, opencode, aider and 21 more — claude	/Users/shulcz/.claude/projects	sessions=306 messages=210713 size=1.5 GB redacted=906
codex	/Users/shulcz/.codex	sessions=34 messages=156 size=1.6 MB redacted=0
gemini	/Users/shulcz/.gemini/tmp	sessions=7 messages=11 size=163.4 KB redacted=0
cursor	/Users/shulcz/.cursor/projects	sessions=19 messages=58 size=14.5 KB redacted=0
antigravity	/Users/shulcz/.gemini	sessions=50 messages=914 size=2.3 MB redacted=1
grok	/Users/shulcz/.grok/sessions/%2FUsers%2Fshulcz%2Fcoding%2Fgoprojects%2Fdeja-vu%2F.claude%2Fworktrees%2Fpin-manifests	sessions=11 messages=130 size=713.6 KB redacted=0
qwen	/Users/shulcz/.qwen/projects	sessions=4 messages=9 size=49.4 KB redacted=0
kimi	/Users/shulcz/.kimi-code/sessions	sessions=4 messages=13 size=487.0 KB redacted=0
goose	/Users/shulcz/.local/share/goose/sessions	sessions=2 messages=4 size=84.0 KB redacted=0
hermes	/Users/shulcz/.hermes	sessions=5 messages=15 size=1.4 MB redacted=0
copilot	/Users/shulcz/.copilot/session-state	sessions=15 messages=52 size=598.6 KB redacted=0
copilot-chat	/Users/shulcz/Library/Application Support/Code/User/workspaceStorage	sessions=17 messages=1860 size=79.1 MB redacted=15
cline	/Users/shulcz/.cline/data/sessions	sessions=15 messages=34 size=104.5 KB redacted=0
roo	/Users/shulcz/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline	sessions=0 messages=0 size=0 B redacted=0
pi	/Users/shulcz/.pi/agent/sessions	sessions=5 messages=8 size=10.6 KB redacted=0
omp	/Users/shulcz/.omp	sessions=12 messages=32 size=135.5 KB redacted=0
prime	/Users/shulcz/.prime/agent/sessions	sessions=0 messages=0 size=0 B redacted=0
amp	/Users/shulcz/.local/share/amp/threads	sessions=0 messages=0 size=0 B redacted=0
openclaw	/Users/shulcz/.openclaw/agents/main/sessions	sessions=13 messages=45 size=22.2 KB redacted=0
deepseek	/Users/shulcz/.dsh/sessions	sessions=43 messages=81 size=618.1 KB redacted=0
zed	/Users/shulcz/Library/Application Support/Zed/threads	sessions=30 messages=3711 size=5.5 MB redacted=63
deja	/Users/shulcz/.local/share/deja	sessions=17 messages=19 size=10.7 KB redacted=0
aider	/Users/shulcz/.aider.chat.history.md	sessions=0 messages=0 size=0 B redacted=0
opencode	/Users/shulcz/.local/share/opencode/opencode.db	sessions=1472 messages=20219 size=3.2 GB redacted=0 lists them.
```

A test ties the count to the same registry number the site and README are held to.

Closes #3382