### PR TITLE
fix: nine from the backlog — the decisions you took today

### DIFF
--- a/cmd/deja/bench_marathon_arm_pin_test.go
+++ b/cmd/deja/bench_marathon_arm_pin_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A marathon that brushes the question across hundreds of turns and the short
+// session that settled it scored alike, so on ten questions phrased from real
+// PR titles the giant took the top place twice and the session that did the
+// work came second (#3214). The bench arm is where that shape is reproducible:
+// the ranking's own unit fixtures are too small to build a marathon out of.
+func TestTheMarathonDoesNotTakeTheSpecificQuestion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("the prompt bench builds a corpus")
+	}
+	outside := t.TempDir()
+	t.Setenv("HOME", outside)
+	t.Setenv("USERPROFILE", outside)
+	t.Setenv("DEJA_EMBED_URL", "http://127.0.0.1:1")
+	out, err := captureRun(t, "bench", "prompt", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report promptReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("invalid prompt JSON: %v", err)
+	}
+	arm := report.SpecificVsMarathon
+	if arm.Cases == 0 {
+		t.Fatal("the arm has no cases, so this measures nothing")
+	}
+	if arm.FalseFires != 0 {
+		t.Errorf("the marathon took %d of %d specific questions", arm.FalseFires, arm.Cases)
+	}
+}

--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -653,13 +653,13 @@ func measurePrompt(seed int64) (promptReport, error) {
 // opening line came from the top of a long transcript does not, and that line
 // is the whole frame an agent reads before deciding to ignore the rest.
 func shownLineCarriesATerm(dir, project string, terms []string) bool {
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		keep = append(keep, s)
@@ -691,7 +691,7 @@ func shownLineCarriesATerm(dir, project string, terms []string) bool {
 // and reports whether its first quoted line carries the subject rather than an
 // ordinary word the question shares with the same session.
 func firstShownLineCarries(dir, project string, terms []string, topic string) bool {
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil || len(ranked) == 0 {
 		return false
 	}
@@ -700,7 +700,7 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -722,14 +722,14 @@ func firstShownLineCarries(dir, project string, terms []string, topic string) bo
 // blockCarries builds the block the hook would inject and reports whether it
 // holds a distinctive word of what the session concluded.
 func blockCarries(dir, project string, terms []string, fact, topic string) bool {
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil || len(ranked) == 0 {
 		return false
 	}
 	terms = byIdentifying(terms, idfOf)
 	var keep []model.Session
 	for i := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		keep = append(keep, ranked[i])
@@ -775,14 +775,14 @@ func promptBenchProbeBlock(dir, project, chainID string, terms []string) (fired,
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil {
 		return false, false
 	}
 	shown := 0
 	var chosen []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {
@@ -816,7 +816,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 	if !promptTermsWorthAsking(terms) {
 		return false, false
 	}
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil {
 		return false, false
 	}
@@ -824,7 +824,7 @@ func promptBenchProbe(dir, project, chainID string, terms []string) (fired, corr
 		// The same bar the hook applies, from the same function — kept in one
 		// place because the two drifted: this one asked whether the query held
 		// an identifier, the hook asked whether the session did.
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		if len(s.Messages) > dejaVuMaxMessages {
@@ -856,13 +856,13 @@ func finishPromptArm(arm *promptArmReport, terms []int) {
 // blockOpensOnEcho reports whether the first line the agent would read is the
 // question it just asked, handed back.
 func blockOpensOnEcho(dir, project string, terms []string, question string) bool {
-	ranked, matched, strong, idfOf, err := index.ProjectRelevant(dir, []string{project}, terms, 8)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, []string{project}, terms, 8, nil)
 	if err != nil {
 		return false
 	}
 	var keep []model.Session
 	for i, s := range ranked {
-		if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+		if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], namingAt(naming, i), idfOf) {
 			continue
 		}
 		keep = append(keep, s)
@@ -924,4 +924,13 @@ func hookEndToEndAs(dir, project, question, fact, topic, sid string) (fired, car
 		}
 	}
 	return true, false
+}
+
+// namingAt is the naming count for one ranked session, or -1 when the ranking
+// could not answer for it (#3351).
+func namingAt(naming []int, i int) int {
+	if i < len(naming) {
+		return naming[i]
+	}
+	return -1
 }

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -22,7 +22,7 @@ const guidanceBody = `Before re-deriving past work, search deja when the user re
 
 Example: for "what did we decide about token refresh?", call recall with query "token refresh decision", then call recall_context if the result needs more detail.
 
-When recalled history genuinely helps — a reused fix, a skipped re-debug, even a partial hint that changed your approach — say so to the user in one short line at the start of your reply: "déjà vu: <what> — <how it was reused> (deja:<session id>)". Never credit recalls that did not help.`
+When recalled history helps — a reused fix, a skipped re-debug, a hint that changed your approach — open your reply with that one line: "déjà vu: <what it said> — reusing it (deja:<session id>)". One line, at the start, and nothing about recalls that did not help.`
 
 // skillBody is the same guidance for harnesses that read a skill file. A skill
 // is loaded when its description looks relevant, so the manual costs nothing in

--- a/cmd/deja/guidance.go
+++ b/cmd/deja/guidance.go
@@ -525,9 +525,16 @@ func installGuidance(harness string, uninstall bool) (installResult, error) {
 		if uerr != nil {
 			return installResult{}, markerErrorFor(alt, uerr)
 		}
-		if _, werr := writeIfChanged(alt, oldAlt, []byte(updatedAlt)); werr != nil {
+		altAction, werr := writeIfChanged(alt, oldAlt, []byte(updatedAlt))
+		if werr != nil {
 			return installResult{}, werr
 		}
+		// Both files, and the shared skill written above: the report is what
+		// says which files were touched, and these three were not among them
+		// (#3254).
+		return wroteAll(installResult{Path: path, Action: a, Note: retiredNote},
+			installResult{Path: alt, Action: altAction},
+			installResult{Path: sharedSkillPath(), Action: altAction}), nil
 	}
 	return installResult{Path: path, Action: a, Note: retiredNote}, nil
 }

--- a/cmd/deja/hook_antigravity.go
+++ b/cmd/deja/hook_antigravity.go
@@ -118,4 +118,4 @@ func runHookAntigravity(dir string, stdin io.Reader, stdout io.Writer) error {
 	return nil
 }
 
-const antigravityLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, say so in one short line at the start of your reply: déjà vu: <what was recalled> — <how you reused it> (deja:<session id>); otherwise do not mention it.\n"
+const antigravityLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. \nIf one of these helps, open your reply with that one line and nothing more about it: déjà vu: <what it said> — reusing it (deja:<session id>). If none helps, say nothing about them.\n"

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -1374,9 +1374,9 @@ func startLead(narrow string) string {
 
 // wideRecallLead is sessionStartLead for DEJA_RECALL=aggressive, where the
 // sessions come from this machine rather than from this checkout.
-const wideRecallLead = "The sessions below are recent work on this machine, not only in this project — deja is set to recall widely. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, say so in one short line at the start of your reply: déjà vu: <what was recalled> — <how you reused it> (deja:<session id>); otherwise do not mention it.\n"
+const wideRecallLead = "The sessions below are recent work on this machine, not only in this project — deja is set to recall widely. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. \nIf one of these helps, open your reply with that one line and nothing more about it: déjà vu: <what it said> — reusing it (deja:<session id>). If none helps, say nothing about them.\n"
 
-const sessionStartLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. If recalled history genuinely helps the task, say so in one short line at the start of your reply: déjà vu: <what was recalled> — <how you reused it> (deja:<session id>); otherwise do not mention it.\n"
+const sessionStartLead = "The sessions below are from this project's recent history. If any is relevant to what the user asks next, call recall_context with a term from it to pull the full details before acting. \nIf one of these helps, open your reply with that one line and nothing more about it: déjà vu: <what it said> — reusing it (deja:<session id>). If none helps, say nothing about them.\n"
 
 // dropHookCaches removes every cached session-start digest beside this index.
 // They are keyed by working directory, so there is one per project a hook has

--- a/cmd/deja/hook_grok_test.go
+++ b/cmd/deja/hook_grok_test.go
@@ -166,18 +166,12 @@ func TestGrokSpawnCarriesMemoryIntoTheSubagent(t *testing.T) {
 func TestGrokToolPayloadNamesTheCommand(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
-	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	for _, id := range []string{"a", "b"} {
-		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
-			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the suite"}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./... -count=1"}}]}}`,
-		})
-	}
+	commandRunWithAnOutcome(t, "go test ./... -count=1", "a", "b")
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}
 	out := toolHookRun(t, `{"hookEventName":"pre_tool_use","toolName":"run_terminal_command",`+
-		`"toolInput":{"command":"go test ./... -count=1","description":"suite"},"sessionId":"grok-3"}`)
+		`"toolInput":{"command":"go test ./... -count=1","description":"suite"},"sessionId":"grok-3","cwd":"/work/app"}`)
 	if out == "" {
 		t.Fatal("a command run in two sessions produced no line from grok's payload")
 	}

--- a/cmd/deja/hook_ignore_test.go
+++ b/cmd/deja/hook_ignore_test.go
@@ -50,22 +50,24 @@ func TestTheCommandHookObeysTheIgnoreRule(t *testing.T) {
 	}
 }
 
-// A command run where recall may go keeps its line.
+// A command run where recall may go keeps its line — and the line is the
+// outcome, since #3415 dropped the bare count.
 func TestTheCommandHookStillSpeaksForAKeptProject(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	root := os.Getenv("DEJA_CLAUDE_ROOT")
 	for _, id := range []string{"k1", "k2"} {
 		writeClaudeFixture(t, filepath.Join(root, "-w-keep", id+".jsonl"), id, []string{
-			`{"type":"user","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"deploy the thing"}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:00:00Z","message":{"role":"user","content":"the apply keeps failing on the state lock"}}`,
 			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"terraform apply -auto-approve"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/w/keep","timestamp":"2026-07-01T10:02:00Z","message":{"role":"assistant","content":"the apply has to take the state lock first: the CI run holds it for another minute."}}`,
 		})
 	}
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}
 	out := commandHookLine(os.Getenv("DEJA_INDEX_DIR"), "/w/keep", "terraform apply -auto-approve")
-	if !strings.Contains(out, "has run that command") {
+	if !strings.Contains(out, "has run that command") || !strings.Contains(out, "last time:") {
 		t.Fatalf("the hook went quiet about a command it may speak of:\n%s", out)
 	}
 }

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -270,7 +270,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	if input.SessionID != "" {
 		skip[input.SessionID] = true
 	}
-	ranked, matched, strong, idfOf, err := index.ProjectRelevantSkipping(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates, skip)
+	ranked, matched, strong, naming, idfOf, err := index.ProjectRelevantNaming(dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates, skip)
 	// The rule every other surface applies: a promoted note goes in front of
 	// the transcript it was distilled from. This hook ranks sessions and never
 	// builds a search.Hit, so it had no note-over-source rule at all and the
@@ -317,7 +317,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// shards — and those copies take the ranking's window with them, so the
 	// answer to the question can sit outside it (#1556).
 	crowdedOut := 0
-	pick := func(ranked []model.Session, matched, strong []int) {
+	pick := func(ranked []model.Session, matched, strong, naming []int) {
 		for i, s := range ranked {
 			// Every other injection path asks the policy first; this one is a
 			// per-prompt injection like any other, and imported projects reach
@@ -333,7 +333,11 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			// hook pays its cost on every message the user sends. Measured on
 			// cross-paired prompts whose answer is absent, the old bar injected on
 			// 94% of them; half of those rested on one ordinary word.
-			if !search.RecallWorthShowing(terms, matched[i], strong[i], idfOf) {
+			named := -1
+			if i < len(naming) {
+				named = naming[i]
+			}
+			if !search.RecallWorthShowingNaming(terms, matched[i], strong[i], named, idfOf) {
 				continue
 			}
 			// A word rare enough to identify something is a real match on its own —
@@ -405,16 +409,16 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			}
 		}
 	}
-	pick(ranked, matched, strong)
+	pick(ranked, matched, strong, naming)
 	// One slot left and duplicates took the window: ask for a wider one. The
 	// second pass costs a ranking read and happens only when the store said
 	// the same thing several times, which is exactly when the answer is
 	// further down than the window reached.
 	if len(ss) < 2 && crowdedOut > 0 {
-		wider, wmatched, wstrong, _, werr := index.ProjectRelevantSkipping(
+		wider, wmatched, wstrong, wnaming, _, werr := index.ProjectRelevantNaming(
 			dir, digest.ProjectNameCandidates(cwd), terms, prompt.Candidates*widerWindow, skip)
 		if werr == nil {
-			pick(wider, wmatched, wstrong)
+			pick(wider, wmatched, wstrong, wnaming)
 		}
 	}
 	if len(ss) == 0 {

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -401,7 +401,12 @@ func commandHookLine(dir, cwd, cmd string) string {
 	if d := commandDecisionLine(dir, cwd, cmd); d != "" {
 		return head + " — last time: " + d
 	}
-	return head + "."
+	// And with neither, nothing. The head alone is a count and a date — "run
+	// in 5 sessions, last 2026-05-21" — which is the pointer this comment
+	// argues against, spent on the one line the hook gets. Measured on a real
+	// store: of ten command shapes, two carried an outcome and two printed the
+	// bare count; the count is what goes (#3415).
+	return ""
 }
 
 // promotedCommandDecision is the decision this project promoted about the

--- a/cmd/deja/hook_tool_bare_count_test.go
+++ b/cmd/deja/hook_tool_bare_count_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The hook gets one line per action, and it was spending some of them on a
+// count and a date: "This machine has run that command in 5 sessions, last
+// 2026-05-21." The comment beside the code that builds it says why that is not
+// worth saying — a line that only says history exists changes nothing — and on
+// a real store two of the four lines it produced were exactly that (#3415).
+func TestTheCommandHookSaysNothingWithoutAnOutcome(t *testing.T) {
+	tmp := hermeticEnv(t)
+	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// Sessions that ran the command and concluded nothing about it.
+	for _, id := range []string{"a", "b", "c"} {
+		writeClaudeFixture(t, filepath.Join(root, "-work-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"push it"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"git push origin main"}}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := commandHookLine(os.Getenv("DEJA_INDEX_DIR"), "/work/app", "git push origin main"); got != "" {
+		t.Errorf("the hook spent its line on a bare count: %q", got)
+	}
+
+	// The same store, one session that says how it went: that line is worth
+	// the action it interrupts.
+	writeClaudeFixture(t, filepath.Join(root, "-work-app", "d.jsonl"), "d", []string{
+		`{"type":"user","sessionId":"d","cwd":"/work/app","timestamp":"2026-01-03T03:04:05Z","message":{"role":"user","content":"the push to origin main keeps being rejected"}}`,
+		`{"type":"assistant","sessionId":"d","cwd":"/work/app","timestamp":"2026-01-03T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"git push origin main"}}]}}`,
+		`{"type":"assistant","sessionId":"d","cwd":"/work/app","timestamp":"2026-01-03T03:04:07Z","message":{"role":"assistant","content":"the push has to go to a branch: origin main is protected and rejects a direct push."}}`,
+	})
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	got := commandHookLine(os.Getenv("DEJA_INDEX_DIR"), "/work/app", "git push origin main")
+	if !strings.Contains(got, "last time:") {
+		t.Errorf("the outcome did not reach the line: %q", got)
+	}
+}

--- a/cmd/deja/hook_tool_test.go
+++ b/cmd/deja/hook_tool_test.go
@@ -22,24 +22,32 @@ func toolHookRun(t *testing.T, payload string) string {
 	return out.String()
 }
 
+// commandRunWithAnOutcome seeds sessions that ran a command and say how it
+// went — which is the only kind the hook speaks for since #3415.
+func commandRunWithAnOutcome(t *testing.T, cmd string, ids ...string) {
+	t.Helper()
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range ids {
+		writeClaudeFixture(t, filepath.Join(root, "-work-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the suite keeps failing on the shared fixture"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"` + cmd + `"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:06:00Z","message":{"role":"assistant","content":"the suite has to run with -p 1: the shared fixture cannot take parallel packages."}}`,
+		})
+	}
+}
+
 // The hook fires on every action an agent takes, so its default is silence and
-// its ceiling is one short line. A command this machine has run before earns
-// that line; anything else does not.
+// its ceiling is one short line. A command this machine has run before, and
+// knows the outcome of, earns that line; anything else does not.
 func TestToolHookSpeaksOnlyForACommandWithAHistory(t *testing.T) {
 	tmp := hermeticEnv(t)
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
-	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	for _, id := range []string{"a", "b"} {
-		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
-			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the suite"}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./... -count=1"}}]}}`,
-		})
-	}
+	commandRunWithAnOutcome(t, "go test ./... -count=1", "a", "b")
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}
 
-	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"go test ./... -count=1"},"session_id":"now"}`)
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"go test ./... -count=1"},"session_id":"now","cwd":"/work/app"}`)
 	if out == "" {
 		t.Fatal("a command run in two sessions produced no line")
 	}
@@ -59,7 +67,7 @@ func TestToolHookSpeaksOnlyForACommandWithAHistory(t *testing.T) {
 
 	// A command with no history at all is silence, not a "nothing found" line:
 	// this is paid once per action.
-	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"terraform apply -auto-approve"},"session_id":"now"}`); got != "" {
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"terraform apply -auto-approve"},"session_id":"now","cwd":"/work/app"}`); got != "" {
 		t.Errorf("spoke about a command it has never seen: %q", got)
 	}
 	// And an editor action on a file nothing has touched stays silent too.
@@ -397,29 +405,30 @@ func TestToolHookSkipsInspectionAndDedupes(t *testing.T) {
 	t.Setenv("DEJA_INDEX_DIR", filepath.Join(tmp, "index.db"))
 	root := os.Getenv("DEJA_CLAUDE_ROOT")
 	for _, id := range []string{"a", "b", "c"} {
-		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
-			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"go"}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git status --short"}}]}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"make deploy-prod REGION=eu"}}]}}`,
+		writeClaudeFixture(t, filepath.Join(root, "-work-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the deploy needs the region set"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"git status --short"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"make deploy-prod REGION=eu"}}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-01-02T03:04:08Z","message":{"role":"assistant","content":"the deploy has to run with REGION=eu: the eu bucket is the only one the role can write."}}`,
 		})
 	}
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}
 	// git status ran in 3 sessions but is inspection — silent.
-	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status --short"},"session_id":"agent1"}`); got != "" {
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git status --short"},"session_id":"agent1","cwd":"/work/app"}`); got != "" {
 		t.Errorf("an inspection command produced a line: %q", got)
 	}
 	// A real deploy command speaks once...
-	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1"}`); got == "" {
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1","cwd":"/work/app"}`); got == "" {
 		t.Fatal("a command with real history stayed silent")
 	}
 	// ...but not a second time in the same agent session.
-	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1"}`); got != "" {
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent1","cwd":"/work/app"}`); got != "" {
 		t.Errorf("the same line was re-injected to the same session: %q", got)
 	}
 	// A different agent session still hears it.
-	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent2"}`); got == "" {
+	if got := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agent2","cwd":"/work/app"}`); got == "" {
 		t.Error("a fresh agent session was wrongly deduped")
 	}
 }
@@ -448,18 +457,12 @@ func TestToolHookRecordsTheInjection(t *testing.T) {
 	tmp := hermeticEnv(t)
 	dir := filepath.Join(tmp, "index.db")
 	t.Setenv("DEJA_INDEX_DIR", dir)
-	root := os.Getenv("DEJA_CLAUDE_ROOT")
-	for _, id := range []string{"a", "b"} {
-		writeClaudeFixture(t, filepath.Join(root, "p", id+".jsonl"), id, []string{
-			`{"type":"user","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"go"}}`,
-			`{"type":"assistant","sessionId":"` + id + `","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"make deploy-prod REGION=eu"}}]}}`,
-		})
-	}
+	commandRunWithAnOutcome(t, "make deploy-prod REGION=eu", "a", "b")
 	if _, err := captureRun(t, "index"); err != nil {
 		t.Fatal(err)
 	}
 	before := usage.Totals(dir).Injections
-	payload := `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agentX"}`
+	payload := `{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make deploy-prod REGION=eu"},"session_id":"agentX","cwd":"/work/app"}`
 	toolHookRun(t, payload)
 	if got := usage.Totals(dir).Injections; got != before+1 {
 		t.Fatalf("injection not recorded: before=%d after=%d", before, got)

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -245,7 +245,19 @@ func runInstall(dir string, args []string, uninstall bool) error {
 		var err error
 		switch {
 		case !uninstall:
-			err = writeCLISkill()
+			var action string
+			action, err = writeCLISkill()
+			// Every -auto target wrote this file and not one of them said so:
+			// nineteen unreported writes on the screen whose job is saying what
+			// was touched (#3254). Named once, here, rather than in each
+			// target's line.
+			if err == nil && action != "" {
+				done = append(done, lineItem{target: "skill", action: action, path: shortHome(cliSkillPath())})
+				touchedPaths = append(touchedPaths, cliSkillPath())
+				if !banner {
+					fmt.Printf("skill: %s %s\n", action, shortHome(cliSkillPath()))
+				}
+			}
 		case !cliSkillStillWanted(targets):
 			err = removeCLISkill()
 		}
@@ -736,10 +748,17 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "kimi":
 		return installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall)
 	case "kimi-auto":
-		if _, err := installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall); err != nil {
+		// Both halves in the result: the report is what says which files were
+		// touched, and this one wrote mcp.json without ever naming it (#3254).
+		mcp, err := installMCPJSON(filepath.Join(sources.KimiConfigDir(), "mcp.json"), exe, uninstall)
+		if err != nil {
 			return installResult{}, err
 		}
-		return installKimiAuto(exe, uninstall)
+		hooks, err := installKimiAuto(exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		return wroteAll(mcp, hooks), nil
 	case "zed":
 		return installZedMCP(sources.ZedSettingsPath(), exe, uninstall)
 	case "cline":
@@ -747,10 +766,15 @@ func installTarget(target, exe string, uninstall bool) (installResult, error) {
 	case "roo":
 		return installRoo(exe, uninstall)
 	case "cline-auto":
-		if _, err := installMCPJSON(sources.ClineMCPSettingsPath(), exe, uninstall); err != nil {
+		mcp, err := installMCPJSON(sources.ClineMCPSettingsPath(), exe, uninstall)
+		if err != nil {
 			return installResult{}, err
 		}
-		return installClineAuto(exe, uninstall)
+		plugin, err := installClineAuto(exe, uninstall)
+		if err != nil {
+			return installResult{}, err
+		}
+		return wroteAll(mcp, plugin), nil
 	case "continue":
 		return installContinue(exe, uninstall)
 	case "crush":

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -363,6 +363,20 @@ func keptSnapshotsLine(touched []string) string {
 		len(paths), pluralS(len(paths)), where)
 }
 
+// indexBuiltLine is what an install says about the store it just built. The
+// harness lines above it count what the parser read; this counts what reached
+// the index, and the two disagree by deja's own recall blocks — stripped
+// before anything counts them. Both numbers are true and they answer different
+// questions, so the difference is named rather than left to be noticed (#3386).
+func indexBuiltLine(b index.BuildSummary) string {
+	line := fmt.Sprintf("index: built (%d session%s, %d message%s",
+		b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
+	if b.Dropped > 0 {
+		line += fmt.Sprintf(" — %d of deja's own blocks not indexed", b.Dropped)
+	}
+	return line + ")\n"
+}
+
 func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 	built := false
 	detected := 0
@@ -383,15 +397,13 @@ func installIndexWarmup(dir string, mcp, hooks, guidance int, summary bool) {
 	}
 	if !summary {
 		if built {
-			b := index.LastBuild
-			fmt.Fprintf(os.Stderr, "index: built (%d session%s, %d message%s)\n", b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
+			fmt.Fprint(os.Stderr, indexBuiltLine(index.LastBuild))
 		}
 		return
 	}
 	fmt.Fprintf(os.Stderr, "installed: %d MCP, %d hooks, %d guidance files\n", mcp, hooks, guidance)
 	if built {
-		b := index.LastBuild
-		fmt.Fprintf(os.Stderr, "index: built (%d session%s, %d message%s)\n", b.Sessions, pluralS(b.Sessions), b.Messages, pluralS(b.Messages))
+		fmt.Fprint(os.Stderr, indexBuiltLine(index.LastBuild))
 	} else if !index.HasManifest(dir) && detected > 0 {
 		fmt.Fprintln(os.Stderr, "next: run `deja index` to finish building memory")
 	} else if n := deniedStoreCount(); !index.HasManifest(dir) && n > 0 {

--- a/cmd/deja/install_built_line_test.go
+++ b/cmd/deja/install_built_line_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// An install prints two counts in a row and they disagree: the parser's line
+// says what it read, this one says what reached the index, and the difference
+// is deja's own recall coming back through a transcript. Both are true, and
+// nothing said why they differed (#3386).
+func TestTheBuiltLineNamesWhatDidNotReachTheIndex(t *testing.T) {
+	got := indexBuiltLine(index.BuildSummary{Sessions: 4, Messages: 6, Dropped: 1})
+	if !strings.Contains(got, "4 sessions, 6 messages") {
+		t.Errorf("the line lost its counts: %q", got)
+	}
+	if !strings.Contains(got, "1 of deja's own blocks not indexed") {
+		t.Errorf("the line does not say where the seventh message went: %q", got)
+	}
+
+	// When the two agree there is nothing to explain, and a note about zero
+	// blocks is noise on the screen a first install shows.
+	if got := indexBuiltLine(index.BuildSummary{Sessions: 4, Messages: 7}); strings.Contains(got, "not indexed") {
+		t.Errorf("the line explained a difference that is not there: %q", got)
+	}
+}

--- a/cmd/deja/install_cline.go
+++ b/cmd/deja/install_cline.go
@@ -59,10 +59,14 @@ func installClineAuto(exe string, uninstall bool) (installResult, error) {
 	if err != nil {
 		return installResult{}, err
 	}
-	if _, err := writeGuidanceFile(filepath.Join(skill, "SKILL.md"), oldSkill, []byte(skillFile(skillBody))); err != nil {
+	skillAction, err := writeGuidanceFile(filepath.Join(skill, "SKILL.md"), oldSkill, []byte(skillFile(skillBody)))
+	if err != nil {
 		return installResult{}, err
 	}
-	return installResult{Path: path, Action: a}, nil
+	// The plugin directory rides along, so the skill inside it is covered by
+	// the line naming the directory rather than going unmentioned (#3254).
+	return wroteAll(installResult{Path: path, Action: a},
+		installResult{Path: dir, Action: skillAction}), nil
 }
 
 func clinePluginJS(exe string) string {

--- a/cmd/deja/install_deepseek.go
+++ b/cmd/deja/install_deepseek.go
@@ -441,7 +441,8 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 	if err != nil {
 		return installResult{}, err
 	}
-	if _, err := writeIfChanged(cmdPath, oldCmd, []byte(dshCommandJS(exe))); err != nil {
+	cmdAction, err := writeIfChanged(cmdPath, oldCmd, []byte(dshCommandJS(exe)))
+	if err != nil {
 		return installResult{}, err
 	}
 	if withAuto {
@@ -450,8 +451,12 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 		if err != nil {
 			return installResult{}, err
 		}
-		if _, err := writeIfChanged(autoPath, oldAuto, []byte(dshAutoJS(exe))); err != nil {
-			return installResult{}, err
+		autoAction, aerr := writeIfChanged(autoPath, oldAuto, []byte(dshAutoJS(exe)))
+		if aerr != nil {
+			return installResult{}, aerr
+		}
+		if autoAction != "unchanged" {
+			cmdAction = autoAction
 		}
 	} else if err := os.Remove(dshAutoPath()); err != nil && !os.IsNotExist(err) {
 		return installResult{}, err
@@ -461,5 +466,11 @@ func installDeepSeek(exe string, uninstall, withAuto bool) (installResult, error
 		return installResult{}, perr
 	}
 	a, err := writeIfChanged(path, old, []byte(patched))
-	return installResult{Path: path, Action: a}, err
+	if err != nil {
+		return installResult{}, err
+	}
+	// The plugin directory rides along: the two files in it are deja's own and
+	// went unnamed on the screen whose job is saying what was touched (#3254).
+	plugins := installResult{Path: filepath.Dir(cmdPath), Action: cmdAction}
+	return wroteAll(installResult{Path: path, Action: a}, plugins), nil
 }

--- a/cmd/deja/install_goose.go
+++ b/cmd/deja/install_goose.go
@@ -321,7 +321,9 @@ func installGooseAuto(exe string, uninstall bool) (installResult, error) {
 	// -auto adds, so `deja install goose` followed by `goose-auto` said
 	// "unchanged" three times while switching session-start recall on.
 	if action != "unchanged" {
-		return installResult{Path: gooseHookPath(), Action: action}, nil
+		return wroteAll(installResult{Path: gooseHookPath(), Action: action},
+			installResult{Path: gooseHintsPath(), Action: action},
+			installResult{Path: gooseRecipePath(), Action: action}), nil
 	}
 	return res, nil
 }

--- a/cmd/deja/install_names_what_it_wrote_test.go
+++ b/cmd/deja/install_names_what_it_wrote_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Four bugs in one week were the same shape: an -auto target writing two files
+// and reporting one (#3185, #3220, #3208, #3171). This is the general form —
+// install each target on an empty home, list what appeared, and require the
+// report to name it, by its own path or by a directory the report named whole
+// (#3254).
+func TestEveryAutoTargetNamesWhatItWrote(t *testing.T) {
+	for _, target := range installTargetNames() {
+		if !strings.HasSuffix(target, "-auto") {
+			continue
+		}
+		t.Run(target, func(t *testing.T) {
+			tmp := hermeticEnv(t)
+			home := filepath.Join(tmp, "home")
+			if err := os.MkdirAll(home, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			before := absFilesUnder(t, home)
+			out, err := captureRun(t, "install", target, "--no-index")
+			if err != nil {
+				t.Skipf("target refused here: %v", err)
+			}
+			for p := range absFilesUnder(t, home) {
+				if before[p] || dejasOwnBookkeeping(p) {
+					continue
+				}
+				if !reportNames(out, p) {
+					t.Errorf("wrote %s and did not say so:\n%s", shortHome(p), out)
+				}
+			}
+		})
+	}
+}
+
+// dejasOwnBookkeeping is what an install writes for itself rather than for the
+// harness: the wiring record, the index, the notes file, the warmup sentinel,
+// and the snapshots, which have a line of their own.
+func dejasOwnBookkeeping(path string) bool {
+	base := filepath.Base(path)
+	switch {
+	case strings.HasSuffix(base, ".bak"), strings.HasPrefix(base, ".deja"):
+		return true
+	case base == "wiring.json", base == "notes.jsonl":
+		return true
+	}
+	return strings.Contains(path, string(filepath.Separator)+".cache"+string(filepath.Separator)) ||
+		strings.Contains(path, "index.db")
+}
+
+// reportNames reports whether the install said it wrote this file: the path
+// itself, or a directory holding it — named as a directory, not as the head of
+// some other path. Both spellings, since the report shortens the home
+// directory to ~.
+func reportNames(out, path string) bool {
+	for p := path; len(p) > 1; p = filepath.Dir(p) {
+		if namedWhole(out, p) || namedWhole(out, shortHome(p)) {
+			return true
+		}
+	}
+	return false
+}
+
+// namedWhole reports whether the text names this path and stops there. Without
+// the boundary, "~/.agents/skills" counts as named because it is the head of
+// the deja-history skill's path, and the file beside it goes unmentioned —
+// which is the shape #3254 is about.
+func namedWhole(out, path string) bool {
+	for i := 0; ; {
+		j := strings.Index(out[i:], path)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(path)
+		if end >= len(out) || (out[end] != '/' && out[end] != '\\') {
+			return true
+		}
+		i = end
+	}
+}
+
+func absFilesUnder(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	err := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return nil
+		}
+		out[p] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/cmd/deja/install_omp_auto.go
+++ b/cmd/deja/install_omp_auto.go
@@ -27,19 +27,23 @@ func ompExtensionDir() string {
 // --auto` installs the -auto target alone, so an -auto that skipped the server
 // would leave the agent with injected memory and no tool to follow it up with.
 func installOmpAuto(exe string, uninstall bool) (installResult, error) {
-	if _, err := installMCPJSON(filepath.Join(sources.OmpConfigDir(), "mcp.json"), exe, uninstall); err != nil {
+	// The MCP half rides in the result rather than being dropped: the report
+	// is what says which files were touched, and mcp.json was written without
+	// ever being named (#3254).
+	mcp, err := installMCPJSON(filepath.Join(sources.OmpConfigDir(), "mcp.json"), exe, uninstall)
+	if err != nil {
 		return installResult{}, err
 	}
 	dir := ompExtensionDir()
 	path := filepath.Join(dir, "index.js")
 	if uninstall {
 		if _, err := os.Stat(path); err != nil {
-			return installResult{Path: path, Action: "unchanged"}, nil
+			return wroteAll(installResult{Path: path, Action: "unchanged"}, mcp), nil
 		}
 		if err := os.RemoveAll(dir); err != nil {
 			return installResult{}, err
 		}
-		return installResult{Path: path, Action: "removed"}, nil
+		return wroteAll(installResult{Path: path, Action: "removed"}, mcp), nil
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return installResult{}, err
@@ -49,7 +53,10 @@ func installOmpAuto(exe string, uninstall bool) (installResult, error) {
 		return installResult{}, err
 	}
 	a, err := writeIfChanged(path, old, []byte(ompExtensionJS(exe)))
-	return installResult{Path: path, Action: a}, err
+	if err != nil {
+		return installResult{}, err
+	}
+	return wroteAll(installResult{Path: path, Action: a}, mcp), nil
 }
 
 func ompExtensionJS(exe string) string {

--- a/cmd/deja/install_openclaw_plugin.go
+++ b/cmd/deja/install_openclaw_plugin.go
@@ -64,7 +64,11 @@ func installOpenClawPlugin(exe string, uninstall bool) (installResult, error) {
 	if _, err := setOpenClawPluginEnabled(true); err != nil {
 		return installResult{}, err
 	}
-	return installResult{Path: entry, Action: a}, nil
+	// The manifest and package.json beside it are deja's own and went unnamed
+	// on the screen whose job is saying what was touched, so the directory
+	// rides along (#3254).
+	return wroteAll(installResult{Path: entry, Action: a},
+		installResult{Path: dir, Action: a}), nil
 }
 
 // setOpenClawPluginEnabled adds or removes our entry under plugins.entries,

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -389,7 +389,7 @@ func cmdWarmup(dir string, _ []string) error {
 	// for it, because the skill deja shipped described MCP tools that were
 	// never installed (#1320). A failure is not the warmup's failure — the
 	// index is built and search works either way.
-	_ = writeCLISkill()
+	_, _ = writeCLISkill()
 	return nil
 }
 

--- a/cmd/deja/prompt_wording_test.go
+++ b/cmd/deja/prompt_wording_test.go
@@ -30,10 +30,18 @@ func TestModelFacingTextHasNoStrayIdentifiers(t *testing.T) {
 			t.Errorf("%s: model-facing text contains the identifier %q: %s", name, "digest.Short", excerpt(text, "digest.Short"))
 		}
 	}
-	// The wording these strings were meant to carry.
+	// The wording these strings were meant to carry: one line, and only when
+	// the recall helped. The exact phrasing moved in #3079 — the old one was
+	// followed on 143 of 6,650 injections — so the check is on the two
+	// properties rather than on one sentence.
 	for _, name := range []string{"mcp tools/list", "hook-prompt lead", "hook-context lead", "antigravity lead", "skill guidance"} {
-		if !strings.Contains(texts[name], "in one short line") {
-			t.Errorf("%s: missing the %q instruction", name, "in one short line")
+		text := texts[name]
+		if !strings.Contains(text, "one short line") && !strings.Contains(text, "one line") {
+			t.Errorf("%s: does not ask for one line", name)
+		}
+		if !strings.Contains(text, "did not help") && !strings.Contains(text, "none helps") &&
+			!strings.Contains(text, "ignore silently") {
+			t.Errorf("%s: does not say to stay quiet when the recall did not help", name)
 		}
 	}
 }

--- a/cmd/deja/recall_frame_test.go
+++ b/cmd/deja/recall_frame_test.go
@@ -74,7 +74,7 @@ func TestInstallBackupAndNewConfigOwnerOnly(t *testing.T) {
 // The narration protocol must be present on every agent-facing surface, and
 // must carry the only-when-it-helped guard so it cannot become spam.
 func TestNarrationProtocolOnAllSurfaces(t *testing.T) {
-	if !strings.Contains(guidanceBody, "déjà vu:") || !strings.Contains(guidanceBody, "Never credit recalls that did not help") {
+	if !strings.Contains(guidanceBody, "déjà vu:") || !strings.Contains(guidanceBody, "did not help") {
 		t.Fatal("guidance missing narration protocol")
 	}
 	for _, m := range []string{"initialize", "tools/list"} {

--- a/cmd/deja/skill_cli.go
+++ b/cmd/deja/skill_cli.go
@@ -86,11 +86,11 @@ func cliSkillFile() string {
 // touches an agent's configuration, and a skill file is deja's own directory
 // rather than a harness's config. An edited copy is kept, the same as any other
 // skill deja writes.
-func writeCLISkill() error {
+func writeCLISkill() (string, error) {
 	path := cliSkillPath()
 	old, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return "", err
 	}
 	// Kept without saying so. writeSkillOfOurs prints "skill: kept your edited
 	// …" when it refuses, which is right for an install someone is watching and
@@ -98,12 +98,12 @@ func writeCLISkill() error {
 	// that line would appear on every run for as long as the edit lives.
 	// `deja install --force` still takes deja's version back.
 	if !forceGuidance && skillWasEdited(path, old) {
-		return nil
+		return "", nil
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return "", err
 	}
-	return writeSkillOfOurs(path, old, []byte(cliSkillFile()))
+	return writeGuidanceFile(path, old, []byte(cliSkillFile()))
 }
 
 // cliSkillStillWanted reports whether any harness deja wired is staying. One

--- a/cmd/deja/skill_cli_test.go
+++ b/cmd/deja/skill_cli_test.go
@@ -105,7 +105,7 @@ func TestUninstallKeepsTheCLISkillWhileAnotherTargetStays(t *testing.T) {
 
 func TestRemoveCLISkillLeavesOneTheUserRewrote(t *testing.T) {
 	hermeticEnv(t)
-	if err := writeCLISkill(); err != nil {
+	if _, err := writeCLISkill(); err != nil {
 		t.Fatal(err)
 	}
 	mine := "my own wording\n"
@@ -123,7 +123,7 @@ func TestRemoveCLISkillLeavesOneTheUserRewrote(t *testing.T) {
 	if err := os.Remove(cliSkillPath()); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeCLISkill(); err != nil {
+	if _, err := writeCLISkill(); err != nil {
 		t.Fatal(err)
 	}
 	if err := removeCLISkill(); err != nil {

--- a/internal/bench/context.go
+++ b/internal/bench/context.go
@@ -20,6 +20,10 @@ const (
 	// At three every arm scored 1.00 whatever the digest did, which is what
 	// made the coverage column unable to move (#2931, #2933).
 	ContextPriorCount = 7
+	// contextFactEvery spreads the three facts over the prior sessions instead
+	// of filing them in the first three: with ContextPriorCount at 7 they land
+	// in the first, fourth and seventh (#2931).
+	contextFactEvery = 3
 )
 
 type ContextChain struct {
@@ -76,10 +80,14 @@ func GenerateContext(seed int64) ContextCorpus {
 			// name the chain was never retrieved, so raising it changed
 			// nothing either (#2933).
 			text := fmt.Sprintf("%s routine update, nothing settled here", id)
+			fact := -1
 			if chain.Negative {
 				text = "routine update with no prior fact"
-			} else if j < len(chain.Facts) {
-				text = chain.Facts[j]
+			} else if j%contextFactEvery == 0 && j/contextFactEvery < len(chain.Facts) {
+				// Spread across the chain rather than filed in its first
+				// sessions, so reaching all three means choosing between
+				// sessions rather than reading the newest few.
+				fact = j / contextFactEvery
 			}
 			t := base.Add(time.Duration(i*10+j) * time.Minute)
 			msgs := []model.Message{{Role: "user", Text: text, Time: t}}
@@ -89,6 +97,14 @@ func GenerateContext(seed int64) ContextCorpus {
 					model.Message{Role: "user", Text: fillerText(rng, "ran the reproduction again and pasted the output"), Time: t.Add(time.Duration(2*k+2) * time.Minute)},
 					model.Message{Role: "assistant", Text: fillerText(rng, "walked through the trace and adjusted the patch"), Time: t.Add(time.Duration(2*k+3) * time.Minute)},
 				)
+			}
+			// The fact is what the session settled, so it sits at the end
+			// rather than opening it. Opening every session with it meant both
+			// surfaces reached all three facts whatever they chose, which is
+			// why coverage stayed at 1.00 with half the arm deleted (#2931).
+			if fact >= 0 {
+				msgs = append(msgs, model.Message{Role: "assistant", Text: chain.Facts[fact],
+					Time: t.Add(time.Duration(2*fillerBlocks+4) * time.Minute)})
 			}
 			msgs = append(msgs, model.Message{Role: "assistant", Text: "Recorded the decision and verified the rollout.", Time: t.Add(time.Hour)})
 			chain.Sessions = append(chain.Sessions, model.Session{

--- a/internal/index/build_dropped_test.go
+++ b/internal/index/build_dropped_test.go
@@ -1,0 +1,43 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The build counts what reached the index; a turn that is only deja's own
+// recall reaches nothing, having been stripped before anything counts it. The
+// difference between the two numbers an install prints is exactly that, and it
+// is now carried rather than left to be worked out (#3386).
+func TestTheBuildSaysHowManyOfItsOwnBlocksItDropped(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(claude, "-tmp-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lines := `{"type":"user","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"why does the quokkabloom retry"}}
+{"type":"assistant","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":"<deja-recall>\nRecalled history from prior sessions.\n</deja-recall>"}}
+{"type":"assistant","sessionId":"s1","cwd":"/tmp/app","timestamp":"2026-01-02T03:04:07Z","message":{"role":"assistant","content":"the retry is capped at three"}}
+`
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Ensure(filepath.Join(tmp, "index.db"), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if LastBuild.Messages != 2 {
+		t.Errorf("indexed %d messages, want the two a person and the agent wrote", LastBuild.Messages)
+	}
+	if LastBuild.Dropped != 1 {
+		t.Errorf("dropped = %d, want deja's own block counted", LastBuild.Dropped)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -186,9 +186,14 @@ type HarnessCount struct {
 // BuildSummary describes the most recent (re)build in this process; the CLI
 // uses it to greet a first-ever index with a summary instead of silence.
 type BuildSummary struct {
-	Initial    bool
-	Sessions   int
-	Messages   int
+	Initial  bool
+	Sessions int
+	Messages int
+	// Dropped is how many parsed messages did not reach the index: deja's own
+	// recall blocks, stripped before anything counts them, and turns that hold
+	// nothing else. The two counts a build prints disagreed by exactly this and
+	// nothing said why (#3386).
+	Dropped    int
 	Harnesses  int
 	PerHarness []HarnessCount
 }

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -30,6 +30,10 @@ import (
 func summarizeBuild(initial bool, sessions int, messages int, ss []model.Session) {
 	counts := map[string]*HarnessCount{}
 	order := []string{}
+	parsed := 0
+	for _, s := range ss {
+		parsed += len(s.Messages)
+	}
 	for _, s := range ss {
 		c := counts[s.Harness]
 		if c == nil {
@@ -45,7 +49,8 @@ func summarizeBuild(initial bool, sessions int, messages int, ss []model.Session
 	for _, name := range order {
 		per = append(per, *counts[name])
 	}
-	LastBuild = BuildSummary{Initial: initial, Sessions: sessions, Messages: messages, Harnesses: len(order), PerHarness: per}
+	LastBuild = BuildSummary{Initial: initial, Sessions: sessions, Messages: messages,
+		Dropped: parsed - messages, Harnesses: len(order), PerHarness: per}
 }
 
 // IngestHealth returns the per-harness ingestion health persisted by the

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -538,6 +538,14 @@ func coverageCounts(all, identifying map[uint32]int, identifyingTerms int) map[u
 	return identifying
 }
 
+// marathonShare is how much a session's score is lifted by the match covering
+// it rather than brushing it. Swept on the prompt and recall benches: at 0.4
+// and below the marathon still takes the top place on two of the four
+// specific-vs-marathon cases, at 0.5 it takes none, and from there to 3.0
+// nothing else moves — no arm of the prompt bench and no recall number
+// (#3214).
+const marathonShare = 0.5
+
 // subjectShare is how much of the question's subject a session has to reach:
 // the rarest naming word the question holds, halved. Measured by sweeping the
 // whole prompt bench — at 0.5 and 0.6 the cross-paired arm loses a false fire
@@ -1364,6 +1372,19 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// Coverage: distinct informative terms beat repetition.
 		if matchedTerms[ord] > 1 {
 			sc *= 1 + 0.15*float64(matchedTerms[ord]-1)
+		}
+		// How much of the session the match is. A marathon that brushes the
+		// question across hundreds of turns and a short session where the
+		// matching turns are most of what it holds scored alike, and on ten
+		// questions phrased from real PR titles the marathon took the top
+		// place twice (#3214). Counted in messages, which is the unit the
+		// match is already measured in.
+		if n := inProject[ord].Counted; n > 0 {
+			share := float64(len(perMessage[ord])) / float64(n)
+			if share > 1 {
+				share = 1
+			}
+			sc *= 1 + marathonShare*share
 		}
 		// Did this session match what the question is about, rather than the
 		// working word beside it. The subject is the question's rarest naming

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/nfcfold"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/query"
+	"github.com/vshulcz/deja-vu/internal/search"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -537,6 +538,14 @@ func coverageCounts(all, identifying map[uint32]int, identifyingTerms int) map[u
 	return identifying
 }
 
+// subjectShare is how much of the question's subject a session has to reach:
+// the rarest naming word the question holds, halved. Measured by sweeping the
+// whole prompt bench — at 0.5 and 0.6 the cross-paired arm loses a false fire
+// and no other arm moves; at 0.9 it loses two more and takes nine of twenty
+// rewordings, four of five Russian questions and eighteen pasted-preamble
+// questions with it (#3351).
+const subjectShare = 0.5
+
 // rankIDF is what a match is WORTH: documents counted in sessions, the unit
 // ranking has always used. Weighting by the gate's number instead lifts every
 // term a few long sessions happen to repeat, which reorders the top of the
@@ -593,6 +602,17 @@ func ProjectRelevant(dir string, projects, terms []string, n int) ([]model.Sessi
 // the 26 it ranks — every one read from disk in full first, only to be dropped
 // on its id.
 func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip map[string]bool) ([]model.Session, []int, []int, map[string]float64, error) {
+	out, matched, strong, _, idf, err := ProjectRelevantNaming(dir, projects, terms, n, skip)
+	return out, matched, strong, idf, err
+}
+
+// ProjectRelevantNaming is ProjectRelevantSkipping plus, per session, how many
+// of the question's naming words it matched. The gate needs that to tell a
+// session that matched the subject from one that matched the verb beside it,
+// which rarity cannot answer in a small store (#3351). It is nil when the
+// bridged retry answered instead: that path ranks on neighbouring terms, so a
+// count of the question's own words would be a claim about the wrong query.
+func ProjectRelevantNaming(dir string, projects, terms []string, n int, skip map[string]bool) ([]model.Session, []int, []int, []int, map[string]float64, error) {
 	if dir == "" {
 		dir = DefaultDir()
 	}
@@ -601,31 +621,36 @@ func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip m
 	// rebuild — which every user hits on an index-format upgrade.
 	unlock, ok, err := tryLockDir(dir)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	if ok {
 		defer unlock()
 	}
 	m, err := readManifestCached(dir)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
-	metas, matched, strong, idf, rerr := relevantMetasMatched(dir, m, projects, terms, n, skip)
+	var keep func(SessionMeta) bool
+	if len(skip) > 0 {
+		keep = func(meta SessionMeta) bool { return !skip[meta.ID] }
+	}
+	rank, rerr := relevantMetasCounts(dir, m, projects, terms, n, keep)
 	if rerr != nil {
 		// A corrupt or unreadable bucket. The hook never rebuilds, so surface
 		// it rather than inject a silently short-ranked déjà vu; the caller
 		// stays quiet on an error.
-		return nil, nil, nil, nil, rerr
+		return nil, nil, nil, nil, nil, rerr
 	}
+	metas, matched, strong, naming, idf := rank.metas, rank.informative, rank.strong, rank.naming, rank.idf
 	if bm, bmatched, bstrong, bidf, ok := bridgedRetry(dir, m, projects, terms, n, skip, strong, idf); ok {
-		metas, matched, strong, idf = bm, bmatched, bstrong, bidf
+		metas, matched, strong, idf, naming = bm, bmatched, bstrong, bidf, nil
 	}
 	if len(metas) == 0 {
-		return nil, nil, nil, nil, nil
+		return nil, nil, nil, nil, nil, nil
 	}
 	out, err := sessionsServable(dir, metas, query.Options{})
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, err
 	}
 	// Paired by identity, not by position. The counts belong to the ranking,
 	// which works on metas; the sessions come back from sessionsServable, which
@@ -633,7 +658,10 @@ func ProjectRelevantSkipping(dir string, projects, terms []string, n int, skip m
 	// caller reads the three positionally, so a single drop had the per-prompt
 	// hook judging each session by its neighbour's terms (#2546).
 	matched, strong = countsFor(out, metas, matched, strong)
-	return out, matched, strong, idf, nil
+	if naming != nil {
+		naming, _ = countsFor(out, metas, naming, naming)
+	}
+	return out, matched, strong, naming, idf, nil
 }
 
 // countsFor re-pairs the per-session counts with the sessions that survived
@@ -800,6 +828,10 @@ type relevanceRanking struct {
 	// that clear the idf floor, that it holds at all, and that are rare enough
 	// to identify something on their own.
 	informative, any, strong []int
+	// naming counts the question's naming words a session actually matched,
+	// judged by shape. Rarity cannot answer that in a small store, so the gate
+	// had nothing to distinguish the subject from the verb beside it (#3351).
+	naming []int
 	// termsKnown is how many of the query's terms the corpus contains at all,
 	// and total how many sessions the ranking scored before n truncated it.
 	termsKnown, total int
@@ -817,7 +849,11 @@ type relevanceScored struct {
 	matched int
 	any     int
 	strong  int
-	focus   float64
+	// naming is how many of the question's naming words this session matched,
+	// judged by shape. The gate needs it to tell a match on the subject from a
+	// match on the verb beside it (#3351).
+	naming int
+	focus  float64
 }
 
 // rrfK damps how much a top place is worth against the ranking's tail. Sixty is
@@ -1015,6 +1051,29 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	// query has been read rather than term by term.
 	identifyingTerms := 0
 	matchedIdentifying := map[uint32]int{}
+	// The rarest term this session matched, against the rarest the question
+	// holds. A short question skips the store check entirely — "a short
+	// question is all subject" — so `decide saltmarsh` asked where saltmarsh
+	// has never been said fired on `decide`, and nothing downstream could tell
+	// the subject from the verb beside it (#3351).
+	bestMatched := map[uint32]float64{}
+	queryBest := 0.0
+	// noteQuerySubject raises that mark for a word that names something. df is
+	// counted over the whole store, before the project scope drops the term, so
+	// a subject that lives somewhere else still counts as the subject — which
+	// is the case this exists for.
+	noteQuerySubject := func(term string, sessions int) {
+		// A word this store has never seen says nothing about what the
+		// question is about here: counting it set a mark no session could
+		// reach, and the recall went silent whenever a question carried one
+		// unseen word — which is most questions.
+		if sessions <= 0 || !search.HasIdentifierTerm([]string{term}) {
+			return
+		}
+		if r := rankIDF(len(m.Sessions), sessions); r > queryBest {
+			queryBest = r
+		}
+	}
 	strongTerms := map[uint32]int{}
 	anyTerms := map[uint32]int{}
 	// perMessage tracks how many distinct terms hit each message (record
@@ -1120,6 +1179,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 				}
 			}
 			if len(hit) == 0 {
+				noteQuerySubject(term, len(df))
 				continue
 			}
 			minDF, minSess = countDF(df), len(df)
@@ -1175,6 +1235,7 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 					offs = keyOffs
 				}
 				if len(hit) == 0 {
+					noteQuerySubject(term, len(df))
 					missed = true
 					break
 				}
@@ -1228,6 +1289,9 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		// Rare enough to identify something on its own: either well past the
 		// ordinary bar, or living in a single session of the whole corpus.
 		strong := idf >= dejaVuStrongIDFFloor || minSess <= 1
+		// The question's own high-water mark: its rarest word is what it is
+		// about, whether or not any session here holds it (#3351).
+		noteQuerySubject(term, minSess)
 		for ord := range hit {
 			mm := perMessage[ord]
 			if mm == nil {
@@ -1259,6 +1323,9 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 			}
 			if identifying {
 				matchedIdentifying[ord]++
+			}
+			if rank > bestMatched[ord] {
+				bestMatched[ord] = rank
 			}
 			if strong {
 				strongTerms[ord]++
@@ -1298,7 +1365,18 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 		if matchedTerms[ord] > 1 {
 			sc *= 1 + 0.15*float64(matchedTerms[ord]-1)
 		}
-		ranked = append(ranked, relevanceScored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord], focus[ord]})
+		// Did this session match what the question is about, rather than the
+		// working word beside it. The subject is the question's rarest naming
+		// word, read over the whole store so one that lives in another project
+		// still counts; a session that matched only commoner words matched
+		// around it. Half the mark, not all of it: a rephrasing reaches the
+		// subject through a neighbouring word, and demanding the exact one cost
+		// the reworded arm nine of twenty (#3351).
+		named := 0
+		if queryBest <= 0 || bestMatched[ord] >= queryBest*subjectShare {
+			named = 1
+		}
+		ranked = append(ranked, relevanceScored{inProject[ord], sc, matchedTerms[ord], anyTerms[ord], strongTerms[ord], named, focus[ord]})
 	}
 	if len(ranked) == 0 {
 		return relevanceRanking{termsKnown: termsKnown}, readErr
@@ -1325,17 +1403,20 @@ func relevantMetasCounts(dir string, m Manifest, projects, terms []string, n int
 	matched := make([]int, 0, len(ranked))
 	anyMatched := make([]int, 0, len(ranked))
 	strong := make([]int, 0, len(ranked))
+	naming := make([]int, 0, len(ranked))
 	for _, r := range ranked {
 		metas = append(metas, r.meta)
 		matched = append(matched, r.matched)
 		anyMatched = append(anyMatched, r.any)
 		strong = append(strong, r.strong)
+		naming = append(naming, r.naming)
 	}
 	return relevanceRanking{
 		metas:       metas,
 		informative: matched,
 		any:         anyMatched,
 		strong:      strong,
+		naming:      naming,
 		termsKnown:  termsKnown,
 		total:       matchedTotal,
 		idf:         idfOf,

--- a/internal/search/worth.go
+++ b/internal/search/worth.go
@@ -30,6 +30,22 @@ import (
 // today; using it is the next rule's decision, and it will now land in every
 // instrument at once.
 func RecallWorthShowing(terms []string, matched, strong int, known map[string]float64) bool {
+	return RecallWorthShowingNaming(terms, matched, strong, -1, known)
+}
+
+// RecallWorthShowingNaming is the same bar with one more fact: how many of the
+// question's naming words this session actually matched.
+//
+// The question naming something was enough on its own, and for a question of
+// three terms or fewer the store was not consulted at all — "a short question
+// is all subject". So `decide saltmarsh` asked where saltmarsh has never been
+// said still fired, on `decide`. Measured on the cross-paired arm, where every
+// fire is a false one: 6 of 47, four of them that shape.
+//
+// naming < 0 means the caller has no such count — the bridged retry ranks on
+// neighbouring terms, so counting the question's own words there would be a
+// claim about a query that was not asked — and the old rule stands.
+func RecallWorthShowingNaming(terms []string, matched, strong, naming int, known map[string]float64) bool {
 	_ = strong // see the note above: taken so the instruments cannot drift
 	if matched < 1 {
 		return false
@@ -40,6 +56,9 @@ func RecallWorthShowing(terms []string, matched, strong int, known map[string]fl
 	// the corpus, the pair answers 11 of 12 real questions with no false fire,
 	// where the session-only rule answers 7 and fires on 2 controls.
 	if HasIdentifierTermKnown(terms, known) {
+		if naming >= 0 && HasIdentifierTerm(terms) {
+			return naming >= 1
+		}
 		return true
 	}
 	return matched >= 2

--- a/internal/search/worth_naming_test.go
+++ b/internal/search/worth_naming_test.go
@@ -1,0 +1,37 @@
+package search
+
+import "testing"
+
+// A question of three terms or fewer skipped the store check entirely — "a
+// short question is all subject" — so `decide saltmarsh` asked where saltmarsh
+// has never been said fired on `decide`. The ranking knows which of the
+// question's words a session actually matched; the gate now asks (#3351).
+func TestAShortQuestionNeedsTheSubjectToHaveMatched(t *testing.T) {
+	terms := []string{"decide", "saltmarsh"}
+
+	if RecallWorthShowingNaming(terms, 1, 0, 0, nil) {
+		t.Error("fired on the working word beside the subject")
+	}
+	if !RecallWorthShowingNaming(terms, 1, 0, 1, nil) {
+		t.Error("the session that matched the subject was refused")
+	}
+	// Nothing matched at all is still nothing.
+	if RecallWorthShowingNaming(terms, 0, 0, 1, nil) {
+		t.Error("fired on a session that matched none of the question")
+	}
+	// A caller with no count — the bridged retry ranks on neighbouring terms,
+	// so counting the question's own words there would be a claim about a
+	// query nobody asked — keeps the older rule.
+	if !RecallWorthShowingNaming(terms, 1, 0, -1, nil) {
+		t.Error("a ranking that cannot answer was treated as a refusal")
+	}
+	// And a question naming nothing is unchanged: two ordinary words earn it,
+	// one does not.
+	plain := []string{"build", "retry"}
+	if RecallWorthShowingNaming(plain, 1, 0, 0, nil) {
+		t.Error("one ordinary word fired")
+	}
+	if !RecallWorthShowingNaming(plain, 2, 0, 0, nil) {
+		t.Error("two ordinary words did not")
+	}
+}

--- a/internal/sources/copilot_chat.go
+++ b/internal/sources/copilot_chat.go
@@ -427,7 +427,81 @@ func copilotChatSession(path string, state map[string]any) ([]model.Session, err
 	if len(s.Messages) == 0 {
 		return nil, nil
 	}
+	appendChatEditedFiles(&s, path, id)
 	return []model.Session{s}, nil
+}
+
+// appendChatEditedFiles adds the files this chat edited, from the state VS Code
+// keeps beside the transcript:
+//
+//	workspaceStorage/<ws>/chatEditingSessions/<session id>/state.json
+//
+// The transcript names a path only when the text does, so a chat that edited
+// eleven files left one `files` record. Measured on this machine: 48 of those
+// state files, and while `recentSnapshot.workingSet` is empty in every one of
+// them, their entries carry 145 resources between them (#3381).
+func appendChatEditedFiles(s *model.Session, path, id string) {
+	if !IndexToolPaths() || id == "" {
+		return
+	}
+	ws := filepath.Dir(filepath.Dir(path))
+	b, err := os.ReadFile(filepath.Join(ws, "chatEditingSessions", id, "state.json"))
+	if err != nil {
+		return
+	}
+	var state struct {
+		RecentSnapshot struct {
+			WorkingSet []struct {
+				Resource any `json:"resource"`
+			} `json:"workingSet"`
+			Entries []struct {
+				Resource any `json:"resource"`
+			} `json:"entries"`
+		} `json:"recentSnapshot"`
+	}
+	if json.Unmarshal(b, &state) != nil {
+		return
+	}
+	seen := map[string]bool{}
+	var paths []string
+	add := func(res any) {
+		p := chatResourcePath(res)
+		if p == "" || seen[p] {
+			return
+		}
+		seen[p] = true
+		paths = append(paths, p)
+	}
+	for _, e := range state.RecentSnapshot.WorkingSet {
+		add(e.Resource)
+	}
+	for _, e := range state.RecentSnapshot.Entries {
+		add(e.Resource)
+	}
+	if len(paths) == 0 {
+		return
+	}
+	at := s.Messages[len(s.Messages)-1].Time
+	s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: strings.Join(paths, "\n"), Time: at})
+}
+
+// chatResourcePath reads the path out of a VS Code URI, which the state file
+// writes either as an object with `path` or as the string form of one.
+func chatResourcePath(res any) string {
+	switch v := res.(type) {
+	case string:
+		if i := strings.Index(v, "://"); i >= 0 {
+			v = v[i+3:]
+			if j := strings.IndexByte(v, '/'); j >= 0 {
+				v = v[j:]
+			}
+		}
+		return strings.TrimSpace(v)
+	case map[string]any:
+		p, _ := v["path"].(string)
+		return strings.TrimSpace(p)
+	}
+	return ""
 }
 
 func copilotChatTitle(state map[string]any) string {

--- a/internal/sources/copilot_chat_edited_files_test.go
+++ b/internal/sources/copilot_chat_edited_files_test.go
@@ -1,0 +1,87 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// VS Code keeps which files a chat edited beside the transcript, and deja read
+// none of it: a `files` record appeared only when the conversation happened to
+// type a path. Measured on this machine — 48 of these state files, their
+// entries carrying 145 resources between them (#3381).
+func TestACopilotChatNamesTheFilesItEdited(t *testing.T) {
+	ws := filepath.Join(t.TempDir(), "workspaceStorage", "abc123")
+	chats := filepath.Join(ws, "chatSessions")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "3f2b9c11-0000-4000-8000-abcdefabcdef"
+	transcript := `{"version":3,"sessionId":"` + id + `","creationDate":1767225600000,` +
+		`"requests":[{"message":{"text":"make the retry budget configurable"},` +
+		`"response":[{"value":"done"}]}]}`
+	path := filepath.Join(chats, id+".json")
+	if err := os.WriteFile(path, []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	edits := filepath.Join(ws, "chatEditingSessions", id)
+	if err := os.MkdirAll(edits, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The shape this machine's own files carry: workingSet empty, the entries
+	// holding the resources.
+	state := `{"version":2,"sessionId":"` + id + `","recentSnapshot":{"workingSet":[],` +
+		`"entries":[{"resource":{"scheme":"file","path":"/work/app/retry.go"}},` +
+		`{"resource":"file:///work/app/retry_test.go"}]}}`
+	if err := os.WriteFile(filepath.Join(edits, "state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseCopilotChatFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want the one transcript", len(ss))
+	}
+	var files string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleFiles {
+			files = m.Text
+		}
+	}
+	for _, want := range []string{"/work/app/retry.go", "/work/app/retry_test.go"} {
+		if !strings.Contains(files, want) {
+			t.Errorf("the files record does not name %s: %q", want, files)
+		}
+	}
+}
+
+// And a chat with no such state file is what it was: no record invented.
+func TestACopilotChatWithoutEditStateIsUnchanged(t *testing.T) {
+	ws := filepath.Join(t.TempDir(), "workspaceStorage", "abc123")
+	chats := filepath.Join(ws, "chatSessions")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const id = "aaaaaaaa-0000-4000-8000-aaaaaaaaaaaa"
+	path := filepath.Join(chats, id+".json")
+	transcript := `{"version":3,"sessionId":"` + id + `","creationDate":1767225600000,` +
+		`"requests":[{"message":{"text":"why does the retry budget reset"},"response":[{"value":"it does not"}]}]}`
+	if err := os.WriteFile(path, []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ss, err := ParseCopilotChatFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d", len(ss))
+	}
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleFiles {
+			t.Errorf("a files record appeared with no edit state: %q", m.Text)
+		}
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -710,13 +710,14 @@ func rememberOldest(p string, oldest time.Time, size int64) {
 func WornSessions(indexDir string) map[string]int {
 	out := map[string]int{}
 	for _, e := range read(Path(indexDir)) {
-		// Agent recalls and the user's own déjà vu moments both count. They
-		// mean different things — one is an agent pulling a session, the other
-		// is the user returning to the same ground — and both say the session
-		// keeps mattering. The bounded boost is what keeps this from becoming
-		// a feedback loop: a session that ranks higher gets surfaced more,
-		// which would compound without the ceiling in wornBoost.
-		if e.Kind != KindRecall && e.Kind != KindContext && e.Kind != KindDejaVu {
+		// Only what was asked for. A `dejavu` event is deja pushing a session
+		// into a prompt because the wording matched, not an agent reaching for
+		// it — and it was 60–70% of the count, so the receipt's "most re-used"
+		// named whichever session shared vocabulary with the project, and the
+		// same number fed wornBoost, which surfaced it more (#3173). The
+		// ceiling in wornBoost bounded that loop; it did not make the number
+		// mean what the word says.
+		if e.Kind != KindRecall && e.Kind != KindContext && e.Kind != KindBlame {
 			continue
 		}
 		for _, id := range e.SessionIDs {

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -188,24 +188,30 @@ func TestRecordSilentOnMkdirFailure(t *testing.T) {
 	}
 }
 
-// A déjà vu moment — the user asking something their own history already
-// answered — is the only signal deja has that the *user* came back, rather than
-// an agent pulling a session. It was recorded without session ids, so it could
-// not reach ranking at all.
-func TestDejaVuMomentsCountTowardsWornSessions(t *testing.T) {
+// Re-use is what was asked for. A `dejavu` event is deja pushing a session
+// into a prompt because the wording matched — on a real sidecar 60–70% of the
+// count, and on one session 854 of 928 — so the receipt's "most re-used" named
+// whichever session shared vocabulary with the project, and the same number fed
+// wornBoost, which surfaced it more (#3173).
+func TestWornSessionsCountWhatWasAskedFor(t *testing.T) {
 	dir := t.TempDir()
 	RecordDigestTerms(dir, KindDejaVu, "digest", 2, 100, []string{"pgbouncer"}, "s1", "s2")
 	RecordServedSessions(dir, KindRecall, 10, 1, false, 50, []string{"s1"})
+	RecordServedSessions(dir, KindContext, 10, 1, false, 50, []string{"s1"})
+	RecordServedSessions(dir, KindBlame, 10, 1, false, 50, []string{"s5"})
 	// Kinds that say nothing about a session mattering must not count.
 	RecordServedSessions(dir, KindSearch, 10, 1, false, 50, []string{"s3"})
 	RecordServedSessions(dir, KindHandoff, 10, 1, false, 50, []string{"s4"})
 
 	worn := WornSessions(dir)
 	if worn["s1"] != 2 {
-		t.Fatalf("s1 = %d, want the déjà vu moment and the recall", worn["s1"])
+		t.Fatalf("s1 = %d, want the recall and the context read", worn["s1"])
 	}
-	if worn["s2"] != 1 {
-		t.Fatalf("s2 = %d, want the déjà vu moment", worn["s2"])
+	if worn["s2"] != 0 {
+		t.Fatalf("s2 = %d, want nothing: it was pushed, not pulled", worn["s2"])
+	}
+	if worn["s5"] != 1 {
+		t.Fatalf("s5 = %d, want the blame", worn["s5"])
 	}
 	for _, id := range []string{"s3", "s4"} {
 		if worn[id] != 0 {


### PR DESCRIPTION
Nine issues, each the shape you chose.

**#3415** — the pre-tool hook said "run in 5 sessions, last 2026-05-21" when it had no outcome to give. Now it says the outcome or nothing.
**#3386** — install printed two message counts that disagreed; the second one names the difference ("3 of deja's own blocks not indexed").
**#3173** — "most re-used" counts what an agent asked for. A per-prompt push was 60–70% of that number and fed the ranking boost that surfaced the same session again.
**#3254** — the report names every file a target wrote: nineteen targets wrote the CLI skill and none said so, and kimi, omp, cline, dsh, goose, openclaw and grok each wrote a second file it never mentioned. The general test from the issue is in.
**#3351** — the gate carries which of the question's words a session matched, so a short question no longer fires on the verb beside its subject. Cross-paired false fires 7 of 51 → 5; no other arm moves.
**#3214** — a match that covers a session beats one that brushes a marathon: specific-vs-marathon loses both false fires, recall and every other prompt arm unchanged.
**#2931** — the context corpus spreads each chain's three facts across three prior sessions as what those sessions settled. The block arm reads 0.67 where it read 1.00, so a change to it is visible.
**#3079** — the credit line hands over the sentence instead of asking for a decision. Baseline to compare against: 143 of 6,650.
**#3381** — measured first: 48 chatEditingSessions state files here, workingSet empty in all of them, and their entries carrying 145 resources between them. So the files a chat edited are read from the entries.

Benches before and after on the same corpora: prompt as above, recall unchanged (r@1 0.20, mrr 0.457), context arms unchanged apart from the corpus change in #2931.