### PR TITLE
fix(fix): an unconfirmed remedy from an excluded tree is withheld like a confirmed one

### DIFF
--- a/cmd/deja/ignore_candidate_fix_test.go
+++ b/cmd/deja/ignore_candidate_fix_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The sweep in ignore_every_surface_test.go writes the same error and remedy in
+// three sessions, so the pair is corroborated and takes the branch that checks
+// the ignore rule. One session — the ordinary case — is held back as an
+// unconfirmed sighting, and that branch checked only the trust policy: `deja
+// fix` handed back a command out of the tree search and `how` refuse to read
+// (#3403).
+func TestFixDoesNotServeAnUnconfirmedRemedyFromTheIgnoredTree(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	policyFile := filepath.Join(tmp, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// One session only, so the remedy stays a sighting; and a remedy that
+	// names nothing the error names, so it is not promoted by sharing a term.
+	writeClaudeFixture(t, filepath.Join(root, "-w-scratch", "s1.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","cwd":"/w/scratch","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer keeps overflowing"}}`,
+		`{"type":"user","sessionId":"s1","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"panic: zonkobuffer overflow at shard 7"}]}}`,
+		`{"type":"assistant","sessionId":"s1","cwd":"/w/scratch","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"terraform apply -target module.klindra"}}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "fix", "panic: zonkobuffer overflow at shard 7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "klindra") {
+		t.Errorf("a withheld session's command reached deja fix:\n%s", out)
+	}
+	if !strings.Contains(out, "no session") {
+		t.Errorf("want the refusal the other surfaces give, got:\n%s", out)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -633,6 +633,12 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	// nothing for the manifest read.
 	var ignored map[string]bool
 	loaded := false
+	ignoredProject := func(project string) bool {
+		if !loaded {
+			ignored, loaded = ProjectsTouchedByIgnore(dir), true
+		}
+		return ignored[project]
+	}
 	for _, p := range ReadFixes(dir) {
 		if !sigs[p.Sig] {
 			continue
@@ -650,10 +656,7 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 		if allow != nil && !allow(p.Project) {
 			continue
 		}
-		if !loaded {
-			ignored, loaded = ProjectsTouchedByIgnore(dir), true
-		}
-		if ignored[p.Project] {
+		if ignoredProject(p.Project) {
 			continue
 		}
 		out = append(out, p)
@@ -667,6 +670,13 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	if len(out) == 0 {
 		for _, p := range held {
 			if allow != nil && !allow(p.Project) {
+				continue
+			}
+			// The rule the confirmed pairs are held to. A sighting was
+			// appended before that check ran, so the one branch that answers
+			// most real errors handed back a command out of the tree search
+			// and `how` refuse to read (#3403).
+			if ignoredProject(p.Project) {
 				continue
 			}
 			out = append(out, p)


### PR DESCRIPTION
`FixesFor` held unconfirmed sightings aside before the ignore-rule check and served them, when nothing was confirmed, past it. Search and `how` refuse those sessions; `fix` handed back the command they ran.

```
$ deja "sprocket bus"
deja: the ignore rule withholds every indexed session from this path (*/.claude/jobs/*)
$ deja fix "zarnakctl: FATAL: could not bind sprocket bus at 127.0.0.1:7788"
before:  ran next, unconfirmed: $ launchctl unload ~/Library/LaunchAgents/io.example.plist
after:   deja: no session on this machine ran a command after that error
```

`FixCandidateSeen` right below it already applies the rule, with a comment saying it is the same rule as this one — so this was the half that was missed, not a decision.

The existing sweep `TestNoSurfaceServesTheIgnoredTree` asks `fix` about an ignored tree and passes, because its fixture repeats the pair in three sessions and takes the confirmed branch. The new test uses one session, which is the ordinary case. Fails before the change with `a withheld session's command reached deja fix: … terraform apply -target module.klindra`.

Three real errors on a copy of this machine's index answer byte-identically before and after.

Closes #3403
