### PR TITLE
fix(friction): two failures that share a URL no longer print as one row twice

### DIFF
--- a/cmd/deja/friction.go
+++ b/cmd/deja/friction.go
@@ -9,12 +9,16 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/jsonout"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
+
+// frictionRowBytes is what one row of the list holds.
+const frictionRowBytes = 79
 
 // `deja friction` names what this machine keeps tripping over.
 //
@@ -156,9 +160,10 @@ func runFriction(dir string, args []string, stdout io.Writer) error {
 		rows = rows[:limit]
 	}
 	fmt.Fprintf(stdout, "what this machine keeps tripping over — %d session%s read\n", sessions, pluralS(sessions))
-	for _, r := range rows {
+	lines := frictionRowLines(rows)
+	for i, r := range rows {
 		where := strings.Join(r.harnesses, ", ")
-		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, trimFriction(r.line))
+		fmt.Fprintf(stdout, "  %2d sessions  %s\n", r.n, lines[i])
 		fmt.Fprintf(stdout, "               %s", where)
 		if !r.when.IsZero() {
 			fmt.Fprintf(stdout, " · last %s", r.when.Local().Format("Jan 2"))
@@ -300,6 +305,50 @@ func scanFriction(dir string, pol policy.Policy) (*frictionScan, error) {
 	}, nil
 }
 
+// frictionRowLines renders the lines about to be printed. Two failures of one
+// service can share every byte before the cut — a connection refused and a
+// connection reset carry the same URL first — and the list then printed one
+// line twice with a count beside each, which reads as a single error counted
+// wrong (#3401). Where the cut collides, it moves into the middle of the line
+// so the end that tells them apart survives.
+func frictionRowLines(rows []frictionRow) []string {
+	out := make([]string, len(rows))
+	same := map[string]int{}
+	for i, r := range rows {
+		out[i] = trimFriction(r.line)
+		same[out[i]]++
+	}
+	for i, r := range rows {
+		if same[out[i]] > 1 {
+			out[i] = elideFrictionMiddle(r.line)
+		}
+	}
+	return out
+}
+
+// elideFrictionMiddle keeps both ends of a line within the row's width. Same
+// bound and same sanitising as trimFriction, rune-safe at both cuts.
+func elideFrictionMiddle(l string) string {
+	const ellipsis = "…"
+	s := search.SafeLine(l)
+	if len(s) <= frictionRowBytes {
+		return s
+	}
+	tail := (frictionRowBytes - len(ellipsis)) / 2
+	head := frictionRowBytes - len(ellipsis) - tail
+	for head > 0 && !utf8.ValidString(s[:head]) {
+		head--
+	}
+	start := len(s) - tail
+	for start < len(s) && !utf8.ValidString(s[start:]) {
+		start++
+	}
+	if head == 0 || start >= len(s) {
+		return truncatePlanBytes(s, frictionRowBytes)
+	}
+	return strings.TrimSpace(s[:head]) + ellipsis + strings.TrimSpace(s[start:])
+}
+
 func trimFriction(l string) string {
 	// Sanitised first. A wall is text out of a transcript deja did not write,
 	// and this was the one surface printing it as recorded: an ANSI escape
@@ -310,7 +359,7 @@ func trimFriction(l string) string {
 	// Rune-safe: a wall recorded in Russian or Chinese was cut mid-character
 	// and printed as a broken byte (#1319). The bound includes the mark, so a
 	// line loses one character rather than gaining one.
-	return truncatePlanBytes(search.SafeLine(l), 79)
+	return truncatePlanBytes(search.SafeLine(l), frictionRowBytes)
 }
 
 // emptiedBy names the rule that leaves a path nothing to read. Both can be in

--- a/cmd/deja/friction_collision_test.go
+++ b/cmd/deja/friction_collision_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// Two failures of one service differ only in how it failed — refused, or reset
+// mid-read — and everything that says which is past the 79 bytes a row holds.
+// The list then printed the same line twice, each with its own count, and the
+// reader had no way to tell them apart (#3401).
+func TestFrictionRowsThatShareTheirHeadStillDiffer(t *testing.T) {
+	root := frictionEnv(t)
+	const shared = `Get "http://toy-load-toy-load.default.svc.cluster.local/work?cpu_ms=20&jitter_ms=5": `
+	lines := []string{
+		shared + "dial tcp 0.0.0.0:0->192.0.2.73:80: connect: connection refused",
+		shared + "read tcp 192.0.2.35:39473->192.0.2.73:80: read: connection reset by peer",
+	}
+	if len(shared) <= 79 {
+		t.Fatalf("the shared head is %d bytes, so the rows never collide", len(shared))
+	}
+	proj := filepath.Join(root, "projects", "repo")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for n, line := range lines {
+		for i := 0; i < index.FrictionMinSessions; i++ {
+			sid := fmt.Sprintf("s%d%02d", n, i)
+			payload, err := json.Marshal(line + "\nexit status 1")
+			if err != nil {
+				t.Fatal(err)
+			}
+			row := `{"type":"user","sessionId":"` + sid + `","cwd":"/repo",` +
+				`"timestamp":"2026-07-30T03:05:05Z","message":{"role":"user","content":` +
+				`[{"type":"tool_result","content":` + string(payload) + `}]}}` + "\n"
+			if err := os.WriteFile(filepath.Join(proj, sid+".jsonl"), []byte(row), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := runFriction(index.DefaultDir(), nil, &buf); err != nil {
+		t.Fatal(err)
+	}
+	var rows []string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "sessions  ") {
+			rows = append(rows, strings.TrimSpace(l))
+		}
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want the two failures as two rows, got %d:\n%s", len(rows), buf.String())
+	}
+	if rows[0] == rows[1] {
+		t.Errorf("both failures print as %q — the reader sees one error twice", rows[0])
+	}
+	for _, r := range rows {
+		if len(r) > 79+len("   5 sessions  ") {
+			t.Errorf("row is %d bytes, past what a terminal row holds: %q", len(r), r)
+		}
+		if !strings.Contains(r, "toy-load") {
+			t.Errorf("row no longer names the failing service: %q", r)
+		}
+	}
+}


### PR DESCRIPTION
On this machine's index two rows of `deja friction` print identically — a connection refused and a connection reset on the same URL, 79 bytes of which is the URL. `--json` shows them as the two different errors they are.

`trimFriction` cuts from the front; where that cut would make two printed rows the same, the cut now moves into the middle so the end survives:

```
before:  5 sessions  Get "http://toy-load-toy-load.default.svc.cluster.local/work?cpu_ms=20&jitte…
         5 sessions  Get "http://toy-load-toy-load.default.svc.cluster.local/work?cpu_ms=20&jitte…
after:   5 sessions  Get "http://toy-load-toy-load.default.…138.73:80: connect: connection refused
         5 sessions  Get "http://toy-load-toy-load.default.….73:80: read: connection reset by peer
```

Rows that do not collide are untouched — the other 13 rows of the same run are byte-identical.

Fails before the change: `TestFrictionRowsThatShareTheirHeadStillDiffer` — `both failures print as "3 sessions  Get \"http://toy-load-…&jitte…" — the reader sees one error twice`.

Closes #3401
