### PR TITLE
fix(doctor): the machine report names the cline root a transcript came from

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -816,10 +816,7 @@ func doctorHarnesses(w io.Writer, dir string) {
 	// Every root the line names is walked, or the count would promise coverage
 	// the row does not have: a stray file under a legacy tasks tree was
 	// invisible while the line advertised that root (review of #3360).
-	clineWalks := []string{clineModern}
-	for _, root := range sources.ClineLegacyRoots() {
-		clineWalks = append(clineWalks, filepath.Join(root, "tasks"))
-	}
+	clineWalks := sources.ClineStoreRoots()
 	printFilesBesideIn("cline", clineLoc, clineWalks, false, clineFiles > 0 || doctorExists(clineModern),
 		sources.ClineSessionFiles(), sources.ClineSidecarFiles()...)
 

--- a/cmd/deja/doctor_cline_json_paths_test.go
+++ b/cmd/deja/doctor_cline_json_paths_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The machine form kept its own path per harness, and cline's named only the
+// CLI store: on a machine whose transcripts are all in the VS Code extension
+// tree the report counted files under a directory it never named, and the
+// directory it did name did not exist (#3399).
+func TestDoctorJSONNamesTheClineRootTheFilesCameFrom(t *testing.T) {
+	legacy := clineLegacyOnlyStore(t)
+
+	check := doctorCheckNamed(t, "cline")
+	if len(check.files) != 1 {
+		t.Fatalf("the walk found %d files, want the one legacy task", len(check.files))
+	}
+	tasks := filepath.Join(legacy, "tasks")
+	found := false
+	for _, p := range check.paths {
+		if p == tasks {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("paths = %v, want the legacy tasks tree the transcript came from", check.paths)
+	}
+}
+
+// And because paths is what the permission walk covers, a legacy tree deja may
+// not read was reported as a harness nobody had used.
+func TestDoctorJSONSaysDeniedForALockedClineLegacyTree(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads everything")
+	}
+	legacy := clineLegacyOnlyStore(t)
+	tasks := filepath.Join(legacy, "tasks")
+	if err := os.Chmod(tasks, 0o000); err != nil {
+		t.Skipf("cannot lock a directory here: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(tasks, 0o755) })
+	if f, err := os.Open(tasks); err == nil {
+		_ = f.Close()
+		t.Skip("this filesystem ignores the mode")
+	}
+
+	store, _ := inspectDoctorStore(doctorCheckNamed(t, "cline"))
+	if store.State != "denied" {
+		t.Errorf("a locked legacy tree reports state %q, want denied", store.State)
+	}
+	if !strings.Contains(store.Denied, "tasks") {
+		t.Errorf("doctor names %q, not the directory it could not read", store.Denied)
+	}
+}
+
+// clineLegacyOnlyStore is the shape of a VS Code Cline user: one task under the
+// extension's globalStorage and no CLI store at all.
+func clineLegacyOnlyStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	legacy := filepath.Join(tmp, "vscode", "globalStorage", "saoudrizwan.claude-dev")
+	task := filepath.Join(legacy, "tasks", "1757000000000")
+	if err := os.MkdirAll(task, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLINE_ROOTS", legacy)
+	t.Setenv("DEJA_CLINE_ROOT", filepath.Join(tmp, "cline", "data", "sessions"))
+	body := `[{"role":"user","content":[{"type":"text","text":"why does the retry loop drop the last attempt"}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"the last attempt is not counted"}]}]`
+	if err := os.WriteFile(filepath.Join(task, "api_conversation_history.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return legacy
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -446,7 +446,7 @@ func doctorStoreChecks() []doctorStoreCheck {
 		// `doctor --json` never named them and "no agent history was found on
 		// this machine" was printed on a machine whose history is theirs
 		// (#999).
-		{"cline", []string{sources.ClineSessionsDir()}, sources.ClineSessionFiles(), sources.ParseClineFile},
+		{"cline", sources.ClineStoreRoots(), sources.ClineSessionFiles(), sources.ParseClineFile},
 		{"roo", sources.RooRoots(), sources.RooTaskFiles(), sources.ParseRooTask},
 		{"deepseek", []string{sources.DeepSeekRoot()}, sources.DeepSeekSessionFiles(), sources.ParseDeepSeekFile},
 		// Zed keeps one SQLite store rather than session files, so the file

--- a/internal/sources/cline.go
+++ b/internal/sources/cline.go
@@ -110,6 +110,18 @@ func ClineLegacyRoots() []string {
 	return out
 }
 
+// ClineStoreRoots names every directory the transcript walk covers: the
+// CLI/SDK sessions directory and each legacy extension root's tasks tree. Both
+// doctor forms read it, so the row and the machine report cannot disagree on
+// where a cline transcript is looked for (#3399).
+func ClineStoreRoots() []string {
+	roots := []string{ClineSessionsDir()}
+	for _, root := range ClineLegacyRoots() {
+		roots = append(roots, filepath.Join(root, "tasks"))
+	}
+	return roots
+}
+
 // ClineSessionFiles lists both generations' transcript files.
 func ClineSessionFiles() []string {
 	files := walkFiles(ClineSessionsDir(), func(p string) bool {

--- a/internal/sources/cline_test.go
+++ b/internal/sources/cline_test.go
@@ -92,3 +92,30 @@ func TestClineSessionFilesHonorsOverrides(t *testing.T) {
 		t.Fatalf("sessions = %d", len(ss))
 	}
 }
+
+// The roots are what doctor walks and what it names, so they have to be the
+// tasks trees themselves rather than the extension roots holding them (#3399).
+func TestClineStoreRootsNamesEachTasksTree(t *testing.T) {
+	tmp := t.TempDir()
+	sessions := filepath.Join(tmp, "cline", "data", "sessions")
+	one := filepath.Join(tmp, "vscode", "globalStorage", "saoudrizwan.claude-dev")
+	two := filepath.Join(tmp, "cursor", "globalStorage", "saoudrizwan.claude-dev")
+	for _, d := range []string{one, two} {
+		if err := os.MkdirAll(filepath.Join(d, "tasks"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLINE_ROOT", sessions)
+	t.Setenv("DEJA_CLINE_ROOTS", one+string(os.PathListSeparator)+two)
+
+	got := ClineStoreRoots()
+	want := []string{sessions, filepath.Join(one, "tasks"), filepath.Join(two, "tasks")}
+	if len(got) != len(want) {
+		t.Fatalf("roots = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("root %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
`doctorStoreChecks()` listed one root for cline while the walk and the printed row use two, so on a VS Code Cline machine `doctor --json` counted files under a directory it never named — and the permission walk, which reads the same list, never entered the legacy tasks tree: a locked one reported `"state":"missing"` instead of `denied`.

Both surfaces now take the list from `sources.ClineStoreRoots()`.

Fails before the change:

```
--- FAIL: TestDoctorJSONNamesTheClineRootTheFilesCameFrom
    paths = [.../cline/data/sessions], want the legacy tasks tree the transcript came from
--- FAIL: TestDoctorJSONSaysDeniedForALockedClineLegacyTree
    a locked legacy tree reports state "unplugged", want denied
```

On a hermetic HOME with one legacy task and no CLI store:

```
before {"name":"cline","state":"ok","paths":[".../.cline/data/sessions"],"files":1}
after  {"name":"cline","state":"ok","paths":[".../.cline/data/sessions",".../saoudrizwan.claude-dev/tasks"],"files":1}
after, tasks chmod 000: "state":"denied","denied":".../saoudrizwan.claude-dev/tasks"
```

This machine has only the CLI store, so its row and json are unchanged (15 files, 15 indexed sessions).

Closes #3399
