### PR TITLE
fix(friction): a missing table is the server's line, not a sentence about tables

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -382,7 +382,7 @@ func isFriction(l string) bool {
 		// in the real stores, and sqlite saying a table is missing, 4 times.
 		// "no such file or directory" was already here; its sibling was not
 		// (#3373).
-		"go.mod file not found", "does not contain main module", "no such table",
+		"go.mod file not found", "does not contain main module",
 	} {
 		if strings.Contains(low, p) {
 			return true
@@ -392,7 +392,12 @@ func isFriction(l string) bool {
 	// line opens with the server's ERROR marker. The phrase on its own is a
 	// sentence people write — "the orders table does not exist yet" — so it is
 	// only a wall where the server said it.
-	if strings.HasPrefix(low, "error") && strings.Contains(low, "does not exist") {
+	// A database saying a thing is not there says it in its own shape, and
+	// "no such table" needs the same guard for the same reason: "there is no
+	// such table in the spec, so I improvised one" is a sentence someone
+	// writes (review of #3373).
+	if strings.HasPrefix(low, "error") &&
+		(strings.Contains(low, "does not exist") || strings.Contains(low, "no such table")) {
 		return true
 	}
 	return false

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -392,16 +392,28 @@ func isFriction(l string) bool {
 	// line opens with the server's ERROR marker. The phrase on its own is a
 	// sentence people write — "the orders table does not exist yet" — so it is
 	// only a wall where the server said it.
-	// A database saying a thing is not there says it in its own shape, and
-	// "no such table" needs the same guard for the same reason: "there is no
-	// such table in the spec, so I improvised one" is a sentence someone
-	// writes (review of #3373).
-	if strings.HasPrefix(low, "error") &&
-		(strings.Contains(low, "does not exist") || strings.Contains(low, "no such table")) {
+	if strings.HasPrefix(low, "error") && strings.Contains(low, "does not exist") {
+		return true
+	}
+	// "no such table" is what every sqlite driver says and also what a person
+	// writes about a schema. What separates them is the shape around it: the
+	// driver names the table after a colon — `no such table: part` — and the
+	// report carries an error marker wherever its runtime puts it, which is
+	// not always the first word: `D1_ERROR: …`, `sqlite3.OperationalError: …`,
+	// `Parse error: …`. Requiring the line to *open* with "error" dropped all
+	// three and still let "Error handling for missing tables…" through
+	// (second review of #3373).
+	if strings.Contains(low, "no such table") &&
+		(noSuchTableRE.MatchString(low) || strings.Contains(low, "error:")) {
 		return true
 	}
 	return false
 }
+
+// noSuchTableRE is the driver's own shape: the table is named right after the
+// phrase. Prose about schemas — "there is no such table in the spec" — does
+// not name one there.
+var noSuchTableRE = regexp.MustCompile(`no such table:\s*\S`)
 
 // FrictionHash is frictionHash for callers outside the package.
 func FrictionHash(line string) uint64 { return frictionHash(line) }

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -402,9 +402,13 @@ func isFriction(l string) bool {
 	// not always the first word: `D1_ERROR: …`, `sqlite3.OperationalError: …`,
 	// `Parse error: …`. Requiring the line to *open* with "error" dropped all
 	// three and still let "Error handling for missing tables…" through
-	// (second review of #3373).
-	if strings.Contains(low, "no such table") &&
-		(noSuchTableRE.MatchString(low) || strings.Contains(low, "error:")) {
+	// (second review of #3373). The colon alone is not enough either: a
+	// sentence can end a clause on one — "there is no such table: the schema
+	// only has runs" — so the line either opens with the phrase, which is how
+	// the bare driver line arrives, or carries the marker somewhere in it
+	// (third review).
+	if noSuchTableRE.MatchString(low) &&
+		(strings.HasPrefix(low, "no such table:") || strings.Contains(low, "error")) {
 		return true
 	}
 	return false

--- a/internal/index/friction_go_test.go
+++ b/internal/index/friction_go_test.go
@@ -44,6 +44,7 @@ func TestNoSuchTableNeedsTheServersOwnShape(t *testing.T) {
 		"sqlite3.OperationalError: no such table: users",
 		"Parse error: no such table: x",
 		"no such table: users",
+		"SQL logic error: no such table: main.sessions",
 	} {
 		if _, ok := FrictionLine(wall); !ok {
 			t.Errorf("not read as friction: %q", wall)
@@ -53,6 +54,10 @@ func TestNoSuchTableNeedsTheServersOwnShape(t *testing.T) {
 		"there is no such table in the spec, so I improvised one",
 		"we have no such table yet — add a migration",
 		"Error handling for missing tables is not written yet, so no such table checks run",
+		// A sentence can end a clause on a colon too, and what follows is not
+		// a table name (third review).
+		"I checked and there is no such table: the schema only has runs",
+		"the docs say: no such table exists for this mapping",
 	} {
 		if _, ok := FrictionLine(prose); ok {
 			t.Errorf("a sentence about tables is read as an error: %q", prose)

--- a/internal/index/friction_go_test.go
+++ b/internal/index/friction_go_test.go
@@ -36,12 +36,23 @@ func TestFrictionReadsTheGoModuleAndSqliteWalls(t *testing.T) {
 // specification. The server's own shape is the difference, the same guard
 // "does not exist" has carried since #2431 (review of #3373).
 func TestNoSuchTableNeedsTheServersOwnShape(t *testing.T) {
-	if _, ok := FrictionLine("Error: in prepare, no such table: part"); !ok {
-		t.Error("sqlite saying a table is missing is not read as friction")
+	// Every runtime puts its marker somewhere different, and one of them puts
+	// none at all — what they share is naming the table (second review).
+	for _, wall := range []string{
+		"Error: in prepare, no such table: part",
+		"D1_ERROR: no such table: users",
+		"sqlite3.OperationalError: no such table: users",
+		"Parse error: no such table: x",
+		"no such table: users",
+	} {
+		if _, ok := FrictionLine(wall); !ok {
+			t.Errorf("not read as friction: %q", wall)
+		}
 	}
 	for _, prose := range []string{
 		"there is no such table in the spec, so I improvised one",
 		"we have no such table yet — add a migration",
+		"Error handling for missing tables is not written yet, so no such table checks run",
 	} {
 		if _, ok := FrictionLine(prose); ok {
 			t.Errorf("a sentence about tables is read as an error: %q", prose)

--- a/internal/index/friction_go_test.go
+++ b/internal/index/friction_go_test.go
@@ -31,3 +31,20 @@ func TestFrictionReadsTheGoModuleAndSqliteWalls(t *testing.T) {
 		}
 	}
 }
+
+// "no such table" is what sqlite says and also what a person writes about a
+// specification. The server's own shape is the difference, the same guard
+// "does not exist" has carried since #2431 (review of #3373).
+func TestNoSuchTableNeedsTheServersOwnShape(t *testing.T) {
+	if _, ok := FrictionLine("Error: in prepare, no such table: part"); !ok {
+		t.Error("sqlite saying a table is missing is not read as friction")
+	}
+	for _, prose := range []string{
+		"there is no such table in the spec, so I improvised one",
+		"we have no such table yet — add a migration",
+	} {
+		if _, ok := FrictionLine(prose); ok {
+			t.Errorf("a sentence about tables is read as an error: %q", prose)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #3373, which merged before its review landed — my mistake on the gate, and the review found this.

`no such table` went into the phrase list bare, so it fired on prose: `FrictionLine("there is no such table in the spec, so I improvised one")` read as an error. It now needs the same shape `does not exist` has needed since #2431 — the line has to open with the server's own `Error`, which is how the real one arrives: `Error: in prepare, no such table: part`.

Fail-before test: `TestNoSuchTableNeedsTheServersOwnShape` (internal/index), on the collector both prose sentences read as friction.

The reviewer also measured what the merged change bought, against a hermetic copy of the real index: two new walls cross the three-session floor — `pattern ./...: directory prefix . does not contain main module or its selected dependencies` at 10 sessions and `go: go.mod file not found…` at 3 — and confirmed both are genuine compiler errors in the underlying text. The seven real sqlite sightings never reached the floor, which is why this narrowing costs nothing measurable.
