### PR TITLE
fix(doctor): a store with one locked root is reported as partly readable

### DIFF
--- a/cmd/deja/doctor_denied_partial_test.go
+++ b/cmd/deja/doctor_denied_partial_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A store with more than one root can be half-readable: the CLI transcripts
+// open and the VS Code tree refuses. The walk below says so — "sessions are
+// missing from recall rather than the whole harness" (#816) — and the stat
+// loop above it returned before setting the field, so the machine form called
+// a half-readable store wholly denied (#3407).
+func TestDoctorJSONSaysPartialWhenOnlyOneRootIsLocked(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads everything")
+	}
+	tmp := hermeticEnv(t)
+	sessions := filepath.Join(tmp, "cline", "data", "sessions", "1757000001_aa11b")
+	legacy := filepath.Join(tmp, "vscode", "globalStorage", "saoudrizwan.claude-dev")
+	task := filepath.Join(legacy, "tasks", "1757000000000")
+	for _, d := range []string{sessions, task} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("DEJA_CLINE_ROOT", filepath.Dir(sessions))
+	t.Setenv("DEJA_CLINE_ROOTS", legacy)
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(sessions, "1757000001_aa11b.messages.json"),
+		`[{"role":"user","content":[{"type":"text","text":"why does the parser skip the first turn"}]}]`)
+	write(filepath.Join(task, "api_conversation_history.json"),
+		`[{"role":"user","content":[{"type":"text","text":"why does the retry loop drop the last attempt"}]}]`)
+
+	locked := filepath.Join(legacy, "tasks")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Skipf("cannot lock a directory here: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+	if f, err := os.Open(locked); err == nil {
+		_ = f.Close()
+		t.Skip("this filesystem ignores the mode")
+	}
+
+	store, _ := inspectDoctorStore(doctorCheckNamed(t, "cline"))
+	if store.State != "denied" {
+		t.Fatalf("state = %q, want denied", store.State)
+	}
+	if store.Files == 0 {
+		t.Fatalf("no file was read at all, so this asserts nothing")
+	}
+	if !store.Partial {
+		t.Errorf("the CLI store read %d file(s) and the report calls the harness wholly denied", store.Files)
+	}
+}

--- a/cmd/deja/doctor_report.go
+++ b/cmd/deja/doctor_report.go
@@ -551,6 +551,15 @@ func parseDoctorHermes(path string) ([]model.Session, error) {
 
 func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 	store := doctorStore{Name: check.name, State: "missing", Paths: check.paths, Files: len(check.files)}
+	// A store with more than one root can be half-readable, and this loop
+	// returns on the first refusal — the walk below has said so since #816
+	// while this said the whole harness was denied (#3407).
+	denyRoot := func(path string) (doctorStore, time.Time) {
+		store.State = "denied"
+		store.Denied = path
+		store.Partial = len(check.files) > 0
+		return store, time.Time{}
+	}
 	for _, path := range check.paths {
 		if path == "" {
 			continue
@@ -558,9 +567,7 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 		fi, err := os.Stat(path)
 		if err != nil {
 			if os.IsPermission(err) {
-				store.State = "denied"
-				store.Denied = path
-				return store, time.Time{}
+				return denyRoot(path)
 			}
 			continue
 		}
@@ -568,18 +575,14 @@ func inspectDoctorStore(check doctorStoreCheck) (doctorStore, time.Time) {
 			f, err := os.Open(path)
 			if err != nil {
 				if os.IsPermission(err) {
-					store.State = "denied"
-					store.Denied = path
-					return store, time.Time{}
+					return denyRoot(path)
 				}
 				continue
 			}
 			_, err = f.Readdirnames(1)
 			_ = f.Close()
 			if err != nil && err != io.EOF && os.IsPermission(err) {
-				store.State = "denied"
-				store.Denied = path
-				return store, time.Time{}
+				return denyRoot(path)
 			}
 		}
 	}


### PR DESCRIPTION
`inspectDoctorStore` stats each root and returns on the first refusal, without setting `partial` — so a store whose other root read fine was reported as a wholly denied harness. The walk below it has set the field since #816.

```
before: {"name":"cline","state":"denied","paths":[…,".../saoudrizwan.claude-dev/tasks"],"files":1,
         "denied":".../saoudrizwan.claude-dev/tasks"}
after:  {…, "partial":true}
```

`files` is 1 there — the CLI store read — which is exactly what `partial` is for.

Reachable for every harness with more than one root: cursor, hermes, roo, antigravity, and cline since #3399. On this machine, with nothing locked, `doctor --json` is byte-identical before and after.

Fails before the change: `TestDoctorJSONSaysPartialWhenOnlyOneRootIsLocked` — `the CLI store read 1 file(s) and the report calls the harness wholly denied`.

Closes #3407
