### PR TITLE
fix(cli): the refusal says how to ask a question that starts with a dash

### DIFF
--- a/cmd/deja/dash_query_test.go
+++ b/cmd/deja/dash_query_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// A question that begins with a dash reads as a flag, and the three verbs that
+// refuse it said so without saying what to do instead. `--` has worked all
+// along — the Amp plugin has used it since it was written — so the error names
+// it now (#3395).
+func TestADashLeadingQueryIsToldAboutTheSeparator(t *testing.T) {
+	hermeticEnv(t)
+	dir := t.TempDir()
+	for _, c := range []struct {
+		name string
+		run  func() error
+	}{
+		{"ctx", func() error { return cmdCtx(dir, []string{"--auto looks for the six harnesses"}) }},
+		{"how", func() error { return runHow(dir, []string{"--auto looks for the six harnesses"}, io.Discard) }},
+	} {
+		err := c.run()
+		if err == nil {
+			t.Errorf("%s: a dash-leading query was accepted; the test no longer covers the message", c.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "goes after `--`") {
+			t.Errorf("%s: %v — the message does not say a dash-leading query goes after `--`", c.name, err)
+		}
+	}
+}

--- a/cmd/deja/how.go
+++ b/cmd/deja/how.go
@@ -121,7 +121,7 @@ func runHow(dir string, args []string, stdout io.Writer) error {
 			i = len(args)
 		default:
 			if strings.HasPrefix(args[i], "-") {
-				return fmt.Errorf("how: unknown flag %q", args[i])
+				return fmt.Errorf("how: unknown flag %q; a query that starts with a dash goes after `--`", args[i])
 			}
 			if strings.TrimSpace(args[i]) != "" {
 				terms = append(terms, args[i])

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -891,7 +891,7 @@ func cmdCtx(dir string, rest []string) error {
 	} else {
 		for _, a := range rest {
 			if strings.HasPrefix(a, "--") {
-				return fmt.Errorf("ctx takes no flags, only a query or id-prefix — got %q", a)
+				return fmt.Errorf("ctx takes no flags, only a query or id-prefix — got %q; a question that starts with a dash goes after `--`", a)
 			}
 		}
 	}
@@ -2631,7 +2631,7 @@ func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
-				return "", o, false, fmt.Errorf("blame: unknown flag %q", a)
+				return "", o, false, fmt.Errorf("blame: unknown flag %q; a path or question that starts with a dash goes after `--`", a)
 			}
 			if path != "" {
 				return "", o, false, fmt.Errorf("blame accepts one path")


### PR DESCRIPTION
Closes #3395.

`ctx`, `how` and `blame` refuse a query that begins with a dash and did not say that `--` takes it. The mechanism has worked all along — deja's own Amp plugin builds `["search", "--", query]` for exactly this — so only the message changed.

Fail-before test: `TestADashLeadingQueryIsToldAboutTheSeparator` (cmd/deja), on the collector both messages come back without the remedy.

```
before:  deja: how: unknown flag "--auto looks for the six harnesses"
after:   deja: how: unknown flag "--auto looks for the six harnesses"; a query that starts with a dash goes after `--`
```

The wording is yours to overrule — I kept each message's existing half and appended one clause in the same voice as the other flag errors. `blame` says "a path or question" because both are valid arguments there.
