### PR TITLE
fix(hermes): the memory provider loads on the build it finds

### DIFF
--- a/cmd/deja/install_hermes.go
+++ b/cmd/deja/install_hermes.go
@@ -99,10 +99,23 @@ def _provider_active():
         from hermes_cli.config import cfg_get, load_config
         if cfg_get(load_config(), "memory", "provider") != "deja-memory":
             return False
-        # Config can outlive the provider (an uninstall, a deleted directory);
-        # then the hook is the memory again, or there would be none at all.
+        # Config can outlive the provider (an uninstall, a deleted directory),
+        # and a provider that is there can still fail to load on a Hermes build
+        # it was not written for — the hook then stood down for a provider that
+        # was answering nothing (#3390). Ask the loader, and fall back to the
+        # file when this build has no loader to ask.
         here = os.path.dirname(os.path.abspath(__file__))
-        return os.path.isfile(os.path.join(os.path.dirname(here), "deja-memory", "__init__.py"))
+        present = os.path.isfile(os.path.join(os.path.dirname(here), "deja-memory", "__init__.py"))
+        if not present:
+            return False
+        try:
+            from plugins.memory import load_memory_provider
+        except Exception:
+            return True
+        try:
+            return load_memory_provider("deja-memory") is not None
+        except Exception:
+            return False
     except Exception:
         return False
 

--- a/cmd/deja/install_hermes_memory.go
+++ b/cmd/deja/install_hermes_memory.go
@@ -85,7 +85,13 @@ import shutil
 import subprocess
 from typing import Any, Dict, List, Optional
 
-from agent.memory_provider import MemoryProvider, RecallStatus
+from agent.memory_provider import MemoryProvider
+
+try:  # Hermes 0.17 has no RecallStatus; the provider loads without it and
+    # loses only the status line (#3390).
+    from agent.memory_provider import RecallStatus
+except ImportError:
+    RecallStatus = None
 
 DEJA = %s
 
@@ -227,8 +233,8 @@ class DejaMemoryProvider(MemoryProvider):
         self._last_count = sum(1 for line in text.splitlines() if line.startswith("- "))
         return text
 
-    def recall_status(self) -> Optional[RecallStatus]:
-        if not self._last_text:
+    def recall_status(self):
+        if RecallStatus is None or not self._last_text:
             return None
         return RecallStatus(provider_label="deja", count=self._last_count)
 

--- a/cmd/deja/install_hermes_provider_test.go
+++ b/cmd/deja/install_hermes_provider_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The provider deja writes has to load on the Hermes it finds, and the hook
+// has to know whether it did. On 0.17 the generated file imported a name that
+// build does not define, so the provider never loaded — while the hook stood
+// down because the config named it (#3390).
+func TestHermesProviderLoadsWithoutRecallStatus(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "hermes")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERMES_HOME", home)
+	if _, err := installHermesMemoryProvider("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, "plugins", "deja-memory", "__init__.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(b)
+	if strings.Contains(src, "import MemoryProvider, RecallStatus") {
+		t.Error("the provider imports RecallStatus unconditionally; a build without it cannot load the file at all")
+	}
+	if !strings.Contains(src, "RecallStatus = None") {
+		t.Error("nothing stands in for RecallStatus on a build that lacks it")
+	}
+}
+
+// And the hook asks whether the provider loaded rather than whether the config
+// names it, or it stands down for a provider that answers nothing.
+func TestHermesHookAsksTheLoaderNotTheConfig(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "hermes")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HERMES_HOME", home)
+	if _, err := installHermesPlugin("/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(filepath.Join(home, "plugins", "deja", "__init__.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "load_memory_provider") {
+		t.Error("_provider_active reads the config alone; a provider that failed to load still silences the hook")
+	}
+}


### PR DESCRIPTION
Closes #3390.

Two halves of one silence:

- the generated provider opened with `from agent.memory_provider import MemoryProvider, RecallStatus`, and Hermes 0.17's module defines only `MemoryProvider`. The import failed, so the file never loaded. `RecallStatus` is now optional and `recall_status` returns nothing when the build has no such class — the status line is all that is lost.
- `_provider_active` decided by reading `memory.provider` from the config, so on a machine that followed the guide the hook stood down for a provider that was not there. It now asks the loader whether the provider actually loaded, keeping the file check as the fallback for a build with no loader to ask.

Fail-before tests: `TestHermesProviderLoadsWithoutRecallStatus` and `TestHermesHookAsksTheLoaderNotTheConfig` (cmd/deja), both failing on the collector with the exact sentences above.

Against the real Hermes 0.17.0 on this machine, hermetic HOME, its own loader:

```
before:  DEBUG:plugins.memory:Failed to exec_module _hermes_user_memory.deja-memory:
           cannot import name 'RecallStatus' from 'agent.memory_provider'
after:   provider loaded: True
```

Found by the fan-out on Hermes; #3202 is the import half of the same thing.
