### PR TITLE
docs(pi): the package's four handlers, and the omp stand-down

### DIFF
--- a/docs/registry/pi.html
+++ b/docs/registry/pi.html
@@ -85,7 +85,7 @@
 <h2 id="session-identity">Session identity</h2>
 <p>The <code>id</code> field from the session header line is used as the session ID. The UUID also appears in the filename.</p>
 <h2 id="package">Package</h2>
-<p><code>pi install npm:@vshulcz/pi-deja</code> installs the recall extension as a pi package (<code>pi-package</code> keyword, <code>pi.extensions</code>); it stands down when <code>deja install pi-auto</code> already wrote <code>~/.pi/agent/extensions/deja.ts</code>.</p>
+<p><code>pi install npm:@vshulcz/pi-deja</code> installs the recall extension as a pi package (<code>pi-package</code> keyword, <code>pi.extensions</code>); it wires the same four handlers the installer writes — session start, prompt, <code>tool_result</code> and <code>session_compact</code> — and stands down when <code>deja install pi-auto</code> already wrote <code>~/.pi/agent/extensions/deja.ts</code>, or when the omp counterpart is in place.</p>
 <h2 id="mcp">MCP</h2>
 <p>pi does not include built-in MCP but supports it via the <code>pi-mcp-adapter</code> package (<code>pi install npm:pi-mcp-adapter</code>). The adapter reads <code>~/.pi/agent/mcp.json</code> with the standard <code>mcpServers</code> shape. <code>deja install pi</code> writes to that file.</p>
 <h2 id="known-quirks-and-drift">Known quirks and drift</h2>

--- a/docs/registry/pi.md
+++ b/docs/registry/pi.md
@@ -69,7 +69,7 @@ The `id` field from the session header line is used as the session ID. The UUID 
 
 ## Package
 
-`pi install npm:@vshulcz/pi-deja` installs the recall extension as a pi package (`pi-package` keyword, `pi.extensions`); it stands down when `deja install pi-auto` already wrote `~/.pi/agent/extensions/deja.ts`.
+`pi install npm:@vshulcz/pi-deja` installs the recall extension as a pi package (`pi-package` keyword, `pi.extensions`); it wires the same four handlers the installer writes — session start, prompt, `tool_result` and `session_compact` — and stands down when `deja install pi-auto` already wrote `~/.pi/agent/extensions/deja.ts`, or when the omp counterpart is in place.
 
 ## MCP
 

--- a/extensions/pi/README.md
+++ b/extensions/pi/README.md
@@ -21,7 +21,7 @@ The deja binary comes with the package; a deja you installed yourself
 `deja install pi-auto` wires pi too, and is the shorter path if you have the
 CLI: it adds deja's MCP server and writes an extension of its own. When that
 extension is present this package stands down, so having both never injects
-twice.
+twice — and the same for omp, whose extension the installer writes elsewhere.
 
 omp loads `pi.extensions` manifests and emits the same `before_agent_start`
 event, so `pi install`'s omp counterpart picks this package up as well.
@@ -33,6 +33,12 @@ event, so `pi install`'s omp counterpart picks this package up as well.
 - **Every prompt** (`before_agent_start`): the prompt is matched against the
   index and, when a past session answers it, that session goes to the model
   with the prompt. Silence is the common case.
+- **After a failed command** (`tool_result`): the repair this machine used the
+  last time that error came up goes in beside the error, in the same turn.
+- **Before an edit** (`tool_result` on a read): what earlier sessions decided
+  about the file the agent just opened.
+- **After a compaction** (`session_compact`): the list of what this session was
+  already shown is cleared, so the recall it lost can come back.
 - **`/deja <query>`**: search the history by hand.
 
 ## Which binary


### PR DESCRIPTION
#3430 gave the npm package the tool_result and session_compact handlers the installer writes, and a stand-down for omp's installed extension. The README and the registry page still described the two it had.