### PR TITLE
fix(index): the sidecar builders are a phase, not eight silent seconds

### DIFF
--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -591,10 +591,20 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 		return err
 	}
 	dropEmptySessions(&m, wrote)
+	// The four sidecars walk every session again — what co-occurs, which
+	// command followed which error, what was run and what failed. On a real
+	// store that is eight seconds of a twenty-second build, and it used to run
+	// under the previous phase's last percentage, so the bar sat still through
+	// it (#3372).
+	reportPhase("mining fixes and commands", 4)
 	buildCooccur(tmp, ss)
+	reportAdvance(1)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
+	reportAdvance(1)
 	buildCommands(tmp, ss)
+	reportAdvance(1)
 	buildCommandFails(tmp, ss)
+	reportAdvance(1)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err
@@ -1145,10 +1155,20 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	if len(ss) >= cooccurMinDF && len(ss) <= cooccurMaxSessions {
 		preRedactSessions(nil, ss)
 	}
+	// The four sidecars walk every session again — what co-occurs, which
+	// command followed which error, what was run and what failed. On a real
+	// store that is eight seconds of a twenty-second build, and it used to run
+	// under the previous phase's last percentage, so the bar sat still through
+	// it (#3372).
+	reportPhase("mining fixes and commands", 4)
 	buildCooccur(tmp, ss)
+	reportAdvance(1)
 	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
+	reportAdvance(1)
 	buildCommands(tmp, ss)
+	reportAdvance(1)
 	buildCommandFails(tmp, ss)
+	reportAdvance(1)
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err

--- a/internal/index/read_progress_test.go
+++ b/internal/index/read_progress_test.go
@@ -134,3 +134,42 @@ func TestTheIndexingPhaseCountsMessagesAsTheyAreIndexed(t *testing.T) {
 		t.Errorf("the phase advanced %d of %d messages", sum, sessions*msgs)
 	}
 }
+
+// The four sidecar builders walked every session under the previous phase's
+// last percentage, so a build stood still for the eight seconds they took on a
+// real store (#3372). They are a phase of their own now.
+func TestTheSidecarsAreAPhaseOfTheirOwn(t *testing.T) {
+	tmp := t.TempDir()
+	claude := filepath.Join(tmp, "claude", "proj")
+	if err := os.MkdirAll(claude, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	line := fmt.Sprintf(`{"type":"user","sessionId":"quokkabloom-side","timestamp":%q,`+
+		`"message":{"role":"user","content":"the quokkabloom exporter drops spans"}}`, at)
+	if err := os.WriteFile(filepath.Join(claude, "side.jsonl"), []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+
+	rec := newPerFileProgress()
+	SetProgress(rec)
+	defer SetProgress(nil)
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	const phase = "mining fixes and commands"
+	if total := rec.totals[phase]; total != 4 {
+		t.Fatalf("%q reports %d units, want one per builder", phase, total)
+	}
+	sum := 0
+	for _, n := range rec.advances(phase) {
+		sum += n
+	}
+	if sum != 4 {
+		t.Errorf("%q advanced %d of 4 — a builder reports nothing", phase, sum)
+	}
+}


### PR DESCRIPTION
The last piece of #3372. After the messages phase, four builders walk every session again — co-occurrence, fix pairs, commands, failed commands — and they ran under the previous phase's last percentage, so the line stood still for the eight seconds they take on this machine's store.

```
before  14s indexing messages 96%   16s 96%   18s 96%   20s 96%   22s writing index
after   14s indexing messages 96%   16s mining fixes and commands 0%   20s 25%   22s writing index 41%
```

Four units, one per builder, in both the cold and the incremental path.