### PR TITLE
fix: four from the backlog — uninstall, pi package, unread stores, live-session appends

### DIFF
--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1288,7 +1288,7 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 			// the rule; the other half is the record, because an empty folder
 			// the reader already had is theirs and used to go with the
 			// uninstall (#3239).
-			if dir := filepath.Dir(path); isRealDir(dir) && wiringCreatedDir(dir) {
+			if dir := filepath.Dir(path); isRealDir(dir) && dirWiringCreated(dir) {
 				_ = os.Remove(dir)
 			}
 			if snapshotTaken(path) {

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -1169,6 +1169,11 @@ func matchLineEndings(old, next []byte) []byte {
 	return b.Bytes()
 }
 
+// createdDirsByThisRun collects the directories this process had to make. The
+// record outlives the run, because the uninstall that prunes them is a
+// different one (#3239).
+var createdDirsByThisRun []string
+
 // createdByThisRun collects the configs this process created, so the record can
 // keep them and a later uninstall can take back a file that turns out to hold
 // nothing but empty containers (#2583).
@@ -1279,9 +1284,11 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 				return "", err
 			}
 			// The directory too, when deja made it and nothing else is in it.
-			// os.Remove fails on a directory that is not empty, which is the
-			// condition wanted (same rule as pruneGuidanceDirs).
-			if dir := filepath.Dir(path); isRealDir(dir) {
+			// os.Remove fails on a directory that is not empty, which is half
+			// the rule; the other half is the record, because an empty folder
+			// the reader already had is theirs and used to go with the
+			// uninstall (#3239).
+			if dir := filepath.Dir(path); isRealDir(dir) && wiringCreatedDir(dir) {
 				_ = os.Remove(dir)
 			}
 			if snapshotTaken(path) {
@@ -1293,7 +1300,11 @@ func writeIfChanged(path string, old, next []byte) (string, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) && !removingWiring {
 		createdByThisRun = append(createdByThisRun, path)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	dir := filepath.Dir(path)
+	if !removingWiring && !isRealDir(dir) {
+		createdDirsByThisRun = append(createdDirsByThisRun, dir)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 	// Config files are very often symlinks into a dotfiles repository. Writing

--- a/cmd/deja/pi_package_parity_test.go
+++ b/cmd/deja/pi_package_parity_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The npm package and the extension `deja install pi-auto` writes are the same
+// integration reaching pi two ways, and they drifted: the package had
+// session_start and before_agent_start only, so anyone who installed from npm
+// got no repair after a failed command, no read-before-edit line, and nothing
+// back after a compaction — features that had shipped months earlier (#3180).
+func TestThePiPackageWiresTheSameEventsAsTheInstaller(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("..", "..", "extensions", "pi", "index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := string(b)
+	installer := piExtensionTS("/usr/local/bin/deja")
+
+	for _, event := range piEventsIn(installer) {
+		if !strings.Contains(pkg, `pi.on("`+event+`"`) {
+			t.Errorf("the package does not handle %q, which the installer's extension does", event)
+		}
+	}
+	// And nothing the installer does not: a handler only the package has is
+	// the same drift facing the other way.
+	for _, event := range piEventsIn(pkg) {
+		if !strings.Contains(installer, `pi.on("`+event+`"`) {
+			t.Errorf("the package handles %q and the installer's extension does not", event)
+		}
+	}
+}
+
+func piEventsIn(src string) []string {
+	var out []string
+	for _, part := range strings.Split(src, `pi.on("`)[1:] {
+		if i := strings.IndexByte(part, '"'); i > 0 {
+			out = append(out, part[:i])
+		}
+	}
+	return out
+}

--- a/cmd/deja/uninstall_kept_dir_test.go
+++ b/cmd/deja/uninstall_kept_dir_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The prune on the way out says "when deja made it and nothing else is in it"
+// and could only test the second half: os.Remove refuses a directory with
+// anything in it, and nothing recorded who made it. A host's own empty folder
+// — a VS Code `User` directory a reader created and had not filled yet — went
+// with the uninstall (#3239).
+func TestUninstallKeepsADirectoryTheReaderAlreadyHad(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "home")
+	dir := filepath.Join(home, ".config", "deja-fixture")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "settings.json")
+
+	if _, err := writeIfChanged(path, nil, []byte(`{"mcpServers":{"deja":{}}}`)); err != nil {
+		t.Fatal(err)
+	}
+	recordWiring([]string{"claude-code"}, false)
+
+	removingWiring = true
+	defer func() { removingWiring = false }()
+	if _, err := writeIfChanged(path, []byte(`{"mcpServers":{"deja":{}}}`), []byte(`{"mcpServers":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Error("the config deja created outlived the uninstall")
+	}
+	if !isRealDir(dir) {
+		t.Error("uninstall removed a directory the reader made")
+	}
+}
+
+// And one deja had to make goes, which is the case the prune was written for.
+func TestUninstallRemovesTheDirectoryItMade(t *testing.T) {
+	tmp := hermeticEnv(t)
+	home := filepath.Join(tmp, "home")
+	dir := filepath.Join(home, ".config", "deja-fixture", "nested")
+	path := filepath.Join(dir, "settings.json")
+
+	if _, err := writeIfChanged(path, nil, []byte(`{"mcpServers":{"deja":{}}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if !isRealDir(dir) {
+		t.Fatal("the install did not create the directory")
+	}
+	recordWiring([]string{"claude-code"}, false)
+
+	removingWiring = true
+	defer func() { removingWiring = false }()
+	if _, err := writeIfChanged(path, []byte(`{"mcpServers":{"deja":{}}}`), []byte(`{"mcpServers":{}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if isRealDir(dir) {
+		t.Error("the directory deja made was left behind")
+	}
+}

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -36,6 +36,12 @@ type wiringState struct {
 	// Knowing which files deja made is what lets the same rule apply to them
 	// without ever removing a config the reader already had (#2583).
 	Created []string `json:"created,omitempty"`
+	// Dirs are the directories deja had to create to write a config into. The
+	// prune on the way out states the rule "when deja made it and nothing else
+	// is in it" and could only test the second half, so an empty folder the
+	// reader already had — a host's `User` directory, say — went with the
+	// uninstall (#3239).
+	Dirs []string `json:"dirs,omitempty"`
 	// Snapshots are the .bak files deja wrote itself. Ownership of a snapshot
 	// cannot be read out of its bytes — a reader's own config that merely says
 	// the word matches every marker list — so the uninstall that deletes one
@@ -172,6 +178,16 @@ func recordWiring(targets []string, uninstall bool) {
 		created = nil
 	}
 	sort.Strings(created)
+	dirs := append([]string(nil), st.Dirs...)
+	for _, p := range createdDirsByThisRun {
+		if !slices.Contains(dirs, p) {
+			dirs = append(dirs, p)
+		}
+	}
+	if len(kept) == 0 {
+		dirs = nil
+	}
+	sort.Strings(dirs)
 	snapshots := append([]string(nil), st.Snapshots...)
 	for _, p := range snapshotsByThisRun {
 		if !slices.Contains(snapshots, p) {
@@ -194,7 +210,7 @@ func recordWiring(targets []string, uninstall bool) {
 	}
 	sort.Strings(blocks)
 	exes := append([]string(nil), st.Exes...)
-	next := wiringState{Version: version, Targets: kept, Created: created, Snapshots: snapshots,
+	next := wiringState{Version: version, Targets: kept, Created: created, Dirs: dirs, Snapshots: snapshots,
 		Blocks: blocks, Exe: exe, Exes: exes, Home: homeDir()}
 	rememberWrittenExe(&next, exe)
 	st = next
@@ -386,6 +402,16 @@ func canonicalSnapshotPath(bak string) string {
 }
 
 // wiringCreated reports that deja created this config rather than finding it.
+// wiringCreatedDir reports that deja had to make this directory to write a
+// config into it. Asked before the prune on the way out: an empty directory
+// the reader already had is theirs (#3239).
+func wiringCreatedDir(dir string) bool {
+	if slices.Contains(createdDirsByThisRun, dir) {
+		return true
+	}
+	return slices.Contains(readWiringState().Dirs, dir)
+}
+
 func wiringCreated(path string) bool {
 	for _, p := range readWiringState().Created {
 		if p == path {

--- a/cmd/deja/wiring_state.go
+++ b/cmd/deja/wiring_state.go
@@ -401,17 +401,17 @@ func canonicalSnapshotPath(bak string) string {
 	return filepath.Join(dir, filepath.Base(bak))
 }
 
-// wiringCreated reports that deja created this config rather than finding it.
-// wiringCreatedDir reports that deja had to make this directory to write a
+// dirWiringCreated reports that deja had to make this directory to write a
 // config into it. Asked before the prune on the way out: an empty directory
 // the reader already had is theirs (#3239).
-func wiringCreatedDir(dir string) bool {
+func dirWiringCreated(dir string) bool {
 	if slices.Contains(createdDirsByThisRun, dir) {
 		return true
 	}
 	return slices.Contains(readWiringState().Dirs, dir)
 }
 
+// wiringCreated reports that deja created this config rather than finding it.
 func wiringCreated(path string) bool {
 	for _, p := range readWiringState().Created {
 		if p == path {

--- a/extensions/pi/index.ts
+++ b/extensions/pi/index.ts
@@ -6,7 +6,7 @@ import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { argv, contextText, installerExtensionPath, sessionKey } from "./lib.mjs";
+import { argv, contextText, installerExtensionPaths, sessionKey } from "./lib.mjs";
 
 const require = createRequire(import.meta.url);
 
@@ -72,11 +72,16 @@ export default function (pi: any) {
   // it already does everything below, and two copies would inject the
   // recall twice and register /deja twice.
   try {
-    if (existsSync(installerExtensionPath(homedir()))) return;
+    if (installerExtensionPaths(homedir()).some((p) => existsSync(p))) return;
   } catch {}
 
   let injected = false;
   let toldBuilding = false;
+  // The tool and compaction events carry no session id of their own, and
+  // recall dedupes per session: without one it repeats itself and forgets
+  // nothing. The prompt handler passes through first and pi keeps the id on
+  // the session manager, so it is read there and held.
+  let session = "";
 
   // pi keeps a footer status line: while the first index builds, that is
   // where the user can see it happening instead of wondering why recall is
@@ -141,6 +146,7 @@ export default function (pi: any) {
         return;
       }
       const key = sessionKey(event, ctx);
+      if (key) session = key;
       const raw = run(["hook-prompt"], JSON.stringify({ prompt: event.prompt || "", session_id: key }));
       if (!raw) return;
       const resp = JSON.parse(raw);
@@ -151,5 +157,77 @@ export default function (pi: any) {
     } catch {
       // memory is optional: never break the session over it
     }
+  });
+
+  // The other half of the point of action, and the half this package was
+  // missing: a command has just failed, and this machine has fixed that same
+  // error before. pi hands tool_result the content the model is about to read
+  // and uses what the handler returns, so the repair goes in beside the error
+  // in the same turn. The installer's own extension has carried this since
+  // #3112/#3113; anyone who installed from npm had neither it nor the
+  // compaction handler below (#3180).
+  const repaired: Record<string, string> = {};
+  pi.on("tool_result", async (event: any, ctx: any) => {
+    try {
+      if (!event) return;
+      const key = sessionKey(event, ctx);
+      if (key) session = key;
+      // A file the agent just opened is the step before it changes that file,
+      // and pi has no handler that runs earlier whose return the model reads.
+      // So the file's own history goes out here: what was decided about it,
+      // from the sessions that decided it. deja answers once per session per
+      // fact, so re-reading the same file stays quiet.
+      if (event.toolName === "read") {
+        const path = String((event.input && (event.input.path || event.input.file_path)) || "");
+        if (!path) return;
+        const parts = Array.isArray(event.content) ? event.content : [];
+        const id = "read:" + String(event.toolCallId || "");
+        if (!(id in repaired)) {
+          repaired[id] = run(["hook-tool", "--plain"], JSON.stringify({
+            tool_name: "read",
+            tool_input: { file_path: path },
+            session_id: session,
+            cwd: process.cwd(),
+          }));
+        }
+        const note = repaired[id];
+        if (!note) return;
+        return { content: parts.concat([{ type: "text", text: note }]) };
+      }
+      if (!event.isError) return;
+      if (event.toolName !== "bash") return;
+      const parts = Array.isArray(event.content) ? event.content : [];
+      const output = parts
+        .filter((p: any) => p && p.type === "text" && typeof p.text === "string")
+        .map((p: any) => p.text)
+        .join("\n");
+      if (!output.trim()) return;
+      const id = String(event.toolCallId || "");
+      if (!(id in repaired)) {
+        repaired[id] = run(["hook-tool-after", "--plain"], JSON.stringify({
+          tool_name: "bash",
+          tool_response: output,
+          session_id: session,
+          cwd: process.cwd(),
+        }));
+      }
+      const line = repaired[id];
+      if (!line) return;
+      return { content: parts.concat([{ type: "text", text: line }]) };
+    } catch {
+      // never turn a failed command into a failed session
+    }
+  });
+
+  // Compaction throws away the blocks this session was shown, and the list
+  // that stops them repeating outlives them. session_compact fires once the
+  // summary has replaced the history, which is exactly when the session should
+  // be allowed to see those blocks again.
+  pi.on("session_compact", async (_event: any, ctx: any) => {
+    try {
+      const key = sessionKey(_event, ctx);
+      if (key) session = key;
+      run(["hook-precompact"], JSON.stringify({ session_id: session }));
+    } catch {}
   });
 }

--- a/extensions/pi/lib.mjs
+++ b/extensions/pi/lib.mjs
@@ -13,6 +13,17 @@ export function installerExtensionPath(home) {
   return join(home || "", ".pi", "agent", "extensions", "deja.ts")
 }
 
+// installerExtensionPaths are every place `deja install` writes an extension
+// this package would duplicate. omp runs the same package and the installer
+// writes it under ~/.omp/agent/extensions/deja/index.js, so checking pi's path
+// alone left both running side by side (#3180).
+export function installerExtensionPaths(home) {
+  return [
+    installerExtensionPath(home),
+    join(home || "", ".omp", "agent", "extensions", "deja", "index.js"),
+  ]
+}
+
 // contextText pulls the recall out of whatever hook-context printed. deja
 // answers in the Claude Code hook shape; older builds and `--plain` print
 // bare text, so both are accepted.

--- a/extensions/pi/test/pure.test.mjs
+++ b/extensions/pi/test/pure.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { argv, contextText, installerExtensionPath, sessionKey } from "../lib.mjs"
+import { argv, contextText, installerExtensionPath, installerExtensionPaths, sessionKey } from "../lib.mjs"
 
 test("the installer's extension is looked for where the installer writes it", () => {
   assert.equal(installerExtensionPath("/home/u"), "/home/u/.pi/agent/extensions/deja.ts")
@@ -25,4 +25,14 @@ test("the session key is what pi keeps on the session manager", () => {
   assert.equal(sessionKey({ sessionId: "e1" }, { session: { id: "c1" } }), "e1")
   assert.equal(sessionKey({}, { session: { id: "c1" } }), "c1")
   assert.equal(sessionKey({}, {}), "")
+})
+
+test("the package stands down for either host's installed extension", () => {
+  // omp runs this same package, and `deja install omp-auto` writes its
+  // extension elsewhere — checking pi's path alone left both running, so the
+  // recall went in twice and /deja was registered twice (#3180).
+  assert.deepEqual(installerExtensionPaths("/home/u"), [
+    "/home/u/.pi/agent/extensions/deja.ts",
+    "/home/u/.omp/agent/extensions/deja/index.js",
+  ])
 })

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -429,6 +429,16 @@ func EnsureForSearchStale(dir string, o query.Options, progress io.Writer) (bool
 	}
 	if !removedAny && canAppendIncremental(changed, m.Files) {
 		mark("decide append")
+		// An append is cheap until it isn't. A live session that has been
+		// writing all day — a Grok `updates.jsonl` in the tens of megabytes —
+		// is appendable, so every search sat through its tail before
+		// answering, including questions about last month's history in another
+		// harness (#3021). Past the cap it is handed to the detached warmup
+		// like rewrite-grade work: the answer comes from the snapshot with the
+		// "as it was" line, and the tail lands before the next question.
+		if tail := appendTailBytes(changed, m.Files); tail > inlineAppendMax {
+			return true, nil
+		}
 		err := updateIndex(dir, o.Harness, "", want, false, progress)
 		mark("append")
 		return false, err
@@ -3206,6 +3216,25 @@ var (
 	resumableKinds     map[string]bool
 	resumableKindsOnce sync.Once
 )
+
+// inlineAppendMax is how many new bytes a search will read before answering.
+// Eight megabytes is about a second of parsing on the machine #3021 was
+// measured on, and larger than any ordinary turn: the sessions that pass it
+// are the ones being written while the question is asked. A variable so a test
+// can put the boundary where its fixtures are.
+var inlineAppendMax int64 = 8 << 20
+
+// appendTailBytes is how much has been added to the files an append would
+// read, which is what the reader waits on.
+func appendTailBytes(changed map[string]FileState, old map[string]FileState) int64 {
+	var n int64
+	for p, f := range changed {
+		if of, ok := old[p]; ok && f.Size > of.Size {
+			n += f.Size - of.Size
+		}
+	}
+	return n
+}
 
 func canAppendIncremental(changed map[string]FileState, old map[string]FileState) bool {
 	if len(changed) == 0 {

--- a/internal/index/inline_append_cap_test.go
+++ b/internal/index/inline_append_cap_test.go
@@ -1,0 +1,80 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// A session still being written is appendable, and an append blocks the
+// answer: a search for last month's history sat through the tail of a live
+// transcript first — seconds per query, scaling with the file rather than with
+// the question (#3021). Past the cap the tail goes to the detached warmup, the
+// way rewrite-grade work already does.
+func TestASearchDoesNotWaitOnALongLiveSession(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(claude, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(proj, "live.jsonl")
+	turn := func(n, text string) string {
+		return `{"type":"user","sessionId":"live","cwd":"/tmp/app","timestamp":"2026-01-0` + n +
+			`T03:04:05Z","message":{"role":"user","content":"` + text + `"}}` + "\n"
+	}
+	if err := os.WriteFile(path, []byte(turn("1", "why does the quokkabloom retry")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// A small append is still read before answering: the wait is the point of
+	// having a current index at all.
+	small, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := small.WriteString(turn("2", "the retry is capped at three")); err != nil {
+		t.Fatal(err)
+	}
+	_ = small.Close()
+	stale, err := EnsureForSearchStale(dir, query.Options{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale {
+		t.Error("an ordinary turn was handed to the warmup instead of being read")
+	}
+
+	// And a session that has been writing all day is not something every
+	// search waits on.
+	inlineAppendMax = 1 << 10
+	t.Cleanup(func() { inlineAppendMax = 8 << 20 })
+	big, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := big.WriteString(turn("3", strings.Repeat("tool output ", 400))); err != nil {
+		t.Fatal(err)
+	}
+	_ = big.Close()
+	stale, err = EnsureForSearchStale(dir, query.Options{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stale {
+		t.Error("the search waited on the tail of a live session")
+	}
+}

--- a/internal/index/unread_store_test.go
+++ b/internal/index/unread_store_test.go
@@ -1,0 +1,45 @@
+package index
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A store deja could not read must not be filed as read. opencode and Cursor
+// hold their sqlite stores while they run, and a lock outlasting the timeout
+// used to be recorded with the store's size and mtime — so the next pass
+// found nothing changed, called the index up to date, and the history stayed
+// missing until someone rebuilt by hand (#3176).
+func TestAStoreThatCouldNotBeReadIsNotFiledAsRead(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 not installed")
+	}
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	db := filepath.Join(tmp, "opencode.db")
+	if err := os.WriteFile(db, []byte("garbage, not a database, sixty-four bytes of nothing useful....."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_OPENCODE_DB", db)
+
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for p := range m.Files {
+		if strings.Contains(p, "opencode.db") {
+			t.Fatalf("a store that could not be read was filed as read: %s", p)
+		}
+	}
+}


### PR DESCRIPTION
Four issues in one pass.

**#3239** — the prune on the way out states "when deja made it and nothing else is in it" and could only test the second half, so an empty directory the reader already had went with the uninstall. The wiring record now holds the directories deja had to create.

**#3180** — the npm pi package had session start and prompt only, so an npm install got no repair after a failed command, no read-before-edit line and nothing back after a compaction. It now wires the same four handlers the installer writes, stands down for omp's installed extension as well as pi's, and a test keeps the two in step.

**#3176** — the fix (dropping stores the loaders could not read from the file table) was on main without a test; added one that goes red without it.

**#3021** — a search waited on the tail of whatever session was being written: appendable is not the same as cheap. Past eight megabytes of new bytes the append is treated as rewrite-grade — answer from the snapshot, tail in the detached warmup — so a question about last month stops paying for a live transcript.

Also closed 60 issues that were already fixed on the collector branch and never closed by the merge in #3420.