### PR TITLE
fix(install): --all says where the hooks are

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -309,6 +309,14 @@ func runInstall(dir string, args []string, uninstall bool) error {
 				info = append(info, fmt.Sprintf("%-*s  %s", nameW, "", d.note))
 			}
 		}
+		// --all writes the MCP entries and nothing else, which is the flag's
+		// job and not what its name suggests: someone repairing a machine
+		// reaches for "all", gets the servers rewired, and the hooks — the
+		// half that carries recall without being asked — are left exactly as
+		// they were (#3422).
+		if targetArgs[0] == "--all" {
+			info = append(info, "", "hooks are not in this list — `deja install --auto` writes those too")
+		}
 		mood := moodReady
 		if hint := installIndexHint(dir); hint != "" {
 			info = append(info, "", hint)

--- a/cmd/deja/install_all_hooks_note_test.go
+++ b/cmd/deja/install_all_hooks_note_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// `--all` writes MCP entries and nothing else. That is the flag's job, and it
+// is not what the name says: someone repairing a machine runs it, watches every
+// harness scroll past as "wrote", and walks away with the hooks exactly as
+// broken as they were — which is how the wiring in #3421 went on firing after a
+// repair that looked complete.
+func TestInstallAllSaysWhereTheHooksAre(t *testing.T) {
+	tmp := hermeticEnv(t)
+	if err := os.MkdirAll(filepath.Join(tmp, "home", ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	restore := logoWanted
+	t.Cleanup(func() { logoWanted = restore })
+	logoWanted = func(*os.File) bool { return true }
+
+	out, err := captureRun(t, "install", "--all", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "deja install --auto") {
+		t.Errorf("--all never said the hooks are elsewhere:\n%s", out)
+	}
+
+	// --auto writes them, so the same line there would be a lie.
+	out, err = captureRun(t, "install", "--auto", "--no-index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out, "hooks are not in this list") {
+		t.Errorf("--auto claimed it had left the hooks alone:\n%s", out)
+	}
+}


### PR DESCRIPTION
Part of #3422.

`deja install --all` writes the MCP entries and nothing else — that is the flag's job, but not what the name suggests. Someone repairing a machine runs it, watches every harness scroll past as "wrote", and leaves with the hook wiring untouched. That happened while chasing #3421: the repair looked complete and the hooks went on firing eight times a prompt.

The banner now ends with one line pointing at `--auto`, and only for `--all`.