### PR TITLE
fix(friction): treat undefined symbol as friction

### DIFF
--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -375,6 +375,7 @@ func isFriction(l string) bool {
 		// sentence someone writes about roles.
 		"duplicate key value", "deadlock detected", "access denied for",
 		"failed to connect to", "cannot import name", "symbol(s) not found",
+		"undefined symbol:", "undefined reference to",
 		"failed to push some refs", "acquiring the state lock",
 		"no space left on device",
 	} {

--- a/internal/index/friction_phrases_test.go
+++ b/internal/index/friction_phrases_test.go
@@ -17,6 +17,9 @@ func TestTheWallsAnAgentActuallyHits(t *testing.T) {
 		`curl: (7) Failed to connect to localhost port 5432 after 0 ms`,
 		`ImportError: cannot import name settings from app`,
 		`ld: symbol(s) not found for architecture arm64`,
+		`ld: undefined symbol: pthread_setname_np`,
+		`ld.lld: error: undefined symbol: pthread_setname_np`,
+		`/usr/bin/ld: server.c:(.text+0x1): undefined reference to 'pthread_setname_np'`,
 		`error: failed to push some refs to origin`,
 		`Error acquiring the state lock: ConditionalCheckFailedException`,
 		`fatal: unable to access https://example.invalid/: Could not resolve host`,
@@ -37,10 +40,37 @@ func TestTheWallsAnAgentActuallyHits(t *testing.T) {
 		`I could not connect the two ideas in that paragraph, rewriting it`,
 		`we should push some refs to origin once the tests are green`,
 		`the plan is to resolve the host name from the config instead`,
+		`this causes an undefined symbol when linking the cgo archive`,
+		`I think this may be an undefined symbol problem in the build`,
 	}
 	for _, l := range prose {
 		if _, ok := FrictionLine(l); ok {
 			t.Errorf("a sentence about a wall was counted as one:\n  %s", l)
 		}
+	}
+
+	// A line that names a linker error is still source when it is a script,
+	// a comment, or a quoted fixture — the same shapes #2430/#2431 reject.
+	about := []string{
+		`echo "undefined symbol: pthread_setname_np" >&2`,
+		`// ld: undefined symbol: pthread_setname_np was the wall last week`,
+		`want = "undefined reference to 'pthread_setname_np'"`,
+		`# ld: undefined symbol: pthread_setname_np in the notes`,
+	}
+	for _, l := range about {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("a line about a linker error was read as one:\n  %s", l)
+		}
+	}
+}
+
+// dyld's first line is `Symbol not found: _foo` (Apple Loader.cpp). That
+// already matches "not found: ", so #1551 does not add a bare
+// "symbol not found" phrase.
+func TestADyldMissingSymbolIsAlreadyAWall(t *testing.T) {
+	// Public abort: https://stackoverflow.com/questions/50247343
+	l := `dyld: Symbol not found: __ZdaPvm`
+	if _, ok := FrictionLine(l); !ok {
+		t.Errorf("dyld's missing-symbol line is not friction:\n  %s", l)
 	}
 }


### PR DESCRIPTION
Closes #1551.

`undefined symbol:` and `undefined reference to` now count as friction. The colon matches the linker diagnostic while avoiding ordinary prose that only mentions an "undefined symbol."

On a local store (1,389 sessions / 2.9M tool-output lines), the change introduced no incidental matches. Public linker diagnostics hit as expected, while the checked prose/source negatives stayed out.