### PR TITLE
test: escape paths pasted into JSON fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,13 @@ jobs:
     # what turns a slow run into a cancellation that prints no test output.
     # 30 was the cap while the windows leg took 26m; on 2026-08-19 it reached
     # 29m30s and died with no output, so the margin is gone rather than the run
-    # being unlucky. 45 keeps a real hang bounded — the go -timeout below still
-    # kills one with a stack long before this.
-    timeout-minutes: 45
+    # being unlucky. On 2026-09-09 two runs of the same commit came in at 12m10s
+    # and past 45m — the step that ran over is `go test`, whose own 12m timeout
+    # covers running tests and not compiling them, so a cold cache on a slow
+    # runner spends the difference in the compiler. 60 keeps a real hang
+    # bounded — the go -timeout below still kills one with a stack long before
+    # this — and stops a slow runner reading as a failure.
+    timeout-minutes: 60
     env:
       # Whether this leg does real work. The windows runner needs twenty-odd
       # minutes for a job the others finish in two, and it varies by a third

--- a/cmd/deja/files_tier_test.go
+++ b/cmd/deja/files_tier_test.go
@@ -25,7 +25,7 @@ func TestFilesAnswersTheSameQuotedOrNot(t *testing.T) {
 	root := os.Getenv("DEJA_CLAUDE_ROOT")
 	writeClaudeFixture(t, filepath.Join(root, "-w-api", "p1.jsonl"), "p1", []string{
 		`{"type":"user","sessionId":"p1","cwd":"/w/api","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the zonkobuffer drops the last attempt of the retry loop"}}`,
-		`{"type":"assistant","sessionId":"p1","cwd":"/w/api","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` + filepath.Join(repo, "retry.go") + `","old_string":"a","new_string":"b"}}]}}`,
+		`{"type":"assistant","sessionId":"p1","cwd":"/w/api","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":"` + jsonEscaped(t, filepath.Join(repo, "retry.go")) + `","old_string":"a","new_string":"b"}}]}}`,
 	})
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)

--- a/cmd/deja/hook_prompt_cursor_conversation_test.go
+++ b/cmd/deja/hook_prompt_cursor_conversation_test.go
@@ -33,7 +33,7 @@ func TestCursorConversationIDIsTheSession(t *testing.T) {
 	ask := func(conversation string) string {
 		t.Helper()
 		var out bytes.Buffer
-		in := strings.NewReader(`{"conversation_id":"` + conversation + `","prompt":"do we need pgbouncer here","workspace_roots":["` + cwd + `"]}`)
+		in := strings.NewReader(`{"conversation_id":"` + conversation + `","prompt":"do we need pgbouncer here","workspace_roots":["` + jsonEscaped(t, cwd) + `"]}`)
 		if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Both tests build a JSON fixture by concatenating a filesystem path into a string. On Windows that path carries backslashes, the line is not valid JSON, and what the test is about never happens: `files` sees no edit and the hook sees no workspace root. They have been red on the windows leg of main since they landed.

Escaped through the same helper the other fixtures use.