### PR TITLE
fix(cli): the refusal of --limit names what last and blame take instead

### DIFF
--- a/cmd/deja/limit_refusal_test.go
+++ b/cmd/deja/limit_refusal_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `files` and `how` take --limit, so a reader arrives at `blame` and `last`
+// having just been told the flag works. Both refuse it, both for a reason, and
+// neither said what to type instead — the sentence `friction` and `install`
+// have printed all along (#3405).
+func TestTheRefusalNamesWhatTheCommandTakes(t *testing.T) {
+	if _, _, _, err := parseLast([]string{"--limit", "3"}); err == nil {
+		t.Fatal("last took --limit")
+	} else if !strings.Contains(err.Error(), "deja last 3") {
+		t.Errorf("last says %q, without the count it takes", err)
+	}
+	if _, _, _, err := parseBlame([]string{"x.go", "--limit", "3"}); err == nil {
+		t.Fatal("blame took --limit")
+	} else if !strings.Contains(err.Error(), "--all") {
+		t.Errorf("blame says %q, without the flag that widens it", err)
+	}
+	// Every other flag keeps the plain refusal: the note is about the one
+	// spelling a reader carries over from the commands beside these.
+	if _, _, _, err := parseLast([]string{"--nonesuch"}); err == nil ||
+		strings.Contains(err.Error(), "deja last 3") {
+		t.Errorf("an unrelated flag gets the count note: %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -2362,6 +2362,12 @@ func parseLast(args []string) (int, search.Options, string, error) {
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
+				if flagName(a) == "--limit" {
+					// The two commands beside this one take --limit, so the
+					// reader is carrying it over rather than guessing; the
+					// count last takes is a bare argument (#3405).
+					return n, o, sinceRaw, fmt.Errorf("last: unknown flag %q — the count is a bare argument, `deja last 3`", a)
+				}
 				return n, o, sinceRaw, fmt.Errorf("last: unknown flag %q", a)
 			}
 			// The only bare argument last takes is the count. Dropping anything
@@ -2631,6 +2637,10 @@ func parseBlame(args []string) (string, search.BlameOptions, bool, error) {
 			}
 		default:
 			if strings.HasPrefix(a, "-") {
+				if flagName(a) == "--limit" {
+					// blame widens with --all rather than a count (#3405).
+					return "", o, false, fmt.Errorf("blame: unknown flag %q — it takes --all to show every session", a)
+				}
 				return "", o, false, fmt.Errorf("blame: unknown flag %q; a path or question that starts with a dash goes after `--`", a)
 			}
 			if path != "" {
@@ -4567,4 +4577,13 @@ func betweenAll(s, marker string) []string {
 		out = append(out, strings.TrimSpace(rest[:j]))
 		s = rest[j+len(marker):]
 	}
+}
+
+// flagName is the flag without its value, so `--limit=3` and `--limit 3` are
+// recognised as the same spelling.
+func flagName(a string) string {
+	if i := strings.IndexByte(a, '='); i >= 0 {
+		return a[:i]
+	}
+	return a
 }


### PR DESCRIPTION
`files` and `how` take `--limit`, so a reader arrives at `blame` and `last` having just been told the flag works. Both refuse it — `blame` widens with `--all`, `last` takes the count as a bare argument — and neither said so:

```
before:  deja: blame: unknown flag "--limit"
         deja: last: unknown flag "--limit"
after:   deja: blame: unknown flag "--limit" — it takes --all to show every session
         deja: last: unknown flag "--limit" — the count is a bare argument, `deja last 3`
```

Only `--limit` gets the note; every other flag keeps the refusal it had, including blame's `--` sentence from #3395. `flagName` makes `--limit=3` the same spelling as `--limit 3`.

The wording follows `friction: unknown flag %q — it takes --limit n and --json` and the same sentence in `install`. Question for the PR: "the count is a bare argument" is my phrasing — `deja last 3` is what the help spells, and I kept it verbatim.

Fails before the change: `TestTheRefusalNamesWhatTheCommandTakes` — `last says "last: unknown flag \"--limit\"", without the count it takes`.

Closes #3405
