### PR TITLE
fix: the introductions count twenty-five harnesses, not eighteen

### DIFF
--- a/cmd/deja/brief.go
+++ b/cmd/deja/brief.go
@@ -552,7 +552,10 @@ func printNoHistory(w io.Writer, stale bool) {
 	fmt.Fprintln(w, "deja-vu "+version+" · no agent history found yet")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "deja reads the session stores your agents already write —")
-	fmt.Fprintln(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and twelve more.")
+	// Counted from the registry: this line is the first screen a machine with
+	// no history sees, and it stood at eighteen while seven more harnesses
+	// landed (#3385).
+	fmt.Fprintf(w, "Claude Code, Codex, opencode, Cursor, Gemini, Copilot and %s more.\n", spelledCount(harnessCount()-6))
 	// A store deja is not allowed to open is not a machine no agent has used,
 	// and this is the first screen a new user sees: sending them after a
 	// missing store when the fix is a permission is the worst place to make

--- a/cmd/deja/harness_count.go
+++ b/cmd/deja/harness_count.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// harnessCount is how many agents deja reads: the registry minus deja's own
+// notes source, which is the same rule the registry pages and the README count
+// by. Written by hand in seven places, it stood at eighteen, twenty and
+// twenty-two in different ones while harnesses landed (#3385).
+func harnessCount() int {
+	n := 0
+	for _, h := range sources.Registry() {
+		if h.Name == "deja" {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// spelledCount writes a small number the way the sentences around it do. Past
+// the list it falls back to digits rather than inventing a word.
+func spelledCount(n int) string {
+	words := []string{"zero", "one", "two", "three", "four", "five", "six", "seven",
+		"eight", "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+		"sixteen", "seventeen", "eighteen", "nineteen", "twenty", "twenty-one",
+		"twenty-two", "twenty-three", "twenty-four", "twenty-five", "twenty-six",
+		"twenty-seven", "twenty-eight", "twenty-nine", "thirty"}
+	if n < 0 || n >= len(words) {
+		return fmt.Sprint(n)
+	}
+	return words[n]
+}

--- a/cmd/deja/harness_count_test.go
+++ b/cmd/deja/harness_count_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The count is spelled by hand wherever deja introduces itself, and every one
+// of those places was written when it was true: the first-run screen said
+// eighteen, four extensions said twenty, a plugin listing said twenty-two,
+// while the registry had twenty-five (#3385). brief.go counts the registry
+// now; these files cannot, so they are checked against it.
+//
+// The rule is the one the sentences use: the names in the phrase plus the
+// number after "and" is every harness deja reads.
+func TestTheIntroductionsCountEveryHarness(t *testing.T) {
+	root := filepath.Join("..", "..")
+	n := registryHarnessCount(t, root)
+	// "and <count> more", with the agents it names in the words just before it.
+	phrase := regexp.MustCompile(`and[\s\n]+([a-z-]+)[\s\n]+more`)
+	names := regexp.MustCompile(`Claude Code|Codex|Cursor|opencode|Gemini|Copilot|Zed`)
+	files := []string{
+		"extensions/zed/README.md",
+		"extensions/kimi/README.md",
+		"extensions/grok/README.md",
+		"extensions/dsh/index.js",
+		"extensions/opencode/index.js",
+		"extensions/grok/.grok-plugin/plugin.json",
+		"extensions/kimi/kimi.plugin.json",
+		// The manifests a plugin listing renders, which live at the repo root.
+		"kimi.plugin.json",
+		"plugin.json",
+		"gemini-extension.json",
+	}
+	checked := 0
+	for _, f := range files {
+		b, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(f)))
+		if err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		text := string(b)
+		for _, loc := range phrase.FindAllStringSubmatchIndex(text, -1) {
+			said := text[loc[2]:loc[3]]
+			// Only the sentence the phrase sits in: a file that says "opencode"
+			// in its own header is not naming it as one of the agents here.
+			from := loc[0] - 100
+			if from < 0 {
+				from = 0
+			}
+			named := len(names.FindAllString(text[from:loc[0]], -1))
+			if named == 0 {
+				continue
+			}
+			checked++
+			if want := spelledCount(n - named); said != want {
+				t.Errorf("%s names %d agents and says %q more; the registry has %d, so it is %q",
+					f, named, said, n, want)
+			}
+		}
+	}
+	if checked < len(files) {
+		t.Errorf("only %d of %d introductions were checked — the phrasing changed and this test stopped seeing them",
+			checked, len(files))
+	}
+}
+
+// And the one that is computed rather than typed.
+func TestTheFirstRunScreenCountsTheRegistry(t *testing.T) {
+	n := registryHarnessCount(t, filepath.Join("..", ".."))
+	if harnessCount() != n {
+		t.Errorf("the binary counts %d harnesses; docs/registry has %d", harnessCount(), n)
+	}
+	if got, want := spelledCount(harnessCount()-6), fmt.Sprint(spelledCount(n-6)); got != want {
+		t.Errorf("the first-run screen would say %q, want %q", got, want)
+	}
+	if strings.Contains(spelledCount(harnessCount()-6), " ") {
+		t.Errorf("the count is not one word: %q", spelledCount(harnessCount()-6))
+	}
+}

--- a/extensions/dsh/index.js
+++ b/extensions/dsh/index.js
@@ -2,7 +2,7 @@
 //
 // dsh answers questions about its own sessions through the built-in
 // session-query subsystem. This plugin answers the other question: what you did
-// in Claude Code, Codex, Cursor, opencode and sixteen more agents, on this
+// in Claude Code, Codex, Cursor, opencode and twenty-one more agents, on this
 // machine, before dsh existed. The index is deja's; this file is the seam.
 
 import { createRequire } from "node:module";

--- a/extensions/grok/.grok-plugin/plugin.json
+++ b/extensions/grok/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.2.0",
-  "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and sixteen more, including work from before deja was installed.",
+  "description": "Recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before deja was installed.",
   "keywords": ["memory", "recall", "sessions", "search", "history"],
   "author": {
     "name": "vshulcz",

--- a/extensions/grok/README.md
+++ b/extensions/grok/README.md
@@ -1,7 +1,7 @@
 # deja for Grok Build
 
 Grok remembers its own sessions. This plugin answers the other question: what
-you did in Claude Code, Codex, Cursor, opencode, Zed and fifteen more agents on
+you did in Claude Code, Codex, Cursor, opencode, Zed and twenty more agents on
 this machine — including the months before you installed anything.
 
 It runs [deja](https://github.com/vshulcz/deja-vu), a local Go binary that

--- a/extensions/kimi/README.md
+++ b/extensions/kimi/README.md
@@ -1,7 +1,7 @@
 # deja for Kimi Code
 
 [deja](https://github.com/vshulcz/deja-vu) indexes the session files coding
-agents already write to disk — Claude Code, Codex, Cursor, opencode and sixteen
+agents already write to disk — Claude Code, Codex, Cursor, opencode and twenty-one
 more — and answers from them. This plugin brings that index into Kimi Code:
 recall arrives with the prompt, and the agent can search history itself.
 

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.19.4",
-  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
+  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",
     "recall",

--- a/extensions/opencode/index.js
+++ b/extensions/opencode/index.js
@@ -1,7 +1,7 @@
 // opencode-deja — the sessions you already have, inside opencode.
 //
 // opencode remembers its own sessions. This plugin answers the other question:
-// what you did in Claude Code, Codex, Cursor, Gemini and sixteen more agents on
+// what you did in Claude Code, Codex, Cursor, Gemini and twenty-one more agents on
 // this machine, including months before deja existed. The index is deja's; this
 // file is the seam: six tools the model can call, plus recall that arrives
 // without being asked for.

--- a/extensions/zed/README.md
+++ b/extensions/zed/README.md
@@ -2,7 +2,7 @@
 
 [deja](https://github.com/vshulcz/deja-vu) indexes the session files that
 coding agents already write to disk — Claude Code, Codex, Cursor, opencode and
-sixteen more — and answers from them. This extension serves that index to Zed's
+twenty-one more — and answers from them. This extension serves that index to Zed's
 agent panel as a context server, so a thread can search what you did before,
 including work from before deja was installed.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.19.4",
-  "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and eighteen more — searchable and recalled, including work from before it was installed.",
+  "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and twenty more — searchable and recalled, including work from before it was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "deja": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deja",
   "version": "0.19.4",
-  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and eighteen more, including work from before it was installed.",
+  "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",
     "recall",

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
   "version": "0.19.4",
-  "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and eighteen more — including work from before it was installed.",
+  "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and twenty-one more — including work from before it was installed.",
   "author": {
     "name": "vshulcz",
     "url": "https://github.com/vshulcz"


### PR DESCRIPTION
Nine places spell the count by hand, and each was written when it was true — the first-run screen said eighteen, four extensions said twenty, the Kimi and Gemini listings twenty-two and twenty.

`brief.go` counts the registry now (`harnessCount()`), so the screen a new user meets cannot drift again. The static files — four extension READMEs and `index.js` headers, and the `kimi`, `grok`, `gemini` and root plugin manifests — are checked against the same registry number by a test that reads the phrase they use ("…and <count> more") and fails when the registry moves.

Same drift as #3347 (the sources line) and llms.txt earlier today; these are the rest of it.

Closes #3385