### PR TITLE
fix(install): a run that changes nothing still names the files it wrote

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -840,7 +840,16 @@ func wroteAll(rs ...installResult) installResult {
 	}
 	var also []string
 	for _, r := range rs {
-		if r.Path == "" || r.Action == "unchanged" || r.Path == out.Path {
+		if r.Path == "" || r.Path == out.Path {
+			continue
+		}
+		// Every file this target handled rides along, changed or not, and so
+		// does anything the other result was already carrying: the
+		// kept-snapshot line reads these paths, and a second run that changes
+		// nothing still has a snapshot beside each of them (review of #3389).
+		out.also = append(out.also, r.Path)
+		out.also = append(out.also, r.also...)
+		if r.Action == "unchanged" {
 			continue
 		}
 		line := fmt.Sprintf("also %s %s", r.Action, shortHome(r.Path))
@@ -850,7 +859,6 @@ func wroteAll(rs ...installResult) installResult {
 			line += " — " + r.Note
 		}
 		also = append(also, line)
-		out.also = append(out.also, r.Path)
 	}
 	for _, line := range also {
 		if out.Note != "" {
@@ -1889,33 +1897,13 @@ func installGrok(exe string, uninstall bool) (installResult, error) {
 		return res, err
 	}
 	// The other CLI sharing this directory reads a different file entirely.
+	// Both go through wroteAll, so the pair is accounted for the way every
+	// other target's pair is — including on a run that changes neither.
 	user, uerr := installGrokUserSettings(exe, uninstall)
 	if uerr != nil {
 		return res, uerr
 	}
-	// Both files, whichever of them the printer is named for: the kept-snapshot
-	// line reads the paths, and dropping the other one meant a snapshot beside
-	// it was never counted — "kept 1 snapshot" with two on disk (#3388).
-	if res.Action == "unchanged" {
-		if res.Note != "" {
-			if user.Note != "" {
-				user.Note = res.Note + "; " + user.Note
-			} else {
-				user.Note = res.Note
-			}
-		}
-		user.also = append(user.also, res.Path)
-		return user, nil
-	}
-	res.also = append(res.also, user.Path)
-	if user.Note != "" {
-		if res.Note != "" {
-			res.Note += "; " + user.Note
-		} else {
-			res.Note = user.Note
-		}
-	}
-	return res, nil
+	return wroteAll(res, user), nil
 }
 
 type tomlMCPBlock struct {

--- a/cmd/deja/install_touched_unchanged_test.go
+++ b/cmd/deja/install_touched_unchanged_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A second install that changes nothing still has a snapshot beside every file
+// it wrote the first time, and the kept-snapshot line reads the paths from the
+// result. `wroteAll` dropped a path whose action was "unchanged", so the second
+// run of grok-auto reported only the hooks file and the two configs vanished
+// from the accounting — the same shape #3389 fixed one layer down (review).
+func TestASecondInstallStillNamesEveryFileItWrote(t *testing.T) {
+	tmp := hermeticEnv(t)
+	grok := filepath.Join(tmp, "grok")
+	if err := os.MkdirAll(grok, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_GROK_ROOT", grok)
+	t.Setenv("GROK_HOME", grok)
+
+	first, err := installTarget("grok-auto", "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.touched()) < 3 {
+		t.Fatalf("first run touched %v, want the config, the settings and the hooks file", first.touched())
+	}
+	second, err := installTarget("grok-auto", "/usr/local/bin/deja", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(second.touched(), " ")
+	for _, want := range []string{"config.toml", "user-settings.json"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("second run touched %v, want %s among them", second.touched(), want)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #3389, which merged before its review landed. The reviewer found the same accounting hole one layer up.

`wroteAll` collected a result's path into `also` only when that result had changed something, and `touched()` reads `also`. So a second `deja install grok-auto` with everything already in place reported the hooks file alone: both configs vanished from the accounting, and the kept-snapshot line would undercount again. `installGrok` also had its own hand-rolled merge, which is why the first fix only helped the first run.

Now every file a target handled rides along, changed or not, along with anything the other result was already carrying, and `installGrok` goes through `wroteAll` like every other paired target. Only the changed ones are narrated, which is what the note was always for.

Fail-before test: `TestASecondInstallStillNamesEveryFileItWrote` (cmd/deja), on the collector: `second run touched [.../hooks/deja.json], want config.toml among them`.

Hermetic HOME, install twice then uninstall:

```
kept 2 snapshots of configs you already had — ~/.grok/config.toml.bak and 1 more — yours to remove
bak files on disk: 2
```

The reviewer's second point — that a run creating both files narrates only one of them — is fixed by the same routing: the sibling's line comes from `wroteAll` now.
