### PR TITLE
fix(install): a build that is not the installed deja leaves the wiring alone

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
@@ -1640,10 +1641,46 @@ func lastShellToken(s string) string {
 	return f[len(f)-1]
 }
 
+// dejaWrittenExes are the binary paths deja has written into configs, read
+// once per process. A build under another name is deja's own when the record
+// says deja installed from that path — the name test below cannot know it, and
+// without this an install from such a build stacked a second entry beside the
+// first (#3421).
+var (
+	writtenExesOnce sync.Once
+	writtenExes     map[string]bool
+)
+
+func dejaWrittenExes() map[string]bool {
+	writtenExesOnce.Do(func() {
+		st := readWiringState()
+		writtenExes = make(map[string]bool, len(st.Exes)+1)
+		for _, p := range append(append([]string(nil), st.Exes...), st.Exe) {
+			if p != "" {
+				writtenExes[p] = true
+			}
+		}
+	})
+	return writtenExes
+}
+
+// forgetWrittenExes drops the cached record so a test — or a process that has
+// just installed — reads it again.
+func forgetWrittenExes() {
+	writtenExesOnce = sync.Once{}
+	writtenExes = nil
+}
+
 // isDejaBinaryToken reports whether a token names the deja binary, quoted or
 // not, under any directory, on either platform's separator.
 func isDejaBinaryToken(tok string) bool {
 	tok = strings.Trim(strings.TrimSpace(tok), `"'`)
+	// A path deja itself installed from is deja's own entry whatever the file
+	// was called — checked on the whole path, before the name is taken out of
+	// it (#3421).
+	if dejaWrittenExes()[tok] {
+		return true
+	}
 	// Both separators whatever this build was compiled for, because configs
 	// travel between machines, and folded because a filesystem that does not
 	// care about case still runs /opt/Deja (#2713).

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -51,6 +51,44 @@ type wiringState struct {
 	// a `go install` over a manual download — and left every config pointing
 	// at a path that no longer exists (#773).
 	Exe string `json:"exe,omitempty"`
+	// Exes are the binary paths deja has written into configs, newest last.
+	// An entry is recognised as deja's own by the command it runs, and that
+	// test used to accept only a file named `deja` — so an install from a
+	// build under another name did not see the old entry as ours and stacked
+	// a second one beside it (#3421). The record is what makes the answer
+	// certain rather than a guess about names.
+	Exes []string `json:"exes,omitempty"`
+}
+
+// wiringExeHistory bounds the remembered paths. Ten covers a machine that
+// reinstalls often; beyond that the oldest is dropped.
+const wiringExeHistory = 10
+
+// fileExists reports whether a path is on disk. Used where the answer decides
+// whether something is a move or a stranger.
+func fileExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// rememberWrittenExe adds a path to the record's history, newest last, without
+// repeating one it already holds.
+func rememberWrittenExe(st *wiringState, exe string) {
+	if exe == "" {
+		return
+	}
+	for _, p := range st.Exes {
+		if p == exe {
+			return
+		}
+	}
+	st.Exes = append(st.Exes, exe)
+	if len(st.Exes) > wiringExeHistory {
+		st.Exes = st.Exes[len(st.Exes)-wiringExeHistory:]
+	}
 }
 
 func wiringStatePath() string {
@@ -155,7 +193,11 @@ func recordWiring(targets []string, uninstall bool) {
 		blocks = nil
 	}
 	sort.Strings(blocks)
-	st = wiringState{Version: version, Targets: kept, Created: created, Snapshots: snapshots, Blocks: blocks, Exe: exe, Home: homeDir()}
+	exes := append([]string(nil), st.Exes...)
+	next := wiringState{Version: version, Targets: kept, Created: created, Snapshots: snapshots,
+		Blocks: blocks, Exe: exe, Exes: exes, Home: homeDir()}
+	rememberWrittenExe(&next, exe)
+	st = next
 	b, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
 		return
@@ -240,6 +282,15 @@ func refreshWiringAfterUpgrade() []string {
 	// of those rewrote every config on the machine to a path that stops
 	// existing, and the reader found out when recall went quiet (#2684).
 	if exeIsTemporary(exe) {
+		return nil
+	}
+	// And not a binary that simply is not the installed one. A temp directory
+	// is the obvious case of that and was the only one guarded, so a build in
+	// a checkout, a home directory or an agent's scratch adopted every config
+	// on its first run — one machine ended with eight entries per event, each
+	// naming a different build and all of them firing (#3421). The honest
+	// "deja moved" case is the recorded binary no longer being there.
+	if st.Exe != "" && st.Exe != exe && fileExists(st.Exe) {
 		return nil
 	}
 	// Only the home the targets were written under: this repairs, it does not

--- a/cmd/deja/wiring_stranger_test.go
+++ b/cmd/deja/wiring_stranger_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The repair exists because deja moves — a release replaces it, a package
+// manager relocates it. It cannot tell that from one run of a build somewhere
+// else, and the only guard was a temp directory (#2684), so a build under a
+// home directory, a checkout or an agent's scratch adopted every config on its
+// first run: one machine ended with eight hook entries per event, each naming a
+// different build, all firing on every prompt (#3421).
+func TestAStrangerDoesNotAdoptTheWiring(t *testing.T) {
+	tmp := hermeticEnv(t)
+	installed := filepath.Join(tmp, "bin", "deja")
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installed, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeWiringFixture(t, wiringState{
+		Version: "older", Targets: []string{"claude-code"}, Exe: installed, Home: homeDir(),
+	})
+
+	// This test binary stands in for the stranger: a different path, and the
+	// recorded one is still on disk.
+	if got := refreshWiringAfterUpgrade(); len(got) != 0 {
+		t.Errorf("a build that is not the installed deja rewrote %v", got)
+	}
+
+	// The honest case: the recorded binary is gone, so this one is the move.
+	if err := os.Remove(installed); err != nil {
+		t.Fatal(err)
+	}
+	if got := refreshWiringAfterUpgrade(); len(got) == 0 {
+		t.Error("the recorded binary is gone and the repair still stood down")
+	}
+}
+
+// An entry deja wrote from a build under another name is still deja's own: the
+// record remembers the paths it installed from, so a later install replaces
+// that entry instead of stacking a second one beside it (#3421).
+func TestAnEntryFromAPreviousPathIsRecognisedAsOurs(t *testing.T) {
+	hermeticEnv(t)
+	const old = "/somewhere/scratch/deja-arm"
+	writeWiringFixture(t, wiringState{
+		Version: "dev", Targets: []string{"claude-code"}, Exe: "/usr/local/bin/deja",
+		Exes: []string{old}, Home: homeDir(),
+	})
+	forgetWrittenExes()
+	t.Cleanup(forgetWrittenExes)
+
+	if !isDejaHookCommand(old+" hook-prompt", "/usr/local/bin/deja hook-prompt") {
+		t.Errorf("an entry deja wrote from %s is not recognised as ours", old)
+	}
+	if isDejaHookCommand("/opt/somebody/else hook-prompt", "/usr/local/bin/deja hook-prompt") {
+		t.Error("a command deja never wrote was claimed as ours")
+	}
+}
+
+func writeWiringFixture(t *testing.T, st wiringState) {
+	t.Helper()
+	p := wiringStatePath()
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Parts 2 and 3 of #3422, which are what #3421 needs to stop happening.

**The repair stands down for a stranger.** `refreshWiringAfterUpgrade` refused only binaries under the system temp (#2684), so a build in a checkout, a home directory or an agent's scratch rewrote every config on its first run. It now also refuses when the recorded install path is a different one that is still on disk — the honest "deja moved" case is the recorded binary being gone, and that still repairs.

**An entry deja wrote is recognised by the path, not the file name.** `isDejaBinaryToken` accepted `deja` and `deja.exe` only, so an entry reading `…/deja-arm hook-prompt` was somebody else's command and a fresh install stacked a second entry beside it — eight per event on the machine in #3421. `wiring.json` now remembers the paths deja has installed from (last ten), and an entry naming one of them is ours to replace.

Both halves have a test that fails without them: a stranger that must not adopt and then, once the recorded binary is gone, must; and an entry from a previous path that must be recognised while a command deja never wrote must not be.

Parts 1 (configs point at a launcher instead of a build) and 4 (`doctor` counts entries, `install --repair`) stay open in #3422 — the first changes what is written into every target and deserves its own pass.