### PR TITLE
fix(install): collapse repeated deja hooks in Claude Code settings

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -249,6 +249,9 @@ func doctorHooks(w io.Writer) {
 		fmt.Fprintf(w, "               %d of %d events wired — no %s; run `deja install`\n",
 			len(claudeHookWiring)-len(missing), len(claudeHookWiring), strings.Join(missing, ", "))
 	}
+	if note := doctorHookRepeats(hooks, claudeHookWiring, "claude-auto"); note != "" {
+		fmt.Fprintf(w, "  %-12s %s\n", "", note)
+	}
 	// Only when something here is actually wired: the note is about the binary
 	// those entries name, and a file with no deja in it names none.
 	if note := hookExeNote(path, "claude-auto"); note != "" && len(missing) < len(claudeHookWiring) {
@@ -318,15 +321,18 @@ func doctorCodexHook(w io.Writer) {
 	}
 	// Trusted is not the same as complete: the entry codex approved may be one
 	// written before the other events existed.
+	var hooks map[string]any
+	if b, rerr := os.ReadFile(hooksPath); rerr == nil {
+		var root map[string]any
+		if json.Unmarshal(b, &root) == nil {
+			hooks, _ = root["hooks"].(map[string]any)
+		}
+	}
 	var missing []string
 	if status == "wired" {
-		var root map[string]any
-		if b, rerr := os.ReadFile(hooksPath); rerr == nil && json.Unmarshal(b, &root) == nil {
-			hooks, _ := root["hooks"].(map[string]any)
-			for _, h := range codexHookWiring {
-				if !hookEventWired(hooks, h.Event, h.Sub) {
-					missing = append(missing, h.Event)
-				}
+		for _, h := range codexHookWiring {
+			if !hookEventWired(hooks, h.Event, h.Sub) {
+				missing = append(missing, h.Event)
 			}
 		}
 		if len(missing) > 0 {
@@ -343,6 +349,9 @@ func doctorCodexHook(w io.Writer) {
 	}
 	if status == "disabled" {
 		line += "  (codex trusts but disabled it — re-enable in codex settings or hooks.state)"
+	}
+	if note := doctorHookRepeats(hooks, codexHookWiring, "codex-auto"); note != "" {
+		line += fmt.Sprintf("\n  %-12s %s", "", note)
 	}
 	fmt.Fprintln(w, line)
 }

--- a/cmd/deja/doctor_hook_repeats.go
+++ b/cmd/deja/doctor_hook_repeats.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// dejaHookCount is how many of deja's hooks a config runs for one event. The
+// entry is the unit a harness fires, and several of them can name the same
+// subcommand: a merge that kept both sides, a hand-edited copy, or — until
+// #3421 — an install from a build under another path, which stacked one more
+// every time instead of taking the existing one over.
+func dejaHookCount(hooks map[string]any, event, sub string) int {
+	entries, _ := hooks[event].([]any)
+	n := 0
+	for _, entryAny := range entries {
+		entry, _ := entryAny.(map[string]any)
+		if entry == nil {
+			continue
+		}
+		hs, _ := entry["hooks"].([]any)
+		for _, hAny := range hs {
+			h, _ := hAny.(map[string]any)
+			if h == nil || h["type"] != "command" {
+				continue
+			}
+			if hookCommandKindOf(h["command"], "deja "+sub) != hookNotDejas {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// doctorHookRepeats is the line a hook row prints when an event runs deja more
+// than once. Nothing else in doctor could say it: every check answered "is the
+// hook there", which a file holding eight copies of it answers yes to. What
+// the reader saw instead was the same memory injected eight times on every
+// prompt, eight processes started for it, and no report naming the cause
+// (#3421, #3422).
+func doctorHookRepeats(hooks map[string]any, wiring []struct{ Event, Sub, Matcher string }, target string) string {
+	var parts []string
+	for _, h := range wiring {
+		if n := dejaHookCount(hooks, h.Event, h.Sub); n > 1 {
+			parts = append(parts, fmt.Sprintf("%s ×%d", h.Event, n))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "runs deja more than once per event (" + strings.Join(parts, ", ") +
+		") — every copy fires; `deja install " + target + "` leaves one"
+}

--- a/cmd/deja/doctor_hook_repeats_test.go
+++ b/cmd/deja/doctor_hook_repeats_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Every hook check answered "is deja's hook here", and a file holding eight
+// copies of it answers yes. What the machine did instead was start eight
+// processes per prompt and inject the same memory eight times, with doctor
+// printing "wired" over it (#3421).
+func TestDoctorCountsRepeatedHookEntries(t *testing.T) {
+	withStatsStores(t)
+	// A file really called deja, and really there: the count keys on the
+	// binary's name, and a missing one would set the row's other note off.
+	exe := filepath.Join(t.TempDir(), "deja")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var events []string
+	for _, h := range claudeHookWiring {
+		one := `{"hooks":[{"type":"command","command":"` + jsonEscaped(t, exe) + ` ` + h.Sub + `"}]}`
+		copies := []string{one}
+		if h.Event == "UserPromptSubmit" {
+			copies = []string{one, one, one}
+		}
+		events = append(events, `"`+h.Event+`":[`+strings.Join(copies, ",")+`]`)
+	}
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"hooks":{`+strings.Join(events, ",")+`}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	got := out.String()
+	if !strings.Contains(got, "UserPromptSubmit ×3") {
+		t.Errorf("doctor did not count the repeated hook:\n%s", got)
+	}
+	if !strings.Contains(got, "deja install claude-auto") {
+		t.Errorf("doctor named no way out of it:\n%s", got)
+	}
+	// The events wired once are not the reader's problem and must not be named.
+	if strings.Contains(got, "SessionStart ×") {
+		t.Errorf("doctor reported an event that runs once:\n%s", got)
+	}
+}
+
+// A config wired the way an install leaves it says nothing about repeats.
+func TestDoctorSaysNothingAboutASingleEntry(t *testing.T) {
+	withStatsStores(t)
+	writeClaudeSettings(t, "SessionStart", "UserPromptSubmit")
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	if got := out.String(); strings.Contains(got, "more than once per event") {
+		t.Errorf("doctor invented a repeat:\n%s", got)
+	}
+}

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1720,7 +1720,10 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 	}
 	entries, _ := hooks[event].([]any)
 	var out []any
-	found := false
+	// A line the reader built around deja's hook already runs it, and it is not
+	// ours to touch — so the collapse below has to know about it before it
+	// reaches its own entry, whichever order the file happens to keep them in.
+	found := !uninstall && eventWrapsDejaHook(entries, cmd)
 	for _, entryAny := range entries {
 		entry, _ := entryAny.(map[string]any)
 		if entry == nil {
@@ -1759,6 +1762,15 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 			}
 			if kind == hookDejas {
 				if uninstall {
+					removed = true
+					continue
+				}
+				// A file that already collected several of ours converges here:
+				// the first line becomes this binary's and the rest go, rather
+				// than being rewritten into byte-identical copies that each
+				// fire on every prompt (#3421). Same as qwen's writer (#2745)
+				// and cursor's (#2691); this one was the last that stacked.
+				if found {
 					removed = true
 					continue
 				}
@@ -1805,6 +1817,28 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 		delete(root, "hooks")
 	}
 	return root
+}
+
+// eventWrapsDejaHook reports whether any entry for this event runs deja's hook
+// inside a command deja did not write.
+func eventWrapsDejaHook(entries []any, cmd string) bool {
+	for _, entryAny := range entries {
+		entry, _ := entryAny.(map[string]any)
+		if entry == nil {
+			continue
+		}
+		hs, _ := entry["hooks"].([]any)
+		for _, hAny := range hs {
+			h, _ := hAny.(map[string]any)
+			if h == nil || h["type"] != "command" {
+				continue
+			}
+			if hookCommandKindOf(h["command"], cmd) == hookWrapsDejas {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // adoptMatcher brings an entry deja already owns up to the matcher this build

--- a/cmd/deja/install_claude_collapse_test.go
+++ b/cmd/deja/install_claude_collapse_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// Claude Code's settings.json is the one hook config that never collapsed a
+// pile of deja's own entries. Every other writer keeps the first and drops the
+// rest (qwen in #2745, cursor in #2691); this one adopted each of them in turn
+// and rewrote them all into byte-identical copies, so an install "succeeded"
+// and left the hook firing once per copy. One machine reached eight entries per
+// event that way — every prompt paid for eight processes and got the same
+// memory eight times (#3421).
+func TestInstallCollapsesClaudeHooksOntoOne(t *testing.T) {
+	hermeticEnv(t)
+	path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var entries []string
+	for i := 0; i < 8; i++ {
+		entries = append(entries, `{"hooks":[{"type":"command","command":"/usr/local/bin/deja hook-prompt"}]}`)
+	}
+	doubled := `{"hooks":{"UserPromptSubmit":[` + strings.Join(entries, ",") + `]}}`
+	if err := os.WriteFile(path, []byte(doubled), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := installTarget("claude-auto", "/usr/local/bin/deja", false); err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(readFile(t, path), "hook-prompt"); n != 1 {
+		t.Fatalf("install left %d copies of the prompt hook:\n%s", n, readFile(t, path))
+	}
+}
+
+// A line the reader wrote around deja's hook is theirs, and it already calls
+// the hook: deja's own entry beside it is the duplicate, and the collapse must
+// take that one rather than the wrapper.
+func TestCollapseKeepsAReadersOwnLine(t *testing.T) {
+	ours := `{"hooks":[{"type":"command","command":"/usr/local/bin/deja hook-prompt"}]}`
+	theirs := `{"hooks":[{"type":"command","command":"/usr/local/bin/deja hook-prompt | tee /tmp/deja.log"}]}`
+	// Either order: the file keeps whichever entry it was written in, and the
+	// wrapper is the one to survive both times.
+	for name, entries := range map[string][]string{
+		"wrapper first": {theirs, ours},
+		"wrapper last":  {ours, theirs},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hermeticEnv(t)
+			path := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			doubled := `{"hooks":{"UserPromptSubmit":[` + strings.Join(entries, ",") + `]}}`
+			if err := os.WriteFile(path, []byte(doubled), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := installTarget("claude-auto", "/usr/local/bin/deja", false); err != nil {
+				t.Fatal(err)
+			}
+			got := readFile(t, path)
+			if !strings.Contains(got, "tee /tmp/deja.log") {
+				t.Fatalf("the collapse threw away a line deja did not write:\n%s", got)
+			}
+			if n := strings.Count(got, "hook-prompt"); n != 1 {
+				t.Fatalf("the hook still runs %d times:\n%s", n, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #3422.

Every hook writer collapses a pile of deja's own entries onto one — qwen since #2745, cursor since #2691. Claude Code's did not: it adopted each copy in turn and rewrote them into byte-identical lines, so an install from a build under another path stacked one more every time instead of taking the existing one over. That is how the machine in #3421 got eight entries per event, each starting a process and injecting the same memory on every prompt.

Install now keeps the first and drops the rest, and a line the reader wrapped around the hook wins over deja's own copy whichever order they sit in. Doctor counts them too — `UserPromptSubmit ×8` under the claude-code and codex-hook rows — since every existing check answered "is the hook there", which a file holding eight of them answers yes to.

Parts 1 (configs point at a launcher instead of a build) and 4's `install --repair` stay open in #3422.