### PR TITLE
test: the hook launcher is deja's own file, not a target's config

### DIFF
--- a/cmd/deja/install_names_what_it_wrote_test.go
+++ b/cmd/deja/install_names_what_it_wrote_test.go
@@ -50,6 +50,12 @@ func dejasOwnBookkeeping(path string) bool {
 		return true
 	case base == "wiring.json", base == "notes.jsonl":
 		return true
+	case base == "deja-hook", base == "deja-hook.cmd":
+		// The launcher the hook entries name (#3422). It lives beside
+		// wiring.json under deja's own directory and is deja's plumbing rather
+		// than a file in the harness's configuration, which is what the report
+		// is a list of.
+		return true
 	}
 	return strings.Contains(path, string(filepath.Separator)+".cache"+string(filepath.Separator)) ||
 		strings.Contains(path, "index.db")


### PR DESCRIPTION
main is red: #3431 landed the check that every -auto target names what it wrote, #3426 landed the launcher the hook entries now point at, and each was green against a main without the other. The launcher is written under ~/.config/deja beside wiring.json — deja's own plumbing, not a file in the harness's configuration, which is what the report lists — so it belongs with the other bookkeeping the check skips.

Nine targets, one line.