### PR TITLE
fix(forget): the cached session-start digests go with the sessions

### DIFF
--- a/cmd/deja/forget_hookcache_test.go
+++ b/cmd/deja/forget_hookcache_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The session-start digest is cached as prose beside the index, one file per
+// working directory, and nothing removed one — so after `deja forget` the
+// block quoting the forgotten session was still on disk. Recall was not
+// serving it (the entry expires in a minute), but the privacy command is about
+// the content, not only the answer (#3411, the shape #2537 closed for a note).
+func TestForgetTakesTheCachedDigestWithIt(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	writeClaudeFixture(t, filepath.Join(root, "-w-api", "s1.jsonl"), "s1", []string{
+		`{"type":"user","sessionId":"s1","cwd":"/w/api","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer overflows under load"}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := hookCacheEntry{At: time.Now(), CWD: cwd, Gate: hookGate(), Digest: "recalled: the zonkobuffer overflows under load", Sessions: 1, Raw: 7}
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := hookCachePath(dir, cwd)
+	if err := os.WriteFile(cache, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := captureRun(t, "forget", "--session", "s1"); err != nil {
+		t.Fatal(err)
+	}
+	left, err := os.ReadFile(cache)
+	if err == nil && strings.Contains(string(left), "zonkobuffer") {
+		t.Errorf("the forgotten session is still quoted in %s", filepath.Base(cache))
+	}
+}

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -1353,3 +1353,20 @@ func startLead(narrow string) string {
 const wideRecallLead = "The sessions below are recent work on this machine, not only in this project — deja is set to recall widely. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, say so in one short line at the start of your reply: déjà vu: <what was recalled> — <how you reused it> (deja:<session id>); otherwise do not mention it.\n"
 
 const sessionStartLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, say so in one short line at the start of your reply: déjà vu: <what was recalled> — <how you reused it> (deja:<session id>); otherwise do not mention it.\n"
+
+// dropHookCaches removes every cached session-start digest beside this index.
+// They are keyed by working directory, so there is one per project a hook has
+// ever run in, and they hold the block as prose (#3411).
+func dropHookCaches(dir string) {
+	matches, err := filepath.Glob(dir + ".hookcache-*")
+	if err != nil {
+		return
+	}
+	// The first cache deja ever wrote had no suffix; a machine that has run
+	// hooks since then still carries it.
+	matches = append(matches, dir+".hookcache")
+	for _, p := range matches {
+		_ = os.Remove(p)
+		_ = os.Remove(p + ".refreshing")
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -3369,6 +3369,14 @@ func runForget(dir string, args []string) error {
 		shared = sharedRowsAmong(dir, pr.Keys)
 	}
 	result, err := index.Forget(dir, o)
+	if !o.DryRun {
+		// The digests cached beside the index quote sessions as prose, and a
+		// forget left them there: recall never served them past their minute,
+		// and the text was still on the disk (#3411). Dropped whether or not
+		// the rebuild succeeded — the next session start pays the ~120 ms the
+		// cache exists to save.
+		dropHookCaches(dir)
+	}
 	if err != nil {
 		// The tombstone is already written; what failed is the rebuild that
 		// takes the records out. Handing back `mkdir /…/idx.tmp: permission


### PR DESCRIPTION
The session-start digest is cached as prose beside the index — one file per working directory, `<index>.hookcache-<hash>` — and nothing ever removed one. After `deja forget`, the block quoting the forgotten session was still on disk: this machine carries 40 of those files, 160 KB, the oldest from 2026-07-24 with a user turn in it.

Recall was not serving them (an entry expires after a minute, and the gate string rejects a stale shape), so this is about the content, not the answer — the same distinction #2537 drew for a promoted note a cached digest kept quoting.

They are dropped on any real forget, not only a matching one: the cache is keyed by directory, not by session, so there is nothing to match against. The next session start pays the ~120 ms the cache exists to save.

Fails before the change: `TestForgetTakesTheCachedDigestWithIt` — `the forgotten session is still quoted in index.db.hookcache-b517da24`.

Closes #3411
