### PR TITLE
fix(fix): the ignore rule reaches the sightings, not only the pairs

### DIFF
--- a/cmd/deja/ignore_fix_candidate_test.go
+++ b/cmd/deja/ignore_fix_candidate_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The ignore rule reached the confirmed pairs and not the sightings held back
+// for a second one: with a single session in an ignored tree, search and `deja
+// how` refused it while `deja fix` handed back the command it ran there
+// (#3403). #2660 is the same defect for the confirmed half.
+func TestFixDoesNotServeASightingFromTheIgnoredTree(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	policyFile := filepath.Join(tmp, "policy.json")
+	t.Setenv("DEJA_POLICY_FILE", policyFile)
+	if err := os.WriteFile(policyFile, []byte(`{"ignore":["*scratch*"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// One session only: two would confirm the pair and take the other path.
+	writeClaudeFixture(t, filepath.Join(root, "-w-scratch", "one.jsonl"), "one", []string{
+		`{"type":"user","sessionId":"one","cwd":"/w/scratch","timestamp":"2026-07-01T10:00:00Z",` +
+			`"message":{"role":"user","content":"the zarnak bus refuses to bind"}}`,
+		`{"type":"user","sessionId":"one","cwd":"/w/scratch","timestamp":"2026-07-01T10:01:00Z",` +
+			`"message":{"role":"user","content":[{"type":"tool_result","content":"zarnakctl: FATAL: could not bind sprocket bus at 192.0.2.7:7788"}]}}`,
+		`{"type":"assistant","sessionId":"one","cwd":"/w/scratch","timestamp":"2026-07-01T10:02:00Z",` +
+			`"message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"terraform apply --zarnak-bus"}}]}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureRun(t, "fix", "zarnakctl: FATAL: could not bind sprocket bus at 192.0.2.7:7788")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "terraform apply") {
+		t.Errorf("deja fix served a sighting out of the ignored tree:\n%s", out)
+	}
+	// And the same store answers once the rule is lifted, so this is the rule
+	// working rather than the fixture never having had anything to serve.
+	if err := os.WriteFile(policyFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err = captureRun(t, "fix", "zarnakctl: FATAL: could not bind sprocket bus at 192.0.2.7:7788")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "terraform apply") {
+		t.Errorf("with the rule lifted the sighting is still withheld:\n%s", out)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -633,6 +633,12 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	// nothing for the manifest read.
 	var ignored map[string]bool
 	loaded := false
+	isIgnored := func(project string) bool {
+		if !loaded {
+			ignored, loaded = ProjectsTouchedByIgnore(dir), true
+		}
+		return ignored[project]
+	}
 	for _, p := range ReadFixes(dir) {
 		if !sigs[p.Sig] {
 			continue
@@ -650,10 +656,7 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 		if allow != nil && !allow(p.Project) {
 			continue
 		}
-		if !loaded {
-			ignored, loaded = ProjectsTouchedByIgnore(dir), true
-		}
-		if ignored[p.Project] {
+		if isIgnored(p.Project) {
 			continue
 		}
 		out = append(out, p)
@@ -667,6 +670,13 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	if len(out) == 0 {
 		for _, p := range held {
 			if allow != nil && !allow(p.Project) {
+				continue
+			}
+			// The ignore rule holds for a sighting as well as for a pair:
+			// search and `deja how` refuse the session, and `deja fix` handed
+			// back what it ran there (#3403). #2660 fixed the confirmed half;
+			// the candidates arrived after it.
+			if isIgnored(p.Project) {
 				continue
 			}
 			out = append(out, p)


### PR DESCRIPTION
`FixesFor` applied the ignore rule to confirmed pairs and not to the single sightings it holds back for a second confirmation, so a store whose only session sits in an ignored tree answered like this:

```
$ deja "sprocket bus"      → nothing; "the ignore rule withholds every indexed session from this path"
$ deja fix "zarnakctl: FATAL: could not bind sprocket bus …"
    ran next, unconfirmed: $ launchctl unload ~/Library/LaunchAgents/io.example.plist
```

One lazy loader now serves both loops. Reproduced on a stand whose store sits under `*/.claude/jobs/*` (the default rule): before, the command came back; after, "no session on this machine ran a command after that error". `FixCandidateSeen` already had the rule, so deja does not announce holding what it will not show.

Test seeds one session (two would confirm the pair and take the other path) and checks both directions — withheld under the rule, served once it is lifted.

Closes #3403