### PR TITLE
fix(files): a quoted topic answers the same as the same words unquoted

### DIFF
--- a/cmd/deja/files.go
+++ b/cmd/deja/files.go
@@ -186,7 +186,11 @@ func runFiles(dir string, args []string, stdout io.Writer) error {
 	// The words the person typed, not the expanded variant list: that one runs
 	// to eighteen stemmed forms for a two-word query, and requiring most of them
 	// in one message matches nothing.
-	needles := lowerAll(terms)
+	//
+	// The words, not the arguments: quoting a topic put the whole sentence in
+	// as one needle, which no single message carries, so `deja files "a b c"`
+	// answered nothing where `deja files a b c` answered (#3409).
+	needles := lowerAll(strings.Fields(q))
 	filtered := 0                    // recorded paths dropped by the repository filter
 	near := map[string]int{}         // path -> times touched near the topic
 	nearSessions := map[string]int{} // path -> how many sessions touched it near the topic

--- a/cmd/deja/files_tier_test.go
+++ b/cmd/deja/files_tier_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The words a topic is asked in are the needles the file list anchors on, and
+// they were taken from argv rather than from the query: `deja files "a b c"`
+// looked for the whole sentence inside one message and found nothing, while
+// `deja files a b c` — the same words, different shell quoting — answered
+// (#3409).
+func TestFilesAnswersTheSameQuotedOrNot(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	repo := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "retry.go"), []byte("package api\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-w-api", "p1.jsonl"), "p1", []string{
+		`{"type":"user","sessionId":"p1","cwd":"/w/api","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer drops the last attempt of the retry loop"}}`,
+		`{"type":"assistant","sessionId":"p1","cwd":"/w/api","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` + filepath.Join(repo, "retry.go") + `","old_string":"a","new_string":"b"}}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	split, err := captureRun(t, "files", "zonkobuffer", "retry", "loop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(split, "retry.go") {
+		t.Fatalf("the fixture does not answer even word by word, so this pins nothing:\n%s", split)
+	}
+	quoted, err := captureRun(t, "files", "zonkobuffer retry loop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(quoted, "retry.go") {
+		t.Errorf("quoting the same words empties the answer:\n%s", quoted)
+	}
+}


### PR DESCRIPTION
The file list anchors on the words of the topic, and it took them from argv rather than from the query — so a quoted topic went in as one needle and `topicTimes` looked for the whole sentence inside a single message:

```
before:  $ deja files "cursor turn timestamps"
         0 sessions mention "cursor turn timestamps", none of them recorded a file near it
         $ deja files cursor turn timestamps
         files touched while working on "cursor turn timestamps" — 10 sessions

after:   both spellings print the same 10 sessions and the same file list
```

Retrieval was never the problem: probed on a fixture it returns the same session and the same close tier for both spellings.

Found while measuring `deja files` against ten questions about tonight's merged work — every one of them passed as a single argument, and every one answered "0 sessions mention …" (#3409).

Fails before the change: `TestFilesAnswersTheSameQuotedOrNot` — `quoting the same words empties the answer`.

Closes #3409
