### PR TITLE
fix(doctor): the gemini row counts its own chats, not another harness's store

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -780,8 +780,15 @@ func doctorHarnesses(w io.Writer, dir string) {
 
 	printRow("aider", doctorAiderLocation(), len(sources.AiderFiles()) > 0, doctorCount(len(sources.AiderFiles()), "file"))
 
+	// The row names the store and counts what is under `tmp`, where the chats
+	// are: Antigravity keeps its own store in a sibling directory of the same
+	// root and has its own row, so walking the whole of ~/.gemini reported its
+	// files — 55 of 77 on a real machine — as chats gemini failed to read
+	// (#3397). The settings and the extensions beside them are not chats
+	// either.
 	geminiRoot := sources.GeminiRoot()
-	printFiles("gemini", geminiRoot, doctorExists(geminiRoot), sources.GeminiChatFiles())
+	printFilesBesideIn("gemini", geminiRoot, []string{filepath.Join(geminiRoot, "tmp")}, false,
+		doctorExists(geminiRoot), sources.GeminiChatFiles(), sources.GeminiSidecarFiles()...)
 
 	printRow("cursor", doctorCursorLocation(), doctorCursorPresent(), doctorCursorDetail(sqlite))
 

--- a/cmd/deja/doctor_gemini_files_test.go
+++ b/cmd/deja/doctor_gemini_files_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The gemini row walked all of ~/.gemini while the reader only looks at
+// tmp/<project>/chats, so Antigravity's store — a sibling directory inside the
+// same root, with its own row — was counted as chats gemini failed to read:
+// 55 of the 77 on this machine, the rest gemini's own configuration (#3397).
+func TestDoctorDoesNotCountAnotherHarnessAsGeminisUnread(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "gemini")
+	chats := filepath.Join(root, "tmp", "proj", "chats")
+	brain := filepath.Join(root, "antigravity", "brain", "f017fad5", ".system_generated", "logs")
+	for _, d := range []string{chats, brain} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_GEMINI_ROOT", root)
+	t.Setenv("DEJA_ANTIGRAVITY_ROOT", filepath.Join(root, "antigravity"))
+
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(chats, "session-2026-08-22T06-32-6b36be8d.jsonl"),
+		`{"sessionId":"6b36be8d","type":"user","content":"why does the retry loop drop the last attempt"}`+"\n")
+	write(filepath.Join(brain, "transcript.jsonl"),
+		`{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","created_at":"2026-07-08T14:18:27Z","content":"<USER_REQUEST>\nanything\n</USER_REQUEST>"}`+"\n")
+	write(filepath.Join(root, "settings.json"), "{}")
+	write(filepath.Join(root, "projects.json"), "{}")
+
+	row := func() string {
+		t.Helper()
+		var buf bytes.Buffer
+		doctorHarnesses(&buf, t.TempDir())
+		for _, l := range strings.Split(buf.String(), "\n") {
+			if strings.Contains(l, "gemini") && strings.Contains(l, "file") {
+				return l
+			}
+		}
+		t.Fatal("no gemini file row in the report at all")
+		return ""
+	}
+	if got := row(); strings.Contains(got, "not recognised") {
+		t.Errorf("row = %q, want no such note — the other store and the settings are not gemini's chats", got)
+	}
+	// And a chat the reader does not take is still what the row is for: the
+	// shape a renamed directory has, which is what layout drift looks like.
+	moved := filepath.Join(root, "tmp", "proj", "conversations")
+	if err := os.MkdirAll(moved, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(filepath.Join(moved, "session-2026-08-22T06-40-6b36be8d.jsonl"), "{}\n")
+	if got := row(); !strings.Contains(got, "1 not recognised here") {
+		t.Errorf("row = %q, want it to name the chat deja did not read", got)
+	}
+}

--- a/internal/sources/antigravity_sidecar_test.go
+++ b/internal/sources/antigravity_sidecar_test.go
@@ -59,3 +59,27 @@ func TestAntigravitySidecarFilesClaimsOnlyWhatItKnows(t *testing.T) {
 		}
 	}
 }
+
+// Gemini's own scratch under `tmp`: the per-project log the CLI writes beside
+// the chats. Everything else under that tree is a chat deja either read or did
+// not (#3397).
+func TestGeminiSidecarFilesClaimsOnlyTheLog(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEJA_GEMINI_ROOT", root)
+	chats := filepath.Join(root, "tmp", "proj", "chats")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{
+		filepath.Join(root, "tmp", "proj", "logs.json"),
+		filepath.Join(chats, "session-2026-08-22T06-32-6b36be8d.jsonl"),
+	} {
+		if err := os.WriteFile(p, []byte("{}\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := GeminiSidecarFiles()
+	if len(got) != 1 || filepath.Base(got[0]) != "logs.json" {
+		t.Errorf("GeminiSidecarFiles() = %v, want the project log alone", got)
+	}
+}

--- a/internal/sources/gemini.go
+++ b/internal/sources/gemini.go
@@ -32,6 +32,16 @@ func GeminiRoot() string {
 	return EnvPath("DEJA_GEMINI_ROOT", GeminiHome())
 }
 
+// GeminiSidecarFiles lists what a Gemini store keeps under `tmp` beside the
+// chats: the per-project log the CLI writes for itself. Everything outside
+// `tmp` is out of the walk entirely, because Antigravity's store lives in a
+// sibling directory of the same root and has its own row (#3397).
+func GeminiSidecarFiles() []string {
+	return walkFiles(filepath.Join(GeminiRoot(), "tmp"), func(p string) bool {
+		return filepath.Base(p) == "logs.json"
+	})
+}
+
 func GeminiChatFiles() []string {
 	root := filepath.Join(GeminiRoot(), "tmp")
 	var out []string


### PR DESCRIPTION
Closes #3397.

The row walked all of `~/.gemini` while the reader only looks at `tmp/<project>/chats`. Antigravity keeps its store in a sibling directory of the same root and has its own row, so its files were counted as chats gemini failed to read — 55 of the 77 on this machine, the other 22 being gemini's settings, extensions and scratch.

The walk is now the `tmp` tree, the row still names `~/.gemini`, and `GeminiSidecarFiles` claims the one thing under `tmp` that is not a chat: the per-project `logs.json`.

Fail-before test: `TestDoctorDoesNotCountAnotherHarnessAsGeminisUnread` (cmd/deja), on the collector: `(1 file, 2 not recognised here)` where the two are the other harness's transcript and a settings file.

Real store:

```
before:  gemini  found  ~/.gemini  (10 files, 77 not recognised here, 4 indexed sessions)
after:   gemini  found  ~/.gemini  (10 files, 4 indexed sessions)
```

and the antigravity row is unchanged at `(50 files, 50 indexed sessions)`.

The test's second half plants a chat in `tmp/<project>/conversations`, which is what a renamed directory would look like, and requires the row to name it.
