### PR TITLE
fix(digest): a line that names nothing is not the session's problem

### DIFF
--- a/internal/search/problem_line_test.go
+++ b/internal/search/problem_line_test.go
@@ -1,0 +1,52 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The session-start digest opened on "продолжай": a real message a person
+// typed, so none of the plumbing rules caught it, and the block then said "go
+// on" and "nothing settled yet" while the session that settled the question
+// came second (#3412). A line that names nothing is not a problem statement.
+func TestABareContinuationIsNotTheProblemStatement(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "claude", Project: "w/proj", ID: "live-1", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: "продолжай", Time: at},
+			{Role: "assistant", Text: "смотрю на батчер, пока ничего не решено", Time: at.Add(time.Minute)},
+			{Role: "user", Text: "the quokkabloom batcher caps the payload at 4 KB", Time: at.Add(2 * time.Minute)},
+		},
+	}
+	got := autoRecallSessionFor(s, at.Add(time.Hour), true, nil)
+	if strings.Contains(got, "User: продолжай") {
+		t.Errorf("a bare continuation is quoted as the problem:\n%s", got)
+	}
+	if !strings.Contains(got, "quokkabloom batcher") {
+		t.Errorf("the line that does name something was not taken instead:\n%s", got)
+	}
+}
+
+// And a session whose only user line names nothing still shows what it
+// concluded rather than disappearing.
+func TestASessionWithNoProblemLineStillShowsItsConclusion(t *testing.T) {
+	at := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	s := model.Session{
+		Harness: "claude", Project: "w/proj", ID: "live-2", Updated: at,
+		Messages: []model.Message{
+			{Role: "user", Text: "давай дальше", Time: at},
+			{Role: "assistant", Text: "the fix: the quokkabloom dial deadline is 5s now", Time: at.Add(time.Minute)},
+		},
+	}
+	got := autoRecallSessionFor(s, at.Add(time.Hour), true, nil)
+	if !strings.Contains(got, "dial deadline is 5s") {
+		t.Errorf("the conclusion went with the filler line:\n%s", got)
+	}
+	if strings.Contains(got, "давай дальше") {
+		t.Errorf("the filler line is still quoted:\n%s", got)
+	}
+}

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/cjkfold"
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/prompt"
 )
 
 const (
@@ -470,7 +471,13 @@ func autoRecallSessionForAsked(s model.Session, now time.Time, provenance bool, 
 		}
 		switch m.Role {
 		case "user":
-			if problem == "" && !noiseMessage(m.Text) {
+			// A line that names nothing is not the session's problem. The
+			// digest opened on "продолжай" — a real message, not plumbing, and
+			// the whole first block then said "go on" and "nothing settled
+			// yet" while the session that settled the thing came second
+			// (#3412). prompt.Terms is what the recall side already searches
+			// on: no terms means there is nothing in the line to search for.
+			if problem == "" && !noiseMessage(m.Text) && len(prompt.Terms(text)) > 0 {
 				problem = firstLine(text, 160)
 			}
 		case "assistant":


### PR DESCRIPTION
The session-start block quoted whatever the person last typed as the session's problem statement, so on a stand with two sessions it opened like this:

```
  - Session: **w/proj** `live-1`
  - User: go on
  - Assistant: still looking at the batcher, nothing settled yet
```

while the session that settled the question came second. A bare continuation is not plumbing, not a smoke test and not a refusal, so none of the existing rules caught it.

The problem line now has to carry a search term — `prompt.Terms` is what the recall side searches on, and it already knows this closed class of continuations in both languages. A session whose only user line names nothing keeps its conclusions and loses just that line.

`bench context` and `bench prompt` are identical on every arm.

Closes #3412