### PR TITLE
fix(doctor): say when the launcher has no deja to run

### DIFF
--- a/cmd/deja/doctor.go
+++ b/cmd/deja/doctor.go
@@ -258,6 +258,11 @@ func doctorHooks(w io.Writer) {
 	if note := hookExeNote(path, "claude-auto"); note != "" && len(missing) < len(claudeHookWiring) {
 		fmt.Fprintf(w, "  %-12s %s\n", "", note)
 	}
+	// The entries name the launcher now, and the launcher is always there —
+	// what can be gone is everything it resolves to (#3422).
+	if note := doctorLauncherNote(path, "claude-auto"); note != "" {
+		fmt.Fprintf(w, "  %-12s %s\n", "", note)
+	}
 }
 
 // doctorWiringExe reports configs that name a binary which is no longer there.

--- a/cmd/deja/doctor_auto.go
+++ b/cmd/deja/doctor_auto.go
@@ -132,6 +132,9 @@ func doctorAutoRecall(w io.Writer) {
 			if exe := hookExeNote(path, a.name+"-auto"); a.marker != "" && exe != "" {
 				fmt.Fprintf(w, "  %-12s %s\n", "", exe)
 			}
+			if note := doctorLauncherNote(path, a.name+"-auto"); a.marker != "" && note != "" {
+				fmt.Fprintf(w, "  %-12s %s\n", "", note)
+			}
 		}
 	}
 }

--- a/cmd/deja/doctor_launcher.go
+++ b/cmd/deja/doctor_launcher.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// launcherResolves reports whether the launcher would find a deja to run, and
+// the path it would run.
+//
+// The check beside this one asks whether the file a hook names is on disk, and
+// since #3422 that file is the launcher, which is always there — so the
+// question it answers moved. What can be gone now is everything the launcher
+// resolves to: the binary the install ran from, the PATH, the usual install
+// locations. A machine in that state has hooks that start, find nothing and
+// exit 0, which is silence that looks exactly like having no history.
+func launcherResolves() (string, bool) {
+	if p := os.Getenv("DEJA_BIN"); executableFile(p) {
+		return p, true
+	}
+	st := readWiringState()
+	for _, p := range append(append([]string(nil), st.Exes...), st.Exe) {
+		if executableFile(p) {
+			return p, true
+		}
+	}
+	for _, p := range launcherCandidates("") {
+		if executableFile(p) {
+			return p, true
+		}
+	}
+	if p, err := exec.LookPath("deja"); err == nil && executableFile(p) {
+		return p, true
+	}
+	return "", false
+}
+
+func executableFile(p string) bool {
+	if p == "" {
+		return false
+	}
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir() && fi.Mode()&0o111 != 0
+}
+
+// doctorLauncherNote is the line a hook row prints when the entries name the
+// launcher and the launcher has nothing to run.
+func doctorLauncherNote(path, target string) string {
+	launcher := dejaLauncherPath()
+	if launcher == "" || strings.TrimSpace(path) == "" {
+		return ""
+	}
+	b, err := os.ReadFile(path)
+	if err != nil || !strings.Contains(string(b), launcher) {
+		return ""
+	}
+	if _, err := os.Stat(launcher); err != nil {
+		return "runs " + reportPath(launcher) + ", which is not there — `deja install " + target + "` writes it again"
+	}
+	if _, ok := launcherResolves(); ok {
+		return ""
+	}
+	return "runs " + reportPath(launcher) + ", which finds no deja to run — put the binary back on the PATH, or set DEJA_BIN to it"
+}

--- a/cmd/deja/doctor_launcher_test.go
+++ b/cmd/deja/doctor_launcher_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The check beside this one asks whether the file a hook names is on disk.
+// Since the launcher landed that file is always there, so the question moved:
+// what can be gone is everything the launcher resolves to. A machine in that
+// state has hooks that start, find nothing and exit 0 — silence that reads as
+// having no history (#3422).
+func TestDoctorSaysWhenTheLauncherFindsNoDeja(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no launcher on windows")
+	}
+	tmp := hermeticEnv(t)
+	// Nothing on the PATH and no well-known copy, so the launcher has only
+	// what the record names.
+	t.Setenv("PATH", filepath.Join(tmp, "empty-path"))
+	t.Setenv("DEJA_BIN", "")
+	saved := launcherWellKnown
+	t.Cleanup(func() { launcherWellKnown = saved })
+	launcherWellKnown = nil
+
+	gone := filepath.Join(tmp, "old", "deja")
+	writeWiringFixture(t, wiringState{Version: "dev", Targets: []string{"claude-code"}, Exe: gone, Home: homeDir()})
+	if _, err := writeDejaLauncher(gone); err != nil {
+		t.Fatal(err)
+	}
+	claude := filepath.Join(sources.ClaudeConfigDir(), "settings.json")
+	if err := os.MkdirAll(filepath.Dir(claude), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]any{"hooks": map[string]any{
+		"SessionStart": []any{map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": dejaLauncherPath() + " hook-context"},
+		}}},
+	}}
+	b, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(claude, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	doctorHooks(&out)
+	if got := out.String(); !strings.Contains(got, "finds no deja to run") {
+		t.Errorf("doctor said nothing about a launcher that resolves to nothing:\n%s", got)
+	}
+
+	// Put a binary where the record says, and the row goes quiet again.
+	if err := os.MkdirAll(filepath.Dir(gone), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gone, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	doctorHooks(&out)
+	if got := out.String(); strings.Contains(got, "finds no deja to run") {
+		t.Errorf("doctor complained about a launcher that resolves:\n%s", got)
+	}
+}


### PR DESCRIPTION
The hook rows check whether the binary a config names is on disk. Since #3426 that file is the launcher, which install always writes — so the check passes on a machine where nothing the launcher resolves to exists any more: no DEJA_BIN, no recorded install path, nothing on the PATH, nothing in the usual places. Those hooks start, find nothing, exit 0, and the silence reads as having no history.

Doctor now resolves the way the launcher does and says so when the answer is nothing. Quiet when it resolves.