### PR TITLE
fix(grok): the install reports both files it wrote

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1865,6 +1865,9 @@ func installGrok(exe string, uninstall bool) (installResult, error) {
 	if uerr != nil {
 		return res, uerr
 	}
+	// Both files, whichever of them the printer is named for: the kept-snapshot
+	// line reads the paths, and dropping the other one meant a snapshot beside
+	// it was never counted — "kept 1 snapshot" with two on disk (#3388).
 	if res.Action == "unchanged" {
 		if res.Note != "" {
 			if user.Note != "" {
@@ -1873,7 +1876,16 @@ func installGrok(exe string, uninstall bool) (installResult, error) {
 				user.Note = res.Note
 			}
 		}
+		user.also = append(user.also, res.Path)
 		return user, nil
+	}
+	res.also = append(res.also, user.Path)
+	if user.Note != "" {
+		if res.Note != "" {
+			res.Note += "; " + user.Note
+		} else {
+			res.Note = user.Note
+		}
 	}
 	return res, nil
 }

--- a/cmd/deja/install_grok_touched_test.go
+++ b/cmd/deja/install_grok_touched_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Grok's install writes two files — config.toml for the CLI and
+// user-settings.json for grok-dev — and the result only ever carried one of
+// them, so the snapshot beside the other was never counted: the uninstall said
+// "kept 1 snapshot" with two of them on disk (#3388).
+func TestGrokInstallReportsBothFilesItWrote(t *testing.T) {
+	tmp := hermeticEnv(t)
+	grok := filepath.Join(tmp, "grok")
+	if err := os.MkdirAll(grok, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GROK_ROOT", grok)
+	t.Setenv("GROK_HOME", grok)
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(grok, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("config.toml", "model = \"grok-4\"\n[mcp_servers.other]\ncommand = \"x\"\n")
+	write("user-settings.json", "{\"theme\":\"dark\"}\n")
+
+	res, err := installGrok("/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var named []string
+	for _, p := range res.touched() {
+		named = append(named, filepath.Base(p))
+	}
+	joined := strings.Join(named, " ")
+	if !strings.Contains(joined, "config.toml") || !strings.Contains(joined, "user-settings.json") {
+		t.Errorf("touched = %v, want both files the install wrote", named)
+	}
+}


### PR DESCRIPTION
Closes #3388 in part.

`installGrok` writes two files — `config.toml` for the CLI and `user-settings.json` for grok-dev — and returned only one result, so the other path never reached `touched()`. The kept-snapshot line reads those paths, which is why an uninstall said `kept 1 snapshot` with two `.bak` files on disk. Both paths ride along now, in either direction, and the notes merge.

Fail-before test: `TestGrokInstallReportsBothFilesItWrote` (cmd/deja), on the collector: `touched = [config.toml], want both files the install wrote`.

Hermetic HOME with both files written by hand:

```
before:  deja: kept 1 snapshot of configs you already had — ~/.grok/config.toml.bak — yours to remove
after:   deja: kept 2 snapshots of configs you already had — ~/.grok/config.toml.bak and 1 more — yours to remove
```

The other half of the issue is left open on purpose: the reader's `user-settings.json` comes back re-serialised — `{"theme":"dark"}` in, `{"theme": "dark"}` out — because the writer round-trips through a map to keep keys deja knows nothing about. Preserving the original formatting is a different change from this one, and the JSONC writers are the precedent for how it would have to work.
