### PR TITLE
feat(doctor): report a session served the same injection twice in a second

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -127,6 +127,7 @@ func runDoctor(w io.Writer, args []string, lookup doctorVersionLookup, dir strin
 	// machine without claude settings, which is exactly a machine whose other
 	// harnesses may still be wired to a binary that moved.
 	doctorWiringExe(w)
+	doctorDoubleInjections(w, dir)
 	fmt.Fprintln(w)
 	doctorIndex(w, report.Index, dir)
 	fmt.Fprintln(w)

--- a/cmd/deja/doctor_double_injection.go
+++ b/cmd/deja/doctor_double_injection.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// doctorDoubleInjections reports a session that was handed the same injection
+// several times in one second.
+//
+// Every other check reads a config and answers "is deja's hook here". This one
+// reads what actually happened: the usage log holds the injections deja served
+// and the session each went to, and one prompt is one injection — the hooks
+// dedupe per session and per prompt. Several inside a second are several hooks
+// running for one event, which is what a config that collected deja's entry
+// more than once does, and what a machine did for a whole day while every
+// check above it said "wired" (#3421).
+func doctorDoubleInjections(w io.Writer, dir string) {
+	repeats := usage.RepeatedInjections(dir)
+	if len(repeats) == 0 {
+		return
+	}
+	worst := repeats[0]
+	for _, r := range repeats {
+		if r.Count > worst.Count {
+			worst = r
+		}
+	}
+	fmt.Fprintf(w, "  %-12s %s\n", "repeated",
+		fmt.Sprintf("one agent session was served %d %s injections inside a second (%s) — the hooks are wired more than once; `deja install --auto` leaves one of each",
+			worst.Count, worst.Kind, worst.At.Local().Format("2006-01-02 15:04:05")))
+}

--- a/cmd/deja/doctor_double_injection_test.go
+++ b/cmd/deja/doctor_double_injection_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The wiring in #3421 served one session eight identical blocks per prompt for
+// a day, and nothing said so: every check read a config and answered "is the
+// hook here", which a file holding eight copies answers yes to. The log deja
+// already keeps had the evidence — the same session, the same second, eight
+// rows.
+func TestDoctorNamesASessionServedTwiceInASecond(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	at := time.Now().UTC()
+	writeInjectionLog(t, dir,
+		usage.Event{Time: at, Kind: usage.KindDejaVu, Bytes: 833, Into: "agent-1"},
+		usage.Event{Time: at.Add(300 * time.Microsecond), Kind: usage.KindDejaVu, Bytes: 833, Into: "agent-1"},
+		usage.Event{Time: at.Add(600 * time.Microsecond), Kind: usage.KindDejaVu, Bytes: 833, Into: "agent-1"},
+	)
+
+	var out bytes.Buffer
+	doctorDoubleInjections(&out, dir)
+	got := out.String()
+	if !strings.Contains(got, "served 3 dejavu injections inside a second") {
+		t.Errorf("doctor did not count the repeated injections:\n%s", got)
+	}
+	if !strings.Contains(got, "deja install --auto") {
+		t.Errorf("doctor named no way out of it:\n%s", got)
+	}
+}
+
+// One injection per prompt is the normal case, and two prompts a second apart
+// are not a doubled hook.
+func TestDoctorSaysNothingAboutOrdinaryInjections(t *testing.T) {
+	hermeticEnv(t)
+	dir := index.DefaultDir()
+	at := time.Now().UTC()
+	writeInjectionLog(t, dir,
+		usage.Event{Time: at, Kind: usage.KindDejaVu, Bytes: 400, Into: "agent-1"},
+		usage.Event{Time: at.Add(3 * time.Second), Kind: usage.KindDejaVu, Bytes: 400, Into: "agent-1"},
+		// Two sessions served in the same second is a fleet, not a repeat.
+		usage.Event{Time: at, Kind: usage.KindDejaVu, Bytes: 400, Into: "agent-2"},
+	)
+
+	var out bytes.Buffer
+	doctorDoubleInjections(&out, dir)
+	if got := out.String(); got != "" {
+		t.Errorf("doctor invented a repeat:\n%s", got)
+	}
+}
+
+func writeInjectionLog(t *testing.T, dir string, events ...usage.Event) {
+	t.Helper()
+	var b bytes.Buffer
+	for _, e := range events {
+		line, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(usage.Path(dir), b.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/usage/repeats.go
+++ b/internal/usage/repeats.go
@@ -1,0 +1,61 @@
+package usage
+
+import (
+	"sort"
+	"time"
+)
+
+// Repeat is one agent session handed the same kind of injection several times
+// in the same second.
+type Repeat struct {
+	Into  string
+	Kind  string
+	Count int
+	At    time.Time
+}
+
+// RepeatedInjections reports sessions that were served the same kind of
+// injection more than once inside a second, newest first.
+//
+// Nothing legitimate does that: the hooks dedupe per session and per prompt,
+// and one prompt is one injection. Several inside a second mean several hooks
+// running for one event — a config that collected deja's entry more than once,
+// which every check before this answered "wired" to. It is the symptom the
+// reader actually sees, in the log deja already keeps: the machine in #3421
+// was serving one session eight identical blocks per prompt for a day.
+func RepeatedInjections(indexDir string) []Repeat {
+	type key struct {
+		into, kind string
+		sec        int64
+	}
+	seen := map[key]*Repeat{}
+	for _, e := range read(Path(indexDir)) {
+		// Only what an injection is: an agent asking a tool twice in a second
+		// is a busy agent, not a doubled hook.
+		if e.Into == "" || !injectedKind(e.Kind) {
+			continue
+		}
+		k := key{e.Into, e.Kind, e.Time.Unix()}
+		if r := seen[k]; r != nil {
+			r.Count++
+			if e.Time.After(r.At) {
+				r.At = e.Time
+			}
+			continue
+		}
+		seen[k] = &Repeat{Into: e.Into, Kind: e.Kind, Count: 1, At: e.Time}
+	}
+	var out []Repeat
+	for _, r := range seen {
+		if r.Count > 1 {
+			out = append(out, *r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].At.Equal(out[j].At) {
+			return out[i].At.After(out[j].At)
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}

--- a/internal/usage/repeats_test.go
+++ b/internal/usage/repeats_test.go
@@ -1,0 +1,115 @@
+package usage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeEvents(t *testing.T, dir string, events ...Event) {
+	t.Helper()
+	var b []byte
+	for _, e := range events {
+		line, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b = append(append(b, line...), '\n')
+	}
+	if err := os.MkdirAll(filepath.Dir(Path(dir)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(dir), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Several injections into one session inside a second is the fingerprint of a
+// config that collected deja's hook more than once (#3421): the hooks dedupe
+// per session and per prompt, so one prompt is one injection.
+func TestRepeatedInjectionsCountsOneSecond(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	at := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	writeEvents(t, dir,
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "a"},
+		Event{Time: at.Add(time.Millisecond), Kind: KindDejaVu, Bytes: 800, Into: "a"},
+		// A later second, one injection: ordinary.
+		Event{Time: at.Add(5 * time.Second), Kind: KindDejaVu, Bytes: 800, Into: "a"},
+		// Another session in the same second is a fleet, not a repeat.
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "b"},
+		// A tool line and a prompt block in the same second are two channels,
+		// not one hook firing twice.
+		Event{Time: at, Kind: KindTool, Bytes: 90, Into: "a"},
+		// Not an injection at all: an agent calling a tool twice is busy.
+		Event{Time: at, Kind: KindRecall, Bytes: 500, Into: "a"},
+		Event{Time: at, Kind: KindRecall, Bytes: 500, Into: "a"},
+		// No receiver recorded, so nothing can be said about repeats.
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800},
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800},
+	)
+
+	got := RepeatedInjections(dir)
+	if len(got) != 1 {
+		t.Fatalf("repeats = %+v, want the one doubled session", got)
+	}
+	if got[0].Into != "a" || got[0].Kind != KindDejaVu || got[0].Count != 2 {
+		t.Errorf("repeat = %+v", got[0])
+	}
+	if !got[0].At.Equal(at.Add(time.Millisecond)) {
+		t.Errorf("At = %v, want the last of the pair", got[0].At)
+	}
+}
+
+// A clean log says nothing.
+func TestRepeatedInjectionsIsSilentOnAHealthyLog(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	at := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	writeEvents(t, dir,
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "a"},
+		Event{Time: at.Add(time.Minute), Kind: KindHook, Bytes: 800, Into: "a"},
+	)
+	if got := RepeatedInjections(dir); got != nil {
+		t.Errorf("repeats = %+v, want none", got)
+	}
+	// And a machine with no log at all.
+	if got := RepeatedInjections(filepath.Join(t.TempDir(), "index.db")); got != nil {
+		t.Errorf("repeats = %+v on a machine that has never served one", got)
+	}
+}
+
+// Worst first when two sessions doubled in the same second, newest first
+// otherwise — the reader reads the top line.
+func TestRepeatedInjectionsOrdersWhatMatters(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "index.db")
+	at := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	var events []Event
+	for i := 0; i < 3; i++ {
+		events = append(events, Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "old"})
+	}
+	for i := 0; i < 2; i++ {
+		events = append(events, Event{Time: at.Add(time.Hour), Kind: KindDejaVu, Bytes: 800, Into: "new"})
+	}
+	writeEvents(t, dir, events...)
+
+	got := RepeatedInjections(dir)
+	if len(got) != 2 {
+		t.Fatalf("repeats = %+v, want both sessions", got)
+	}
+	if got[0].Into != "new" {
+		t.Errorf("order = %+v, want the newest first", got)
+	}
+
+	// Same second, different counts: the heavier one leads.
+	writeEvents(t, dir,
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "light"},
+		Event{Time: at, Kind: KindDejaVu, Bytes: 800, Into: "light"},
+		Event{Time: at, Kind: KindTool, Bytes: 90, Into: "heavy"},
+		Event{Time: at, Kind: KindTool, Bytes: 90, Into: "heavy"},
+		Event{Time: at, Kind: KindTool, Bytes: 90, Into: "heavy"},
+	)
+	if got := RepeatedInjections(dir); len(got) != 2 || got[0].Into != "heavy" {
+		t.Errorf("order = %+v, want the worst first", got)
+	}
+}


### PR DESCRIPTION
The last part of the net in #3422/#3421.

Every wiring check reads a config and answers "is deja's hook here", which a file holding eight copies of it answers yes to. The usage log has the other side of it: what was injected, and into which agent session. One prompt is one injection — the hooks dedupe per session and per prompt — so several inside a second mean several hooks firing for one event. That is what the machine in #3421 did for a day while every check said wired.

Doctor now names the worst case under the hook rows. Two sessions served in the same second is a fleet, not a repeat, and is not reported.