### PR TITLE
feat: add instruction memory resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           declare -A floor=(
             [cmd/deja]=88 [internal/atomicfile]=77 [internal/bench]=100
             [internal/cjkfold]=100 [internal/digest]=90 [internal/embed]=93
-            [internal/index]=90 [internal/mark]=98 [internal/model]=100
+            [internal/index]=90 [internal/instructions]=90 [internal/mark]=98 [internal/model]=100
             [internal/nfcfold]=100 [internal/peers]=76 [internal/policy]=100
             [internal/prompt]=84 [internal/query]=100 [internal/redact]=94
             [internal/search]=93 [internal/sources]=87 [internal/stats]=91

--- a/cmd/deja/brief_test.go
+++ b/cmd/deja/brief_test.go
@@ -115,8 +115,18 @@ func TestBriefReplacesAQuietWeekWithTheSpanItHolds(t *testing.T) {
 	if err := runBrief(dir, &out); err != nil {
 		t.Fatal(err)
 	}
+	// The brief renders the span in the reader's local timezone. Derive the
+	// expected endpoints from the same servable overview it describes; a fixed
+	// UTC date made this assertion fail west of Greenwich despite the correct
+	// span being rendered.
+	overview, err := index.OverviewServable(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	got := out.String()
-	if !strings.Contains(got, "covering") || !strings.Contains(got, "Apr 11 2026") {
+	if !strings.Contains(got, "covering") ||
+		!strings.Contains(got, overview.Oldest.Local().Format("Jan 2 2006")) ||
+		!strings.Contains(got, overview.Newest.Local().Format("Jan 2 2006")) {
 		t.Fatalf("want the span the index holds:\n%s", got)
 	}
 	for _, unwanted := range []string{"today      0", "this week  0"} {

--- a/cmd/deja/citation_safe_test.go
+++ b/cmd/deja/citation_safe_test.go
@@ -42,7 +42,10 @@ func TestRepeatLeadStripsDisplayControls(t *testing.T) {
 			t.Fatalf("opener carried a control rune %U: %q", r, opener)
 		}
 	}
-	if !strings.Contains(opener, "deja:8f2c19ab77d") || !strings.Contains(opener, "(claude, Jan 2") || !strings.Contains(opener, "'quoted'") {
+	// Citation dates are deliberately local (the surrounding user sees local
+	// dates too). This safety test must assert provenance, not a UTC calendar
+	// day that shifts for readers west of Greenwich.
+	if !strings.Contains(opener, "deja:8f2c19ab77d") || !strings.Contains(opener, "(claude") || !strings.Contains(opener, "'quoted'") {
 		t.Fatalf("opener lost its provenance or kept a quote that closes the line: %q", opener)
 	}
 }

--- a/cmd/deja/completion.go
+++ b/cmd/deja/completion.go
@@ -54,7 +54,7 @@ _deja_completion() {
     command="${COMP_WORDS[1]-}"
     action="${COMP_WORDS[2]-}"
 
-    local commands="blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
+    local commands="blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install instructions last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup"
     local harnesses="%HARNESSES%"
     local install_targets="%INSTALL_TARGETS% --all --auto"
 
@@ -103,6 +103,15 @@ _deja_completion() {
             ;;
         index)
             COMPREPLY=( $(compgen -W "--rebuild -rebuild" -- "$cur") )
+            ;;
+        instructions)
+            if (( COMP_CWORD == 2 )); then
+                COMPREPLY=( $(compgen -W "example apply export resolve hook install" -- "$cur") )
+            elif [[ "$prev" == "--store" ]]; then
+                COMPREPLY=( $(compgen -f -- "$cur") )
+            else
+                COMPREPLY=( $(compgen -W "--store --help" -- "$cur") )
+            fi
             ;;
         install|uninstall)
             COMPREPLY=( $(compgen -W "$install_targets --no-guidance" -- "$cur") )
@@ -185,6 +194,7 @@ _deja() {
     'help:print the command reference'
     'index:build or refresh the index'
     'install:wire deja into an agent'
+    'instructions:resolve approved operating instructions (experimental)'
     'last:list recent sessions'
     'brief:the screen bare deja prints on a terminal'
     'log:show what deja served to agents'
@@ -244,6 +254,13 @@ _deja() {
     index)
       _arguments '--rebuild[force a full rebuild]' '-rebuild[force a full rebuild]'
       ;;
+    instructions)
+      if (( CURRENT == 3 )); then
+        _values 'instruction action' example apply export resolve hook install
+      else
+        _arguments '--store=[approved registry]:path:_files' '--help[show instruction help]'
+      fi
+      ;;
     install|uninstall)
       _arguments '--no-guidance[skip guidance files]' "1:target:($install_targets)"
       ;;
@@ -288,7 +305,7 @@ const fishCompletion = `function __deja_needs_command
     test (count (commandline -opc)) -eq 1
 end
 
-complete -c deja -n '__deja_needs_command' -a 'blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
+complete -c deja -n '__deja_needs_command' -a 'blame bench brief check completion ctx doctor embed files fix forget friction handoff help how index install instructions last log mcp promote remember restore resume search share show sources stats statusline sync uninstall update version view warmup'
 complete -c deja -n '__deja_needs_command' -l json -d 'Print JSON'
 complete -c deja -n '__deja_needs_command' -l re -d 'Interpret query as a regular expression'
 complete -c deja -n '__deja_needs_command' -l all -d 'Include all results'
@@ -301,6 +318,10 @@ complete -c deja -n '__deja_needs_command' -l session -r
 complete -c deja -n '__deja_needs_command' -l rebuild
 complete -c deja -n '__deja_needs_command' -l limit -r -d 'Max sessions to return (1-100)'
 complete -c deja -n '__fish_seen_subcommand_from search' -l limit -r -d 'Max sessions to return (1-100)'
+
+complete -c deja -n '__fish_seen_subcommand_from instructions; and test (count (commandline -opc)) -eq 2' -a 'example apply export resolve hook install'
+complete -c deja -n '__fish_seen_subcommand_from instructions' -l store -r -F
+complete -c deja -n '__fish_seen_subcommand_from instructions' -l help
 
 complete -c deja -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish powershell pwsh'
 complete -c deja -n '__fish_seen_subcommand_from blame' -l all
@@ -328,8 +349,8 @@ complete -c deja -n '__fish_seen_subcommand_from handoff' -l exec
 complete -c deja -n '__fish_seen_subcommand_from hook-context' -l plain
 complete -c deja -n '__fish_seen_subcommand_from hook-context' -l once
 complete -c deja -n '__fish_seen_subcommand_from index' -l rebuild
-complete -c deja -n '__fish_seen_subcommand_from install uninstall' -a '%INSTALL_TARGETS% --all --auto'
-complete -c deja -n '__fish_seen_subcommand_from install uninstall' -l no-guidance
+complete -c deja -n '__fish_seen_subcommand_from install uninstall; and not __fish_seen_subcommand_from instructions' -a '%INSTALL_TARGETS% --all --auto'
+complete -c deja -n '__fish_seen_subcommand_from install uninstall; and not __fish_seen_subcommand_from instructions' -l no-guidance
 complete -c deja -n '__fish_seen_subcommand_from show' -l json
 complete -c deja -n '__fish_seen_subcommand_from show' -l harness -r -a '%HARNESSES%'
 complete -c deja -n '__fish_seen_subcommand_from show' -l offset -r
@@ -353,8 +374,8 @@ complete -c deja -n '__fish_seen_subcommand_from stats' -l project -r
 complete -c deja -n '__fish_seen_subcommand_from stats' -l since -r
 complete -c deja -n '__fish_seen_subcommand_from stats' -l role -r -a '%ROLES%'
 complete -c deja -n '__fish_seen_subcommand_from sync; and not __fish_seen_subcommand_from export import ssh' -a 'export import ssh'
-complete -c deja -n '__fish_seen_subcommand_from export' -l full
-complete -c deja -n '__fish_seen_subcommand_from export' -F
+complete -c deja -n '__fish_seen_subcommand_from export; and not __fish_seen_subcommand_from instructions' -l full
+complete -c deja -n '__fish_seen_subcommand_from export; and not __fish_seen_subcommand_from instructions' -F
 complete -c deja -n '__fish_seen_subcommand_from import' -F
 complete -c deja -n '__fish_seen_subcommand_from ssh' -l pull
 complete -c deja -n '__fish_seen_subcommand_from ssh' -l full
@@ -367,7 +388,7 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
     $commands = @(
         'blame', 'bench', 'brief', 'check', 'completion', 'ctx', 'doctor', 'embed',
         'files', 'fix', 'forget', 'friction', 'handoff', 'help', 'how',
-        'index', 'install', 'last', 'log', 'mcp', 'promote', 'remember',
+        'index', 'install', 'instructions', 'last', 'log', 'mcp', 'promote', 'remember',
         'restore', 'resume', 'search', 'share', 'show', 'sources', 'stats',
         'statusline', 'sync', 'uninstall', 'update', 'version', 'view', 'warmup'
     )
@@ -415,6 +436,10 @@ Register-ArgumentCompleter -Native -CommandName deja -ScriptBlock {
                 else { @('--to', '--exec') }
             }
             'hook-context' { @('--plain', '--once') }
+            'instructions' {
+                if ($argumentPosition -eq 1) { @('example', 'apply', 'export', 'resolve', 'hook', 'install') }
+                else { @('--store', '--help') }
+            }
             'index' { @('--rebuild', '-rebuild') }
             { $_ -in @('install', 'uninstall') } { $installTargets + @('--no-guidance') }
             'last' {

--- a/cmd/deja/hook_context.go
+++ b/cmd/deja/hook_context.go
@@ -329,6 +329,10 @@ func runHookContext(dir string, plain bool) error {
 // harness that has no session-start channel and has to carry the digest on its
 // per-prompt hook.
 func runHookContextMode(dir string, plain, once bool) error {
+	return runHookContextIO(dir, plain, once, os.Stdin, os.Stdout)
+}
+
+func runHookContextIO(dir string, plain, once bool, stdin io.Reader, stdout io.Writer) error {
 	// A session start is the one moment deja is guaranteed to run on every
 	// harness, which makes it the only reliable place to repair wiring left
 	// behind by an older binary. It costs one small file read when nothing
@@ -366,7 +370,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 	// cannot decode carries the session this injection went to, and losing it
 	// without a word left the audit log unable to tell that case from a host
 	// that sent nothing at all (#2161).
-	payload := readHookStdin()
+	payload := readHookPayload(stdin, hookStdinWait)
 	unreadable := len(bytes.TrimSpace(payload)) > 0 && json.Unmarshal(payload, &input) != nil
 	input.SessionID = adoptGrok(adoptGrok(input.SessionID, input.grokEnvelope.SessionID), input.ConversationID)
 	if once {
@@ -376,7 +380,15 @@ func runHookContextMode(dir string, plain, once bool) error {
 		if sessionHadDigest(dir, input.SessionID) {
 			return nil
 		}
-		rememberSessionDigest(dir, input.SessionID)
+		if shared, ok := stdout.(*sharedRecallOutput); ok {
+			defer func() {
+				if !shared.omitted {
+					rememberSessionDigest(dir, input.SessionID)
+				}
+			}()
+		} else {
+			rememberSessionDigest(dir, input.SessionID)
+		}
 	}
 	input.WorkspaceRoots = adoptGrokRoots(input.WorkspaceRoots, input.WorkspaceRoot)
 	// The harness tells us which project this is; deja read only the
@@ -393,6 +405,9 @@ func runHookContextMode(dir string, plain, once bool) error {
 		// stood here is what taught it to.
 		if env, from := environmentBlockFrom(dir, policy.ActivationAuto); env != "" {
 			out := frameRecall(env)
+			if !allowHookContext(stdout, out) {
+				return nil
+			}
 			// The block is about the machine and names no project, so without
 			// the projects behind its walls a forget of one of them could not
 			// reach the stored text (#2349).
@@ -402,7 +417,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 				usage.RecordDigestPolicyFrom(dir, usage.KindHook, out, input.SessionID, 0, 0, from, policy.Load().Describe(policy.ActivationAuto))
 			}
 			if plain {
-				fmt.Fprintln(os.Stdout, out)
+				fmt.Fprintln(stdout, out)
 				return nil
 			}
 			var resp sessionStartHookResponse
@@ -417,7 +432,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 			// like (#3065).
 			resp.SystemMessage = joinNotes(resp.SystemMessage, joinNotes(builtNote(dir), weekNote(dir)))
 			if b, err := json.Marshal(resp); err == nil {
-				fmt.Fprintln(os.Stdout, string(b))
+				fmt.Fprintln(stdout, string(b))
 			}
 			return nil
 		}
@@ -451,7 +466,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 				resp.HookSpecificOutput.HookEventName = "SessionStart"
 				resp.SystemMessage = line
 				if b, err := json.Marshal(resp); err == nil {
-					fmt.Fprintln(os.Stdout, string(b))
+					fmt.Fprintln(stdout, string(b))
 				}
 			}
 		}
@@ -475,6 +490,9 @@ func runHookContextMode(dir string, plain, once bool) error {
 		digest += "\n" + tip
 	}
 	digest = frameRecall(digest)
+	if !allowHookContext(stdout, digest) {
+		return nil
+	}
 	polName := policy.Load().Describe(policy.ActivationAuto)
 	if unreadable {
 		usage.RecordDigestPolicySessionsUnread(dir, usage.KindHook, digest, input.SessionID, sessions, raw, polName, servedIDs, servedProjects)
@@ -490,7 +508,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 	// prompt about what the start just mentioned got nothing back.
 	rememberInjectedIDsFor(dir, sessionStartKeyPrefix+input.SessionID, hookProjectKey(hookProjectPath(input.CWD, input.WorkspaceRoots)), servedIDs)
 	if plain {
-		fmt.Fprintln(os.Stdout, digest)
+		fmt.Fprintln(stdout, digest)
 		return nil
 	}
 	var resp sessionStartHookResponse
@@ -589,7 +607,7 @@ func runHookContextMode(dir string, plain, once bool) error {
 	if err != nil {
 		return nil
 	}
-	fmt.Fprintln(os.Stdout, string(b))
+	fmt.Fprintln(stdout, string(b))
 	return nil
 }
 

--- a/cmd/deja/hook_nudge.go
+++ b/cmd/deja/hook_nudge.go
@@ -30,6 +30,8 @@ import (
 
 const nudgeGap = 20 * time.Minute
 
+const failureNudgeText = "The user just said an approach did not hold. Dead ends are the one thing this store never records — if that is what happened, save it now with `deja remember \"<what was tried, why it failed>\"`, in one line, before moving on."
+
 // failureNudge returns the line to add when the user has just reported backing
 // something out, or "" for the silence that is the default.
 func failureNudge(dir, prompt string) string {
@@ -39,7 +41,7 @@ func failureNudge(dir, prompt string) string {
 	if !nudgeDue(dir) {
 		return ""
 	}
-	return "The user just said an approach did not hold. Dead ends are the one thing this store never records — if that is what happened, save it now with `deja remember \"<what was tried, why it failed>\"`, in one line, before moving on."
+	return failureNudgeText
 }
 
 // reportsFailure reads the user's own words, line by line, using the same rule
@@ -57,14 +59,25 @@ func reportsFailure(prompt string) bool {
 // prompt hook is paid on every message, and advice repeated on every message
 // is noise within a minute.
 func nudgeDue(dir string) bool {
+	if !nudgeAvailable(dir) {
+		return false
+	}
+	markNudge(dir)
+	return true
+}
+
+func nudgeAvailable(dir string) bool {
 	p := dir + ".nudge"
 	if b, err := os.ReadFile(p); err == nil {
 		if ts, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64); err == nil && time.Since(time.Unix(ts, 0)) < nudgeGap {
 			return false
 		}
 	}
-	_ = os.WriteFile(p, []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
 	return true
+}
+
+func markNudge(dir string) {
+	_ = os.WriteFile(dir+".nudge", []byte(strconv.FormatInt(time.Now().Unix(), 10)), 0o600)
 }
 
 // emitNudgeOnly writes the nudge when there is no recall to carry it. It
@@ -74,6 +87,9 @@ func emitNudgeOnly(stdout io.Writer, plain bool, nudge string) error {
 		return nil
 	}
 	out := frameRecall(nudge)
+	if !allowHookContext(stdout, out) {
+		return nil
+	}
 	if plain {
 		fmt.Fprintln(stdout, out)
 		return nil

--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -177,7 +177,7 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 	// with the host's reminder appended is still the question, and the
 	// reminder's own words are not what to search for (#3156).
 	asked := digest.StripHarnessBlocks(string(input.Prompt))
-	nudge := failureNudge(dir, asked)
+	nudge := failureNudgeForOutput(dir, asked, stdout)
 	// Nobody asked. A harness delivers its own plumbing as the next user turn —
 	// a finished background task, a system reminder, a slash command's envelope
 	// — and the hook fires on it like a question. The terms are then the
@@ -501,6 +501,9 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 		return emitNudgeOnly(stdout, plain, nudge)
 	}
 	out := frameRecall(body)
+	if !allowHookContext(stdout, out) {
+		return nil
+	}
 	rememberInjectedIDs(dir, input.SessionID, blockFingerprint(body))
 	// Stamped, because the question is answered again once the window passes,
 	// where a block fingerprint holds for the life of the session.

--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -169,9 +169,12 @@ func runHookToolMode(dir string, stdin io.Reader, stdout io.Writer, shape hookTo
 	if alreadyInjected(dir, input.SessionID)[token] {
 		return nil
 	}
-	rememberInjectedIDs(dir, input.SessionID, token)
 	line = truncateToolLine(line, toolHookMaxBytes)
 	out := frameRecall(line)
+	if !allowHookContext(stdout, out) {
+		return nil
+	}
+	rememberInjectedIDs(dir, input.SessionID, token)
 	// Record the injection so deja's most frequent surface is not invisible to
 	// stats and the receipt. Deduped above, so this counts a distinct fact
 	// served, not every action.

--- a/cmd/deja/install.go
+++ b/cmd/deja/install.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/instructions"
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
@@ -1658,10 +1659,20 @@ func hookCommandKindOf(existing any, cmd string) hookCommandKind {
 	if !ok || s == "" {
 		return hookNotDejas
 	}
+	sub := cmd[strings.LastIndex(cmd, " ")+1:]
+	// An opt-in instruction-store tail belongs to the ordinary deja hook. It
+	// must be stripped before ownership is checked, then preserved if this
+	// install repoints the executable. Malformed shell-looking tails are not
+	// accepted: a reader's command is safer left alone than guessed at.
+	if base, _, _, hasInstructions := instructions.StripInstructionSuffix(s); hasInstructions {
+		s = base
+		if instructions.IsBareHookCommand(s, sub) {
+			return hookDejas
+		}
+	}
 	if s == cmd {
 		return hookDejas
 	}
-	sub := cmd[strings.LastIndex(cmd, " ")+1:]
 	for i := 0; i < len(s); {
 		j := strings.Index(s[i:], " "+sub)
 		if j < 0 {
@@ -1678,6 +1689,21 @@ func hookCommandKindOf(existing any, cmd string) hookCommandKind {
 		i = end
 	}
 	return hookNotDejas
+}
+
+// preserveInstructionSuffix carries a validated opt-in instruction registry
+// through a normal deja reinstall. It intentionally returns the ordinary
+// command when the old command has no canonical suffix.
+func preserveInstructionSuffix(existing, command string) string {
+	_, store, agent, ok := instructions.StripInstructionSuffix(existing)
+	if !ok {
+		return command
+	}
+	combined, err := instructions.WithInstructionSuffix(command, store, agent)
+	if err != nil {
+		return command
+	}
+	return combined
 }
 
 // isDejaHookCommand reports whether deja's hook runs in this command at all,
@@ -1837,7 +1863,15 @@ func updateClaudeHook(root map[string]any, event, cmd, matcher string, uninstall
 				// rather than adding a second one: installing from a new path
 				// used to leave the old entry behind, and both would fire.
 				found = true
-				h["command"] = cmd
+				existing, _ := h["command"].(string)
+				integrated := false
+				if _, _, _, integrated = instructions.StripInstructionSuffix(existing); integrated && event == "PreToolUse" {
+					// The instruction installer has already split any foreign
+					// matcher group. Its combined handler must see every tool so
+					// path-scoped constraints can decide for themselves.
+					matcher = ""
+				}
+				h["command"] = preserveInstructionSuffix(existing, cmd)
 				if msg := hookStatusMessage(event); msg != "" {
 					h["statusMessage"] = msg
 				}

--- a/cmd/deja/install_auto.go
+++ b/cmd/deja/install_auto.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vshulcz/deja-vu/internal/instructions"
 	"github.com/vshulcz/deja-vu/internal/sources"
 )
 
@@ -103,16 +104,26 @@ func updateCodexHook(root map[string]any, event, cmd, matcher string, uninstall 
 				continue
 			}
 			found = true
+			integrated := event == "PreToolUse" && entryHasIntegratedHook(entry, cmd)
 			adoptCodexHookEntry(entry, cmd, event)
 			// The matcher is part of the wiring, not a user setting, so an
 			// upgrade has to rewrite it: the SessionStart entry written when
 			// this meant "startup|resume" went on missing every compaction
 			// through any number of installs, because adopting it left the
 			// pattern alone.
-			if matcher == "" {
-				delete(entry, "matcher")
-			} else {
-				entry["matcher"] = matcher
+			entryMatcher := matcher
+			if integrated {
+				entryMatcher = ""
+			}
+			// A matcher belongs to the group, so never change one that also
+			// governs a reader's handler. The instruction installer splits
+			// those groups before it asks normal install to adopt them.
+			if entryHasOnlyOwnedHook(entry, cmd) {
+				if entryMatcher == "" {
+					delete(entry, "matcher")
+				} else {
+					entry["matcher"] = entryMatcher
+				}
 			}
 		}
 		kept = append(kept, entryAny)
@@ -163,11 +174,35 @@ func adoptCodexHookEntry(entry map[string]any, cmd, event string) {
 		if h == nil || h["type"] != "command" || hookCommandKindOf(h["command"], cmd) != hookDejas {
 			continue
 		}
-		h["command"] = cmd
+		existing, _ := h["command"].(string)
+		h["command"] = preserveInstructionSuffix(existing, cmd)
 		if msg := hookStatusMessage(event); msg != "" {
 			h["statusMessage"] = msg
 		}
 	}
+}
+
+func entryHasIntegratedHook(entry map[string]any, cmd string) bool {
+	for _, hAny := range entry["hooks"].([]any) {
+		h, _ := hAny.(map[string]any)
+		command, _ := h["command"].(string)
+		if hookCommandKindOf(command, cmd) != hookDejas {
+			continue
+		}
+		if _, _, _, ok := instructions.StripInstructionSuffix(command); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func entryHasOnlyOwnedHook(entry map[string]any, cmd string) bool {
+	hs, _ := entry["hooks"].([]any)
+	if len(hs) != 1 {
+		return false
+	}
+	h, _ := hs[0].(map[string]any)
+	return h != nil && hookCommandKindOf(h["command"], cmd) == hookDejas
 }
 
 // entryHasCommand matches on the trailing subcommand rather than the whole

--- a/cmd/deja/install_instructions_shared_test.go
+++ b/cmd/deja/install_instructions_shared_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/instructions"
+)
+
+func TestAutomaticHooksKeepInstructionStoreInEitherInstallOrder(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("instruction hook installer supports macOS/Linux only")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name, agent string
+		path        func(string) string
+		install     func(string, bool) (installResult, error)
+	}{
+		{"claude", "claude", func(home string) string { return filepath.Join(home, ".claude", "settings.json") }, installClaudeHook},
+		{"codex", "codex", func(home string) string { return filepath.Join(home, ".codex", "hooks.json") }, installCodexHooks},
+	} {
+		for _, instructionsFirst := range []bool{false, true} {
+			order := "auto-then-instructions"
+			if instructionsFirst {
+				order = "instructions-then-auto"
+			}
+			t.Run(tc.name+"/"+order, func(t *testing.T) {
+				home := sharedHookTestHome(t)
+				path := tc.path(home)
+				store := filepath.Join(home, "approved registry's copy.json")
+				installAuto := func() {
+					if _, err := tc.install(exe, false); err != nil {
+						t.Fatalf("automatic install: %v", err)
+					}
+				}
+				installInstructions := func() {
+					if _, err := instructions.Install(tc.agent, path, exe, store); err != nil {
+						t.Fatalf("instruction install: %v", err)
+					}
+				}
+				if instructionsFirst {
+					installInstructions()
+					installAuto()
+				} else {
+					installAuto()
+					installInstructions()
+				}
+				// A later ordinary `deja install <agent>-auto` must adopt its old
+				// command instead of dropping the explicit opt-in registry.
+				installAuto()
+				root := readSharedHookConfig(t, path)
+				for event, sub := range map[string]string{
+					"SessionStart": "hook-context", "UserPromptSubmit": "hook-prompt", "PreToolUse": "hook-tool",
+				} {
+					handlers := matchingSharedHandlers(root, event, sub)
+					if len(handlers) != 1 {
+						t.Fatalf("%s %s handlers = %#v", tc.name, event, handlers)
+					}
+					if _, gotStore, gotAgent, ok := instructions.StripInstructionSuffix(handlers[0]["command"].(string)); !ok || gotStore != store || gotAgent != tc.agent {
+						t.Fatalf("%s %s lost the instruction store: %#v", tc.name, event, handlers[0])
+					}
+				}
+				if subagent := matchingSharedHandlers(root, "SubagentStart", "instructions hook"); len(subagent) != 1 {
+					t.Fatalf("%s SubagentStart handlers = %#v", tc.name, subagent)
+				}
+				if tc.agent == "codex" {
+					for _, handler := range matchingSharedHandlers(root, "SessionStart", "hook-context") {
+						if limit, ok := handler["additionalContextLimit"].(float64); !ok || limit != 0 {
+							t.Fatalf("codex instruction context limit = %#v", handler["additionalContextLimit"])
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestInstructionInstallSplitsThirdPartyPreToolMatcher(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("instruction hook installer supports macOS/Linux only")
+	}
+	home := sharedHookTestHome(t)
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"deja hook-tool"},{"type":"command","command":"third-party"}]}]}}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := instructions.Install("claude", path, exe, filepath.Join(home, "approved.json")); err != nil {
+		t.Fatal(err)
+	}
+	root := readSharedHookConfig(t, path)
+	pre := root["hooks"].(map[string]any)["PreToolUse"].([]any)
+	var foreignMatcher, unfiltered bool
+	for _, groupAny := range pre {
+		group := groupAny.(map[string]any)
+		commands := groupHookCommands(group)
+		if strings.Contains(strings.Join(commands, "\n"), "third-party") && group["matcher"] == "Bash" {
+			foreignMatcher = true
+		}
+		if strings.Contains(strings.Join(commands, "\n"), "hook-tool") {
+			_, hasMatcher := group["matcher"]
+			unfiltered = !hasMatcher
+		}
+	}
+	if !foreignMatcher || !unfiltered {
+		t.Fatalf("PreToolUse did not preserve foreign matcher and widen ours: %#v", pre)
+	}
+}
+
+func TestAutomaticPreToolMatcherWidensOnlyForIntegratedInstructions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("instruction hook installer supports macOS/Linux only")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, agent, wantMatcher string
+		path                     func(string) string
+		install                  func(string, bool) (installResult, error)
+	}{
+		{"claude", "claude", "Bash|Edit|Write|MultiEdit|NotebookEdit|Task|Agent", func(home string) string { return filepath.Join(home, ".claude", "settings.json") }, installClaudeHook},
+		{"codex", "codex", "Bash|apply_patch", func(home string) string { return filepath.Join(home, ".codex", "hooks.json") }, installCodexHooks},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := sharedHookTestHome(t)
+			path := tc.path(home)
+			if _, err := tc.install(exe, false); err != nil {
+				t.Fatal(err)
+			}
+			if matcher := preToolMatcherFor(t, readSharedHookConfig(t, path), false); matcher != tc.wantMatcher {
+				t.Fatalf("default PreToolUse matcher = %q, want %q", matcher, tc.wantMatcher)
+			}
+			if _, err := instructions.Install(tc.agent, path, exe, filepath.Join(home, "approved.json")); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tc.install(exe, false); err != nil {
+				t.Fatal(err)
+			}
+			if matcher := preToolMatcherFor(t, readSharedHookConfig(t, path), true); matcher != "" {
+				t.Fatalf("integrated PreToolUse matcher = %q, want unfiltered", matcher)
+			}
+		})
+	}
+}
+
+func sharedHookTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("DEJA_CLAUDE_ROOT", "")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude"))
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(home, ".codex"))
+	return home
+}
+
+func readSharedHookConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(b, &root); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func matchingSharedHandlers(root map[string]any, event, contains string) []map[string]any {
+	var out []map[string]any
+	hooks, _ := root["hooks"].(map[string]any)
+	for _, groupAny := range hooks[event].([]any) {
+		for _, handlerAny := range groupAny.(map[string]any)["hooks"].([]any) {
+			handler, _ := handlerAny.(map[string]any)
+			command, _ := handler["command"].(string)
+			if strings.Contains(command, contains) {
+				out = append(out, handler)
+			}
+		}
+	}
+	return out
+}
+
+func groupHookCommands(group map[string]any) []string {
+	var out []string
+	for _, handlerAny := range group["hooks"].([]any) {
+		if handler, _ := handlerAny.(map[string]any); handler != nil {
+			if command, _ := handler["command"].(string); command != "" {
+				out = append(out, command)
+			}
+		}
+	}
+	return out
+}
+
+func preToolMatcherFor(t *testing.T, root map[string]any, integrated bool) string {
+	t.Helper()
+	hooks := root["hooks"].(map[string]any)
+	for _, groupAny := range hooks["PreToolUse"].([]any) {
+		group := groupAny.(map[string]any)
+		for _, command := range groupHookCommands(group) {
+			if !strings.Contains(command, "hook-tool") {
+				continue
+			}
+			_, _, _, hasSuffix := instructions.StripInstructionSuffix(command)
+			if hasSuffix == integrated {
+				matcher, _ := group["matcher"].(string)
+				return matcher
+			}
+		}
+	}
+	t.Fatalf("no PreToolUse hook with integrated=%t", integrated)
+	return ""
+}

--- a/cmd/deja/instructions.go
+++ b/cmd/deja/instructions.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"github.com/vshulcz/deja-vu/internal/instructions"
+)
+
+func init() {
+	commands["instructions"] = func(_ string, args []string) error {
+		return instructions.Run(args, os.Stdin, os.Stdout)
+	}
+	// Experimental, opt-in, documented in its own help and guide until full
+	// repository and real-harness delivery validation has been completed.
+	helpHidden["instructions"] = true
+	worksWithNoHome["instructions"] = true // the independent store validates its path
+}

--- a/cmd/deja/instructions_dispatch_test.go
+++ b/cmd/deja/instructions_dispatch_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInstructionsDispatch(t *testing.T) {
+	handler, ok := commands["instructions"]
+	if !ok {
+		t.Fatal("instructions command is not registered")
+	}
+	err := handler("unused-index-directory", []string{"not-a-command"})
+	if err == nil || !strings.Contains(err.Error(), "unknown instructions command") {
+		t.Fatalf("instructions did not reach its independent dispatcher: %v", err)
+	}
+	if !worksWithNoHome["instructions"] {
+		t.Fatal("independent instruction store is blocked by the history-index home guard")
+	}
+}

--- a/cmd/deja/instructions_once_test.go
+++ b/cmd/deja/instructions_once_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/instructions"
+)
+
+func TestSharedOnceRetriesSessionStartRecallAfterBudgetReject(t *testing.T) {
+	tmp := hermeticEnv(t)
+	work := filepath.Join(tmp, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workJSON, err := json.Marshal(work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), encodedProjectDir(work), "prior.jsonl"), "prior", []string{
+		`{"type":"user","sessionId":"prior","cwd":` + string(workJSON) + `,"timestamp":"` + at + `","message":{"role":"user","content":"budget-retry-marker records the session-start decision"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"hook_event_name": "SessionStart",
+		"session_id":      "once-budget",
+		"cwd":             work,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocked := &sharedRecallOutput{budget: 0}
+	if err := runHookContextIO(index.DefaultDir(), false, true, strings.NewReader(string(payload)), blocked); err != nil {
+		t.Fatal(err)
+	}
+	if !blocked.omitted || blocked.Len() != 0 {
+		t.Fatalf("rejected recall = %#v", blocked)
+	}
+	if sessionHadDigest(index.DefaultDir(), "once-budget") {
+		t.Fatal("an omitted shared recall consumed the once-per-session delivery")
+	}
+
+	delivered := &sharedRecallOutput{budget: instructions.DefaultBudget}
+	if err := runHookContextIO(index.DefaultDir(), false, true, strings.NewReader(string(payload)), delivered); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(delivered.String(), "budget-retry-marker") {
+		t.Fatalf("same session did not retry the admitted recall: %s", delivered.String())
+	}
+	if !sessionHadDigest(index.DefaultDir(), "once-budget") {
+		t.Fatal("an admitted recall did not consume the once-per-session delivery")
+	}
+}

--- a/cmd/deja/instructions_shared.go
+++ b/cmd/deja/instructions_shared.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/instructions"
+)
+
+// runSharedInstructionHook is selected only by explicitly installed flags. The
+// payload is read once and both resolvers run in this process. Ordinary hooks
+// retain their existing fast path, output formats and budgets.
+func runSharedInstructionHook(dir, event string, args []string, stdin io.Reader, stdout io.Writer) (bool, error) {
+	enabled := false
+	for _, arg := range args {
+		if arg == "--instructions-store" || arg == "--instructions-agent" || strings.HasPrefix(arg, "--instructions-store=") || strings.HasPrefix(arg, "--instructions-agent=") {
+			enabled = true
+		}
+	}
+	if !enabled {
+		return false, nil
+	}
+	f := flag.NewFlagSet("shared instruction hook", flag.ContinueOnError)
+	f.SetOutput(io.Discard)
+	store := f.String("instructions-store", "", "approved registry")
+	agent := f.String("instructions-agent", "", "claude or codex")
+	var plain, once bool
+	f.BoolVar(&plain, "plain", false, "plain output")
+	f.BoolVar(&once, "once", false, "once per session")
+	if err := f.Parse(args); err != nil {
+		return true, err
+	}
+	if f.NArg() != 0 || !filepath.IsAbs(*store) || filepath.Clean(*store) != *store || (*agent != "claude" && *agent != "codex") {
+		return true, fmt.Errorf("shared instructions require a clean absolute --instructions-store and --instructions-agent claude|codex")
+	}
+	raw := readHookPayload(stdin, hookStdinWait)
+	var approved bytes.Buffer
+	recall := sharedRecallOutput{budget: instructions.DefaultBudget}
+	err := instructions.Hook(instructions.FileStore{Path: *store}, *agent, os.Getenv("DEJA_TASK_ID"), os.Getenv("DEJA_ENVIRONMENT"), bytes.NewReader(raw), &approved, time.Now())
+	if err != nil {
+		return true, err
+	}
+	var packet struct {
+		SystemMessage string `json:"systemMessage"`
+		Specific      struct {
+			Context string `json:"additionalContext"`
+		} `json:"hookSpecificOutput"`
+	}
+	if approved.Len() > 0 {
+		if err := json.Unmarshal(approved.Bytes(), &packet); err != nil {
+			return true, err
+		}
+	}
+	text := packet.Specific.Context
+	if text == "" {
+		text = packet.SystemMessage
+	}
+	if text != "" {
+		recall.budget -= min(len(text), instructions.DefaultBudget) + 1
+	}
+	switch event {
+	case "SessionStart":
+		err = runHookContextIO(dir, false, once, bytes.NewReader(raw), &recall)
+	case "UserPromptSubmit":
+		err = runHookPromptMode(dir, bytes.NewReader(raw), &recall, false)
+	case "PreToolUse":
+		err = runHookToolMode(dir, bytes.NewReader(raw), &recall, hookToolClaude)
+	default:
+		return true, fmt.Errorf("unsupported shared hook event %q", event)
+	}
+	if err != nil {
+		return true, err
+	}
+	if recall.omitted && recall.Len() == 0 {
+		if err := json.NewEncoder(&recall).Encode(map[string]string{"systemMessage": sharedRecallOmitted}); err != nil {
+			return true, err
+		}
+	}
+	return true, emitSharedInstructionContext(event, recall.Bytes(), approved.Bytes(), stdout, plain)
+}
+
+// Required instructions get the context budget first. Recall is omitted as a
+// whole if it does not fit: neither approved rules nor a framed recall block is
+// cut in half. Preserve other hook fields, including tool-input updates and UI
+// messages, while emitting exactly one response.
+func emitSharedInstructionContext(event string, recall, approved []byte, out io.Writer, plain bool) error {
+	response := map[string]any{}
+	if len(bytes.TrimSpace(recall)) > 0 {
+		decoder := json.NewDecoder(bytes.NewReader(recall))
+		decoder.UseNumber()
+		if err := decoder.Decode(&response); err != nil {
+			return err
+		}
+	}
+	instruction := map[string]any{}
+	if len(bytes.TrimSpace(approved)) > 0 {
+		if err := json.Unmarshal(approved, &instruction); err != nil {
+			return err
+		}
+	}
+	specific, _ := response["hookSpecificOutput"].(map[string]any)
+	if specific == nil {
+		specific = map[string]any{}
+	}
+	extra, _ := instruction["hookSpecificOutput"].(map[string]any)
+	ruleText, _ := extra["additionalContext"].(string)
+	history, _ := specific["additionalContext"].(string)
+	notice, _ := response["systemMessage"].(string)
+	warning, _ := instruction["systemMessage"].(string)
+	if ruleText == "" && warning != "" {
+		ruleText = warning
+	}
+	if len(ruleText) > instructions.DefaultBudget {
+		ruleText = "Deja instruction context INCOMPLETE: warning exceeds the context budget. Resolve the registry before relying on remembered instructions; this hook has not blocked the action."
+		warning = ruleText
+	}
+	context := ruleText
+	if history != "" {
+		joined := joinNotes(ruleText, history)
+		if len(joined) <= instructions.DefaultBudget {
+			context = joined
+		} else {
+			notice = joinNotes(notice, sharedRecallOmitted)
+		}
+	}
+	notice = joinNotes(warning, notice)
+	if notice != "" {
+		response["systemMessage"] = notice
+	}
+	if context != "" || len(specific) > 0 {
+		specific["hookEventName"] = event
+		specific["additionalContext"] = context
+		response["hookSpecificOutput"] = specific
+	}
+	if plain {
+		_, err := io.WriteString(out, context)
+		return err
+	}
+	if len(response) == 0 {
+		return nil
+	}
+	return json.NewEncoder(out).Encode(response)
+}
+
+const sharedRecallOmitted = "Deja omitted recalled history to keep approved instructions within the shared context budget."
+
+// Admission happens before a history producer records or deduplicates a block.
+// Otherwise an omitted block would be recorded as served and disappear on the
+// next prompt even after there was room to deliver it.
+type sharedRecallOutput struct {
+	bytes.Buffer
+	budget   int
+	omitted  bool
+	nudgeDir string
+}
+
+func allowHookContext(out io.Writer, text string) bool {
+	if shared, ok := out.(*sharedRecallOutput); ok {
+		if len(text) > shared.budget {
+			shared.omitted = true
+			return false
+		}
+		if shared.nudgeDir != "" && strings.Contains(text, failureNudgeText) {
+			markNudge(shared.nudgeDir)
+			shared.nudgeDir = ""
+		}
+	}
+	return true
+}
+
+func failureNudgeForOutput(dir, prompt string, out io.Writer) string {
+	shared, ok := out.(*sharedRecallOutput)
+	if !ok {
+		return failureNudge(dir, prompt)
+	}
+	if !reportsFailure(prompt) || !nudgeAvailable(dir) {
+		return ""
+	}
+	shared.nudgeDir = dir
+	return failureNudgeText
+}

--- a/cmd/deja/instructions_shared_test.go
+++ b/cmd/deja/instructions_shared_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/vshulcz/deja-vu/internal/index"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/instructions"
+)
+
+func sharedInstructionFixture(t *testing.T) (string, string) {
+	t.Helper()
+	root := hermeticEnv(t)
+	t.Setenv("DEJA_TASK_ID", "")
+	t.Setenv("DEJA_ENVIRONMENT", "")
+	t.Setenv("DEJA_RECALL", "off")
+	// A missing history index must not hide independently approved instructions.
+	store := filepath.Join(root, "approved.json")
+	_, err := (instructions.FileStore{Path: store}).Replace(0, instructions.Snapshot{Version: instructions.Version, Rules: []instructions.Rule{{ID: "shared.required", Revision: 1, Kind: "constraint", Text: "Preserve the approved synthetic fixture.", Authority: "owner", Status: "active", Strength: "must", Lifetime: "persistent", Source: "synthetic test approval"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root, store
+}
+
+func TestSharedInstructionsReachExistingHookCommands(t *testing.T) {
+	for command, event := range map[string]string{"hook-context": "SessionStart", "hook-prompt": "UserPromptSubmit", "hook-tool": "PreToolUse"} {
+		t.Run(command, func(t *testing.T) {
+			root, store := sharedInstructionFixture(t)
+			payload, err := json.Marshal(map[string]any{"hook_event_name": event, "cwd": root, "session_id": "shared-session", "prompt": "ok", "tool_name": "Read", "tool_input": map[string]string{"file_path": "new.go"}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			withHookStdin(t, string(payload))
+			out, err := captureRun(t, command, "--instructions-store", store, "--instructions-agent", "claude")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var response sessionStartHookResponse
+			if err := json.Unmarshal([]byte(out), &response); err != nil {
+				t.Fatalf("one JSON response required: %v: %s", err, out)
+			}
+			if response.HookSpecificOutput.HookEventName != event || strings.Count(response.HookSpecificOutput.AdditionalContext, "shared.required@1") != 1 {
+				t.Fatalf("missing or repeated instructions: %s", out)
+			}
+			if _, err := os.Stat(store); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSharedInstructionContextPreservesRecallAndToolUpdates(t *testing.T) {
+	recall := []byte(`{"systemMessage":"recall receipt","hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"ranked memory","updatedInput":{"prompt":"original child task plus recall","large":9007199254740993},"permissionDecision":"allow"}}`)
+	approved := []byte(`{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"approved required rule"}}`)
+	var out strings.Builder
+	if err := emitSharedInstructionContext("PreToolUse", recall, approved, &out, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "9007199254740993") || !strings.Contains(out.String(), "original child task plus recall") || !strings.Contains(out.String(), `"permissionDecision":"allow"`) {
+		t.Fatalf("changed the existing hook's tool update: %s", out.String())
+	}
+	var response sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out.String()), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.HookSpecificOutput.AdditionalContext != "approved required rule\nranked memory" || response.SystemMessage != "recall receipt" {
+		t.Fatal(out.String())
+	}
+}
+
+func TestSharedInstructionContextBudgetKeepsRequiredRulesWhole(t *testing.T) {
+	required := strings.Repeat("界", 2500)
+	approved, err := json.Marshal(map[string]any{"hookSpecificOutput": map[string]string{"additionalContext": required}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recall, err := json.Marshal(map[string]any{"hookSpecificOutput": map[string]string{"additionalContext": strings.Repeat("history", 200)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	if err := emitSharedInstructionContext("SessionStart", recall, approved, &out, false); err != nil {
+		t.Fatal(err)
+	}
+	var response sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out.String()), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.HookSpecificOutput.AdditionalContext != required || len(response.HookSpecificOutput.AdditionalContext) > instructions.DefaultBudget || !strings.Contains(response.SystemMessage, "omitted recalled history") {
+		t.Fatal("required rules truncated or budget exceeded", out.String())
+	}
+}
+
+func TestSharedInstructionsFailOpenAndRemainOptIn(t *testing.T) {
+	root, store := sharedInstructionFixture(t)
+	var out strings.Builder
+	handled, err := runSharedInstructionHook("unused", "PreToolUse", nil, strings.NewReader("not json"), &out)
+	if handled || err != nil || out.Len() != 0 {
+		t.Fatal("ordinary hook opted in", handled, err, out.String())
+	}
+	for _, payload := range []string{"not json", `{"hook_event_name":"PreToolUse","cwd":"missing"}`} {
+		out.Reset()
+		handled, err = runSharedInstructionHook("unused", "PreToolUse", []string{"--instructions-store", store, "--instructions-agent", "codex"}, strings.NewReader(payload), &out)
+		if !handled || err != nil || !strings.Contains(out.String(), "INCOMPLETE") {
+			t.Fatal(handled, err, out.String())
+		}
+		if strings.Contains(out.String(), "permissionDecision") {
+			t.Fatal("instruction warning made a permission decision", out.String())
+		}
+	}
+	// A missing approved registry must remain visible even when recall is off.
+	if err := os.Remove(store); err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := json.Marshal(map[string]string{"hook_event_name": "PreToolUse", "cwd": root})
+	out.Reset()
+	_, err = runSharedInstructionHook("unused", "PreToolUse", []string{"--instructions-store", store, "--instructions-agent", "claude"}, strings.NewReader(string(payload)), &out)
+	if err != nil || !strings.Contains(out.String(), "cannot load approved registry") {
+		t.Fatal(err, out.String())
+	}
+}
+
+func TestSharedInstructionsAndRealRecallArriveTogether(t *testing.T) {
+	root, store := sharedInstructionFixture(t)
+	t.Setenv("DEJA_RECALL", "")
+	// The sessions and command are synthetic; both the real history producer and
+	// real instruction resolver must contribute to the same response.
+	for _, id := range []string{"shared-a", "shared-b"} {
+		cwdJSON, err := json.Marshal(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeClaudeFixture(t, filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), strings.ReplaceAll(root, string(filepath.Separator), "-"), id+".jsonl"), id, []string{
+			fmt.Sprintf(`{"type":"user","sessionId":%q,"cwd":%s,"timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"the suite keeps failing on the shared fixture"}}`, id, cwdJSON),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"cwd":%s,"timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"go test ./... -count=1"}}]}}`, id, cwdJSON),
+			fmt.Sprintf(`{"type":"assistant","sessionId":%q,"cwd":%s,"timestamp":"2026-01-02T03:06:00Z","message":{"role":"assistant","content":"the suite has to run with -p 1: the shared fixture cannot take parallel packages."}}`, id, cwdJSON),
+		})
+	}
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(map[string]any{"hook_event_name": "PreToolUse", "cwd": root, "session_id": "both", "tool_name": "Bash", "tool_input": map[string]string{"command": "go test ./... -count=1"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Exhaust the shared budget first. This must not mark the history as served:
+	// the same session should receive it once a subsequent approval frees space.
+	registry := instructions.FileStore{Path: store}
+	snapshot, err := registry.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := snapshot.Rules[0].Text
+	snapshot.Rules[0].Revision++
+	snapshot.Rules[0].Text = strings.Repeat("r", 7700)
+	saved, err := registry.Replace(snapshot.Revision, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var omitted strings.Builder
+	handled, err := runSharedInstructionHook(index.DefaultDir(), "PreToolUse", []string{"--instructions-store", store, "--instructions-agent", "claude"}, strings.NewReader(string(payload)), &omitted)
+	if !handled || err != nil || !strings.Contains(omitted.String(), "omitted recalled history") || strings.Contains(omitted.String(), "2 sessions") {
+		t.Fatal(handled, err, omitted.String())
+	}
+	saved.Rules[0].Revision++
+	saved.Rules[0].Text = original
+	if _, err := registry.Replace(saved.Revision, saved); err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	handled, err = runSharedInstructionHook(index.DefaultDir(), "PreToolUse", []string{"--instructions-store", store, "--instructions-agent", "claude"}, strings.NewReader(string(payload)), &out)
+	if !handled || err != nil {
+		t.Fatal(handled, err)
+	}
+	var response sessionStartHookResponse
+	if err := json.Unmarshal([]byte(out.String()), &response); err != nil {
+		t.Fatal(err)
+	}
+	context := response.HookSpecificOutput.AdditionalContext
+	if !strings.Contains(context, "shared.required@3") || !strings.Contains(context, "2 sessions") {
+		t.Fatalf("one producer disappeared: %s", out.String())
+	}
+}
+
+func TestSharedInstructionBudgetDoesNotSpendOmittedNudge(t *testing.T) {
+	root, _ := sharedInstructionFixture(t)
+	t.Setenv("DEJA_RECALL", "")
+	saved := spawnWarmup
+	spawnWarmup = func(_, _ string) error { return nil }
+	t.Cleanup(func() { spawnWarmup = saved })
+	dir := filepath.Join(root, "index.db")
+	payload, err := json.Marshal(map[string]string{"hook_event_name": "UserPromptSubmit", "cwd": root, "session_id": "nudge", "prompt": "ok we rolled back that change"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	omitted := sharedRecallOutput{budget: 0}
+	if err := runHookPromptMode(dir, strings.NewReader(string(payload)), &omitted, false); err != nil {
+		t.Fatal(err)
+	}
+	if !omitted.omitted {
+		t.Fatal("fixture did not try to deliver a nudge")
+	}
+	if _, err := os.Stat(dir + ".nudge"); !os.IsNotExist(err) {
+		t.Fatalf("undelivered nudge consumed timer: %v", err)
+	}
+	delivered := sharedRecallOutput{budget: instructions.DefaultBudget}
+	if err := runHookPromptMode(dir, strings.NewReader(string(payload)), &delivered, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(delivered.String(), "deja remember") {
+		t.Fatal("omitted nudge was lost", delivered.String())
+	}
+	if _, err := os.Stat(dir + ".nudge"); err != nil {
+		t.Fatalf("delivered nudge did not consume timer: %v", err)
+	}
+}

--- a/cmd/deja/main.go
+++ b/cmd/deja/main.go
@@ -221,6 +221,9 @@ var commands = map[string]command{
 		if sayIfTypedByHand("hook-prompt") {
 			return nil
 		}
+		if handled, err := runSharedInstructionHook(dir, "UserPromptSubmit", rest, os.Stdin, os.Stdout); handled {
+			return err
+		}
 		plain := len(rest) > 0 && (rest[0] == "--plain" || rest[0] == "-plain")
 		return runHookPromptMode(dir, os.Stdin, os.Stdout, plain)
 	},
@@ -236,6 +239,9 @@ var commands = map[string]command{
 	"hook-tool": func(dir string, rest []string) error {
 		if sayIfTypedByHand("hook-tool") {
 			return nil
+		}
+		if handled, err := runSharedInstructionHook(dir, "PreToolUse", rest, os.Stdin, os.Stdout); handled {
+			return err
 		}
 		return runHookToolMode(dir, os.Stdin, os.Stdout, hookToolShapeOf(rest))
 	},
@@ -549,6 +555,9 @@ func cmdIndex(dir string, rest []string) error {
 }
 
 func cmdHookContext(dir string, rest []string) error {
+	if handled, err := runSharedInstructionHook(dir, "SessionStart", rest, os.Stdin, os.Stdout); handled {
+		return err
+	}
 	plain := false
 	once := false
 	for _, a := range rest {
@@ -3677,6 +3686,8 @@ Usage:
   deja hook-plan     (PreToolUse ExitPlanMode hook: factual plan/history co-occurrences)
   deja hook-tool [--plain] [--crush]  (PreToolUse Bash/Edit hook: one line on what this command or file already has)
   deja hook-tool-after  (PostToolUse Bash hook: the command that followed this error before)
+  Experimental instruction delivery for hook-context/hook-prompt/hook-tool:
+    --instructions-store <absolute-path> --instructions-agent claude|codex
   deja check -       (read a plan from stdin and print factual co-occurrences)
   deja view [--no-open]  (browse your memory: sessions, recalls, notes — one local HTML)
   deja ctx <query|id-prefix>

--- a/docs/guide/commands.html
+++ b/docs/guide/commands.html
@@ -101,6 +101,7 @@
 <tr><td><code>deja "query"</code></td><td>Search indexed history. Filters: <code>--harness --project --since --role --limit --re --json</code>.</td></tr>
 <tr><td><code>deja show &lt;id&gt;</code></td><td>Read one session. Machine reads use an exact composite identity: <code>--harness name --json</code>, with bounded <code>--offset</code> and <code>--limit</code> message windows.</td></tr>
 <tr><td><code>deja ctx "query"</code></td><td>Print a context digest to stdout (for piping into an agent).</td></tr>
+<tr><td><code>deja instructions &lt;resolve|apply|export|hook|install&gt;</code></td><td>Manage the local approved-instruction registry. Rules resolve by scope and time; <code>apply --approve</code> records an owner-reviewed rule.</td></tr>
 <tr><td><code>deja blame &lt;path&gt;</code></td><td>Sessions that discussed a file, most specific first.</td></tr>
 <tr><td><code>deja files &lt;topic&gt;</code></td><td>Which files were opened or edited while that subject was being worked on, ranked by how specific each one is to it. <code>--project</code>, <code>--limit</code>. Reads the file and command records deja extracts from Claude Code, opencode, Cursor and Codex transcripts.</td></tr>
 <tr><td><code>deja friction</code></td><td>Errors that recur across three or more separate sessions, with the harnesses that hit them and the newest occurrence. Specific failures only — a missing binary, an uninstalled module — not generic <code>Traceback</code> lines. <code>--limit</code>.</td></tr>

--- a/docs/instruction-memory.md
+++ b/docs/instruction-memory.md
@@ -72,17 +72,20 @@ The schema is JSON, version 1. Each rule needs `id`, positive `revision`, `kind`
 | --- | --- |
 | kind | constraint, preference, decision, procedure |
 | authority | owner, project, inferred; inferred records cannot be active |
-| status | candidate, active, revoked |
+| status | candidate, active, superseded, revoked |
 | strength | must, must_not, should; preferences must use should |
 | absolute | Required text; only a current-revision owner-approved exception waives it |
 | priority | -1000 through 1000; ordering/default selection, never a waiver of a must |
 | lifetime | persistent, task, session, ttl |
+| effective_from | Optional RFC3339 start; the rule is excluded as not effective yet before this instant |
+| supersedes | Optional explicit predecessor rule IDs; an applicable successor excludes its predecessor only when it does not weaken an absolute, mandatory, or owner-authored rule. Competing successors remain an explicit conflict |
 | scope | repository, worktree, task, session, environment, path_prefix, tools |
 | source | Original provenance; preserve the original statement and reference |
 | conflict_key + value | Explicit mutually-exclusive setting, such as backend=local |
 | runbook | An absolute local path and lowercase SHA256 for a procedure |
 
-Persistent means until explicitly revised/revoked and forbids an expiry.
+`effective_from` must precede `expires_at` when both are set. Persistent means
+until explicitly revised, superseded, or revoked and forbids an expiry.
 Task/session lifetimes require their matching identity. TTL requires
 `expires_at` in RFC3339. Expiry is inclusive: at that instant it no longer applies.
 Task closure is NOT integrated with a task tracker in v0: clear/change the task

--- a/docs/instruction-memory.md
+++ b/docs/instruction-memory.md
@@ -1,7 +1,7 @@
 # Instruction memory: experimental first pass
 
 This adds `deja instructions`, a separate, opt-in subsystem inside the existing
-binary. History recall remains unchanged. The new command is intentionally
+binary. History ranking remains unchanged. The new command is intentionally
 absent from the general help until full repository and live-harness validation
 is complete; `deja instructions help` describes the experimental interface.
 
@@ -15,15 +15,27 @@ claim to detect contradictions in arbitrary prose.
 
 The same registry can deliver context to Claude Code and Codex at SessionStart,
 UserPromptSubmit, PreToolUse, and SubagentStart. SessionStart also handles
-resume/compact events the harness emits. The installer preserves existing Deja
-history hooks and unrelated configuration. Installation is separate from
-`deja install`, and never bypasses native hook review/trust.
+resume/compact events the harness emits. The opt-in installer attaches approved
+context to `hook-context`, `hook-prompt`, and `hook-tool`, so each event uses one
+Deja process and one combined response. It migrates the previous separate
+instruction hooks and preserves unrelated configuration. `SubagentStart` keeps
+an instruction-only hook because it has no existing history hook. Installation
+is separate from `deja install`, and never bypasses native hook review/trust.
+Reinstalling the normal hooks preserves the explicit instruction opt-in. The
+combined pre-tool hook receives every tool event so tool/path scopes also apply
+to reads; normal history recall still uses its existing relevance gates.
 
-**This is instruction delivery, not enforcement.** Hooks emit no permission
-allow/deny decisions. A delivered runbook is not evidence that it was executed;
+**This is instruction delivery, not enforcement.** Instruction delivery adds no
+permission allow/deny decisions; existing history-hook tool updates are preserved. A delivered runbook is not evidence that it was executed;
 pre-tool injection does not prove the agent reconsidered its pending call.
 Failures produce an INCOMPLETE warning, plus model-visible context for supported
 events, rather than silently pretending that no instructions applied.
+
+Compared with Deja's existing promoted notes, the registry adds path, tool,
+worktree, task, and environment scopes; `must` rules that accumulate rather
+than rank; and effective windows, expiry, and checked supersession. The cost is
+a separate store, CLI, and explicit provenance/approval model. It remains
+advisory delivery, not enforcement.
 
 ## Try it in a scratch configuration first
 
@@ -140,10 +152,13 @@ refuses unresolved conflicts. Nothing extracts/promotes history automatically.
 
 Duplicate JSON keys, unknown record fields, malformed JSON, unsupported schemas,
 relative paths and unbounded inputs are refused. A concurrent approval requires
-a matching registry revision. Process-wide locks refuse competing writers;
-a crashed writer can leave a lock that requires inspection before removal.
-No stale lock is automatically broken. Hook config backups retain exact prior
-bytes, including large numeric values and unrelated hook definitions.
+a matching registry revision. `apply` replaces the entire approved snapshot; it
+does not merge concurrent drafts. If another approval wins the compare-and-swap,
+the loser must reload the current snapshot, reconcile its draft, and reapply it
+deliberately. Process-wide locks refuse competing writers; a crashed writer can
+leave a lock that requires inspection before removal. No stale lock is
+automatically broken. Hook config backups retain exact prior bytes, including
+large numeric values and unrelated hook definitions.
 
 ## Budget, storage and trust boundaries
 
@@ -155,7 +170,11 @@ that cost before scaling this backend. No per-tool history writes occur.
 
 The context budget is 8,000 UTF-8 bytes, not tokens or complete JSON wire bytes.
 All applicable/conditional mandatory text must fit in full or rendering fails.
-Only optional defaults may be omitted, with a count. Repeated injection can add
+Only optional defaults may be omitted, with a count. With shared hooks, approved
+instructions receive that budget first; recalled history is included only when
+the complete block also fits. If it does not fit, a UI note explains its omission.
+Instruction delivery remains enabled when `DEJA_RECALL=off`; that switch controls
+history recall, not the separately approved instruction opt-in. Repeated injection can add
 material context cost; delivery receipts/deduplication with compaction-aware
 invalidation are not implemented yet.
 

--- a/docs/instruction-memory.md
+++ b/docs/instruction-memory.md
@@ -1,0 +1,197 @@
+# Instruction memory: experimental first pass
+
+This adds `deja instructions`, a separate, opt-in subsystem inside the existing
+binary. History recall remains unchanged. The new command is intentionally
+absent from the general help until full repository and live-harness validation
+is complete; `deja instructions help` describes the experimental interface.
+
+## What it does
+
+Approved instructions are resolved deterministically, not ranked alongside
+transcripts. Required rules accumulate. Absolute rules do not decay or lose to
+higher numeric priorities. Preferences are defaults, not permission to waive a
+requirement. Explicit conflict keys detect incompatible settings; this does not
+claim to detect contradictions in arbitrary prose.
+
+The same registry can deliver context to Claude Code and Codex at SessionStart,
+UserPromptSubmit, PreToolUse, and SubagentStart. SessionStart also handles
+resume/compact events the harness emits. The installer preserves existing Deja
+history hooks and unrelated configuration. Installation is separate from
+`deja install`, and never bypasses native hook review/trust.
+
+**This is instruction delivery, not enforcement.** Hooks emit no permission
+allow/deny decisions. A delivered runbook is not evidence that it was executed;
+pre-tool injection does not prove the agent reconsidered its pending call.
+Failures produce an INCOMPLETE warning, plus model-visible context for supported
+events, rather than silently pretending that no instructions applied.
+
+## Try it in a scratch configuration first
+
+Build with the repository-required Go version. The example is synthetic;
+review it before approving it. These commands do not touch existing agent
+configuration unless the explicit install commands are run against it.
+
+```sh
+go build -o /tmp/deja-instruction-test ./cmd/deja
+/tmp/deja-instruction-test instructions example > /tmp/instruction-draft.json
+# Review/edit the draft. Its starting registry revision is 0.
+/tmp/deja-instruction-test instructions apply \
+  --store /tmp/deja-approved-instructions.json \
+  --file /tmp/instruction-draft.json --expect 0 --approve
+/tmp/deja-instruction-test instructions resolve \
+  --store /tmp/deja-approved-instructions.json --json
+```
+
+Use unique scratch paths when working in parallel. For a retained installation,
+use your installed feature binary rather than a temporary build:
+
+```sh
+deja instructions example > instruction-draft.json
+# Review before approval. This initializes only an absent registry.
+deja instructions apply --file instruction-draft.json --expect 0 --approve
+deja instructions install --agent claude
+deja instructions install --agent codex
+```
+
+The default store is `DEJA_INSTRUCTIONS_FILE`, or
+`$XDG_CONFIG_HOME/deja/instructions.json`, or
+`~/.config/deja/instructions.json`. Relative store/config overrides are refused.
+`install --config ABSOLUTE_FILE --binary ABSOLUTE_DEJA` supports scratch setups.
+The installer currently supports macOS/Linux; core tests use portable paths.
+Review/trust the generated hook definitions and start a new agent session.
+Codex's `additionalContextLimit: 0` prevents its default summarization of the
+already-budgeted approved context; this field is not emitted for Claude.
+
+## Record semantics
+
+The schema is JSON, version 1. Each rule needs `id`, positive `revision`, `kind`,
+`text`, `authority`, `status`, `strength`, `lifetime`, `scope`, and `source`.
+`priority` defaults to zero and `absolute` to false.
+
+| Field | Values / meaning |
+| --- | --- |
+| kind | constraint, preference, decision, procedure |
+| authority | owner, project, inferred; inferred records cannot be active |
+| status | candidate, active, revoked |
+| strength | must, must_not, should; preferences must use should |
+| absolute | Required text; only a current-revision owner-approved exception waives it |
+| priority | -1000 through 1000; ordering/default selection, never a waiver of a must |
+| lifetime | persistent, task, session, ttl |
+| scope | repository, worktree, task, session, environment, path_prefix, tools |
+| source | Original provenance; preserve the original statement and reference |
+| conflict_key + value | Explicit mutually-exclusive setting, such as backend=local |
+| runbook | An absolute local path and lowercase SHA256 for a procedure |
+
+Persistent means until explicitly revised/revoked and forbids an expiry.
+Task/session lifetimes require their matching identity. TTL requires
+`expires_at` in RFC3339. Expiry is inclusive: at that instant it no longer applies.
+Task closure is NOT integrated with a task tracker in v0: clear/change the task
+identity or explicitly revoke its rules. Task IDs must not be recycled.
+
+Supply task/environment through `DEJA_TASK_ID`, `DEJA_ENVIRONMENT`, or the
+corresponding command flags. Task continuity between agents requires the same
+explicit task identity. It is never inferred from prompt wording.
+
+A known scope mismatch excludes a rule. Missing task, environment, tool or path
+context makes it **conditional**, not irrelevant or universally binding.
+Repository/worktree roots are clean absolute paths. Hook discovery resolves
+symlinks and Git linked-worktree metadata; separate clones remain distinct.
+Path selectors match components (`src` does not match `src-old`). Tools use exact
+canonical hook names. Shell commands, MCP operations and multi-file patches
+are not guessed into single-file targets: path requirements remain conditional.
+
+Required constraints accumulate regardless of authority or priority. For keyed
+preferences only, higher authority, then more nonempty scope selectors, then
+priority determine the default. An exact tied conflict is reported. Counting
+scope selectors is a deliberately limited first-pass specificity model, not a
+general semantic ordering of all scopes. Unkeyed prose is not conflict-checked.
+
+An exception names `id`, `rule_id`, `rule_revision`, a nonempty `task`, an
+`expires_at` deadline, `approved_by`, and a `reason`. It inherits the rule's scope,
+never broadens it, and never follows a later rule revision. Retained exception
+IDs cannot be mutated to broaden an existing grant; remove it to revoke it and
+use a new ID for a replacement.
+
+Procedures require `kind: procedure`, `strength: must`, and
+`runbook: {"path": "/absolute/SKILL.md", "sha256": "..."}`. Applicable runbooks
+are read and verified against their exact approved bytes before full delivery.
+A changed/unavailable runbook produces INCOMPLETE, not stale content.
+Conditional runbooks are referenced but not expanded. No step execution or
+completion receipt is recorded in this version.
+
+## Review and change instructions
+
+```sh
+deja instructions export > instruction-draft.json
+# Edit a rule, increment its rule revision by one, retain registry revision N.
+deja instructions apply --file instruction-draft.json --expect N --approve
+deja instructions resolve --task example-task --tool Bash --json
+```
+
+Global registry revision and individual rule revisions are separate. New rules
+start at 1. Existing rules cannot be deleted from the current snapshot: revoke
+with a new rule revision. Every successful approval archives the new snapshot.
+`resolve --json` includes applicable, conditional, excluded reasons and
+conflicts; callers MUST inspect conflicts and conditional entries. Text rendering
+refuses unresolved conflicts. Nothing extracts/promotes history automatically.
+
+Duplicate JSON keys, unknown record fields, malformed JSON, unsupported schemas,
+relative paths and unbounded inputs are refused. A concurrent approval requires
+a matching registry revision. Process-wide locks refuse competing writers;
+a crashed writer can leave a lock that requires inspection before removal.
+No stale lock is automatically broken. Hook config backups retain exact prior
+bytes, including large numeric values and unrelated hook definitions.
+
+## Budget, storage and trust boundaries
+
+The first backend is a bounded approved-configuration snapshot, behind a `Store`
+interface. It is not a new conversation database. Maximum: 8 MiB and 10,000 rules
+or exceptions per collection. It rereads/validates per invocation; large
+registries are not a constant-time lookup. Use the benchmarks below to evaluate
+that cost before scaling this backend. No per-tool history writes occur.
+
+The context budget is 8,000 UTF-8 bytes, not tokens or complete JSON wire bytes.
+All applicable/conditional mandatory text must fit in full or rendering fails.
+Only optional defaults may be omitted, with a count. Repeated injection can add
+material context cost; delivery receipts/deduplication with compaction-aware
+invalidation are not implemented yet.
+
+Writes use a same-directory temporary file, file sync and rename, without
+unlinking the old snapshot first. Directory entries are NOT fsynced in v0:
+there is no full power-loss durability guarantee. Use local filesystems, not a
+shared network mount. Archives are written before the live snapshot; an
+interrupted write can be retried with the same approved draft. A conflicting
+archived draft is an explicit recovery error. Archive retention/GC is deferred.
+
+`--approve` and `approved_by` are not authentication. An agent with the same OS
+user's write access can change the registry/checker. Do not present this as a
+security boundary. Keep approved files outside untrusted checkouts; stronger
+approval isolation and resource-enforced action gates are separate work.
+Do not put secrets in rules/runbooks: delivered instructions enter the agent's
+model context. This subsystem does not import Deja's historical redaction or
+privacy configuration, nor change its history hooks' fail-open contract.
+
+## Verification and follow-on work
+
+```sh
+go test ./internal/instructions -race -count=1 -coverprofile=coverage.out
+go vet ./internal/instructions
+go test ./internal/instructions -run '^$' -bench . -benchmem
+# Also required before merge:
+go test ./... -race -count=1
+go vet ./...
+go build ./cmd/deja
+```
+
+Synthetic tests exercise expiry, precedence, conflicts, unknown scope, exact
+runbook hashes, budgets, concurrent processes, symlinked new files, configuration
+preservation and event JSON. They do not prove bytes reached a real model.
+Follow `.claude/commands/harness.md` with scratch profiles and recording endpoints
+for both agents, including compaction/subagents and UI inspection, before
+claiming end-to-end support. Existing `deja doctor` does not inspect this subsystem.
+
+Remaining: real-harness/version probes, native guidance/skill packaging,
+automatic candidate intake from Deja with approval, task/obligation lifecycle,
+verified execution receipts, controlled action gates, stable identities across
+clones/machines, registry indexing/caching and stronger crash durability.
+Storage workload analysis is in [instruction-storage.md](instruction-storage.md).

--- a/docs/instruction-runtime-design.md
+++ b/docs/instruction-runtime-design.md
@@ -1,0 +1,620 @@
+# Cross-agent instruction runtime: design of record
+
+Status: proposed next design, not implemented behavior. Updated: 2026-09-06.
+Baseline: `feat/instructions-set` at `a6b760b9039e37d1aaf178beba29b0455c67e142` (PR #1).
+
+This document develops the rest of the local instruction-memory system from the
+advisory v0. It does not change that binary, approve any user instructions,
+install hooks, select a database, or enable action enforcement.
+
+Read alongside the [v0 usage guide](instruction-memory.md),
+[storage decision](instruction-runtime-storage.md), and
+[implementation and acceptance plan](instruction-runtime-plan.md).
+The v0 guide remains the authority for commands that actually exist.
+
+## 1. Outcome and boundaries
+
+An instruction established once should apply to the right task in either Codex
+or Claude Code without the agent having to remember to search for it. Required
+skills and runbooks should become visible before the work that needs them.
+Permanent requirements must survive compaction and handoffs; temporary ones
+must not spread to unrelated work. Every inclusion, omission, exception, and
+conflict must be explainable.
+
+Deja remains one application with two responsibilities:
+
+- History recall answers what happened, was attempted, or was discussed.
+- Instruction resolution answers what currently applies and what remains due.
+
+The second is not a new ranking boost in the first. Use the existing history
+sources, provenance, privacy controls, and agent plumbing; keep the approved
+instruction model and deterministic resolver separate. Codegraph and ACR may
+supply supporting references later, but neither is a runtime dependency.
+
+Non-goals for this iteration: another conversation index, an autonomous planner,
+a general shell-policy interpreter, a distributed database, hosted memory,
+or a claim that text injection guarantees obedience. Local storage also does
+not mean local-only model processing: delivered text goes to the configured
+agent/model provider. No independent network service is required for history.
+
+The scope is design and staged implementation, not a requirement to ship all
+components in one PR. Useful advisory delivery should precede optional gates.
+
+## 2. What the branch actually contains
+
+The following inventory is based on the source at the baseline commit.
+
+| Area | Present in v0 | Remaining gap |
+| --- | --- | --- |
+| `internal/instructions/model.go` | Typed rules, scope, strength, absolute flag, lifetime, exceptions, runbook hash | Named sets, authenticated approval semantics, structured effects, stable identities |
+| `resolve.go` | Mandatory accumulation, explicit keyed conflicts, conditional unknowns | Scope containment, compatible defaults, selective candidates, per-action resolution |
+| `store.go` | Full JSON snapshot, global compare-and-swap, revision archives, writer lock | Selective reads, transactional task state, crash recovery, retention |
+| `render.go` | Complete required text or an error; 8,000-byte packet limit | Context epochs, safe delivery deduplication, staged runbooks, actionable partial states |
+| `hook.go` | Four events; Git-root/worktree discovery; single-file tool targets | Child-run identity, actual action/resource mapping, result observation, task binding |
+| `install.go` | Opt-in, preserves unrelated hook configuration | Capability probes, ownership-aware uninstall/repair, native guidance reconciliation |
+| `cli.go` | Example/apply/export/resolve/hook/install | Candidate inbox, single-rule edits, task operations, procedure status, diagnostics |
+
+Specific design corrections, rather than assertions that these are solved:
+
+1. `specificity` counts nonempty selectors. It does not establish that one scope
+   is a subset of another; two overlapping scopes can be incomparable.
+2. A mandatory keyed rule currently suppresses all preferences for the key.
+   For `must_not backend=remote`, a compatible `should backend=local` should
+   remain eligible, not disappear.
+3. Unknown task/path/tool scope is rendered as conditional text. Many unrelated
+   conditional rules can exhaust the packet. Unknown must stay explicit without
+   requiring every potentially relevant procedure body at every lifecycle event.
+4. `Store.Load` and `Resolve` both validate, and explanation output carries
+   excluded records. Changing a database underneath this full-snapshot interface
+   alone does not remove the work proportional to the whole registry.
+5. `--approve` and `approved_by` record intent/provenance, not authentication.
+   A same-user agent can still edit the files/checker. No adversarial isolation
+   has been implemented.
+6. Task identity is an explicit string, with no task-closure state. Session
+   identity does not namespace the harness or identify a child run. Rendering
+   a procedure records neither delivery acknowledgement nor completion.
+
+These are bounded follow-ups to the first pass, not reasons to replace Deja.
+
+## 3. Components and data ownership
+
+```mermaid
+flowchart TD
+    A[Deja sources and user-owned instruction files] --> B[Candidate intake]
+    B --> C[Owner review or pre-approved import policy]
+    C --> D[Published revisioned instruction catalog]
+    E[Task and agent-run bindings] --> F[Deterministic resolver]
+    D --> F
+    G[Normalized action and resources] --> F
+    F --> H[Context compiler]
+    H --> I[Codex and Claude adapters]
+    F --> J[Procedure obligations]
+    I --> K[Delivery observations]
+    J --> L[Checks and execution evidence]
+    L --> M[Optional protected-action adapter]
+```
+
+The catalog is authoritative for approved instructions. Draft Markdown/JSON
+files are authoring inputs until published; generated AGENTS/CLAUDE fragments
+are projections. The runtime store is authoritative for task/obligation state.
+Historical analytics and cached projections are rebuildable and never grant
+permission. There must not be two independently editable copies of one rule.
+
+Keep the pure resolver in `internal/instructions`. Add small modules for
+catalog/publication, intake, task state, procedures, delivery, and adapters as
+those responsibilities become real. Avoid a generic plugin framework initially.
+The existing `internal/policy` history privacy policy is not renamed or silently
+reused as an action-enforcement engine.
+
+For the stateful multi-agent phase, use one profile-local writer in the Deja
+binary, with a private local IPC endpoint and an in-memory scoped read model.
+It can be launched on demand by an explicitly enabled integration; it is not
+another application or a requirement to run ACR. See the storage decision for
+why this topology keeps both SQLite and DuckDB eligible. V0 remains usable
+without this process. A future offline mode is read-only and must report when
+it cannot establish current task or approval state; it is not a second writer.
+
+## 4. Records and identities
+
+### 4.1 Instruction sets and rule revisions
+
+An `InstructionSet` groups rules, not their evidence-ranking scores. Examples
+are a personal baseline, a repository workflow, and release procedures. A set
+has a stable ID, owner, revision, activation scope, and explicit inclusion list.
+A published bundle pins every included set/rule/procedure revision. Inclusion
+cycles and missing references fail publication. No floating `latest` dependency
+is permitted in a published bundle.
+
+Set scope intersects rule scope. Set validity also restricts rule validity;
+a child cannot broaden its parent's scope or outlive a task-bound parent.
+Set membership and revisions are part of the catalog generation. Disabling a
+set containing protected requirements is a policy change, not a preference
+that an ordinary agent can quietly toggle.
+
+A `RuleRevision` contains these separate dimensions:
+
+| Dimension | Contract |
+| --- | --- |
+| Identity | Namespaced rule ID, immutable revision, payload digest |
+| Meaning | Kind, original wording, approved operative text, optional rationale |
+| Authority | Principal and delegation reference; source is not authority |
+| Requirement | Required, prohibited, or preferred |
+| Override | Explicit exception, authorized scoped override, or no exception without revising the rule |
+| Scope | Conjunction of supported typed selectors |
+| Activation | Lifecycle phases and/or action/resource predicates |
+| Lifetime | Persistent, task-bound, run-bound, or explicit interval |
+| Effect | Optional structured effect with key, operator, and value |
+| Provenance | Source identity, exact span/reference, content digest, extraction version |
+| State | Candidate, active revision, superseded, revoked, or quarantined |
+
+Expiration is computed from validity, not dependent on a cleanup job. A review
+reminder does not expire a persistent rule. Numerical priority only orders
+otherwise eligible guidance or explicitly resolves equally scoped defaults.
+It never turns a requirement into a preference or waives a prohibition.
+
+For v2, replace the ambiguous `absolute` Boolean with an explicit override
+contract. Preserve the v0 meaning during migration: an absolute needs an owner
+exception naming its revision. The optional stronger mode disallows exceptions
+until the owner revises/revokes the rule. Neither mode overrides platform or
+managed instructions. Persistent and absolute remain independent properties.
+
+A rule should express one obligation. Compound prose may remain verbatim, but
+partial exceptions require splitting it into separately approved rule IDs;
+do not infer which half of a paragraph the owner intended to waive.
+
+### 4.2 Repository, checkout, task, and run identity
+
+Repository identity must survive a directory move but must not be borrowed from
+an untrusted repository-provided UUID. Maintain a local owner-controlled
+mapping of repository IDs to approved Git-common-directory identities. A
+remote URL is a discovery hint, not proof that a new clone inherits private
+rules. Aliasing additional clones requires explicit mapping. Strip credentials
+from origin references. Keep checkout/worktree IDs separate from repository IDs.
+
+A `Task` uses an opaque non-recycled ID plus an optional external reference.
+An issue number or branch name is a label, not the primary ID. One task can have
+several runs and checkouts. A run records profile, harness, native session ID,
+child-agent ID where available, incarnation, and parent-run ID. Parent/native
+session ID alone is not sufficient to identify all child contexts.
+
+A run-to-task binding is explicit, revisioned, and recoverable. At first use an
+adapter can create a session-local task automatically. Cross-agent handoff
+attaches to the exported task ID rather than guessing from prompt similarity.
+Two concurrent sessions in one worktree must not silently share an active task.
+Where child identity is unavailable, report reduced isolation and do not share
+its delivery-dedup state with the parent.
+
+### 4.3 Remaining records
+
+| Record | Purpose |
+| --- | --- |
+| `Candidate` | Proposed capture/revision with source and review state |
+| `ProcedureRevision` | Approved procedure content, steps, dependencies, check definitions and digests |
+| `ExceptionGrant` | Rule revision, approving principal, allowed scope, lifetime and reason |
+| `Obligation` | A procedure/requirement instantiated for a task and resource set |
+| `EvidenceReceipt` | What was observed, by which observer, against which inputs |
+| `DeliveryRecord` | A packet emitted or observed in a particular run/context epoch |
+| `AuditEvent` | Idempotent record of a state transition with ordering and provenance |
+
+## 5. Deterministic resolution contract
+
+Resolution takes a catalog generation, task/binding revision, normalized
+context, proposed action/resources, and explicit evaluation time. Its result
+contains applicable, deferred/unknown, excluded, conflicted and excepted rules,
+required procedures, generation identifiers, missing context fields, and
+reason codes. Unknown is not success, and not a fabricated match.
+
+### 5.1 Selection
+
+Use exact indexed selectors for profile/set, repository, checkout, task, run,
+environment, action kind, and path components. Within a selector an explicit
+list means OR; across selectors means AND. Start with this bounded language,
+not arbitrary code or model-generated predicates.
+
+Retrieve a conservative superset for deterministic evaluation. Index absence
+must never discard global rules, wildcard selectors, or potential matches for
+unknown fields. Test the indexed selector against a full-scan oracle. Ordinary
+hook packets need only selected records and reason summaries; a paged explain
+operation can load all exclusions. Do not copy the whole registry to explain
+that most of it was irrelevant.
+
+Evaluate applicability and activation separately. A production deployment rule
+need not expand its runbook at startup. Its activation descriptor can be in the
+repository's bootstrap guidance; when a deployment is proposed, the precise
+requirements must be resolved. A protected deployment with unknown environment
+is unresolved and cannot receive a positive gate result. Ordinary read-only
+work should not be globally blocked by this missing deployment context.
+
+### 5.2 Effects, conflicts, and defaults
+
+Mandatory rules accumulate. A preference cannot defeat one, regardless of its
+recency, frequency, authority label, specificity, or numerical priority.
+
+For initial structured conflicts, support a small setting model: `require
+value`, `forbid value`, and `prefer value`. Conflict identity is `(effect
+namespace, key, resolved resource)`, so unrelated targets do not conflict.
+Two different required values for the same single-valued setting conflict;
+requiring a forbidden value conflicts. Multiple forbidden values accumulate.
+A preferred value not forbidden by any required constraint stays eligible.
+Arbitrary prose contradictions are review candidates, not a claimed capability
+of this deterministic setting model.
+
+Among compatible defaults, apply the explicit delegated authority order first.
+Within equal authority, scope A is more specific than B only if A is a strict
+subset of B in the supported selector language. A deeper path prefix and a
+narrower tool list can establish containment; counting fields cannot. Priority
+breaks ties only for equivalent scopes in the same authority tier. Different
+values under overlapping incomparable scopes remain an unresolved default
+conflict unless an approved `overrides` relationship resolves them. Same-value
+defaults may coalesce for display while preserving every source ID.
+
+Do not let a preference conflict erase unrelated mandatory context. The result
+is structured and action-scoped: report the conflict alongside unaffected
+instructions. Only an affected protected action is denied by a gate. In
+advisory mode the model gets the conflict and its alternatives, not an invented
+winner. Stable IDs provide display order, never semantic tie-breaking.
+
+### 5.3 Revisions and exceptions
+
+A new approved revision supersedes that rule's previous revision. A newer
+unrelated message does not. A grant must name the exact rule revision and
+narrow its scope; an exception cannot broaden who or what the rule governs.
+Bound grants by task and expiry and, when needed, environment, resource and
+run. A grant does not flow to subagents unless its inheritance mode explicitly
+allows that task subtree. Follow-on tasks receive none by default.
+
+Revoke grants explicitly; do not reuse their IDs. A rule change invalidates
+prior grants unless the owner approves new ones. Exception application and the
+remaining requirements must be visible in explanations and delivery updates.
+Authorization to perform an action is distinct from an exception to a workflow
+rule: passing a runbook does not authorize a deployment the user never requested.
+
+### 5.4 Lifetime
+
+Persistent means until approved revision/revocation. Task-bound rules remain
+active while the task is open or suspended and apply to its explicitly bound
+runs. A process exit, model stop, compaction, handoff, or inactivity timeout does
+not complete the task. Task close/cancel ends task-bound applicability; reopen
+creates a new task incarnation and does not silently reactivate old exceptions.
+Run-bound rules never cross runs without an explicit conversion to task scope.
+
+Use UTC timestamps for durable intervals and explicit inclusive expiry
+(`now >= expires_at`). Cache validity ends at the earliest relevant boundary,
+including a future activation time, exception expiry and task-binding change.
+Detected clock rollback invalidates time-dependent cached approvals; protected
+operations require re-evaluation rather than resurrecting an expired grant.
+Wall-clock expiry without a trusted clock is a stated limitation, not a secure
+lease guarantee.
+
+## 6. Capture without another manual memory chore
+
+Candidate intake is incremental from Deja's existing normalized sources and
+promoted notes. It must honor the existing privacy/exclusion/forget policy
+before copying content and again before serving it. Store stable source IDs,
+span/content hashes and parser versions rather than trusting file offsets after
+a transcript rewrite. Do not add another transcript parser or full scan to each
+hook. `deja promote --state accepted` remains a curated historical note, not
+implicit permission to activate an instruction.
+
+Capture paths:
+
+- Direct owner authoring/publishing creates an active revision through the
+  configured approval channel. An explicit temporary directive can become a
+  task overlay without demanding that the owner approve the same directive a
+  second time, but only when the adapter preserves its trusted origin.
+- Inferred absolutes, corrections, preferences and procedural references enter
+  a candidate inbox. The candidate proposes scope/lifetime and shows the exact
+  original wording. Missing intent is marked unknown, not silently global.
+- User-owned AGENTS.md, CLAUDE.md and SKILL.md/runbook content can be imported as
+  reviewable sets/procedures. Retain the original path, native meaning and hash.
+  Edits produce reviewable revisions, not silently updated approved content.
+
+A pre-approved import policy may accept specified changes from named trusted
+sources within a maximum scope and authority. It must be explicit, auditable,
+and revocable. Do not give every source a generic auto-approve Boolean.
+An optional configured extraction model may propose records outside the action
+path; no model call is required for resolution, expiry or conflict checking.
+No remote inference/embedding upload is introduced by default.
+
+Normalizing a transcript role to `user` is not proof of owner authorship.
+Distinguish original user messages, quoted text, tool results and agent-authored
+summaries. Never activate an instruction from a quoted command, a third-party
+README, or a previous assistant assertion merely because it contains "always"
+or "never". Repeated sightings can prioritize review, not increase authority.
+
+Candidates use idempotency keys based on source identity, span hash and extractor
+version. Re-ingest and retries cannot create duplicate active rules. Link
+potential duplicates and proposed supersessions; do not silently merge their
+meaning. Exclude Deja's own injected packets, fixture probes and generated
+projections from intake to prevent self-reinforcing memory loops.
+
+The review surface should show one compact change: operative text, original
+text, applicability, lifetime, strength, override rights and affected rules.
+Make single-rule edits possible without exporting/reapproving the entire store.
+An ambiguous candidate must not interrupt every tool call; batch nonblocking
+review notices and ask only when a real task/action needs the missing decision.
+
+## 7. Procedures, skills, and evidence
+
+A skill is content/instructions for doing something. A binding specifies when
+it is required. An obligation is a particular task's outstanding instance.
+Installing or listing a skill satisfies none of these automatically.
+
+A `ProcedureRevision` has a stable ID, approved text, bounded step IDs,
+prerequisites, activation bindings, and evidence requirements. Start with ordered
+steps plus explicit prerequisite references, not a general workflow language.
+Reject dependency cycles and missing step references during publication.
+A procedure can include an agent-specific skill invocation, but its canonical
+requirements must not depend on implicit skill selection.
+
+Package the approved procedure as a content-addressed local bundle. Pin the
+entry document and any declared scripts/templates/subprocedures that affect
+execution; hashing only SKILL.md while its referenced script changes is
+insufficient. Retain source-relative locators and local path mappings so a move
+does not change procedure identity. Dependencies outside the bundle are explicit
+unresolved prerequisites, not implicitly trusted downloads.
+
+Large runbooks require author-approved stage boundaries. Deliver the whole
+operative instruction for the current stage plus persistent constraints and
+next-stage requirements. Rationale and examples can be fetched separately.
+Do not use a model-generated summary as a replacement for approved normative
+steps. A single indivisible required stage that exceeds the channel budget is
+an actionable delivery failure, not silent truncation.
+
+Obligation states are `pending`, `in_progress`, `satisfied`, `waived`, `blocked`,
+`invalidated` and `cancelled`. Delivery state is separate. Acknowledging a
+procedure changes neither its completion state nor evidence quality. Deduplicate
+an obligation using task incarnation, rule revision, procedure revision and
+resolved resource identity, not the native session ID.
+
+Evidence distinguishes `agent_reported`, `tool_observed`, `executor_verified`
+and `owner_attested`. A check definition specifies which evidence level is
+acceptable. A human architectural review may require an attestation; an
+executable preflight can require an executor's recorded exit status and input
+binding. Do not pretend to prove the quality of model reasoning.
+
+Receipts include task/run identity, procedure and rule revisions, check ID,
+observer identity, input/output digests, environment fingerprint, start/finish
+times, outcome and redacted evidence references. Bind to actual relevant bytes,
+including uncommitted/untracked inputs, not just the commit SHA. A procedure
+must declare its input/dependency closure; use a conservatively broader closure
+when uncertainty exists. File mtimes are optimization hints, not validity proof.
+Changed relevant inputs invalidate evidence. Unrelated edits need not rerun every
+check if the dependency closure has been established correctly.
+
+Concurrent runs may cooperate on an obligation, with revision checks and short
+claims to avoid duplicate execution. A claimed step is not completed. A crashed
+executor leaves an unknown/unfinished outcome; do not automatically replay a
+non-idempotent operation. Cancellation and late results are bound to the task
+incarnation and cannot complete a later task.
+
+## 8. Agent delivery and context lifetime
+
+### 8.1 Event adapters
+
+Adapters translate tested native payloads into the shared model. They do not
+embed precedence logic. Capability profiles record agent version, event schema,
+identity fields, output limits, context placement, supported decisions and
+known bypass paths. Install only the supported wiring and make unsupported
+capabilities visible in `doctor`.
+
+| Logical point | Responsibility |
+| --- | --- |
+| Start/resume/clear | Establish run/context epoch; send standing and task-applicable guidance |
+| Prompt/task change | Capture trusted directives or propose candidates; bind task and activate known procedures |
+| Pre-action | Resolve actual resource/action requirements; provide targeted context or a supported gate decision |
+| Result/failure | Record observations; update obligations and invalidate affected evidence |
+| Compaction | Advance context epoch and rehydrate active guidance before the next supported model continuation |
+| Child start | Create distinct child run, inherit explicit task scope, deliver applicable requirements |
+| Stop/child stop | Report outstanding obligations; do not equate a response ending with task completion |
+| Explicit task close | Verify completion policy, record outcome, retire task-bound state |
+
+Current native constraints require versioned integration tests, not shared JSON
+by assumption. Codex documents parent session IDs on subagent hooks and tool
+paths that bypass pre-tool checks, including input into an existing execution
+session. Claude documents that hooks do not themselves invoke slash commands,
+and that pre-tool additional context is placed beside tool results. See the
+primary references below. These facts affect adapter design; they do not imply
+support has been validated on the user's installed agents.
+
+Normalize direct file operations into a resource set. A supported patch parser
+must include old and new paths, renames, deletes and all changed files. Map known
+MCP tools through exact schemas. For shell execution, preserve executable/argv,
+cwd and recognized environment separately; never infer sensitive action coverage
+from a substring in arbitrary shell text. Unknown compound commands are unknown.
+Known check wrappers can provide stronger bindings than general shell analysis.
+
+### 8.2 Packets and deduplication
+
+Every packet contains catalog generation, task/binding revision, run and context
+epoch, exact rule/procedure revisions, applicability reasons, unresolved fields,
+exceptions and delivery completeness. Separate normative text from optional
+historical rationale. An instruction hash/reference alone does not deliver the
+instruction unless those exact bytes are already known to reside in this context.
+
+Use a small baseline at start and targeted changes thereafter. Re-evaluate at
+action boundaries without repeating unchanged text on every action. Dedup keys
+include run, context epoch, rule revision, activation phase and resolved scope.
+Never use one global "already shown" flag shared across Codex and Claude or
+between a parent and child.
+
+Track `selected`, `emitted`, and, only when observed, `wire_observed`. None means
+"understood". A write to hook stdout proves emission only. A recording endpoint
+can prove model-request inclusion in a synthetic harness test; do not log real
+model requests by default. Where native consumption is not observable, report
+that limit and favor bounded re-delivery on resume, compaction, errors or uncertain
+context retention. A failed output write cannot commit a successful delivery.
+
+Policy updates send replacement/revocation notices for earlier revisions; new
+positive guidance alone does not remove stale text already present in the chat.
+Old revisions remain historical and cannot satisfy a current gate. Changes
+become visible at the next supported delivery boundary; there is no claim of
+instantaneous steering of an already-running model call.
+
+Budget in UTF-8 bytes and the tested harness's real channel constraints; measure
+tokens independently where supported. V0's 8,000-byte cap is a starting bound,
+not a performance promise. Codex's documented `additionalContextLimit: 0` is
+usable only with our strict cap. Claude's documented oversized-output handling
+also requires checking actual model-request content. Other installed hooks share
+context space: dedup/co-budget with Deja history rather than allowing two
+independent subsystems to double the existing overhead.
+
+Unknown scope stays in structured diagnostics. At bootstrap, deliver relevant
+activation descriptors and a concise missing-context notice, not all procedure
+bodies. At a triggered action, deliver all definitely applicable requirements
+and the specific unresolved ones affecting that action. A budget error marks
+the packet incomplete; a protected action cannot treat an incomplete packet as
+permission. Advisory mode warns and preserves the useful unaffected guidance.
+
+## 9. Publication, caching and failure handling
+
+Replace `Load everything` on the hot path with a scoped store contract. A
+candidate request contains known dimensions and unknown markers; its response
+has a generation and a completeness guarantee for that selector language.
+Publish/approve is transactional across revisions, membership, exceptions and
+audit events. Compare-and-swap uses both catalog generation and rule revision
+where appropriate. Idempotency keys distinguish a retry from a new operation.
+
+The runtime publishes a validated immutable in-memory catalog after durable
+commit. Read requests observe one coherent generation, not a mixture of old
+rules and new exceptions. Notify peers after publication, but notifications
+are an acceleration mechanism: every protected action checks current generation
+and task/evidence validity again at admission. An old-session cache does not
+graduate into authority merely because its TTL has not elapsed.
+
+Cache entries include generation, task/binding revision, adapter/action mapping
+version, context dimensions and earliest validity boundary. Unrelated catalog
+updates may be optimized later using dependency fingerprints, but start with
+conservative invalidation. Do not cache time-sensitive grants indefinitely.
+
+Startup is single-flight per private profile endpoint. Use process-aware
+locking and explicit recovery; do not steal a lock because it is old. Handle
+PID reuse and partial publication. No silently empty registry when the service
+is unavailable. V0's file-only mode and future runtime mode are not concurrent
+writers to the same authoritative state.
+
+| Failure | Advisory behavior | Protected operation behavior |
+| --- | --- | --- |
+| Store/runtime unavailable | Bounded warning; read-only snapshot marked with its limits | Deny affected operation when current approval cannot be checked |
+| Missing action scope | Display needed fields and keep unrelated work available | Deny only operations whose protected scope cannot be established |
+| Conflict or changed runbook | Report exact conflict/hash mismatch; do not invent a resolution | Require correction or authorized scoped exception |
+| Audit sink backlog | Report dropped optional telemetry with counters | Required evidence/publication remains durable before admission |
+| Hook disabled or untrusted | Diagnose no delivery/guard coverage | Never claim the hook guarantees a block; a resource broker is needed |
+| Interrupted protected execution | Record unknown outcome and reconciliation reference | No automatic non-idempotent replay |
+
+## 10. Trust, privacy and gates
+
+Reliability against ordinary agent mistakes is the default threat model. An
+agent with unrestricted same-user filesystem/IPC access can tamper with a
+registry or submit forged receipts. Private file permissions and an IPC socket
+reduce accidental exposure but do not distinguish two processes of the same
+user. Call the default approval mode cooperative; do not market it as security.
+
+An optional isolated approval mode needs an owner channel/capability outside
+the agent's sandbox and a separately protected signer/authorizer. Agent tools
+may propose records but cannot mint that approval. Installation must demonstrate
+the separation before claiming it. A field named `approved_by`, a CLI flag, a
+self-reported principal, or a token placed in the agent's readable environment
+is not that separation.
+
+Retain original text separately from approved operative text. Secret detection
+at intake/publication and output-policy checks must run before delivery. Do not
+silently redact a required command into a different operative instruction;
+quarantine it for review or use a secret reference supplied at execution time.
+Error messages, paths and evidence payloads also require privacy handling.
+
+Forgetting source history and revoking an approved rule are distinct operations.
+A separately approved rule need not become false because its original transcript
+was deleted, but retained excerpts must honor the forget request. Show derived
+records in a preview and support explicit cascade deletion/revocation. A new
+privacy restriction may withhold a rule from a model without waiving the actual
+obligation; report incomplete delivery and block only its protected operation.
+Publication/exception audit retention is owner-configured; never silently prune
+live requirements. Raw tool output is off by default; retain redacted bounded
+references and digests. Optional analytics exports inherit the same filters.
+
+Enforcement is independently opt-in by action adapter:
+
+- Advisory: required guidance is delivered; the model can still miss it.
+- Harness guard: supported native tool paths receive tested blocking decisions.
+- Resource gate: the operation's necessary capability is controlled by an
+  executor/broker that admits the exact approved action and immutable inputs.
+
+Do not return permissive native approval just to add context or bypass another
+hook. For missing prerequisites, deny the pending supported action, deliver the
+requirement and allow a newly evaluated attempt. Passing a gate is not blanket
+authorization. Admission checks bind catalog/task/procedure revisions, actual
+resource/environment and input digest. Use scoped short-lived grants and an
+idempotency key for execution. Where inputs can mutate after checking, the
+executor must use an immutable artifact or an appropriate lock/recheck; a
+pre-tool hook alone cannot eliminate that race.
+
+## 11. Proposed API and user workflow
+
+These names describe proposed interfaces, not commands already shipped.
+
+| Interface | Responsibility |
+| --- | --- |
+| `instructions propose/import/review` | Capture candidates and approve bounded changes |
+| `instructions set/rule show` | Inspect identity, revision, source and override semantics |
+| `instructions resolve/explain` | Effective instructions and actionable reasons |
+| `instructions task start/attach/handoff/close` | Cross-agent task identity and lifecycle |
+| `instructions procedure status` | Outstanding steps and evidence validity |
+| `instructions exception request/grant/revoke` | Explicit bounded waivers through the configured approval channel |
+| `instructions doctor` | Adapter, store, delivery, generation, privacy and coverage diagnostics |
+| `instructions install/uninstall` | Preview/preserve managed wiring and native guidance |
+
+Expose read/propose/task/status operations through Deja's existing MCP server;
+publication rights follow the approval mode. MCP is an inspection/control
+surface, not the only route for automatic delivery. Legacy `remember` and
+`promote` keep their historical meanings. Generated native fragments identify
+their owning set and revision and are excluded from capture. Native unmanaged
+files remain independently effective; detect disagreements without overwriting
+them or pretending Deja controls the platform's instruction precedence.
+
+Example flow: a user establishes a persistent release preflight, then asks
+Claude to prepare a release under task T. The binding creates an obligation.
+Claude loads the approved stage and executes its check. Codex attaches to T;
+it receives the requirement and the observed check state, not a fresh empty
+task. If the artifact changes, that receipt is invalid. Publication is denied
+only through an enabled covered gate until the check passes for the new artifact.
+Closing T retires its temporary overlay, while the standing preflight remains.
+
+## 12. Compatibility and unresolved decisions
+
+Do not make existing v1 registries parse as v2 by accident. `migrate --dry-run`
+should report every mapping and ambiguity before any write. Preserve source
+text, IDs, revisions and absolute semantics. Map path identities through the
+local repository registry, session lifetimes through run identities, and keyed
+values into structured setting effects. Ambiguous mappings need review; do not
+silently broaden scope. Existing exception inheritance was not recorded, so
+migration must not invent child grants.
+
+A migration writes a new store/profile with a validated mapping report and a
+rollback export; v1 files remain untouched until an explicit cutover. Only one
+writer mode is active. A rollback after v2 edits requires an explicit export of
+representable state, not silently resuming an obsolete v1 snapshot. Unknown
+schema or compiler versions fail explicitly. Runtime/API/storage versions are
+separate so an adapter upgrade need not rewrite all user instructions.
+
+Recommended sequence and decision gates are in the acceptance plan. The design
+has deliberately not selected: the operational database/Go driver, the stronger
+approval mechanism, untested installed harness versions, exact production
+performance limits, or a protected-action adapter beyond an initial pilot.
+Those choices need measurements or a defined capability boundary, not more
+confidence in an unverified design.
+
+## Primary references
+
+Repository sources are pinned by the baseline above: `internal/instructions/*`,
+`cmd/deja/promote.go`, `docs/ARCHITECTURE.md`, `CONTRIBUTING.md`, and
+`.claude/commands/harness.md`. In particular, Deja's source model distinguishes
+tool output from original user messages, and its harness runbook requires
+observing bytes in the actual model request.
+
+External documentation checked 2026-09-06; adapters must also probe installed versions:
+
+- Codex hooks: https://developers.openai.com/codex/hooks (redirects to https://learn.chatgpt.com/docs/hooks).
+- Codex skills: https://developers.openai.com/codex/skills.
+- Claude hooks: https://code.claude.com/docs/en/hooks.
+- Claude hook limits: https://code.claude.com/docs/en/hooks-guide.

--- a/docs/instruction-runtime-plan.md
+++ b/docs/instruction-runtime-plan.md
@@ -1,0 +1,305 @@
+# Instruction runtime implementation and acceptance plan
+
+Status: proposed work, not completed tasks. Updated: 2026-09-06.
+Baseline: PR #1, `feat/instructions-set` at
+`a6b760b9039e37d1aaf178beba29b0455c67e142`.
+
+The [design](instruction-runtime-design.md) defines behavior. The
+[storage decision](instruction-runtime-storage.md) defines the database
+selection experiment. The [v0 guide](instruction-memory.md) defines the current
+CLI. This plan does not imply that any proposed command, state machine,
+benchmark target or enforcement adapter has already been implemented.
+
+## 1. Implementation strategy
+
+Keep PR #1 as the reviewed baseline. Continue on `feat/instructions-set`; do not
+reset, force-update, merge or delete `feat/instruction-memory` as part of this
+work. Build small reviewable changes with tests and current-behavior docs.
+Use the phase/test IDs below for design traceability; they are not GitHub or
+Linear issue IDs and no external project is implied.
+
+The next two implementation passes should make the system useful before adding
+a large service surface:
+
+1. Stabilize and observe v0, then fix resolution semantics and context identity.
+   A standing rule must actually reach the intended model context, survive a
+   restart/compaction boundary, and not disappear due to an unrelated conflict.
+2. Add safe source-to-candidate intake and instruction/skill import so users do
+   not maintain the same requirements in several independent files. Keep review
+   explicit for inferred changes and make direct trusted directives frictionless.
+
+Start the storage experiment in parallel with those passes. Do not require a
+production database migration before proving basic rule delivery; do not add
+stateful multi-agent receipts until the store provides the needed guarantees.
+
+## 2. Phased changes and exit criteria
+
+### P0: Verify and stabilize the existing implementation
+
+Scope: baseline only, no feature claims beyond advisory delivery.
+
+Run the repository-required Go 1.25 toolchain, `go test ./... -race -count=1`,
+`go vet ./...`, and `go build ./cmd/deja`. Measure touched-package coverage;
+retain existing CI floors and >=90% for new packages as CONTRIBUTING requires.
+Do not lower Go requirements or coverage floors to make a local run pass.
+
+Use the synthetic scratch harness prescribed in
+`.claude/commands/harness.md`. Observe a unique instruction token in a real
+Codex request and a real Claude request, rather than accepting valid hook JSON
+as delivery proof. Pin installed agent versions and test start, resume,
+compaction and child start. Read the visible UI output too.
+
+Exit: reproducible test results, actual capability matrix, combined history and
+instruction overhead, and a documented list of unsupported cases. Lack of
+installed agents/Go is a blocked verification, not a passed test. Keep the
+feature experimental until that bar is met.
+
+Likely paths: `cmd/deja/instructions_dispatch_test.go`,
+`internal/instructions/hook_test.go`, `docs/instruction-memory.md`; add only
+synthetic fixtures and versioned recording-stand configuration.
+
+### P1: Correct semantics and introduce explicit context identity
+
+Scope: pure resolver contracts first, still advisory.
+
+Replace selector-count specificity with containment/equivalence semantics.
+Preserve compatible keyed defaults under prohibitions. Scope conflicts to the
+same effect/resource; report unrelated mandatory guidance alongside conflicts.
+Add named set membership, clear override rights and versioned schema handling.
+Do not reinterpret v1 registries in place.
+
+Introduce distinct repository/checkout/task/run identifiers and context epochs.
+Start with owner-controlled local mappings, not global repository identity or
+remote sync. A child must not inherit its parent's delivery-cache identity.
+Unknown fields must remain distinguishable from explicitly absent selectors.
+
+Before writing a selective store, create the full-scan reference resolver and
+fixtures for the new semantics. Define schema-v1 migration mappings, ambiguity
+reports and rollback exports. Unsupported scope expressions fail publication;
+do not guess containment for arbitrary predicates.
+
+Exit: deterministic/property tests for all combinations of requirement,
+authority, scope, revision, validity and exception inheritance; explicit migration
+preview; no accidental broadening of existing user rules.
+
+Likely paths: `internal/instructions/model.go`, `resolve.go`, `resolve_test.go`,
+plus small `catalog`/`identity` components where separation is justified.
+
+### P2: Candidate intake and portable instruction/skill authoring
+
+Scope: eliminate repeated manual entry without giving retrieved text authority.
+
+Bridge Deja's normalized source/provenance pipeline into a candidate inbox. Read
+incrementally outside the per-action path. Preserve privacy/exclusion/forget
+checks already used by promotion. Import owner-selected native instruction
+files and skills as bounded sets/procedure revisions; their native files remain
+unmodified unless a managed projection is explicitly requested.
+
+Candidates show the original text and proposed operative text, scope, lifetime,
+requirement and override rights. Support single-rule review/edits and explicit
+supersession. Agent-authored proposals and imported `accepted` notes are not
+active rules by default. An optional owner-defined import policy must bound
+which sources, scopes and changes it can approve.
+
+Generated native fragments and injected output must be excluded from intake.
+Detect drift and duplicate installations. Preview managed updates, preserve
+unrelated configuration and provide ownership-aware uninstall/restore. A prompt
+hook that cannot prove direct user origin proposes a change instead of claiming
+owner approval.
+
+Exit: one correction captured once can be reviewed once and delivered in both
+agents; repeated indexing creates no duplicates; quotes/tool output cannot
+activate a rule; changed imported content becomes an explicit revision candidate.
+
+Likely paths: `cmd/deja/promote.go` integration boundary, existing source/privacy
+helpers, `internal/instructions` intake/authoring code and managed installer tests.
+Do not change `deja remember` or `deja promote` semantics by surprise.
+
+### P3: Measured storage and a profile-local stateful runtime
+
+Scope: single-writer topology and selective/cached reads, not general hosting.
+
+Complete the storage experiment before selecting a Go driver or relaxing the
+no-runtime-dependencies constraint. Compare SQLite and DuckDB under the same
+runtime ownership model. Use a semantic store interface and a full-scan oracle;
+no engine-specific behavior may change instruction applicability.
+
+Implement transactionally published generations, idempotent change sets,
+private local IPC, single-flight startup, bounded queues, failure/recovery,
+retention and read-only offline diagnostics. Fix file-store publication/recovery
+limitations or retire that writer path explicitly; never run both concurrently.
+Move optional analytics off action admission and avoid duplicate authoritative
+writes. Do not introduce Quack/PostgreSQL solely for local coordination.
+
+Exit: both correctness and crash-injection suite pass for the selected backend;
+benchmarks include cold startup/IPC/p99/concurrent agents, not only SQL timings;
+old snapshots cannot grant new actions; migration and rollback are exercised.
+
+Likely paths: an `instructions` store/runtime component, adapters in the same
+binary, `tools/instruction-storage`, and profiling documentation. Keep existing
+conversation storage unchanged.
+
+### P4: Task continuity, procedures and evidence
+
+Scope: tasks and outstanding work survive agent switches accurately.
+
+Add task start/attach/handoff/close/cancel with revisioned bindings. Process stop
+or model response completion is not task completion. Child-run inheritance is
+explicit; exception grants default to no child inheritance. Reopen uses a new
+task incarnation. Implement obligations independently of delivery receipts.
+
+Add approved procedure bundles, pinned dependencies, staged normative content,
+check identities and declared input closures. Bind evidence to dirty/untracked
+inputs and environment identity, not only Git commits. Track self-report,
+observation, executor verification and owner attestation separately. Invalidate
+only when the relevant closure changes, falling back conservatively when it is
+unknown. Handle parallel step claims, late results, failures and unknown outcomes.
+
+Exit: a Claude-to-Codex handoff restores the same outstanding requirements;
+changed artifacts invalidate the old check; a delivered/read procedure never
+becomes completed without the configured evidence; task-local rules retire at
+explicit closure without deleting standing policy.
+
+### P5: Complete delivery integration and diagnostics
+
+Scope: make context selection and actual consumption observable and bounded.
+
+Use tested version-specific event adapters. Normalize multi-file edits and known
+MCP actions; mark unsupported shell/tool paths unknown. Compile baseline plus
+action-specific deltas. Treat emission separately from model-wire observation.
+Dedup only within the correct run/context epoch and rehydrate on uncertain
+retention. Include replacement/revocation notices; do not leave stale guidance
+unqualified in the working context.
+
+Extend existing `deja doctor`, install and MCP surfaces through small shared
+components. Report active generation, task binding, missing context, candidates
+awaiting review, procedure status, delivery channel support and actual guard
+coverage. Reconcile overlapping Deja history hooks without global silent
+suppression. A result with missing delivery must not look like "nothing applied".
+
+Exit: both real-agent recording stands pass, including negative/mutated fixtures;
+combined hook latency and bytes meet agreed measured budgets; missing adapters,
+overflow, crash and disabled-hook cases produce truthful diagnostics.
+Do this validation incrementally during earlier phases too, not only at the end.
+
+### P6: Optional targeted action gates
+
+Scope: one defined operation, not universal enforcement.
+
+Choose an initial adapter whose inputs and execution can be controlled, such as
+publishing a specific immutable release artifact. Define what constitutes user
+authorization independently from procedural readiness. A native pre-tool guard
+may deny a supported attempt, but cannot claim to cover unmediated execution.
+A resource gate requires control of the operation's necessary capability.
+
+Before admission, check current catalog/task/procedure revisions, scoped grants,
+evidence validity, immutable inputs and idempotency. A timeout/unknown result
+requires reconciliation before retrying a non-idempotent action. Demonstrate
+that alternate tool paths cannot bypass the resource gate before labelling that
+coverage enforced. Same-user cooperative checks are not isolated approval.
+
+Exit: supported violations are denied; unrelated read-only work remains possible;
+expiry/revision/race/replay cases fail as designed; authority and coverage limits
+are visible. Broader enforcement and isolated approval remain separate decisions.
+
+## 3. Acceptance cases
+
+Each case needs a synthetic fixture, expected resolution/state, and a negative
+control where practical. These are requirements, not a report of tests run.
+
+| ID | Fixture/action | Expected result |
+| --- | --- | --- |
+| R01 | Required rule versus higher-priority preference | Required rule remains; preference cannot waive it |
+| R02 | Forbid backend=remote; prefer backend=local | Compatible local default survives |
+| R03 | Same-authority scopes overlap but neither contains the other | Conflicting defaults remain unresolved despite different field counts |
+| R04 | Deeper path subset versus general path default | Narrower compatible default applies only inside that path |
+| R05 | Two mandatory values for one target plus an unrelated requirement | Target conflict reported; unrelated requirement still delivered |
+| R06 | Same setting on distinct resources | No false cross-resource conflict |
+| R07 | Rule revoked/new revision published during a session | Next supported boundary reports replacement; stale receipt/grant cannot satisfy current gate |
+| R08 | Scope dimension unknown; index includes global and unspecified-selector buckets | Indexed/full-scan selections agree; no top-k exclusion |
+| L01 | Persistent style preference plus temporary no-write requirement | Lifetime does not determine requirement strength |
+| L02 | Task suspended, process exits, then another agent attaches | Task rules/obligations remain; run-local state does not leak |
+| L03 | Task closes then is reopened under a new incarnation | Old overlays/grants are not resurrected |
+| L04 | Expiry exactly at boundary; clock moves backwards | Expired grant not accepted from cache; time uncertainty visible |
+| L05 | Two sessions share checkout but are different tasks | No accidental task binding or exception sharing |
+| C01 | Quoted "never" in a tool result or previous assistant summary | Candidate at most; no owner approval inferred |
+| C02 | Rewritten/appended transcript ingested twice | Cursor/hash reconciliation; no duplicate active rule |
+| C03 | Deja's own injected instruction appears in history | Excluded from candidate intake; no self-reinforcement |
+| C04 | Project is excluded or source is forgotten | Derived content obeys privacy/cascade policy; no covert provenance copy |
+| P01 | Skill is installed but procedure not delivered | Obligation still pending; installation is not completion |
+| P02 | SKILL.md unchanged but declared script dependency changes | Bundle/evidence invalidated |
+| P03 | Relevant dirty/untracked file changes after check; commit SHA unchanged | Old check cannot satisfy current artifact requirement |
+| P04 | Only proven unrelated inputs change | Relevant receipt remains valid |
+| P05 | Two agents claim/check one step; one crashes or reports late | Revisioned claim and idempotency prevent false double completion |
+| D01 | Parent and children reuse native session ID | Distinct run/epoch delivery state; each required context is delivered |
+| D02 | Compaction/resume drops previously emitted context | Full required rehydration in new epoch; old dedup receipt cannot suppress it |
+| D03 | Packet emitted but output write/agent ingestion fails | No fabricated wire-observed receipt; bounded retry/re-delivery |
+| D04 | Required stage too large for actual channel | Explicit incomplete result; no silent truncation/summarization |
+| D05 | Unrelated mandatory rule conflicts or a conditional runbook is unresolved | Useful unaffected context survives; only affected gate is blocked |
+| A01 | Multi-file patch includes rename and deletion | All affected old/new resources represented |
+| A02 | Interactive exec receives later stdin; unsupported hosted path | Coverage limitation explicit; no universal guard claim |
+| S01 | Concurrent publications use the same expected generation | One wins; other receives conflict, never lost update |
+| S02 | Commit succeeds but client times out and retries request ID | Original outcome returned; no duplicate state transition |
+| S03 | Process crashes after DB commit before cache notification | Reload committed generation; never serve uncommitted generation |
+| S04 | Analytical scan and telemetry flood run during action requests | Bounded queues; measured tail latency; required evidence not silently dropped |
+| G01 | Approved procedure passes but user never authorized action | No execution authorization is inferred |
+| G02 | Gate checks artifact A; executor is asked to publish artifact B | Denied/rechecked; input substitution cannot reuse receipt |
+| G03 | Agent edits approval/checker with same-user permissions | Cooperative mode reports limitation; isolated mode must prove separation |
+
+Add metamorphic/property checks: input record order cannot change meaning;
+adding irrelevant history cannot hide mandatory rules; increasing optional
+priority cannot remove a requirement; a narrower exception cannot waive a
+broader unmatched target; and indexed candidate selection equals the reference
+selector for all supported expressions.
+
+## 4. Recording stand and metrics
+
+Follow the repository's existing harness runbook rather than inventing an
+alternate success criterion. Use scratch HOME/USERPROFILE, every relevant
+DEJA location, CODEX_HOME/CLAUDE_CONFIG_DIR and synthetic repositories. Keep
+real histories, credentials and provider logs out of fixtures and commits.
+Record exact harness/binary versions and use fresh identities per case.
+
+For delivery, assert that the actual outbound model request contains a unique
+rule token only when applicable. Test absence for a different task/checkout as
+well as presence for the correct one. Include a mutation that disables or
+misroutes the hook and makes the test fail. Inspect the actual UI rendering.
+Do not call an HTTP request recorder an end-to-end behavioral eval: it proves
+bytes, not obedience. Test behavior separately and report the rate honestly.
+
+Report these distinct measurements:
+
+| Metric | Definition |
+| --- | --- |
+| Mandatory selector coverage | Expected applicable required rules selected / applicable required rules in the oracle |
+| Wire delivery coverage | Selected required text observed in recorded model requests / required text expected at that boundary |
+| Scope leakage | Rules observed outside authorized/applicable scope, with event count denominator |
+| Procedure validity | Obligations satisfied only by evidence meeting the configured grade and current input binding |
+| Behavioral adherence | Tested agent actions following delivered guidance / evaluated opportunities; model/version-specific |
+| Cost | p50/p95/p99 added latency, bytes/tokens per turn, redundant delivered bytes, runtime memory and disk growth |
+| Enforcement coverage | Enumerated action paths actually mediated / enumerated supported paths; never a vague global percentage |
+
+Initial correctness targets are zero deterministic selector misses, zero
+cross-task leaks and zero stale grant/receipt admissions in the fixture suite.
+They are finite-test acceptance targets, not claims of universal perfection.
+Performance targets and workload sweeps live in the storage decision; measure
+combined Deja history/instruction overhead against a before run on the same
+machine. Required context never gets silently omitted to improve a metric.
+
+## 5. Review and release gates
+
+For every implementation increment, include behavior, exact tests run,
+measurements, affected source paths, unsupported cases and migration impact in
+the PR. Preserve existing tests, unrelated configuration and runtime flags.
+Do not count a skipped test or missing agent installation as a passing test.
+
+Do not merge or release from this plan alone. Before broad enablement require
+repository CI, package coverage, native-agent delivery proof, privacy tests,
+rollback rehearsal and an accurate user guide. Gate status is explicit:
+implemented, locally verified, harness-verified, blocked or deferred.
+
+Decisions still requiring evidence/approval are the database/driver and packaging
+change; stronger approval isolation; performance budgets on target machines;
+which protected operation to pilot; and any cross-machine instruction sync.
+Keep sync out of the first local release. An ordinary agent handoff on one
+machine should not depend on solving distributed policy conflict resolution.

--- a/docs/instruction-runtime-storage.md
+++ b/docs/instruction-runtime-storage.md
@@ -1,0 +1,264 @@
+# Instruction runtime storage: workload-driven decision
+
+Status: proposed topology; engine selection open. Updated: 2026-09-06.
+Baseline: `feat/instructions-set` at `a6b760b9039e37d1aaf178beba29b0455c67e142`.
+This supplements the [initial storage note](instruction-storage.md), not a
+storage migration. See the [runtime design](instruction-runtime-design.md)
+and [implementation plan](instruction-runtime-plan.md).
+
+## Decision summary
+
+Do not choose the engine from total conversation volume alone. Keep Deja's
+existing history index intact during instruction work. Remove full-registry
+loading from the instruction action path. For the later stateful multi-agent
+runtime, compare SQLite and DuckDB under the same profile-local, single-writer
+Deja process, with identical correctness and latency requirements.
+
+This does not preselect SQLite for operational state or require DuckDB to be
+analytics-only. DuckDB remains a legitimate operational candidate when one
+runtime owns its embedded database. Analytical exports are a separate optional
+capability; two databases are not required simply to remember instructions.
+
+V0's JSON backend remains a bounded bootstrap implementation until a measured
+replacement is ready. Its `Store.Load/Replace` interface is not sufficient to
+make a database migration a performance improvement by itself.
+
+## 1. Separate the data and query shapes
+
+The existing index uses `records.bin`, token posting buckets, and Gob metadata.
+Explicit notes use JSONL; some external harness databases are SQLite inputs.
+`docs/ARCHITECTURE.md` describes these formats. Therefore there is no existing
+Deja-owned SQLite history database to swap wholesale for DuckDB.
+
+| Data class | Typical work | Required property |
+| --- | --- | --- |
+| Approved rules and procedure metadata | Scoped lookup and occasional revisioned publication | Complete mandatory selection, reproducible revisions |
+| Candidate inbox and source cursors | Incremental ingest, review, deduplication | Bounded ingest, idempotency, provenance and privacy |
+| Live tasks, obligations and grants | Small correlated reads/writes by many agent clients | Transactions, race handling, reliable handoff |
+| Delivery observations | Frequent small records; many repeated/no-op events | Bounded storage, deduplication, truthful completeness |
+| Retained receipt/audit analysis | Time-window scans, grouping, joins | Efficient bulk queries and retention |
+| Existing conversation search | Token postings and ranked recall | Preserve existing behavior; evaluate separately |
+
+The database may hold large historical volumes while the active working set is
+small. Conversely, a small file can still be slow if reopened, reparsed and
+fully explained before every tool use. Measure both axes independently.
+
+## 2. Proposed process ownership
+
+In the stateful phase, one explicitly enabled `deja instructions serve` process
+owns operational writes for one user/profile. This is a proposed command, not
+part of v0. Clients use a private local socket, bounded requests and timeouts;
+there is no TCP listener or cloud dependency by default. Use existing process
+facilities where suitable, not a deployment platform.
+
+The runtime owns a connection pool appropriate to the engine, a published
+immutable in-memory rule catalog, task state and a bounded ingest queue. Rule
+selection normally queries the in-memory scoped projection, not SQL on every
+rule. Point state mutations use transactions; optional analytical work cannot
+starve action admission.
+
+This is a concurrency topology, not an authentication boundary. A private socket
+only excludes other users where the OS supports that protection; same-user
+agent processes are still within the cooperative threat model.
+
+A single writer is relevant to both candidates. SQLite WAL allows readers with
+a writer but still has one writer at a time. DuckDB supports concurrent work
+inside a process, while direct cross-process access has different constraints;
+its current documentation describes Quack for remote multi-process writes and
+labels that protocol beta. None of those facts prevents Deja from owning one
+embedded DuckDB instance behind local IPC. Do not add Quack, PostgreSQL or
+DuckLake merely to satisfy a local instruction workload. [S1, S2]
+
+V0's stateless CLI remains available while advanced runtime work is developed.
+A future offline resolver may read a published snapshot with an explicit
+freshness/task-state limitation. It must not perform hidden parallel writes,
+grant exceptions, or claim to validate live execution receipts while disconnected.
+
+## 3. Store contracts before engine bindings
+
+Keep the storage boundary semantic. These are logical operations, not final Go
+signatures or permission grants:
+
+```text
+ReadGeneration(profile) -> generation, schema, published_digest
+SelectCandidates(selector, generation) -> records, selection_completeness
+GetRule(id, revision) -> immutable_payload
+Publish(change_set, expected_generation, request_id) -> committed_generation
+MutateTask(change_set, expected_task_revision, request_id) -> task_revision
+RecordEvidence(receipt, expected_obligation_revision, request_id) -> receipt_id
+ReadTaskPacket(task_id, consistent_revision) -> bindings, obligations, grants
+Explain(selector, generation, cursor) -> paged selection reasons
+```
+
+`Publish` includes approval provenance, changed rules, membership, exception
+changes and an audit event in one transaction. Separate procedure content blobs
+may be written first; the transaction references only durable verified blobs.
+An unreferenced blob after a crash is collectable. A committed catalog must not
+reference missing content.
+
+The change-set digest is bound to the request ID. Retrying the same ID/payload
+returns the original result; reusing the ID with different content is an error.
+A client timeout is an unknown commit outcome, not proof that the write failed.
+Query the operation result before retrying non-idempotent work.
+
+Logical tables/collections:
+
+- `catalog_generations`, `sets`, `set_members`, `rule_revisions`,
+  `procedure_revisions`, `exceptions`, and `approval_records`.
+- `tasks`, `task_bindings`, `agent_runs`, `obligations`, and `evidence_receipts`.
+- `candidates`, `source_cursors`, `delivery_records`, `audit_events`, and
+  `operation_results`.
+
+These names are a model, not a mandate for one table per noun. Keep immutable
+large text/blobs out of frequently updated rows. Index current revision,
+profile/set/repository/task selectors, obligation identity, and event sequence.
+Do not use insertion timestamp as a unique key or sole total order. Enforce
+foreign references and uniqueness either transactionally in the engine or in
+a tested store implementation; do not assume driver defaults enforce them.
+
+## 4. Hot-path selection and caching
+
+The selector must return a conservative superset of applicable rules. Combine
+exact-ID buckets with global/unspecified-selector buckets; path prefixes use
+component-aware lookup. Unknown selector dimensions retain potential matches.
+Final matching remains pure and deterministic. Compare indexed selection to a
+full-scan oracle across generated scopes, times and exceptions.
+
+A request caches by catalog generation, task/binding revision, normalized
+resources, adapter version and action. Expiry is the minimum of future validity
+starts, relevant expirations and configured freshness limits. An empty result
+also has a generation and validity boundary; negative caches can otherwise hide
+new requirements.
+
+Do not validate the entire catalog twice per request or build every exclusion
+explanation for a short hook packet. Validate at publication/load, verify the
+published generation, and evaluate selected records. Full diagnostics are paged.
+Keep source scanning, embeddings, transcript parsing, procedure discovery and
+analytical queries outside action admission.
+
+A broadcast invalidates client caches promptly; correctness must not depend on
+receiving it. Every protected operation resolves current catalog/task/evidence
+state in the runtime at admission. A generation change during an immutable
+artifact's execution is recorded; whether it cancels the operation must be
+specified by that action adapter rather than retroactively claimed.
+
+## 5. Durability, recovery and retention
+
+V0 syncs file contents and renames, but does not sync directory entries. Its
+archive and current-snapshot publication are separate writes; a crashed writer
+can leave a lock. These limitations are documented in `store.go`. They must not
+be inherited as production durability claims by a new store.
+
+For each database candidate, test acknowledged publication across process kill,
+restart, disk-full, interrupted migration and contention. Distinguish a process
+crash test from power-loss durability: the latter also depends on filesystem,
+OS and device behavior. Record journal/checkpoint/durability settings explicitly.
+Do not lower durability to make one benchmark appear faster. [S1]
+
+Only publish the in-memory generation after durable commit. A crash between
+commit and notification is recovered by reloading current state; an uncommitted
+change must never be rendered as active. Required evidence and operation
+admission records must be durable before permitting a protected action.
+Optional no-op delivery telemetry can be batched or sampled with dropped-event
+counters, but that history cannot then claim exact delivery counts.
+
+Avoid retaining full repeated packets or unrestricted tool output. Store packet
+hashes and revision references, bounded redacted diagnostics, and explicit
+emission/observation state. Suggested initial configurable retention is 30 days
+for detailed delivery events and 90 days for completed-task operational detail;
+these are proposed defaults, not existing behavior. Preserve active tasks,
+current rules, live grants and evidence still referenced by open obligations.
+Approval/revocation provenance has a separate owner-selected retention policy.
+Deletion/forget must propagate through projections and exports.
+
+Analytics reads sealed, privacy-filtered exports or a consistent read snapshot.
+If a separate DuckDB analytical file is used, it is rebuildable and not part of
+the approval transaction. No dual writes to competing sources of authority.
+
+## 6. What has and has not been measured
+
+The original bundle contains a short synthetic JSON registry probe and a
+SQLite-only SQL probe. They do not establish an engine winner or live agent
+latency. No new head-to-head result is claimed in this design pass: DuckDB was
+not installed in this runtime, and the package-install attempt failed because
+the runtime could not resolve its package host.
+
+The checked-in `tools/instruction-storage/compare.py` is still useful for
+reproducing isolated lookup/scan/commit/reopen cases. It uses Python drivers,
+different bulk-loading implementations, a simple schema and very few scan/
+commit repeats by default. It does not test the proposed Go runtime, IPC,
+concurrent clients, active-rule selection or failure recovery. Do not use its
+file sizes or load times as a general SQLite/DuckDB verdict.
+
+DuckDB's indexing documentation describes ART indexes for constraints and
+selective lookups, alongside costs and limitations. The storage spike must
+inspect actual plans rather than assuming that a created index is used or
+that scan-oriented execution cannot perform point queries. [S3]
+
+## 7. Required comparative experiment
+
+Use the same corpus seed, logical records, result oracle, durability objectives,
+hardware and Go/runtime ownership model. Record engine/driver/compiler versions,
+CPU/RAM/filesystem, query plans, settings, repeats and errors. Randomize engine
+order and run several independent trials; label warm, startup and OS-cold
+measurements separately. Caches must have the same semantics on both paths.
+
+| Experiment | Sweep | What it decides |
+| --- | --- | --- |
+| Catalog selection | 100 / 1,000 / 10,000 / 100,000 total rules; vary applicable count independently | Scope indexing and output cost, not transcript volume |
+| Operational retention | 100,000 / 1 million / 10 million synthetic events | Historical volume impact on current lookup/write latency |
+| Agent contention | 1 / 4 / 16 / 32 client processes | IPC queueing, transaction conflicts, retry behavior |
+| Rule publication | Single-rule edits and bounded set revisions amid reads | Generation visibility and exactly one current revision |
+| Task/receipt traffic | Handoff, child runs, check completion and invalidation | Correctness under realistic mixed operations |
+| Context reuse | No-op tools, task changes, compaction and resumed children | Saved bytes without incorrect suppression |
+| Failure injection | Crash at each publication boundary; timeout; disk full | No lost acknowledged policy or forged completion |
+| Analytics isolation | Grouped event queries concurrent with action requests | Whether analytical work harms interaction latency |
+
+Publish p50/p95/p99 latency, throughput at fixed arrival rates, queue depth,
+errors/retries, resident memory, allocations, bytes delivered and storage growth.
+Avoid a closed-loop test that conceals overload by reducing arrival rate when
+queries become slow. Verify every result, including exception expiry, before
+including a timing sample as a success. Test rollback-clock and stale-cache cases.
+
+Proposed initial engineering budgets, subject to measurement on target machines:
+no-match warm instruction overhead p95 <= 10 ms and p99 <= 25 ms; small matched
+packets p95 <= 25 ms excluding actual check execution; cold rule-context delivery
+p95 <= 100 ms. Record process/IPC time, not only the resolver function. Large
+procedure stages get a separate budget; never compress required content merely
+to meet a latency number. Measure combined Deja history plus instruction cost
+against the existing harness baseline rather than adding the two budgets.
+
+## 8. Adoption gate
+
+Both candidates must first pass the same semantic and recovery suite. Then
+choose on tail latency, concurrent behavior, resource use, packaging, maintenance
+and deployment simplicity. Do not select by a bulk-ingest or grouped-scan win
+alone. The existing no-runtime-Go-dependencies constraint means a new driver
+or external executable needs an explicit packaging decision: supported OS/CPU,
+CGO/cross-compilation, binary size, licensing, upgrade and crash isolation.
+
+If SQLite meets the operational targets with simpler packaging, that is evidence
+for using it, not an assumption that size never matters. If DuckDB meets those
+targets and offers a better total design, use it operationally behind the writer.
+If neither does, inspect selection/serialization/queueing before adding another
+engine. A compact catalog with optional DuckDB analytics remains a candidate,
+not the predetermined architecture.
+
+No automatic conversion of `records.bin`/notes or rewriting external harness
+databases is part of this decision. A future history migration needs its own
+search-quality, incremental-ingest, privacy, export and rollback evaluation.
+
+## Primary references
+
+[S1] SQLite WAL: https://www.sqlite.org/wal.html and appropriate uses:
+https://www.sqlite.org/whentouse.html (checked 2026-09-06).
+
+[S2] DuckDB concurrency: https://duckdb.org/docs/current/connect/concurrency
+(checked 2026-09-06; distinguish current docs from LTS behavior).
+
+[S3] DuckDB indexes: https://duckdb.org/docs/current/guides/performance/indexing
+(checked 2026-09-06).
+
+Repository evidence: `docs/ARCHITECTURE.md`, `internal/instructions/store.go`,
+`internal/instructions/resolve.go`, `internal/instructions/benchmark_test.go`,
+and `tools/instruction-storage/compare.py` at the baseline commit above.

--- a/docs/instruction-storage.md
+++ b/docs/instruction-storage.md
@@ -1,0 +1,77 @@
+# Storage decision: no blanket SQLite-to-DuckDB migration
+
+Status: provisional; a history storage migration is deliberately not in this PR.
+
+The existing Deja index is not SQLite. `docs/ARCHITECTURE.md` describes
+`records.bin`, token posting buckets and Gob metadata under an `index.db`
+directory. Primary explicit notes use JSONL. Some harness source databases are
+read using the SQLite CLI. Changing those external source formats is not a Deja
+storage-engine decision.
+
+Instruction configuration, action receipts and historical analytics are three
+different workloads. This PR only implements the first, behind a backend
+interface. Versioned JSON is a reviewable first backend, not a recommendation
+for high-volume records or an argument against DuckDB.
+
+For selection, compare:
+
+| Workload | Necessary measurement |
+| --- | --- |
+| Active instruction resolution | Small scoped reads, complete mandatory recall, hook startup and parse cost |
+| Rule approval and exception changes | Atomic writes, revision checks, recovery and concurrent processes |
+| Action/receipt history | Append throughput, bounded retention, scan and grouping cost |
+| Transcript research | Search postings/FTS versus scans; scope filtering and replay/update costs |
+
+SQLite's suitability cannot be inferred from database size alone. Its official
+usage guide describes efficient embedded/local storage and a single writer per
+database file with concurrent readers. Indexes, query shapes, transactions and
+contention need measurement, not a blanket claim that SQLite is slow.
+
+DuckDB is an important candidate for grouped event/receipt analytics. Its
+current concurrency documentation distinguishes direct embedded access (one
+read/write process, or multiple read-only processes) from multi-process write
+access through Quack's remote protocol. Quack is documented as beta. Choosing
+that path changes the architecture: a shared writer/server is not the same as
+many independent hooks opening one embedded database for writes.
+
+A likely future split worth testing is a compact active-rule projection for
+hooks with DuckDB for retained receipt/history analysis. That is a hypothesis,
+not an implemented or benchmark-proven decision. A direct DuckDB backend also
+needs packaging and Go dependency decisions; this PR adds no runtime Go deps.
+
+## Reproducible probes
+
+```sh
+# Bounded registry: resolution alone and load+resolve+render, 100/1000/10000 rules.
+go test ./internal/instructions -run '^$' -bench . -benchmem
+
+# Synthetic SQL workloads. DuckDB's Python package must already be available.
+python3 tools/instruction-storage/compare.py --rows 100000
+python3 tools/instruction-storage/compare.py --rows 1000000
+
+# An explicit one-engine run is not a comparison.
+python3 tools/instruction-storage/compare.py --engines sqlite --rows 100000
+```
+
+The SQL probe verifies primary-key lookups and grouped results and measures
+warm indexed reads, grouped scans, single-row commits, and reopen+lookup cost.
+It creates only temporary synthetic data and records engine versions. SQLite
+uses WAL/FULL; DuckDB query threads are one. Bulk loaders differ, so loader
+seconds are labeled non-comparable. It does not measure OS cold caches, process
+startup, real Deja retrieval, Quack, multi-process concurrency, or a workload
+with agent-specific payload distributions. Do not generalize it into an engine
+winner without the missing tests.
+
+The registry probe uses one applicable rule and many explicitly unrelated tasks.
+It measures complete explanation construction too; it is not a million-message
+history benchmark. Large-snapshot JSON validation/copying is a real limitation
+of this first backend. Keep runtime lookup optimization separate from storage
+migration, and test actual hook latency/context size before enabling broadly.
+
+## Primary references (checked September 6, 2026)
+
+- Existing repository: `docs/ARCHITECTURE.md`, index format and notes source.
+- SQLite: https://www.sqlite.org/whentouse.html
+- DuckDB: https://duckdb.org/docs/current/connect/concurrency
+- Codex: https://developers.openai.com/codex/hooks
+- Claude Code: https://code.claude.com/docs/en/hooks

--- a/internal/index/zed_watermark_test.go
+++ b/internal/index/zed_watermark_test.go
@@ -57,13 +57,20 @@ func zedThread(t *testing.T, db, id, updated string, texts []string) {
     id text primary key, summary text not null, updated_at text not null,
     data_type text not null, data blob not null, parent_id text,
     folder_paths text, folder_paths_order text, created_at text);
-` + fmt.Sprintf("insert or replace into threads (id,summary,updated_at,data_type,data,folder_paths) values (%q,'pool timeouts',%q,'zstd',x'%s','[\"/work/app\"]');",
-		id, updated, hex.EncodeToString(out.Bytes()))
+` + fmt.Sprintf("insert or replace into threads (id,summary,updated_at,data_type,data,folder_paths) values (%s,'pool timeouts',%s,'zstd',x'%s','[\"/work/app\"]');",
+		sqliteLiteral(id), sqliteLiteral(updated), hex.EncodeToString(out.Bytes()))
 	c := exec.Command("sqlite3", db)
 	c.Stdin = strings.NewReader(stmts)
 	if o, err := c.CombinedOutput(); err != nil {
 		t.Fatalf("sqlite3 seed: %v %s", err, o)
 	}
+}
+
+// sqliteLiteral uses SQL string literals, not Go's %q double-quoted strings.
+// SQLite historically accepted double-quoted strings in some builds, but that
+// compatibility is optional and strict builds parse them as identifiers.
+func sqliteLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func zedHits(t *testing.T, dir, marker string) int {

--- a/internal/instructions/benchmark_test.go
+++ b/internal/instructions/benchmark_test.go
@@ -1,0 +1,65 @@
+package instructions
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkResolve(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			s := snapshot()
+			c := ctx()
+			c.Task = "current"
+			for i := 0; i < n; i++ {
+				r := rule(fmt.Sprintf("rule-%d", i))
+				r.Scope.Task = fmt.Sprintf("other-%d", i)
+				s.Rules = append(s.Rules, r)
+			}
+			s.Rules[0].Scope.Task = "current"
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r, err := Resolve(s, c)
+				if err != nil || len(r.Applicable) != 1 {
+					b.Fatal(r, err)
+				}
+			}
+		})
+	}
+}
+func BenchmarkLoadResolveRender(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			s := snapshot()
+			c := ctx()
+			c.Task = "current"
+			for i := 0; i < n; i++ {
+				r := rule(fmt.Sprintf("rule-%d", i))
+				r.Scope.Task = fmt.Sprintf("other-%d", i)
+				s.Rules = append(s.Rules, r)
+			}
+			s.Rules[0].Scope.Task = "current"
+			store := FileStore{Path: filepath.Join(b.TempDir(), "registry.json")}
+			if _, err := store.Replace(0, s); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				s, err := store.Load()
+				if err != nil {
+					b.Fatal(err)
+				}
+				r, err := Resolve(s, c)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err = Render(r, DefaultBudget); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/instructions/cli.go
+++ b/internal/instructions/cli.go
@@ -1,0 +1,186 @@
+package instructions
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const Help = `deja instructions (experimental; opt-in advisory delivery)
+  example                         print a starter registry
+  apply --file FILE --expect N --approve
+                                  approve a registry revision with compare-and-swap
+  export                          print current registry for editing
+  resolve [--repo ROOT] [--worktree ROOT] [--task ID] [--session ID]
+          [--environment NAME] [--tool NAME] [--path RELATIVE] [--json]
+  hook --agent claude|codex        read a lifecycle event on stdin
+  install --agent claude|codex     preserve existing hooks and add instruction hooks
+
+All commands accept --store ABSOLUTE_FILE. Default: DEJA_INSTRUCTIONS_FILE,
+then XDG_CONFIG_HOME/deja/instructions.json, then ~/.config/deja/instructions.json.
+Task/environment default to DEJA_TASK_ID and DEJA_ENVIRONMENT, never prompt text.
+Runbooks are delivered, not executed or certified. See docs/instruction-memory.md.
+`
+
+func DefaultPath() (string, error) {
+	p := os.Getenv("DEJA_INSTRUCTIONS_FILE")
+	if p == "" {
+		root := os.Getenv("XDG_CONFIG_HOME")
+		if root == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			root = filepath.Join(home, ".config")
+		}
+		p = filepath.Join(root, "deja", "instructions.json")
+	}
+	if !absolutePath(p) {
+		return "", fmt.Errorf("store location must be a clean absolute path")
+	}
+	return p, nil
+}
+func Run(args []string, in io.Reader, out io.Writer) error {
+	if len(args) == 0 || oneOf(args[0], "help", "--help", "-h") {
+		_, err := io.WriteString(out, Help)
+		return err
+	}
+	name := args[0]
+	if !oneOf(name, "example", "apply", "export", "resolve", "hook", "install") {
+		return fmt.Errorf("unknown instructions command %q", name)
+	}
+	f := flag.NewFlagSet("instructions "+name, flag.ContinueOnError)
+	f.SetOutput(io.Discard)
+	storePath := f.String("store", "", "approved registry file")
+	var file, expected, agent, config, binary string
+	var approve, asJSON bool
+	var c Context
+	budget := DefaultBudget
+	switch name {
+	case "apply":
+		f.StringVar(&file, "file", "", "registry to approve")
+		f.StringVar(&expected, "expect", "", "expected revision")
+		f.BoolVar(&approve, "approve", false, "explicitly approve registry")
+	case "resolve", "hook":
+		f.StringVar(&c.Task, "task", os.Getenv("DEJA_TASK_ID"), "task identity")
+		f.StringVar(&c.Environment, "environment", os.Getenv("DEJA_ENVIRONMENT"), "environment")
+		if name == "hook" {
+			f.StringVar(&agent, "agent", "", "claude or codex")
+		} else {
+			f.StringVar(&c.Repository, "repo", "", "main repository root")
+			f.StringVar(&c.Worktree, "worktree", "", "checkout root")
+			f.StringVar(&c.Session, "session", "", "session identity")
+			f.StringVar(&c.Tool, "tool", "", "exact hook tool name")
+			f.StringVar(&c.Path, "path", "", "relative path")
+			f.BoolVar(&asJSON, "json", false, "resolution explanations")
+			f.IntVar(&budget, "budget", DefaultBudget, "context byte budget")
+		}
+	case "install":
+		f.StringVar(&agent, "agent", "", "claude or codex")
+		f.StringVar(&config, "config", "", "absolute config path")
+		f.StringVar(&binary, "binary", "", "absolute deja executable")
+	}
+	if err := f.Parse(args[1:]); err != nil {
+		if err == flag.ErrHelp {
+			_, err = io.WriteString(out, Help)
+		}
+		return err
+	}
+	if f.NArg() != 0 {
+		return fmt.Errorf("unexpected argument %q", f.Arg(0))
+	}
+	if name == "example" {
+		return json.NewEncoder(out).Encode(Snapshot{Version: Version, Rules: []Rule{{ID: "work.preserve-unrelated", Revision: 1, Kind: "constraint", Text: "Preserve unrelated work. Do not discard changes outside the task.", Authority: "owner", Status: "active", Strength: "must", Absolute: true, Lifetime: "persistent", Source: "Example: review and explicitly approve before installation."}}})
+	}
+	if *storePath == "" {
+		p, err := DefaultPath()
+		if err != nil {
+			return err
+		}
+		*storePath = p
+	}
+	if !absolutePath(*storePath) {
+		return fmt.Errorf("--store must be a clean absolute path")
+	}
+	store := FileStore{Path: *storePath}
+	switch name {
+	case "apply":
+		if !approve || file == "" || expected == "" {
+			return fmt.Errorf("apply requires --file, --expect and --approve")
+		}
+		n, err := strconv.ParseUint(expected, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid expected revision: %w", err)
+		}
+		b, err := readBounded(file, MaxRegistryBytes)
+		if err != nil {
+			return err
+		}
+		var next Snapshot
+		if err = decode(bytes.NewReader(b), &next, MaxRegistryBytes, true); err != nil {
+			return err
+		}
+		saved, err := store.Replace(n, next)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(out).Encode(saved)
+	case "export":
+		s, err := store.Load()
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(out).Encode(s)
+	case "hook":
+		return Hook(store, agent, c.Task, c.Environment, in, out, time.Now())
+	case "install":
+		if _, err := store.Load(); err != nil {
+			return fmt.Errorf("approve a valid registry before installing hooks: %w", err)
+		}
+		p, err := Install(agent, config, binary, *storePath)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(out, "Instruction hooks written to %s. Review/trust them in the agent, then start a new session. Delivery is advisory, not enforcement.\n", p)
+		return err
+	default:
+		if c.Repository == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			repo, wt, err := Workspace(cwd)
+			if err != nil {
+				return err
+			}
+			c.Repository = repo
+			if c.Worktree == "" {
+				c.Worktree = wt
+			}
+		}
+		c.Now = time.Now()
+		s, err := store.Load()
+		if err != nil {
+			return err
+		}
+		result, err := Resolve(s, c)
+		if err != nil {
+			return err
+		}
+		if asJSON {
+			return json.NewEncoder(out).Encode(result)
+		}
+		text, err := Render(result, budget)
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(out, text)
+		return err
+	}
+}

--- a/internal/instructions/cli.go
+++ b/internal/instructions/cli.go
@@ -20,7 +20,7 @@ const Help = `deja instructions (experimental; opt-in advisory delivery)
   resolve [--repo ROOT] [--worktree ROOT] [--task ID] [--session ID]
           [--environment NAME] [--tool NAME] [--path RELATIVE] [--json]
   hook --agent claude|codex        read a lifecycle event on stdin
-  install --agent claude|codex     preserve existing hooks and add instruction hooks
+  install --agent claude|codex     attach approved instruction context to deja hooks
 
 All commands accept --store ABSOLUTE_FILE. Default: DEJA_INSTRUCTIONS_FILE,
 then XDG_CONFIG_HOME/deja/instructions.json, then ~/.config/deja/instructions.json.

--- a/internal/instructions/cli_test.go
+++ b/internal/instructions/cli_test.go
@@ -81,7 +81,7 @@ func TestInstall(t *testing.T) {
 		if e != nil {
 			t.Fatal(e)
 		}
-		for _, needle := range []string{"deja hook-tool", "keep", "9007199254740993"} {
+		for _, needle := range []string{"hook-tool", "keep", "9007199254740993"} {
 			if !bytes.Contains(first, []byte(needle)) {
 				t.Fatalf("clobbered %s", needle)
 			}

--- a/internal/instructions/cli_test.go
+++ b/internal/instructions/cli_test.go
@@ -1,0 +1,134 @@
+package instructions
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCLI(t *testing.T) {
+	d := isolated(t)
+	p := filepath.Join(d, "deja", "instructions.json")
+	got, e := DefaultPath()
+	if e != nil || got != p {
+		t.Fatal(got, e)
+	}
+	var out bytes.Buffer
+	if e = Run([]string{"example"}, nil, &out); e != nil {
+		t.Fatal(e)
+	}
+	draft := filepath.Join(d, "draft.json")
+	write(t, draft, out.Bytes())
+	out.Reset()
+	if e = Run([]string{"apply", "--file", draft, "--expect", "0", "--approve"}, nil, &out); e != nil {
+		t.Fatal(e)
+	}
+	for _, args := range [][]string{{"export"}, {"resolve", "--repo", d}, {"resolve", "--repo", d, "--json"}, {"resolve"}, {"hook", "--agent", "codex"}, {"help"}, {}, {"resolve", "--help"}} {
+		out.Reset()
+		input := bytes.NewReader(encoded(t, HookInput{Event: "SessionStart", CWD: d}))
+		if e = Run(args, input, &out); e != nil || out.Len() == 0 {
+			t.Fatalf("%v: %s %v", args, out.String(), e)
+		}
+	}
+	for _, args := range [][]string{{"unknown"}, {"export", "extra"}, {"export", "--unknown"}, {"apply"}, {"apply", "--file", draft, "--expect", "bad", "--approve"}, {"apply", "--file", draft + "missing", "--expect", "1", "--approve"}, {"resolve", "--repo", "relative"}, {"resolve", "--repo", d, "--budget", "1"}, {"export", "--store", "relative"}, {"install", "--agent", "unsupported"}} {
+		bad(t, Run(args, nil, io.Discard))
+	}
+	write(t, draft, []byte("broken"))
+	bad(t, Run([]string{"apply", "--file", draft, "--expect", "1", "--approve"}, nil, io.Discard))
+	t.Setenv("DEJA_INSTRUCTIONS_FILE", "relative")
+	_, e = DefaultPath()
+	bad(t, e)
+	bad(t, Run([]string{"export"}, nil, io.Discard))
+	t.Setenv("DEJA_INSTRUCTIONS_FILE", p)
+	if got, e = DefaultPath(); e != nil || got != p {
+		t.Fatal(got, e)
+	}
+	t.Setenv("DEJA_INSTRUCTIONS_FILE", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got, e = DefaultPath(); e != nil || got != filepath.Join(d, ".config", "deja", "instructions.json") {
+		t.Fatal(got, e)
+	}
+	bad(t, Run(nil, nil, failingWriter{}))
+	bad(t, Run([]string{"install", "--agent", "codex", "--store", filepath.Join(d, "absent.json")}, nil, io.Discard))
+	if runtime.GOOS != "windows" {
+		if e = Run([]string{"install", "--agent", "codex", "--store", p}, nil, io.Discard); e != nil {
+			t.Fatal(e)
+		}
+	}
+}
+func TestInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer explicitly supports macOS/Linux only")
+	}
+	d := isolated(t)
+	store := filepath.Join(d, "registry.json")
+	binary, e := os.Executable()
+	if e != nil {
+		t.Fatal(e)
+	}
+	for _, agent := range []string{"claude", "codex"} {
+		config := filepath.Join(d, agent+".json")
+		original := []byte(`{"other":{"keep":true,"large":9007199254740993},"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"deja hook-tool"}]}]}}`)
+		write(t, config, original)
+		p, e := Install(agent, config, binary, store)
+		if e != nil || p != config {
+			t.Fatal(p, e)
+		}
+		first, e := os.ReadFile(config)
+		if e != nil {
+			t.Fatal(e)
+		}
+		for _, needle := range []string{"deja hook-tool", "keep", "9007199254740993"} {
+			if !bytes.Contains(first, []byte(needle)) {
+				t.Fatalf("clobbered %s", needle)
+			}
+		}
+		if bytes.Contains(first, []byte("additionalContextLimit")) != (agent == "codex") {
+			t.Fatal("wrong agent's context-limit field")
+		}
+		if _, e = Install(agent, config, binary, store); e != nil {
+			t.Fatal(e)
+		}
+		second, e := os.ReadFile(config)
+		if e != nil || !bytes.Equal(first, second) {
+			t.Fatal("non-idempotent install", e)
+		}
+		backups, e := filepath.Glob(config + ".deja-instructions-backup-*")
+		if e != nil || len(backups) != 1 {
+			t.Fatal(backups, e)
+		}
+		b, e := os.ReadFile(backups[0])
+		if e != nil || !bytes.Equal(b, original) {
+			t.Fatal("backup changed", e)
+		}
+		if _, e = Install(agent, "", "", store); e != nil {
+			t.Fatal(e)
+		}
+	}
+	for _, tc := range []struct{ agent, config, binary, store string }{{"other", "", binary, store}, {"claude", "relative", binary, store}, {"codex", "", "relative", store}, {"codex", "", binary, "relative"}, {"claude", "", d, store}, {"claude", "", filepath.Join(d, "absent"), store}} {
+		_, e = Install(tc.agent, tc.config, tc.binary, tc.store)
+		bad(t, e)
+	}
+	for _, invalid := range []string{`not json`, `null`, `{"hooks":null}`, `{"hooks":{"SessionStart":1}}`, `{"hooks":{"SessionStart":[1]}}`, `{"hooks":{"SessionStart":[{}]}}`, `{"hooks":{"SessionStart":[{"hooks":[1]}]}}`} {
+		config := filepath.Join(d, "broken.json")
+		write(t, config, []byte(invalid))
+		_, e = Install("claude", config, binary, store)
+		bad(t, e)
+		b, err := os.ReadFile(config)
+		if err != nil || string(b) != invalid {
+			t.Fatal("bad config overwritten", err)
+		}
+	}
+	config := filepath.Join(d, "lock.json")
+	if e = os.Mkdir(config+".deja-instructions.lock", 0700); e != nil {
+		t.Fatal(e)
+	}
+	_, e = Install("claude", config, binary, store)
+	bad(t, e)
+	if quoted := shellQuote("a' b;$HOME"); quoted != "'a'\"'\"' b;$HOME'" {
+		t.Fatal(quoted)
+	}
+}

--- a/internal/instructions/hook.go
+++ b/internal/instructions/hook.go
@@ -1,0 +1,189 @@
+package instructions
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type HookInput struct {
+	Event   string          `json:"hook_event_name"`
+	CWD     string          `json:"cwd"`
+	Session string          `json:"session_id"`
+	Tool    string          `json:"tool_name"`
+	Input   json.RawMessage `json:"tool_input"`
+}
+
+// Hook is advisory in v0. No allow/deny decisions or compliance claims are made.
+// Parse/load/resolve failures are visible, including in model context when the
+// event supports it. This does not depend on the history hook's fail-open path.
+func Hook(store Store, agent, task, environment string, in io.Reader, out io.Writer, now time.Time) error {
+	if !oneOf(agent, "claude", "codex") {
+		return fmt.Errorf("agent must be claude or codex")
+	}
+	var input HookInput
+	if err := decode(in, &input, 1<<20, false); err != nil {
+		return hookWarning(out, "", "malformed hook input: "+err.Error())
+	}
+	if !oneOf(input.Event, "SessionStart", "UserPromptSubmit", "PreToolUse", "SubagentStart") {
+		return hookWarning(out, "", "unsupported event "+input.Event)
+	}
+	warn := func(err error) error { return hookWarning(out, input.Event, err.Error()) }
+	repo, worktree, err := Workspace(input.CWD)
+	if err != nil {
+		return warn(err)
+	}
+	c := Context{Repository: repo, Worktree: worktree, Task: task, Environment: environment, Session: input.Session, Tool: input.Tool, Now: now}
+	// Shells, MCP tools and patches can affect multiple paths. Never infer their
+	// targets from command substrings. Those path selectors remain conditional.
+	if oneOf(input.Tool, "Read", "Write", "Edit") {
+		var args struct {
+			FilePath string `json:"file_path"`
+			Path     string `json:"path"`
+		}
+		if len(input.Input) > 0 {
+			if err = json.Unmarshal(input.Input, &args); err != nil {
+				return warn(fmt.Errorf("malformed file-tool arguments"))
+			}
+		}
+		target := args.FilePath
+		if target == "" {
+			target = args.Path
+		}
+		if target != "" {
+			if !filepath.IsAbs(target) {
+				target = filepath.Join(input.CWD, target)
+			}
+			target, err = canonicalTarget(target)
+			if err != nil {
+				return warn(err)
+			}
+			rel, e := filepath.Rel(worktree, target)
+			if e == nil && relativePath(filepath.ToSlash(rel)) {
+				c.Path = filepath.ToSlash(rel)
+			}
+		}
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		return warn(fmt.Errorf("cannot load approved registry: %w", err))
+	}
+	result, err := Resolve(snapshot, c)
+	if err != nil {
+		return warn(err)
+	}
+	text, err := Render(result, DefaultBudget)
+	if err != nil {
+		return warn(err)
+	}
+	if text == "" {
+		return nil
+	}
+	return json.NewEncoder(out).Encode(map[string]any{"hookSpecificOutput": map[string]string{"hookEventName": input.Event, "additionalContext": text}})
+}
+func hookWarning(out io.Writer, event, reason string) error {
+	message := "Deja instruction context INCOMPLETE: " + reason + ". Resolve before relying on remembered instructions; this hook has not blocked the action."
+	result := map[string]any{"systemMessage": message}
+	if event != "" {
+		result["hookSpecificOutput"] = map[string]string{"hookEventName": event, "additionalContext": message}
+	}
+	return json.NewEncoder(out).Encode(result)
+}
+
+// Resolve the nearest existing ancestor, including for a new file underneath a
+// symlink. A dangling symlink is an error, not a lexical in-repository target.
+func canonicalTarget(target string) (string, error) {
+	var tail []string
+	for current := filepath.Clean(target); ; current = filepath.Dir(current) {
+		_, err := os.Lstat(current)
+		if err == nil {
+			root, err := filepath.EvalSymlinks(current)
+			if err != nil {
+				return "", err
+			}
+			for i := len(tail) - 1; i >= 0; i-- {
+				root = filepath.Join(root, tail[i])
+			}
+			return root, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) || filepath.Dir(current) == current {
+			return "", err
+		}
+		tail = append(tail, filepath.Base(current))
+	}
+}
+
+// Workspace follows Git worktree metadata without invoking git. Separate clones
+// remain distinct; bare/common layouts without a main .git root are unsupported.
+func Workspace(cwd string) (repository, worktree string, err error) {
+	if !absolutePath(cwd) {
+		return "", "", fmt.Errorf("cwd must be a clean absolute path")
+	}
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return "", "", err
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", "", err
+	}
+	if !info.IsDir() {
+		return "", "", fmt.Errorf("cwd is not a directory")
+	}
+	for root := cwd; ; root = filepath.Dir(root) {
+		git := filepath.Join(root, ".git")
+		info, e := os.Stat(git)
+		if e == nil {
+			if !info.IsDir() {
+				b, e := readBounded(git, 4096)
+				if e != nil {
+					return "", "", e
+				}
+				if !strings.HasPrefix(string(b), "gitdir: ") {
+					return "", "", fmt.Errorf("invalid .git file")
+				}
+				git = strings.TrimSpace(strings.TrimPrefix(string(b), "gitdir: "))
+				if git == "" {
+					return "", "", fmt.Errorf("empty gitdir")
+				}
+				if !filepath.IsAbs(git) {
+					git = filepath.Join(root, git)
+				}
+			}
+			common, e := readBounded(filepath.Join(git, "commondir"), 4096)
+			if errors.Is(e, os.ErrNotExist) {
+				return root, root, nil
+			}
+			if e != nil {
+				return "", "", e
+			}
+			dir := strings.TrimSpace(string(common))
+			if dir == "" {
+				return "", "", fmt.Errorf("empty git commondir")
+			}
+			if !filepath.IsAbs(dir) {
+				dir = filepath.Join(git, dir)
+			}
+			dir, e = filepath.EvalSymlinks(dir)
+			if e != nil {
+				return "", "", e
+			}
+			if filepath.Base(dir) != ".git" {
+				return "", "", fmt.Errorf("unsupported bare/common Git layout")
+			}
+			return filepath.Dir(dir), root, nil
+		}
+		if !errors.Is(e, os.ErrNotExist) {
+			return "", "", e
+		}
+		if filepath.Dir(root) == root {
+			break
+		}
+	}
+	return cwd, cwd, nil
+}

--- a/internal/instructions/hook_test.go
+++ b/internal/instructions/hook_test.go
@@ -147,7 +147,10 @@ func TestNewFileSymlinkTarget(t *testing.T) {
 		t.Skip("requires symlink privilege")
 	}
 	d := isolated(t)
-	outside := t.TempDir()
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if e := os.Symlink(outside, filepath.Join(d, "link")); e != nil {
 		t.Fatal(e)
 	}

--- a/internal/instructions/hook_test.go
+++ b/internal/instructions/hook_test.go
@@ -1,0 +1,225 @@
+package instructions
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunbookAndBudget(t *testing.T) {
+	d := isolated(t)
+	p := filepath.Join(d, "RUNBOOK.md")
+	body := []byte("Step 1: run synthetic checks.\nStep 2: inspect results.")
+	write(t, p, body)
+	h := sha256.Sum256(body)
+	r := rule("runbook")
+	r.Kind = "procedure"
+	r.Runbook = &Runbook{Path: p, SHA256: hex.EncodeToString(h[:])}
+	resolved, e := Resolve(snapshot(r), ctx())
+	if e != nil {
+		t.Fatal(e)
+	}
+	text, e := Render(resolved, DefaultBudget)
+	if e != nil || !strings.Contains(text, string(body)) {
+		t.Fatal(text, e)
+	}
+	write(t, p, []byte("unapproved edit"))
+	_, e = Render(resolved, DefaultBudget)
+	bad(t, e)
+	r.Scope.Tools = []string{"Bash"}
+	resolved, e = Resolve(snapshot(r), ctx())
+	if e != nil {
+		t.Fatal(e)
+	}
+	text, e = Render(resolved, DefaultBudget)
+	if e != nil || !strings.Contains(text, "CONDITIONAL") || strings.Contains(text, "unapproved edit") {
+		t.Fatal(text, e)
+	}
+	for _, budget := range []int{0, 1, DefaultBudget + 1} {
+		_, e = Render(resolved, budget)
+		bad(t, e)
+	}
+	resolved.Conflicts = []Conflict{{Key: "x", RuleIDs: []string{"a", "b"}}}
+	_, e = Render(resolved, DefaultBudget)
+	bad(t, e)
+	if text, e = Render(Result{}, DefaultBudget); e != nil || text != "" {
+		t.Fatal(text, e)
+	}
+	r = rule("large")
+	r.Text = strings.Repeat("x", DefaultBudget)
+	resolved, _ = Resolve(snapshot(r), ctx())
+	text, e = Render(resolved, DefaultBudget)
+	if e == nil || text != "" {
+		t.Fatal("mandatory truncation")
+	}
+	r.Strength = "should"
+	resolved, _ = Resolve(snapshot(r, rule("must")), ctx())
+	text, e = Render(resolved, 1000)
+	if e != nil || !strings.Contains(text, "Optional preferences omitted: 1") || !strings.Contains(text, "must@1") {
+		t.Fatal(text, e)
+	}
+	r.Text = "A small preference."
+	resolved, _ = Resolve(snapshot(r), ctx())
+	text, e = Render(resolved, 1000)
+	if e != nil || !strings.Contains(text, r.Text) {
+		t.Fatal(text, e)
+	}
+	r.Kind = "procedure"
+	r.Strength = "must"
+	r.Runbook = &Runbook{Path: p, SHA256: strings.Repeat("0", 64)}
+	if e = os.Remove(p); e != nil {
+		t.Fatal(e)
+	}
+	resolved, _ = Resolve(snapshot(r), ctx())
+	_, e = Render(resolved, DefaultBudget)
+	bad(t, e)
+	invalid := []byte{0xff, 0xfe}
+	write(t, p, invalid)
+	h = sha256.Sum256(invalid)
+	r.Runbook.SHA256 = hex.EncodeToString(h[:])
+	resolved, _ = Resolve(snapshot(r), ctx())
+	_, e = Render(resolved, DefaultBudget)
+	bad(t, e)
+}
+func TestWorkspace(t *testing.T) {
+	d := isolated(t)
+	root := filepath.Join(d, "repo")
+	git := filepath.Join(root, ".git")
+	sub := filepath.Join(root, "src")
+	if e := os.MkdirAll(git, 0700); e != nil {
+		t.Fatal(e)
+	}
+	if e := os.Mkdir(sub, 0700); e != nil {
+		t.Fatal(e)
+	}
+	repo, wt, e := Workspace(sub)
+	if e != nil || repo != root || wt != root {
+		t.Fatal(repo, wt, e)
+	}
+	plain := filepath.Join(d, "plain")
+	if e = os.Mkdir(plain, 0700); e != nil {
+		t.Fatal(e)
+	}
+	repo, wt, e = Workspace(plain)
+	if e != nil || repo != plain || wt != plain {
+		t.Fatal(repo, wt, e)
+	}
+	worktree := filepath.Join(d, "checkout")
+	meta := filepath.Join(git, "worktrees", "checkout")
+	if e = os.MkdirAll(meta, 0700); e != nil {
+		t.Fatal(e)
+	}
+	if e = os.Mkdir(worktree, 0700); e != nil {
+		t.Fatal(e)
+	}
+	write(t, filepath.Join(worktree, ".git"), []byte("gitdir: "+meta+"\n"))
+	write(t, filepath.Join(meta, "commondir"), []byte("../..\n"))
+	repo, wt, e = Workspace(worktree)
+	if e != nil || repo != root || wt != worktree {
+		t.Fatal(repo, wt, e)
+	}
+	for _, invalid := range []string{"relative", filepath.Join(d, "missing"), filepath.Join(worktree, ".git")} {
+		_, _, e = Workspace(invalid)
+		bad(t, e)
+	}
+	for _, text := range []string{"invalid", "gitdir: "} {
+		write(t, filepath.Join(worktree, ".git"), []byte(text))
+		_, _, e = Workspace(worktree)
+		bad(t, e)
+	}
+	write(t, filepath.Join(worktree, ".git"), []byte("gitdir: ../repo/.git/worktrees/checkout\n"))
+	write(t, filepath.Join(meta, "commondir"), []byte(""))
+	_, _, e = Workspace(worktree)
+	bad(t, e)
+	write(t, filepath.Join(meta, "commondir"), []byte(d))
+	_, _, e = Workspace(worktree)
+	bad(t, e)
+}
+func TestNewFileSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires symlink privilege")
+	}
+	d := isolated(t)
+	outside := t.TempDir()
+	if e := os.Symlink(outside, filepath.Join(d, "link")); e != nil {
+		t.Fatal(e)
+	}
+	got, e := canonicalTarget(filepath.Join(d, "link", "new", "file.go"))
+	if e != nil || got != filepath.Join(outside, "new", "file.go") {
+		t.Fatal(got, e)
+	}
+	if e = os.Symlink(filepath.Join(d, "missing"), filepath.Join(d, "dangling")); e != nil {
+		t.Fatal(e)
+	}
+	_, e = canonicalTarget(filepath.Join(d, "dangling", "file.go"))
+	bad(t, e)
+}
+
+type memoryStore struct {
+	s   Snapshot
+	err error
+}
+
+func (m memoryStore) Load() (Snapshot, error) { return m.s, m.err }
+func (m memoryStore) Replace(uint64, Snapshot) (Snapshot, error) {
+	return Snapshot{}, errors.New("read only")
+}
+func TestHookAdapters(t *testing.T) {
+	d := isolated(t)
+	r := rule("absolute")
+	r.Absolute = true
+	for _, agent := range []string{"claude", "codex"} {
+		for _, event := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "SubagentStart"} {
+			input := HookInput{Event: event, CWD: d, Session: "synthetic", Tool: "Edit", Input: json.RawMessage(`{"file_path":"src/new.go"}`)}
+			var out bytes.Buffer
+			if e := Hook(memoryStore{s: snapshot(r)}, agent, "T", "local", bytes.NewReader(encoded(t, input)), &out, instant); e != nil {
+				t.Fatal(e)
+			}
+			var result map[string]any
+			if e := json.Unmarshal(out.Bytes(), &result); e != nil {
+				t.Fatal(e)
+			}
+			specific, ok := result["hookSpecificOutput"].(map[string]any)
+			if !ok || specific["hookEventName"] != event || !strings.Contains(specific["additionalContext"].(string), "absolute@1") {
+				t.Fatal(out.String())
+			}
+			if _, ok := specific["permissionDecision"]; ok {
+				t.Fatal("advisory hook granted permission")
+			}
+		}
+	}
+	for _, data := range []string{`not json`, `{"hook_event_name":"Unsupported","cwd":"x"}`, `{"hook_event_name":"SessionStart","cwd":"relative"}`} {
+		var out bytes.Buffer
+		if e := Hook(memoryStore{s: snapshot(r)}, "codex", "", "", strings.NewReader(data), &out, instant); e != nil || !strings.Contains(out.String(), "INCOMPLETE") {
+			t.Fatal(out.String(), e)
+		}
+	}
+	input := HookInput{Event: "PreToolUse", CWD: d, Tool: "Read", Input: json.RawMessage(`{"path":"src/a.go"}`)}
+	var out bytes.Buffer
+	for _, store := range []memoryStore{{err: errors.New("broken store")}, {s: Snapshot{}}, {s: snapshot(func() Rule { x := rule("oversize"); x.Text = strings.Repeat("x", 9000); return x }())}} {
+		out.Reset()
+		if e := Hook(store, "claude", "", "", bytes.NewReader(encoded(t, input)), &out, instant); e != nil || !strings.Contains(out.String(), "INCOMPLETE") || !strings.Contains(out.String(), "additionalContext") {
+			t.Fatal(out.String(), e)
+		}
+	}
+	out.Reset()
+	input.Input = json.RawMessage(`"wrong shape"`)
+	if e := Hook(memoryStore{s: snapshot(r)}, "claude", "", "", bytes.NewReader(encoded(t, input)), &out, instant); e != nil || !strings.Contains(out.String(), "INCOMPLETE") {
+		t.Fatal(out.String(), e)
+	}
+	bad(t, Hook(memoryStore{}, "other", "", "", strings.NewReader(`{}`), &out, instant))
+	input.Input = nil
+	out.Reset()
+	if e := Hook(memoryStore{s: snapshot()}, "codex", "", "", bytes.NewReader(encoded(t, input)), &out, instant); e != nil || out.Len() != 0 {
+		t.Fatal(out.String(), e)
+	}
+	bad(t, Hook(memoryStore{s: snapshot(r)}, "codex", "", "", bytes.NewReader(encoded(t, input)), failingWriter{}, instant))
+	bad(t, hookWarning(failingWriter{}, "", "test"))
+}

--- a/internal/instructions/install.go
+++ b/internal/instructions/install.go
@@ -1,0 +1,184 @@
+package instructions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const hookMarker = "Loading approved Deja instructions"
+
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'" }
+
+// Install is explicitly invoked, never part of general deja install. It neither
+// alters history hooks nor bypasses the agent's review/trust requirements.
+func Install(agent, config, binary, store string) (result string, err error) {
+	if !oneOf(agent, "claude", "codex") {
+		return "", fmt.Errorf("agent must be claude or codex")
+	}
+	if runtime.GOOS == "windows" {
+		return "", fmt.Errorf("experimental hook installer supports macOS/Linux only")
+	}
+	if !absolutePath(store) {
+		return "", fmt.Errorf("store must be a clean absolute path")
+	}
+	if binary == "" {
+		binary, err = os.Executable()
+		if err != nil {
+			return "", err
+		}
+	}
+	if !absolutePath(binary) {
+		return "", fmt.Errorf("binary must be a clean absolute path")
+	}
+	info, err := os.Stat(binary)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0111 == 0 {
+		return "", fmt.Errorf("binary is not an executable regular file")
+	}
+	if config == "" {
+		variable, folder, filename := "CLAUDE_CONFIG_DIR", ".claude", "settings.json"
+		if agent == "codex" {
+			variable, folder, filename = "CODEX_HOME", ".codex", "hooks.json"
+		}
+		root := os.Getenv(variable)
+		if root == "" {
+			home, e := os.UserHomeDir()
+			if e != nil {
+				return "", e
+			}
+			root = filepath.Join(home, folder)
+		}
+		config = filepath.Join(root, filename)
+	}
+	if !absolutePath(config) {
+		return "", fmt.Errorf("config must be a clean absolute path")
+	}
+	if config == store {
+		return "", fmt.Errorf("hook configuration and instruction registry must be different files")
+	}
+	if err = os.MkdirAll(filepath.Dir(config), 0700); err != nil {
+		return "", err
+	}
+	lock := config + ".deja-instructions.lock"
+	if err = os.Mkdir(lock, 0700); err != nil {
+		return "", fmt.Errorf("cannot lock config: %w", err)
+	}
+	defer func() { err = errors.Join(err, os.Remove(lock)) }()
+	data := map[string]any{}
+	old, readErr := readBounded(config, MaxRegistryBytes)
+	if readErr == nil {
+		info, e := os.Lstat(config)
+		if e != nil {
+			return "", e
+		}
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("config must be a regular file, not a symlink")
+		}
+		if err = decode(bytes.NewReader(old), &data, MaxRegistryBytes, true); err != nil {
+			return "", err
+		}
+		if data == nil {
+			return "", fmt.Errorf("config must be a JSON object")
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		return "", readErr
+	}
+	command := shellQuote(binary) + " instructions hook --agent " + shellQuote(agent) + " --store " + shellQuote(store)
+	if err = mergeHooks(data, command, agent); err != nil {
+		return "", err
+	}
+	updated, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	updated = append(updated, '\n')
+	if len(updated) > MaxRegistryBytes {
+		return "", fmt.Errorf("updated hook config exceeds byte limit")
+	}
+	if bytes.Equal(old, updated) {
+		return config, nil
+	}
+	if len(old) > 0 {
+		backup, e := os.CreateTemp(filepath.Dir(config), filepath.Base(config)+".deja-instructions-backup-*")
+		if e != nil {
+			return "", e
+		}
+		_, w := backup.Write(old)
+		e = errors.Join(w, backup.Sync(), backup.Close())
+		if e != nil {
+			return "", e
+		}
+	}
+	if err = atomicWrite(config, updated); err != nil {
+		return "", err
+	}
+	return config, nil
+}
+func mergeHooks(config map[string]any, command, agent string) error {
+	hooks := map[string]any{}
+	if existing, ok := config["hooks"]; ok {
+		var valid bool
+		hooks, valid = existing.(map[string]any)
+		if !valid || hooks == nil {
+			return fmt.Errorf("hooks must be a JSON object")
+		}
+	}
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "SubagentStart"} {
+		groups := []any{}
+		if existing, ok := hooks[event]; ok {
+			var valid bool
+			groups, valid = existing.([]any)
+			if !valid {
+				return fmt.Errorf("%s hooks must be an array", event)
+			}
+		}
+		clean := []any{}
+		for _, value := range groups {
+			group, ok := value.(map[string]any)
+			if !ok {
+				return fmt.Errorf("invalid %s matcher group", event)
+			}
+			handlers, ok := group["hooks"].([]any)
+			if !ok {
+				return fmt.Errorf("invalid %s handler array", event)
+			}
+			kept := []any{}
+			removed := false
+			for _, h := range handlers {
+				handler, ok := h.(map[string]any)
+				if !ok {
+					return fmt.Errorf("invalid %s handler", event)
+				}
+				cmd, _ := handler["command"].(string)
+				if handler["statusMessage"] == hookMarker && strings.Contains(cmd, " instructions hook --agent ") {
+					removed = true
+					continue
+				}
+				kept = append(kept, h)
+			}
+			if removed && len(kept) == 0 {
+				continue
+			}
+			group["hooks"] = kept
+			clean = append(clean, group)
+		}
+		handler := map[string]any{"type": "command", "command": command, "timeout": 5, "statusMessage": hookMarker}
+		// Codex otherwise summarizes large additionalContext. We already enforce an
+		// explicit byte budget; approved mandatory text must not be summarized away.
+		if agent == "codex" {
+			handler["additionalContextLimit"] = 0
+		}
+		clean = append(clean, map[string]any{"hooks": []any{handler}})
+		hooks[event] = clean
+	}
+	config["hooks"] = hooks
+	return nil
+}

--- a/internal/instructions/install.go
+++ b/internal/instructions/install.go
@@ -15,8 +15,90 @@ const hookMarker = "Loading approved Deja instructions"
 
 func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'" }
 
-// Install is explicitly invoked, never part of general deja install. It neither
-// alters history hooks nor bypasses the agent's review/trust requirements.
+// InstructionSuffix is the exact opt-in tail that an ordinary deja lifecycle
+// hook carries. It is deliberately a shell fragment rather than an argv slice:
+// Claude and Codex persist hook commands as strings. Callers must not evaluate
+// it while inspecting a configuration; StripInstructionSuffix parses only this
+// narrow, canonical form.
+func InstructionSuffix(store, agent string) (string, error) {
+	if !absolutePath(store) {
+		return "", fmt.Errorf("store must be a clean absolute path")
+	}
+	if !oneOf(agent, "claude", "codex") {
+		return "", fmt.Errorf("agent must be claude or codex")
+	}
+	return " --instructions-store " + shellQuote(store) + " --instructions-agent " + agent, nil
+}
+
+// WithInstructionSuffix attaches the canonical instruction-store options to a
+// plain deja hook command.
+func WithInstructionSuffix(command, store, agent string) (string, error) {
+	suffix, err := InstructionSuffix(store, agent)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(command) == "" {
+		return "", fmt.Errorf("hook command must not be empty")
+	}
+	return command + suffix, nil
+}
+
+// StripInstructionSuffix recognizes exactly the suffix emitted by
+// WithInstructionSuffix. It does not invoke a shell or accept general shell
+// syntax: the store word is a canonical single-quoted word, including the
+// standard quote-escape sequence for apostrophes.
+func StripInstructionSuffix(command string) (base, store, agent string, ok bool) {
+	const storeFlag = " --instructions-store "
+	// A legal absolute path can itself contain the flag text. Try each textual
+	// occurrence and accept only one whose remaining bytes are our exact
+	// canonical suffix; no shell syntax is evaluated here.
+	for start := 0; start < len(command); {
+		i := strings.Index(command[start:], storeFlag)
+		if i < 0 {
+			break
+		}
+		i += start
+		candidateBase := command[:i]
+		rest := command[i+len(storeFlag):]
+		candidateStore, candidateRest, parsed := parseQuotedStore(rest)
+		if parsed && strings.HasPrefix(candidateRest, " --instructions-agent ") {
+			candidateAgent := strings.TrimPrefix(candidateRest, " --instructions-agent ")
+			suffix, err := InstructionSuffix(candidateStore, candidateAgent)
+			if err == nil && command == candidateBase+suffix {
+				return candidateBase, candidateStore, candidateAgent, true
+			}
+		}
+		start = i + len(storeFlag)
+	}
+	return "", "", "", false
+}
+
+// parseQuotedStore accepts the output of shellQuote only. Shell's concatenated
+// single/double/single quote escape for an apostrophe is the one exception to a
+// simple single-quoted word. The unconsumed suffix begins with a space.
+func parseQuotedStore(s string) (value, rest string, ok bool) {
+	if !strings.HasPrefix(s, "'") {
+		return "", "", false
+	}
+	s = s[1:]
+	for {
+		i := strings.IndexByte(s, '\'')
+		if i < 0 {
+			return "", "", false
+		}
+		value += s[:i]
+		s = s[i+1:]
+		if strings.HasPrefix(s, "\"'\"'") {
+			value += "'"
+			s = s[4:]
+			continue
+		}
+		return value, s, true
+	}
+}
+
+// Install is explicitly invoked, never part of general deja install. It augments
+// the existing lifecycle hooks and does not bypass review/trust requirements.
 func Install(agent, config, binary, store string) (result string, err error) {
 	if !oneOf(agent, "claude", "codex") {
 		return "", fmt.Errorf("agent must be claude or codex")
@@ -91,8 +173,7 @@ func Install(agent, config, binary, store string) (result string, err error) {
 	} else if !errors.Is(readErr, os.ErrNotExist) {
 		return "", readErr
 	}
-	command := shellQuote(binary) + " instructions hook --agent " + shellQuote(agent) + " --store " + shellQuote(store)
-	if err = mergeHooks(data, command, agent); err != nil {
+	if err = mergeHooks(data, binary, store, agent); err != nil {
 		return "", err
 	}
 	updated, err := json.MarshalIndent(data, "", "  ")
@@ -122,7 +203,7 @@ func Install(agent, config, binary, store string) (result string, err error) {
 	}
 	return config, nil
 }
-func mergeHooks(config map[string]any, command, agent string) error {
+func mergeHooks(config map[string]any, binary, store, agent string) error {
 	hooks := map[string]any{}
 	if existing, ok := config["hooks"]; ok {
 		var valid bool
@@ -130,6 +211,11 @@ func mergeHooks(config map[string]any, command, agent string) error {
 		if !valid || hooks == nil {
 			return fmt.Errorf("hooks must be a JSON object")
 		}
+	}
+	shared := map[string]string{
+		"SessionStart":     "hook-context",
+		"UserPromptSubmit": "hook-prompt",
+		"PreToolUse":       "hook-tool",
 	}
 	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "SubagentStart"} {
 		groups := []any{}
@@ -141,6 +227,15 @@ func mergeHooks(config map[string]any, command, agent string) error {
 			}
 		}
 		clean := []any{}
+		var adopted bool
+		var appendIntegrated bool
+		var standalone bool
+		if sub, sharedEvent := shared[event]; sharedEvent {
+			standalone = false
+			_ = sub
+		} else {
+			standalone = true
+		}
 		for _, value := range groups {
 			group, ok := value.(map[string]any)
 			if !ok {
@@ -158,9 +253,45 @@ func mergeHooks(config map[string]any, command, agent string) error {
 					return fmt.Errorf("invalid %s handler", event)
 				}
 				cmd, _ := handler["command"].(string)
-				if handler["statusMessage"] == hookMarker && strings.Contains(cmd, " instructions hook --agent ") {
+				if handler["statusMessage"] == hookMarker && markedStandaloneInstructionHook(cmd, binary) {
 					removed = true
 					continue
+				}
+				if sub, sharedEvent := shared[event]; sharedEvent && handler["type"] == "command" {
+					kind, _ := sharedHookKindOf(cmd, binary, sub)
+					if kind == sharedHookWrapper {
+						return fmt.Errorf("cannot safely integrate instructions into wrapped %s hook", event)
+					}
+					if kind == sharedHookOwned {
+						if adopted {
+							removed = true
+							continue
+						}
+						adopted = true
+						if event == "PreToolUse" && groupHasForeignHandlers(handlers) {
+							// A matcher governs the whole group. Leave the reader's
+							// group intact and put the combined command in an unfiltered
+							// group below.
+							removed = true
+							appendIntegrated = true
+							continue
+						}
+						// The explicit binary is part of this installer contract. An
+						// older deja/deja-hook command may not understand the opt-in
+						// flags, so adopt its ownership but point at the validated
+						// executable supplied for this install.
+						command, e := WithInstructionSuffix(sharedBase(binary, sub), store, agent)
+						if e != nil {
+							return e
+						}
+						handler["command"] = command
+						if agent == "codex" {
+							handler["additionalContextLimit"] = 0
+						}
+						if event == "PreToolUse" {
+							delete(group, "matcher")
+						}
+					}
 				}
 				kept = append(kept, h)
 			}
@@ -170,15 +301,142 @@ func mergeHooks(config map[string]any, command, agent string) error {
 			group["hooks"] = kept
 			clean = append(clean, group)
 		}
-		handler := map[string]any{"type": "command", "command": command, "timeout": 5, "statusMessage": hookMarker}
-		// Codex otherwise summarizes large additionalContext. We already enforce an
-		// explicit byte budget; approved mandatory text must not be summarized away.
-		if agent == "codex" {
-			handler["additionalContextLimit"] = 0
+		if standalone {
+			command := shellQuote(binary) + " instructions hook --agent " + shellQuote(agent) + " --store " + shellQuote(store)
+			handler := instructionHandler(command, agent)
+			clean = append(clean, map[string]any{"hooks": []any{handler}})
+		} else if !adopted || appendIntegrated {
+			sub := shared[event]
+			command, e := WithInstructionSuffix(sharedBase(binary, sub), store, agent)
+			if e != nil {
+				return e
+			}
+			clean = append(clean, map[string]any{"hooks": []any{instructionHandler(command, agent)}})
 		}
-		clean = append(clean, map[string]any{"hooks": []any{handler}})
 		hooks[event] = clean
 	}
 	config["hooks"] = hooks
 	return nil
+}
+
+func instructionHandler(command, agent string) map[string]any {
+	handler := map[string]any{"type": "command", "command": command, "timeout": 5, "statusMessage": hookMarker}
+	// Codex otherwise summarizes large additionalContext. We already enforce an
+	// explicit byte budget; approved mandatory text must not be summarized away.
+	if agent == "codex" {
+		handler["additionalContextLimit"] = 0
+	}
+	return handler
+}
+
+type sharedCommandKind uint8
+
+const (
+	sharedHookOther sharedCommandKind = iota
+	sharedHookOwned
+	sharedHookWrapper
+)
+
+// sharedHookKind recognizes only a bare deja/deja-hook command, or the exact
+// executable supplied to Install. Anything that merely contains one is a
+// wrapper the reader owns; adding another command beside it would fire twice,
+// so the caller rejects that ambiguity instead.
+func sharedHookKindOf(command, binary, sub string) (sharedCommandKind, bool) {
+	base, _, _, integrated := StripInstructionSuffix(command)
+	if integrated {
+		command = base
+	}
+	if token, ok := bareHookToken(command, sub); ok && knownDejaToken(token, binary) {
+		return sharedHookOwned, integrated
+	}
+	if strings.Contains(command, " "+sub) && strings.Contains(command, "deja") {
+		return sharedHookWrapper, false
+	}
+	return sharedHookOther, false
+}
+
+func sharedBase(binary, sub string) string { return shellQuote(binary) + " " + sub }
+
+// markedStandaloneInstructionHook identifies the old installer line only when
+// it is a bare command deja could itself have written. A status message is
+// reader-visible text, not an ownership marker for an arbitrary shell chain.
+func markedStandaloneInstructionHook(command, binary string) bool {
+	exe, rest, ok := parseBareShellToken(command)
+	if !ok || !knownDejaToken(exe, binary) {
+		return false
+	}
+	const agentFlag = " instructions hook --agent "
+	if !strings.HasPrefix(rest, agentFlag) {
+		return false
+	}
+	agent, rest, ok := parseQuotedStore(strings.TrimPrefix(rest, agentFlag))
+	if !ok || !oneOf(agent, "claude", "codex") {
+		return false
+	}
+	const storeFlag = " --store "
+	if !strings.HasPrefix(rest, storeFlag) {
+		return false
+	}
+	store, rest, ok := parseQuotedStore(strings.TrimPrefix(rest, storeFlag))
+	return ok && rest == "" && absolutePath(store)
+}
+
+// bareHookToken extracts the executable from a two-word command without
+// interpreting shell syntax. The quoted case accepts only shellQuote's form;
+// everything with a wrapper, redirect, assignment, or extra argument is left
+// to its owner.
+func bareHookToken(command, sub string) (string, bool) {
+	want := " " + sub
+	if !strings.HasSuffix(command, want) {
+		return "", false
+	}
+	token, rest, ok := parseBareShellToken(strings.TrimSuffix(command, want))
+	return token, ok && rest == ""
+}
+
+// parseBareShellToken accepts exactly one shell word: an unquoted path with no
+// shell metacharacters, or shellQuote's single-quoted form. It returns the
+// unconsumed command text (which starts with a space when present) without ever
+// evaluating it.
+func parseBareShellToken(command string) (token, rest string, ok bool) {
+	if command == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(command, "'") {
+		return parseQuotedStore(command)
+	}
+	i := strings.IndexAny(command, " \t")
+	if i < 0 {
+		token = command
+	} else {
+		token, rest = command[:i], command[i:]
+	}
+	if token == "" || strings.ContainsAny(token, "'\";|&<>`$\r\n\\*?[]{}()!~#=") {
+		return "", "", false
+	}
+	return token, rest, true
+}
+
+// IsBareHookCommand reports whether command is exactly one executable token
+// followed by sub. It accepts the canonical single-quoted token that
+// shellQuote emits, but does not parse or evaluate arbitrary shell syntax.
+func IsBareHookCommand(command, sub string) bool {
+	_, ok := bareHookToken(command, sub)
+	return ok
+}
+
+func knownDejaToken(token, binary string) bool {
+	if token == binary {
+		return true
+	}
+	base := token
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.ToLower(base)
+	return base == "deja" || base == "deja-hook"
+}
+
+func groupHasForeignHandlers(handlers []any) bool {
+	return len(handlers) != 1
 }

--- a/internal/instructions/install_test.go
+++ b/internal/instructions/install_test.go
@@ -1,0 +1,235 @@
+package instructions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInstructionSuffixRoundTripsQuotedStore(t *testing.T) {
+	for _, name := range []string{
+		"Deja's approved registry.json",
+		"approved --instructions-store registry's copy.json",
+	} {
+		store := filepath.Join(t.TempDir(), name)
+		cmd, err := WithInstructionSuffix("deja hook-context", store, "claude")
+		if err != nil {
+			t.Fatal(err)
+		}
+		base, gotStore, agent, ok := StripInstructionSuffix(cmd)
+		if !ok || base != "deja hook-context" || gotStore != store || agent != "claude" {
+			t.Fatalf("StripInstructionSuffix(%q) = %q, %q, %q, %v", cmd, base, gotStore, agent, ok)
+		}
+	}
+	for _, malformed := range []string{
+		"deja hook-context --instructions-store /tmp/plain --instructions-agent claude",
+		"deja hook-context --instructions-store '/tmp/a' --instructions-agent claude extra",
+		"deja hook-context --instructions-store '/tmp/a' --instructions-agent other",
+	} {
+		if _, _, _, ok := StripInstructionSuffix(malformed); ok {
+			t.Fatalf("accepted non-canonical suffix %q", malformed)
+		}
+	}
+}
+
+func TestSharedHookKindRecognizesBareDejaAndLauncherOnly(t *testing.T) {
+	for _, command := range []string{
+		"deja hook-context",
+		"/home/me/.config/deja/bin/deja-hook hook-context",
+		"'/tmp/Deja App/deja-hook' hook-context",
+		"'/tmp/the exact binary' hook-context",
+	} {
+		binary := "/tmp/the exact binary"
+		kind, _ := sharedHookKindOf(command, binary, "hook-context")
+		if kind != sharedHookOwned {
+			t.Fatalf("%q kind = %v, want owned", command, kind)
+		}
+	}
+	kind, _ := sharedHookKindOf("sh -c 'deja hook-context'", "/tmp/deja", "hook-context")
+	if kind != sharedHookWrapper {
+		t.Fatalf("wrapper kind = %v, want wrapper", kind)
+	}
+}
+
+func TestInstallSharesExistingHooksAndMigratesStandaloneEntries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer explicitly supports macOS/Linux only")
+	}
+	d := isolated(t)
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(d, "approved registry's copy.json")
+	config := filepath.Join(d, "settings.json")
+	// This is the exact line a prior install wrote from an older binary. A
+	// current install must remove it even though its executable differs.
+	old := shellQuote("/opt/old/deja") + " instructions hook --agent " + shellQuote("claude") + " --store " + shellQuote(store)
+	seed := map[string]any{"hooks": map[string]any{
+		"SessionStart": []any{map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": "deja hook-context"},
+			map[string]any{"type": "command", "command": old, "statusMessage": hookMarker},
+		}}},
+		"UserPromptSubmit": []any{map[string]any{"hooks": []any{
+			map[string]any{"type": "command", "command": "deja hook-prompt"},
+		}}},
+		"PreToolUse": []any{map[string]any{"matcher": "Bash|Write", "hooks": []any{
+			map[string]any{"type": "command", "command": "deja hook-tool"},
+			map[string]any{"type": "command", "command": "theirs"},
+		}}},
+	}}
+	seedJSON, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, config, seedJSON)
+	if _, err := Install("claude", config, binary, store); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+	hooks := root["hooks"].(map[string]any)
+	for event, sub := range map[string]string{
+		"SessionStart": "hook-context", "UserPromptSubmit": "hook-prompt", "PreToolUse": "hook-tool",
+	} {
+		cmds := eventCommands(t, hooks, event)
+		var integrated []string
+		for _, command := range cmds {
+			if strings.Contains(command, sub) {
+				integrated = append(integrated, command)
+			}
+		}
+		if len(integrated) != 1 {
+			t.Fatalf("%s commands = %#v", event, cmds)
+		}
+		if _, gotStore, gotAgent, ok := StripInstructionSuffix(integrated[0]); !ok || gotStore != store || gotAgent != "claude" {
+			t.Fatalf("%s lost canonical suffix: %q", event, integrated[0])
+		}
+		if !strings.HasPrefix(integrated[0], shellQuote(binary)+" "+sub) {
+			t.Fatalf("%s kept the old executable instead of requested binary: %q", event, integrated[0])
+		}
+	}
+	if strings.Contains(string(data), old) {
+		t.Fatalf("old standalone command survived:\n%s", data)
+	}
+	subagent := eventCommands(t, hooks, "SubagentStart")
+	if len(subagent) != 1 || !strings.Contains(subagent[0], " instructions hook --agent ") {
+		t.Fatalf("SubagentStart commands = %#v", subagent)
+	}
+	pre := hooks["PreToolUse"].([]any)
+	if len(pre) != 2 {
+		t.Fatalf("PreToolUse groups = %#v", pre)
+	}
+	var unfiltered bool
+	for _, groupAny := range pre {
+		group := groupAny.(map[string]any)
+		cmds := groupCommands(group)
+		if len(cmds) == 1 && strings.Contains(cmds[0], "hook-tool") {
+			_, hasMatcher := group["matcher"]
+			unfiltered = !hasMatcher
+		}
+	}
+	if !unfiltered || !strings.Contains(string(data), `"command": "theirs"`) {
+		t.Fatalf("PreToolUse did not split the foreign matcher group:\n%s", data)
+	}
+	first := string(data)
+	if _, err := Install("claude", config, binary, store); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(config)
+	if err != nil || string(second) != first {
+		t.Fatalf("non-idempotent integration: %v\n%s", err, second)
+	}
+}
+
+func TestInstallPreservesStandaloneInstructionWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer explicitly supports macOS/Linux only")
+	}
+	d := isolated(t)
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := filepath.Join(d, "approved.json")
+	old := shellQuote("/opt/old/deja") + " instructions hook --agent " + shellQuote("claude") + " --store " + shellQuote(store)
+	wrapped := old + "; reader-command"
+	if markedStandaloneInstructionHook(wrapped, binary) {
+		t.Fatal("a wrapped old command was claimed as installer-owned")
+	}
+	config := filepath.Join(d, "settings.json")
+	seed := map[string]any{"hooks": map[string]any{"SessionStart": []any{map[string]any{"hooks": []any{
+		map[string]any{"type": "command", "command": wrapped, "statusMessage": hookMarker},
+	}}}}}
+	b, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, config, b)
+	if _, err := Install("claude", config, binary, store); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(config)
+	if err != nil || !strings.Contains(string(got), wrapped) {
+		t.Fatalf("wrapped reader command was changed: %v\n%s", err, got)
+	}
+}
+
+func TestInstallRejectsWrappedSharedHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer explicitly supports macOS/Linux only")
+	}
+	d := isolated(t)
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(d, "settings.json")
+	original := `{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"sh -c 'deja hook-context'"}]}]}}`
+	write(t, config, []byte(original))
+	if _, err := Install("claude", config, binary, filepath.Join(d, "approved.json")); err == nil {
+		t.Fatal("wrapped hook was silently duplicated")
+	}
+	got, err := os.ReadFile(config)
+	if err != nil || string(got) != original {
+		t.Fatalf("wrapper was changed: %v\n%s", err, got)
+	}
+}
+
+func eventCommands(t *testing.T, hooks map[string]any, event string) []string {
+	t.Helper()
+	var out []string
+	for _, groupAny := range hooks[event].([]any) {
+		out = append(out, groupCommands(groupAny.(map[string]any))...)
+	}
+	return out
+}
+
+func groupCommands(group map[string]any) []string {
+	var out []string
+	for _, handlerAny := range group["hooks"].([]any) {
+		if handler, _ := handlerAny.(map[string]any); handler != nil {
+			if command, _ := handler["command"].(string); command != "" {
+				out = append(out, command)
+			}
+		}
+	}
+	return out
+}
+
+func TestBareInstructionHookRejectsShellExpansionsAndLines(t *testing.T) {
+	for _, prefix := range []string{"deja*", "deja\nother", "deja\r", "~/deja", "deja\\-old", "(deja)", "NAME=value", "'deja' 'extra'"} {
+		if IsBareHookCommand(prefix+" hook-context", "hook-context") {
+			t.Fatalf("accepted shell syntax as owned executable: %q", prefix)
+		}
+	}
+}

--- a/internal/instructions/model.go
+++ b/internal/instructions/model.go
@@ -27,22 +27,24 @@ type Snapshot struct {
 }
 
 type Rule struct {
-	ID          string     `json:"id"`
-	Revision    uint64     `json:"revision"`
-	Kind        string     `json:"kind"`
-	Text        string     `json:"text"`
-	Authority   string     `json:"authority"`
-	Status      string     `json:"status"`
-	Strength    string     `json:"strength"`
-	Absolute    bool       `json:"absolute"`
-	Priority    int        `json:"priority"`
-	Scope       Scope      `json:"scope"`
-	Lifetime    string     `json:"lifetime"`
-	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
-	Source      string     `json:"source"`
-	ConflictKey string     `json:"conflict_key,omitempty"`
-	Value       string     `json:"value,omitempty"`
-	Runbook     *Runbook   `json:"runbook,omitempty"`
+	ID            string     `json:"id"`
+	Revision      uint64     `json:"revision"`
+	Kind          string     `json:"kind"`
+	Text          string     `json:"text"`
+	Authority     string     `json:"authority"`
+	Status        string     `json:"status"`
+	Strength      string     `json:"strength"`
+	Absolute      bool       `json:"absolute"`
+	Priority      int        `json:"priority"`
+	Scope         Scope      `json:"scope"`
+	Lifetime      string     `json:"lifetime"`
+	EffectiveFrom *time.Time `json:"effective_from,omitempty"`
+	ExpiresAt     *time.Time `json:"expires_at,omitempty"`
+	Supersedes    []string   `json:"supersedes,omitempty"`
+	Source        string     `json:"source"`
+	ConflictKey   string     `json:"conflict_key,omitempty"`
+	Value         string     `json:"value,omitempty"`
+	Runbook       *Runbook   `json:"runbook,omitempty"`
 }
 
 type Scope struct {
@@ -119,6 +121,25 @@ func (s Snapshot) Validate() error {
 		}
 		rules[r.ID] = r
 	}
+	for _, r := range s.Rules {
+		seenSupersedes := make(map[string]bool, len(r.Supersedes))
+		for _, id := range r.Supersedes {
+			if !identifier.MatchString(id) || id == r.ID || seenSupersedes[id] {
+				return fmt.Errorf("rule %q has invalid supersession target %q", r.ID, id)
+			}
+			predecessor, ok := rules[id]
+			if !ok {
+				return fmt.Errorf("rule %q supersedes unknown rule %q", r.ID, id)
+			}
+			if !canSupersede(r, predecessor) {
+				return fmt.Errorf("rule %q cannot weaken superseded rule %q", r.ID, id)
+			}
+			seenSupersedes[id] = true
+		}
+	}
+	if err := validateSupersessionGraph(rules); err != nil {
+		return err
+	}
 	seen := make(map[string]bool, len(s.Exceptions))
 	for _, e := range s.Exceptions {
 		r, ok := rules[e.RuleID]
@@ -133,6 +154,55 @@ func (s Snapshot) Validate() error {
 	return nil
 }
 
+// Supersession is a directed replacement relation. A cycle would make every
+// member both obsolete and authoritative, so reject it at registry approval
+// time instead of letting resolution discard binding rules.
+func validateSupersessionGraph(rules map[string]Rule) error {
+	const (
+		unseen = iota
+		visiting
+		finished
+	)
+	state := make(map[string]int, len(rules))
+	var visit func(string) error
+	visit = func(id string) error {
+		switch state[id] {
+		case visiting:
+			return fmt.Errorf("supersession cycle includes rule %q", id)
+		case finished:
+			return nil
+		}
+		state[id] = visiting
+		for _, next := range rules[id].Supersedes {
+			if err := visit(next); err != nil {
+				return err
+			}
+		}
+		state[id] = finished
+		return nil
+	}
+	for id := range rules {
+		if err := visit(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// canSupersede rejects a registry relationship that would waive a protected
+// rule. An explicit successor may replace a peer or strengthen it, but cannot
+// use a preference or lower authority to disable an absolute, mandatory, or
+// owner-authored constraint.
+func canSupersede(successor, predecessor Rule) bool {
+	if predecessor.Absolute && !successor.Absolute {
+		return false
+	}
+	if predecessor.Strength != "should" && successor.Strength == "should" {
+		return false
+	}
+	return predecessor.Authority != "owner" || successor.Authority == "owner"
+}
+
 func (r Rule) validate() error {
 	if !identifier.MatchString(r.ID) || r.Revision == 0 {
 		return fmt.Errorf("id and positive revision required")
@@ -140,7 +210,7 @@ func (r Rule) validate() error {
 	if !cleanText(r.Text) || len(r.Text) > 32768 || !cleanText(r.Source) {
 		return fmt.Errorf("bounded instruction text and provenance required")
 	}
-	if !oneOf(r.Kind, "constraint", "preference", "decision", "procedure") || !oneOf(r.Authority, "owner", "project", "inferred") || !oneOf(r.Status, "candidate", "active", "revoked") || !oneOf(r.Strength, "must", "must_not", "should") {
+	if !oneOf(r.Kind, "constraint", "preference", "decision", "procedure") || !oneOf(r.Authority, "owner", "project", "inferred") || !oneOf(r.Status, "candidate", "active", "superseded", "revoked") || !oneOf(r.Strength, "must", "must_not", "should") {
 		return fmt.Errorf("invalid kind, authority, status, or strength")
 	}
 	if r.Authority == "inferred" && r.Status == "active" {
@@ -186,6 +256,9 @@ func (r Rule) validate() error {
 		}
 	default:
 		return fmt.Errorf("invalid lifetime")
+	}
+	if r.EffectiveFrom != nil && r.ExpiresAt != nil && !r.EffectiveFrom.Before(*r.ExpiresAt) {
+		return fmt.Errorf("effective_from must precede expires_at")
 	}
 	if (r.ConflictKey == "") != (r.Value == "") || (r.ConflictKey != "" && (!identifier.MatchString(r.ConflictKey) || !scalar(r.Value))) {
 		return fmt.Errorf("conflict_key and value must be valid and supplied together")

--- a/internal/instructions/model.go
+++ b/internal/instructions/model.go
@@ -1,0 +1,200 @@
+// Package instructions resolves approved operating instructions independently of
+// ranked conversation recall. It does not infer authority or invoke a model.
+package instructions
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const Version = 1
+const MaxRegistryBytes = 8 << 20
+const DefaultBudget = 8000
+
+var identifier = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.:-]{0,127}$`)
+var digest = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+type Snapshot struct {
+	Version    int         `json:"version"`
+	Revision   uint64      `json:"revision"`
+	Rules      []Rule      `json:"rules"`
+	Exceptions []Exception `json:"exceptions,omitempty"`
+}
+
+type Rule struct {
+	ID          string     `json:"id"`
+	Revision    uint64     `json:"revision"`
+	Kind        string     `json:"kind"`
+	Text        string     `json:"text"`
+	Authority   string     `json:"authority"`
+	Status      string     `json:"status"`
+	Strength    string     `json:"strength"`
+	Absolute    bool       `json:"absolute"`
+	Priority    int        `json:"priority"`
+	Scope       Scope      `json:"scope"`
+	Lifetime    string     `json:"lifetime"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
+	Source      string     `json:"source"`
+	ConflictKey string     `json:"conflict_key,omitempty"`
+	Value       string     `json:"value,omitempty"`
+	Runbook     *Runbook   `json:"runbook,omitempty"`
+}
+
+type Scope struct {
+	Repository  string   `json:"repository,omitempty"`
+	Worktree    string   `json:"worktree,omitempty"`
+	Task        string   `json:"task,omitempty"`
+	Session     string   `json:"session,omitempty"`
+	Environment string   `json:"environment,omitempty"`
+	PathPrefix  string   `json:"path_prefix,omitempty"`
+	Tools       []string `json:"tools,omitempty"`
+}
+
+type Runbook struct {
+	Path   string `json:"path"`
+	SHA256 string `json:"sha256"`
+}
+
+// ApprovedBy is provenance, not authentication. The protected/owner-controlled
+// registry is the trust boundary. Exceptions never follow a new rule revision.
+type Exception struct {
+	ID           string    `json:"id"`
+	RuleID       string    `json:"rule_id"`
+	RuleRevision uint64    `json:"rule_revision"`
+	Task         string    `json:"task"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	ApprovedBy   string    `json:"approved_by"`
+	Reason       string    `json:"reason"`
+}
+
+type Context struct {
+	Repository  string    `json:"repository,omitempty"`
+	Worktree    string    `json:"worktree,omitempty"`
+	Task        string    `json:"task,omitempty"`
+	Session     string    `json:"session,omitempty"`
+	Environment string    `json:"environment,omitempty"`
+	Path        string    `json:"path,omitempty"`
+	Tool        string    `json:"tool,omitempty"`
+	Now         time.Time `json:"-"`
+}
+
+func oneOf(s string, choices ...string) bool {
+	for _, c := range choices {
+		if s == c {
+			return true
+		}
+	}
+	return false
+}
+func cleanText(s string) bool {
+	return strings.TrimSpace(s) != "" && !strings.ContainsFunc(s, func(r rune) bool {
+		return unicode.IsControl(r) && r != '\n' && r != '\t'
+	})
+}
+func scalar(s string) bool       { return cleanText(s) && !strings.ContainsAny(s, "\n\t\r") }
+func absolutePath(s string) bool { return scalar(s) && filepath.IsAbs(s) && filepath.Clean(s) == s }
+func relativePath(s string) bool {
+	return scalar(s) && s != "." && !strings.ContainsAny(s, `\:`) && !path.IsAbs(s) && path.Clean(s) == s && s != ".." && !strings.HasPrefix(s, "../")
+}
+
+func (s Snapshot) Validate() error {
+	if s.Version != Version {
+		return fmt.Errorf("unsupported instructions version %d", s.Version)
+	}
+	if len(s.Rules) > 10000 || len(s.Exceptions) > 10000 {
+		return fmt.Errorf("registry exceeds 10000 records per collection")
+	}
+	rules := make(map[string]Rule, len(s.Rules))
+	for _, r := range s.Rules {
+		if _, ok := rules[r.ID]; ok {
+			return fmt.Errorf("duplicate rule %q", r.ID)
+		}
+		if err := r.validate(); err != nil {
+			return fmt.Errorf("rule %q: %w", r.ID, err)
+		}
+		rules[r.ID] = r
+	}
+	seen := make(map[string]bool, len(s.Exceptions))
+	for _, e := range s.Exceptions {
+		r, ok := rules[e.RuleID]
+		if !identifier.MatchString(e.ID) || seen[e.ID] || !ok || e.RuleRevision == 0 || e.RuleRevision > r.Revision || !scalar(e.Task) || e.ExpiresAt.IsZero() || !scalar(e.ApprovedBy) || !cleanText(e.Reason) {
+			return fmt.Errorf("invalid or duplicate exception %q", e.ID)
+		}
+		if r.Absolute && e.RuleRevision == r.Revision && e.ApprovedBy != "owner" {
+			return fmt.Errorf("absolute rule %q requires owner approval", r.ID)
+		}
+		seen[e.ID] = true
+	}
+	return nil
+}
+
+func (r Rule) validate() error {
+	if !identifier.MatchString(r.ID) || r.Revision == 0 {
+		return fmt.Errorf("id and positive revision required")
+	}
+	if !cleanText(r.Text) || len(r.Text) > 32768 || !cleanText(r.Source) {
+		return fmt.Errorf("bounded instruction text and provenance required")
+	}
+	if !oneOf(r.Kind, "constraint", "preference", "decision", "procedure") || !oneOf(r.Authority, "owner", "project", "inferred") || !oneOf(r.Status, "candidate", "active", "revoked") || !oneOf(r.Strength, "must", "must_not", "should") {
+		return fmt.Errorf("invalid kind, authority, status, or strength")
+	}
+	if r.Authority == "inferred" && r.Status == "active" {
+		return fmt.Errorf("inferred records cannot be active")
+	}
+	if (r.Absolute && r.Strength == "should") || (r.Kind == "preference" && r.Strength != "should") || r.Priority < -1000 || r.Priority > 1000 {
+		return fmt.Errorf("invalid absolute, strength, or priority combination")
+	}
+	for _, p := range []string{r.Scope.Repository, r.Scope.Worktree} {
+		if p != "" && !absolutePath(p) {
+			return fmt.Errorf("repository and worktree require clean absolute paths")
+		}
+	}
+	for _, v := range []string{r.Scope.Task, r.Scope.Session, r.Scope.Environment} {
+		if v != "" && !scalar(v) {
+			return fmt.Errorf("scope identities must be nonempty single lines")
+		}
+	}
+	if r.Scope.PathPrefix != "" && (r.Scope.Repository == "" || !relativePath(r.Scope.PathPrefix)) {
+		return fmt.Errorf("path_prefix requires repository and clean relative path")
+	}
+	for _, t := range r.Scope.Tools {
+		if !scalar(t) || strings.ContainsAny(t, "*|") {
+			return fmt.Errorf("tools must be exact hook names")
+		}
+	}
+	switch r.Lifetime {
+	case "persistent":
+		if r.ExpiresAt != nil {
+			return fmt.Errorf("persistent rules cannot expire")
+		}
+	case "task":
+		if r.Scope.Task == "" {
+			return fmt.Errorf("task lifetime requires task scope")
+		}
+	case "session":
+		if r.Scope.Session == "" {
+			return fmt.Errorf("session lifetime requires session scope")
+		}
+	case "ttl":
+		if r.ExpiresAt == nil || r.ExpiresAt.IsZero() {
+			return fmt.Errorf("ttl requires expires_at")
+		}
+	default:
+		return fmt.Errorf("invalid lifetime")
+	}
+	if (r.ConflictKey == "") != (r.Value == "") || (r.ConflictKey != "" && (!identifier.MatchString(r.ConflictKey) || !scalar(r.Value))) {
+		return fmt.Errorf("conflict_key and value must be valid and supplied together")
+	}
+	if r.Kind == "procedure" && (r.Runbook == nil || r.Strength != "must") {
+		return fmt.Errorf("procedure requires pinned runbook and must strength")
+	}
+	if r.Runbook != nil && (r.Kind != "procedure" || !absolutePath(r.Runbook.Path) || !digest.MatchString(r.Runbook.SHA256)) {
+		return fmt.Errorf("runbook requires absolute path and lowercase SHA256")
+	}
+	return nil
+}

--- a/internal/instructions/render.go
+++ b/internal/instructions/render.go
@@ -1,0 +1,90 @@
+package instructions
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Render either includes every required block or returns an error. Only optional
+// defaults can be omitted. Budget counts UTF-8 context bytes, not model tokens.
+func Render(result Result, budget int) (string, error) {
+	if budget <= 0 || budget > DefaultBudget {
+		return "", fmt.Errorf("budget must be between 1 and %d bytes", DefaultBudget)
+	}
+	if len(result.Conflicts) > 0 {
+		return "", fmt.Errorf("unresolved instruction conflicts: %v", result.Conflicts)
+	}
+	if len(result.Applicable)+len(result.Conditional) == 0 {
+		return "", nil
+	}
+	var required, optional []string
+	for _, group := range []struct {
+		items       []Selection
+		conditional bool
+	}{{result.Applicable, false}, {result.Conditional, true}} {
+		for _, item := range group.items {
+			r := item.Rule
+			label := "APPLICABLE"
+			if group.conditional {
+				label = "CONDITIONAL"
+			}
+			absolute := ""
+			if r.Absolute {
+				absolute = "; absolute: explicit owner exception required"
+			}
+			text := fmt.Sprintf("\n[%s %s@%d; %s; %s; %s%s]\n%s\n", label, r.ID, r.Revision, r.Strength, r.Authority, r.Lifetime, absolute, r.Text)
+			if group.conditional {
+				scope, _ := json.Marshal(r.Scope)
+				text += "Applies only when scope matches: " + string(scope) + " (" + item.Reason + ").\n"
+			}
+			if r.Runbook != nil {
+				text += fmt.Sprintf("Runbook: %s sha256:%s\n", r.Runbook.Path, r.Runbook.SHA256)
+				if group.conditional {
+					text += "Runbook content deferred until applicability is known.\n"
+				} else {
+					b, err := readBounded(r.Runbook.Path, MaxRegistryBytes)
+					if err != nil {
+						return "", fmt.Errorf("runbook %s unavailable: %w", r.ID, err)
+					}
+					h := sha256.Sum256(b)
+					if hex.EncodeToString(h[:]) != r.Runbook.SHA256 {
+						return "", fmt.Errorf("runbook %s changed since approval; review and pin a new revision", r.ID)
+					}
+					if !utf8.Valid(b) {
+						return "", fmt.Errorf("runbook %s is not UTF-8", r.ID)
+					}
+					text += "--- approved runbook ---\n" + string(b) + "\n--- end runbook ---\n"
+				}
+			}
+			if r.Strength == "should" {
+				optional = append(optional, text)
+			} else {
+				required = append(required, text)
+			}
+		}
+	}
+	body := fmt.Sprintf("Deja approved instructions, registry revision %d.\nRequired rules accumulate; ordering cannot waive one.\nConditional rules remain unresolved. Runbook delivery is not execution evidence.\n", result.Revision) + strings.Join(required, "")
+	reserve := ""
+	if len(optional) > 0 {
+		reserve = fmt.Sprintf("\nOptional preferences omitted: %d.\n", len(optional))
+	}
+	if len(body)+len(reserve) > budget {
+		return "", fmt.Errorf("required instruction packet exceeds %d-byte budget; narrow scope or shorten approved instructions", budget)
+	}
+	omitted := 0
+	for _, text := range optional {
+		if len(body)+len(text)+len(reserve) <= budget {
+			body += text
+		} else {
+			omitted++
+		}
+	}
+	if omitted > 0 {
+		body += fmt.Sprintf("\nOptional preferences omitted: %d.\n", omitted)
+	}
+	return body, nil
+}

--- a/internal/instructions/resolve.go
+++ b/internal/instructions/resolve.go
@@ -57,6 +57,11 @@ func Resolve(s Snapshot, c Context) (Result, error) {
 			out.Excluded = append(out.Excluded, item)
 			continue
 		}
+		if r.EffectiveFrom != nil && c.Now.Before(*r.EffectiveFrom) {
+			item.Reason = "not effective yet"
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
 		if r.ExpiresAt != nil && !c.Now.Before(*r.ExpiresAt) {
 			item.Reason = "expired"
 			out.Excluded = append(out.Excluded, item)
@@ -81,6 +86,9 @@ func Resolve(s Snapshot, c Context) (Result, error) {
 	}
 	sortSelections(out.Applicable)
 	sortSelections(out.Conditional)
+	var supersessionConflicts []Conflict
+	out.Applicable, out.Excluded, supersessionConflicts = applySupersession(out.Applicable, out.Excluded)
+	out.Conflicts = append(out.Conflicts, supersessionConflicts...)
 	groups := make(map[string][]Rule)
 	for _, item := range out.Applicable {
 		if item.Rule.ConflictKey != "" {
@@ -164,6 +172,45 @@ func Resolve(s Snapshot, c Context) (Result, error) {
 	sortSelections(out.Excluded)
 	sort.Slice(out.Conflicts, func(i, j int) bool { return out.Conflicts[i].Key < out.Conflicts[j].Key })
 	return out, nil
+}
+
+// applySupersession only removes a rule when one, applicable active rule names
+// it as its successor. Several successors are an explicit unresolved conflict:
+// guessing a winner would make an approved instruction disappear silently.
+func applySupersession(applicable, excluded []Selection) ([]Selection, []Selection, []Conflict) {
+	byID := make(map[string]Selection, len(applicable))
+	for _, item := range applicable {
+		byID[item.Rule.ID] = item
+	}
+	successors := make(map[string][]string)
+	for _, item := range applicable {
+		for _, target := range item.Rule.Supersedes {
+			if _, ok := byID[target]; ok {
+				successors[target] = append(successors[target], item.Rule.ID)
+			}
+		}
+	}
+	drop := make(map[string]string)
+	var conflicts []Conflict
+	for target, ids := range successors {
+		sort.Strings(ids)
+		if len(ids) == 1 {
+			drop[target] = ids[0]
+			continue
+		}
+		conflicts = append(conflicts, Conflict{Key: "supersession:" + target, RuleIDs: append([]string{target}, ids...)})
+	}
+	kept := make([]Selection, 0, len(applicable))
+	for _, item := range applicable {
+		if successor, ok := drop[item.Rule.ID]; ok {
+			item.Reason = "explicitly superseded by " + successor
+			excluded = append(excluded, item)
+			continue
+		}
+		kept = append(kept, item)
+	}
+	sortSelections(kept)
+	return kept, excluded, conflicts
 }
 
 func match(s Scope, c Context) (string, string) {

--- a/internal/instructions/resolve.go
+++ b/internal/instructions/resolve.go
@@ -1,0 +1,241 @@
+package instructions
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Selection struct {
+	Rule   Rule   `json:"rule"`
+	Reason string `json:"reason"`
+}
+type Conflict struct {
+	Key     string   `json:"key"`
+	RuleIDs []string `json:"rule_ids"`
+}
+type Result struct {
+	Revision    uint64      `json:"revision"`
+	Applicable  []Selection `json:"applicable"`
+	Conditional []Selection `json:"conditional"`
+	Excluded    []Selection `json:"excluded"`
+	Conflicts   []Conflict  `json:"conflicts"`
+}
+
+// Resolve has no clock, store, search-score or agent dependency. Mandatory
+// instructions accumulate. Unknown scope stays conditional, not inapplicable.
+func Resolve(s Snapshot, c Context) (Result, error) {
+	out := Result{Revision: s.Revision, Applicable: []Selection{}, Conditional: []Selection{}, Excluded: []Selection{}, Conflicts: []Conflict{}}
+	if err := s.Validate(); err != nil {
+		return out, err
+	}
+	if c.Now.IsZero() {
+		return out, fmt.Errorf("resolution requires an explicit clock")
+	}
+	if c.Path != "" && !relativePath(c.Path) {
+		return out, fmt.Errorf("context path must be clean and repository-relative")
+	}
+	for _, p := range []string{c.Repository, c.Worktree} {
+		if p != "" && !absolutePath(p) {
+			return out, fmt.Errorf("context roots must be clean absolute paths")
+		}
+	}
+	grants := make(map[string]Exception)
+	for _, e := range s.Exceptions {
+		if c.Task == "" || e.Task != c.Task || !c.Now.Before(e.ExpiresAt) {
+			continue
+		}
+		key := fmt.Sprintf("%s@%d", e.RuleID, e.RuleRevision)
+		if old, ok := grants[key]; !ok || e.ID < old.ID {
+			grants[key] = e
+		}
+	}
+	for _, r := range s.Rules {
+		item := Selection{Rule: r}
+		if r.Status != "active" {
+			item.Reason = r.Status
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
+		if r.ExpiresAt != nil && !c.Now.Before(*r.ExpiresAt) {
+			item.Reason = "expired"
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
+		state, reason := match(r.Scope, c)
+		item.Reason = reason
+		if state == "excluded" {
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
+		if e, ok := grants[fmt.Sprintf("%s@%d", r.ID, r.Revision)]; ok {
+			item.Reason = "exception: " + e.ID
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
+		if state == "conditional" {
+			out.Conditional = append(out.Conditional, item)
+		} else {
+			out.Applicable = append(out.Applicable, item)
+		}
+	}
+	sortSelections(out.Applicable)
+	sortSelections(out.Conditional)
+	groups := make(map[string][]Rule)
+	for _, item := range out.Applicable {
+		if item.Rule.ConflictKey != "" {
+			groups[item.Rule.ConflictKey] = append(groups[item.Rule.ConflictKey], item.Rule)
+		}
+	}
+	required := make(map[string]bool)
+	// Grouping by explicit decision value avoids pairwise comparisons at volume.
+	for key, rs := range groups {
+		must, not := make(map[string][]string), make(map[string][]string)
+		for _, r := range rs {
+			switch r.Strength {
+			case "must":
+				must[r.Value] = append(must[r.Value], r.ID)
+				required[key] = true
+			case "must_not":
+				not[r.Value] = append(not[r.Value], r.ID)
+				required[key] = true
+			}
+		}
+		ids := make(map[string]bool)
+		for value, yes := range must {
+			if len(must) > 1 || len(not[value]) > 0 {
+				for _, id := range yes {
+					ids[id] = true
+				}
+			}
+			for _, id := range not[value] {
+				ids[id] = true
+			}
+		}
+		if len(ids) > 0 {
+			conflict := Conflict{Key: key}
+			for id := range ids {
+				conflict.RuleIDs = append(conflict.RuleIDs, id)
+			}
+			sort.Strings(conflict.RuleIDs)
+			out.Conflicts = append(out.Conflicts, conflict)
+		}
+	}
+	kept := make([]Selection, 0, len(out.Applicable))
+	defaults := make(map[string]Rule)
+	ties := make(map[string]map[string]bool)
+	for _, item := range out.Applicable {
+		r := item.Rule
+		if r.Strength != "should" || r.ConflictKey == "" {
+			kept = append(kept, item)
+			continue
+		}
+		if required[r.ConflictKey] {
+			item.Reason = "required constraint controls this key"
+			out.Excluded = append(out.Excluded, item)
+			continue
+		}
+		winner, ok := defaults[r.ConflictKey]
+		if !ok {
+			defaults[r.ConflictKey] = r
+			kept = append(kept, item)
+			continue
+		}
+		if authority(winner) == authority(r) && specificity(winner.Scope) == specificity(r.Scope) && winner.Priority == r.Priority && winner.Value != r.Value {
+			if ties[r.ConflictKey] == nil {
+				ties[r.ConflictKey] = map[string]bool{winner.ID: true}
+			}
+			ties[r.ConflictKey][r.ID] = true
+			kept = append(kept, item)
+			continue
+		}
+		item.Reason = "default ordered below: " + winner.ID
+		out.Excluded = append(out.Excluded, item)
+	}
+	for key, ids := range ties {
+		conflict := Conflict{Key: key}
+		for id := range ids {
+			conflict.RuleIDs = append(conflict.RuleIDs, id)
+		}
+		sort.Strings(conflict.RuleIDs)
+		out.Conflicts = append(out.Conflicts, conflict)
+	}
+	out.Applicable = kept
+	sortSelections(out.Excluded)
+	sort.Slice(out.Conflicts, func(i, j int) bool { return out.Conflicts[i].Key < out.Conflicts[j].Key })
+	return out, nil
+}
+
+func match(s Scope, c Context) (string, string) {
+	missing := []string{}
+	for _, p := range []struct{ name, want, got string }{{"repository", s.Repository, c.Repository}, {"worktree", s.Worktree, c.Worktree}, {"task", s.Task, c.Task}, {"session", s.Session, c.Session}, {"environment", s.Environment, c.Environment}} {
+		if p.want == "" {
+			continue
+		}
+		if p.got == "" {
+			missing = append(missing, p.name)
+		} else if p.want != p.got {
+			return "excluded", p.name + " mismatch"
+		}
+	}
+	if s.PathPrefix != "" {
+		if c.Path == "" {
+			missing = append(missing, "path")
+		} else if c.Path != s.PathPrefix && !strings.HasPrefix(c.Path, s.PathPrefix+"/") {
+			return "excluded", "path mismatch"
+		}
+	}
+	if len(s.Tools) > 0 {
+		if c.Tool == "" {
+			missing = append(missing, "tool")
+		} else if !oneOf(c.Tool, s.Tools...) {
+			return "excluded", "tool mismatch"
+		}
+	}
+	if len(missing) > 0 {
+		return "conditional", "unknown: " + strings.Join(missing, ", ")
+	}
+	return "applicable", "all selectors match"
+}
+func authority(r Rule) int {
+	switch r.Authority {
+	case "owner":
+		return 2
+	case "project":
+		return 1
+	}
+	return 0
+}
+func specificity(s Scope) int {
+	n := 0
+	for _, v := range []string{s.Repository, s.Worktree, s.Task, s.Session, s.Environment, s.PathPrefix} {
+		if v != "" {
+			n++
+		}
+	}
+	if len(s.Tools) > 0 {
+		n++
+	}
+	return n
+}
+func before(a, b Rule) bool {
+	if (a.Strength == "should") != (b.Strength == "should") {
+		return a.Strength != "should"
+	}
+	if a.Absolute != b.Absolute {
+		return a.Absolute
+	}
+	if authority(a) != authority(b) {
+		return authority(a) > authority(b)
+	}
+	if specificity(a.Scope) != specificity(b.Scope) {
+		return specificity(a.Scope) > specificity(b.Scope)
+	}
+	if a.Priority != b.Priority {
+		return a.Priority > b.Priority
+	}
+	return a.ID < b.ID
+}
+func sortSelections(items []Selection) {
+	sort.Slice(items, func(i, j int) bool { return before(items[i].Rule, items[j].Rule) })
+}

--- a/internal/instructions/resolve_test.go
+++ b/internal/instructions/resolve_test.go
@@ -260,6 +260,89 @@ func TestConflictAndDefaults(t *testing.T) {
 		t.Fatal("default competed with a must")
 	}
 }
+func TestExplicitSupersessionAndEffectiveWindow(t *testing.T) {
+	old := rule("old")
+	newer := rule("new")
+	newer.Supersedes = []string{"old"}
+	result, err := Resolve(snapshot(old, newer), ctx())
+	if err != nil || len(result.Applicable) != 1 || result.Applicable[0].Rule.ID != "new" {
+		t.Fatalf("explicit successor did not win: %#v %v", result, err)
+	}
+	if len(result.Excluded) != 1 || result.Excluded[0].Reason != "explicitly superseded by new" {
+		t.Fatalf("superseded predecessor was hidden: %#v", result.Excluded)
+	}
+
+	future := rule("future")
+	starts := instant.Add(time.Hour)
+	future.EffectiveFrom = &starts
+	result, err = Resolve(snapshot(future), ctx())
+	if err != nil || len(result.Applicable) != 0 || len(result.Excluded) != 1 || result.Excluded[0].Reason != "not effective yet" {
+		t.Fatalf("effective window=%#v %v", result, err)
+	}
+	future.EffectiveFrom = &instant
+	result, err = Resolve(snapshot(future), ctx())
+	if err != nil || len(result.Applicable) != 1 {
+		t.Fatalf("effective_from boundary excluded its rule: %#v %v", result, err)
+	}
+	badWindow := rule("bad-window")
+	badWindow.EffectiveFrom = &starts
+	ends := instant
+	badWindow.ExpiresAt = &ends
+	bad(t, snapshot(badWindow).Validate())
+
+	first, second := rule("first"), rule("second")
+	first.Supersedes, second.Supersedes = []string{"old"}, []string{"old"}
+	result, err = Resolve(snapshot(old, first, second), ctx())
+	if err != nil || len(result.Conflicts) != 1 || result.Conflicts[0].Key != "supersession:old" || len(result.Applicable) != 3 || len(result.Excluded) != 0 {
+		t.Fatalf("competing successors were not explicit and non-destructive: %#v %v", result, err)
+	}
+
+	mandatory := rule("mandatory")
+	weak := rule("weak")
+	weak.Kind, weak.Strength, weak.Supersedes = "preference", "should", []string{"mandatory"}
+	bad(t, snapshot(mandatory, weak).Validate())
+	ownerRule := rule("owner-rule")
+	projectSuccessor := rule("project-successor")
+	projectSuccessor.Authority, projectSuccessor.Supersedes = "project", []string{"owner-rule"}
+	bad(t, snapshot(ownerRule, projectSuccessor).Validate())
+	absolute := rule("absolute")
+	absolute.Absolute = true
+	nonAbsolute := rule("non-absolute")
+	nonAbsolute.Supersedes = []string{"absolute"}
+	bad(t, snapshot(absolute, nonAbsolute).Validate())
+	absoluteSuccessor := rule("absolute-successor")
+	absoluteSuccessor.Absolute, absoluteSuccessor.Supersedes = true, []string{"absolute"}
+	if err := snapshot(absolute, absoluteSuccessor).Validate(); err != nil {
+		t.Fatalf("equally absolute successor was rejected: %v", err)
+	}
+
+	inactive := rule("inactive-successor")
+	inactive.Status, inactive.Supersedes = "candidate", []string{"old"}
+	result, err = Resolve(snapshot(old, inactive), ctx())
+	if err != nil || len(result.Applicable) != 1 || result.Applicable[0].Rule.ID != "old" {
+		t.Fatalf("inactive successor superseded a binding rule: %#v %v", result, err)
+	}
+
+	superseded := rule("already-superseded")
+	superseded.Status = "superseded"
+	if err := snapshot(superseded).Validate(); err != nil {
+		t.Fatalf("superseded status was rejected: %v", err)
+	}
+
+	unknown := rule("unknown")
+	unknown.Supersedes = []string{"missing"}
+	bad(t, snapshot(unknown).Validate())
+	self := rule("self")
+	self.Supersedes = []string{"self"}
+	bad(t, snapshot(self).Validate())
+	duplicate, target := rule("duplicate"), rule("target")
+	duplicate.Supersedes = []string{"target", "target"}
+	bad(t, snapshot(duplicate, target).Validate())
+	cycleA, cycleB := rule("cycle-a"), rule("cycle-b")
+	cycleA.Supersedes, cycleB.Supersedes = []string{"cycle-b"}, []string{"cycle-a"}
+	bad(t, snapshot(cycleA, cycleB).Validate())
+}
+
 func TestStrictJSON(t *testing.T) {
 	for _, data := range []string{`{"version":1,"version":2}`, `{"version":1,"rules":[{"id":"a","id":"b"}]}`, `{} {}`, `{"unknown":1}`, `{"version":`, strings.Repeat("[", 66) + strings.Repeat("]", 66), `{"a":]}`, `[}`} {
 		var s Snapshot

--- a/internal/instructions/resolve_test.go
+++ b/internal/instructions/resolve_test.go
@@ -34,7 +34,10 @@ func encoded(t *testing.T, v any) []byte {
 }
 func isolated(t *testing.T) string {
 	t.Helper()
-	d := t.TempDir()
+	d, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "CLAUDE_CONFIG_DIR", "CODEX_HOME"} {
 		t.Setenv(k, d)
 	}

--- a/internal/instructions/resolve_test.go
+++ b/internal/instructions/resolve_test.go
@@ -1,0 +1,274 @@
+package instructions
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var instant = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+func rule(id string) Rule {
+	return Rule{ID: id, Revision: 1, Kind: "constraint", Text: "Preserve unrelated work.", Authority: "owner", Status: "active", Strength: "must", Lifetime: "persistent", Source: "synthetic owner approval"}
+}
+func snapshot(rs ...Rule) Snapshot { return Snapshot{Version: Version, Rules: rs} }
+func ctx() Context                 { return Context{Now: instant} }
+func write(t *testing.T, p string, b []byte) {
+	t.Helper()
+	if err := os.WriteFile(p, b, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+func encoded(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+func isolated(t *testing.T) string {
+	t.Helper()
+	d := t.TempDir()
+	for _, k := range []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME", "CLAUDE_CONFIG_DIR", "CODEX_HOME"} {
+		t.Setenv(k, d)
+	}
+	for _, k := range []string{"DEJA_INSTRUCTIONS_FILE", "DEJA_TASK_ID", "DEJA_ENVIRONMENT", "DEJA_INSTRUCTION_TEST_WRITER"} {
+		t.Setenv(k, "")
+	}
+	return d
+}
+func bad(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected refusal")
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, errors.New("synthetic read failure") }
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("synthetic write failure") }
+
+func TestValidation(t *testing.T) {
+	cases := map[string]func(*Rule){
+		"id": func(r *Rule) { r.ID = "../bad" }, "revision": func(r *Rule) { r.Revision = 0 }, "text": func(r *Rule) { r.Text = "" }, "control": func(r *Rule) { r.Text = "bad\x1b" }, "long": func(r *Rule) { r.Text = strings.Repeat("x", 32769) }, "source": func(r *Rule) { r.Source = "" },
+		"kind": func(r *Rule) { r.Kind = "fact" }, "strength": func(r *Rule) { r.Strength = "maybe" }, "authority": func(r *Rule) { r.Authority = "root" }, "status": func(r *Rule) { r.Status = "expired" }, "inferred": func(r *Rule) { r.Authority = "inferred" },
+		"absolute preference": func(r *Rule) { r.Strength = "should"; r.Absolute = true }, "preference must": func(r *Rule) { r.Kind = "preference" }, "priority": func(r *Rule) { r.Priority = 1001 },
+		"root": func(r *Rule) { r.Scope.Repository = "relative" }, "path scope": func(r *Rule) { r.Scope.PathPrefix = "src" }, "path escape": func(r *Rule) { r.Scope.Repository = filepath.Clean(os.TempDir()); r.Scope.PathPrefix = "../src" }, "tool": func(r *Rule) { r.Scope.Tools = []string{"Bash*"} }, "scope control": func(r *Rule) { r.Scope.Task = "bad\nvalue" },
+		"permanent expiry": func(r *Rule) { r.ExpiresAt = &instant }, "lifetime": func(r *Rule) { r.Lifetime = "forever-ish" }, "task": func(r *Rule) { r.Lifetime = "task" }, "session": func(r *Rule) { r.Lifetime = "session" }, "ttl": func(r *Rule) { r.Lifetime = "ttl" },
+		"key": func(r *Rule) { r.ConflictKey = "setting" }, "value": func(r *Rule) { r.Value = "one" }, "invalid key": func(r *Rule) { r.ConflictKey = "../key"; r.Value = "one" }, "procedure": func(r *Rule) { r.Kind = "procedure" }, "bad runbook": func(r *Rule) { r.Runbook = &Runbook{Path: "relative"} },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) { r := rule("test"); mutate(&r); bad(t, snapshot(r).Validate()) })
+	}
+	for _, lifetime := range []string{"persistent", "task", "session", "ttl"} {
+		r := rule("good")
+		r.Lifetime = lifetime
+		r.Scope.Task = "T"
+		r.Scope.Session = "S"
+		if lifetime == "ttl" {
+			r.ExpiresAt = &instant
+		}
+		if err := snapshot(r).Validate(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := rule("candidate")
+	r.Authority = "inferred"
+	r.Status = "candidate"
+	if err := snapshot(r).Validate(); err != nil {
+		t.Fatal(err)
+	}
+	s := snapshot(rule("one"), rule("one"))
+	bad(t, s.Validate())
+	s.Version = 2
+	bad(t, s.Validate())
+	s = snapshot()
+	s.Rules = make([]Rule, 10001)
+	bad(t, s.Validate())
+}
+func TestExceptionsAndLifetime(t *testing.T) {
+	r := rule("absolute")
+	r.Absolute = true
+	r.Revision = 2
+	e := Exception{ID: "exception", RuleID: r.ID, RuleRevision: 2, Task: "task-a", ExpiresAt: instant.Add(time.Hour), ApprovedBy: "owner", Reason: "synthetic temporary exception"}
+	s := snapshot(r)
+	s.Exceptions = []Exception{e}
+	for _, tc := range []struct {
+		name, task string
+		now        time.Time
+		revision   uint64
+		want       int
+	}{{"active", "task-a", instant, 2, 0}, {"other task", "task-b", instant, 2, 1}, {"unknown task", "", instant, 2, 1}, {"boundary", "task-a", e.ExpiresAt, 2, 1}, {"new revision", "task-a", instant, 3, 1}} {
+		t.Run(tc.name, func(t *testing.T) {
+			s.Rules[0].Revision = tc.revision
+			c := ctx()
+			c.Task = tc.task
+			c.Now = tc.now
+			result, err := Resolve(s, c)
+			if err != nil || len(result.Applicable) != tc.want {
+				t.Fatalf("%+v %v", result, err)
+			}
+		})
+	}
+	s.Rules[0].Revision = 2
+	for name, mutate := range map[string]func(*Exception){"id": func(e *Exception) { e.ID = "" }, "target": func(e *Exception) { e.RuleID = "missing" }, "revision": func(e *Exception) { e.RuleRevision = 3 }, "zero revision": func(e *Exception) { e.RuleRevision = 0 }, "task": func(e *Exception) { e.Task = "" }, "expiry": func(e *Exception) { e.ExpiresAt = time.Time{} }, "approval": func(e *Exception) { e.ApprovedBy = "project" }, "reason": func(e *Exception) { e.Reason = "" }} {
+		t.Run(name, func(t *testing.T) {
+			invalid := e
+			mutate(&invalid)
+			s.Exceptions = []Exception{invalid}
+			bad(t, s.Validate())
+		})
+	}
+	s.Exceptions = []Exception{e, e}
+	bad(t, s.Validate())
+	s.Exceptions = []Exception{e}
+	e.ID = "a-first"
+	s.Exceptions = append(s.Exceptions, e)
+	c := ctx()
+	c.Task = "task-a"
+	result, err := Resolve(s, c)
+	if err != nil || !strings.Contains(result.Excluded[0].Reason, "a-first") {
+		t.Fatalf("unstable exception choice: %+v %v", result, err)
+	}
+	// Changing an ordinary rule into an absolute invalidates, rather than renews,
+	// an older project-approved exception. Its historical record remains valid.
+	s.Rules[0].Revision = 3
+	s.Exceptions[0].ApprovedBy = "project"
+	result, err = Resolve(s, c)
+	if err != nil || len(result.Applicable) != 1 {
+		t.Fatal(result, err)
+	}
+	ttl := rule("ttl")
+	ttl.Lifetime = "ttl"
+	ttl.ExpiresAt = &instant
+	candidate := rule("candidate")
+	candidate.Status = "candidate"
+	result, err = Resolve(snapshot(ttl, candidate, rule("persistent")), ctx())
+	if err != nil || len(result.Applicable) != 1 || len(result.Excluded) != 2 {
+		t.Fatalf("%+v %v", result, err)
+	}
+}
+func TestScopesAndOrdering(t *testing.T) {
+	root := t.TempDir()
+	r := rule("scoped")
+	r.Scope = Scope{Repository: root, Worktree: root, Task: "T", Session: "S", Environment: "local", PathPrefix: "src", Tools: []string{"Edit", "Write"}}
+	c := Context{Repository: root, Worktree: root, Task: "T", Session: "S", Environment: "local", Path: "src/a.go", Tool: "Edit", Now: instant}
+	result, err := Resolve(snapshot(r), c)
+	if err != nil || len(result.Applicable) != 1 {
+		t.Fatalf("%+v %v", result, err)
+	}
+	for _, field := range []string{"Repository", "Worktree", "Task", "Session", "Environment", "Path", "Tool"} {
+		t.Run(field, func(t *testing.T) {
+			copy := c
+			v := reflect.ValueOf(&copy).Elem().FieldByName(field)
+			v.SetString("")
+			got, e := Resolve(snapshot(r), copy)
+			if e != nil || len(got.Conditional) != 1 {
+				t.Fatalf("missing scope guessed: %+v %v", got, e)
+			}
+			value := "other"
+			if field == "Repository" || field == "Worktree" {
+				value = filepath.Join(root, "other")
+			}
+			v.SetString(value)
+			got, e = Resolve(snapshot(r), copy)
+			if e != nil || len(got.Excluded) != 1 {
+				t.Fatalf("scope mismatch: %+v %v", got, e)
+			}
+		})
+	}
+	c.Path = "src-other/a.go"
+	result, err = Resolve(snapshot(r), c)
+	if err != nil || len(result.Excluded) != 1 {
+		t.Fatal("path prefix leaked")
+	}
+	for _, invalid := range []Context{{}, {Now: instant, Path: "../a"}, {Now: instant, Repository: "relative"}} {
+		_, e := Resolve(snapshot(r), invalid)
+		bad(t, e)
+	}
+	_, e := Resolve(Snapshot{}, ctx())
+	bad(t, e)
+	a, b, d := rule("absolute"), rule("high-priority"), rule("preference")
+	a.Absolute = true
+	a.Priority = -1000
+	b.Priority = 1000
+	d.Strength = "should"
+	d.Priority = 1000
+	result, err = Resolve(snapshot(d, b, a), ctx())
+	if err != nil || result.Applicable[0].Rule.ID != a.ID || len(result.Applicable) != 3 {
+		t.Fatalf("priority waived must: %+v %v", result, err)
+	}
+	x, _ := Resolve(snapshot(d, b, a), ctx())
+	y, _ := Resolve(snapshot(a, b, d), ctx())
+	if !reflect.DeepEqual(x, y) {
+		t.Fatal("non-deterministic result")
+	}
+}
+func TestConflictAndDefaults(t *testing.T) {
+	a, b := rule("a"), rule("b")
+	a.ConflictKey = "backend"
+	a.Value = "one"
+	b.ConflictKey = a.ConflictKey
+	b.Value = "two"
+	for _, tc := range []struct {
+		sa, sb, va, vb string
+		conflict       bool
+	}{{"must", "must", "one", "two", true}, {"must", "must", "one", "one", false}, {"must", "must_not", "one", "one", true}, {"must", "must_not", "one", "two", false}, {"must_not", "must_not", "one", "two", false}} {
+		a.Strength, b.Strength, a.Value, b.Value = tc.sa, tc.sb, tc.va, tc.vb
+		got, e := Resolve(snapshot(a, b), ctx())
+		if e != nil || (len(got.Conflicts) > 0) != tc.conflict {
+			t.Fatalf("%+v %v", got, e)
+		}
+	}
+	a.Strength, b.Strength = "should", "should"
+	a.Value, b.Value = "one", "two"
+	got, e := Resolve(snapshot(b, a), ctx())
+	if e != nil || len(got.Conflicts) != 1 {
+		t.Fatal("tied conflicting defaults silently won")
+	}
+	b.Priority = 1
+	got, e = Resolve(snapshot(a, b), ctx())
+	if e != nil || len(got.Applicable) != 1 || got.Applicable[0].Rule.ID != "b" {
+		t.Fatal(got, e)
+	}
+	b.Authority = "project"
+	got, e = Resolve(snapshot(a, b), ctx())
+	if e != nil || got.Applicable[0].Rule.ID != "a" {
+		t.Fatal("priority overrode authority")
+	}
+	b.Authority = "owner"
+	b.Scope.Task = "T"
+	c := ctx()
+	c.Task = "T"
+	got, e = Resolve(snapshot(a, b), c)
+	if e != nil || got.Applicable[0].Rule.ID != "b" {
+		t.Fatal("specific default not selected")
+	}
+	a.Strength = "must"
+	got, e = Resolve(snapshot(a, b), c)
+	if e != nil || len(got.Applicable) != 1 || got.Applicable[0].Rule.ID != "a" {
+		t.Fatal("default competed with a must")
+	}
+}
+func TestStrictJSON(t *testing.T) {
+	for _, data := range []string{`{"version":1,"version":2}`, `{"version":1,"rules":[{"id":"a","id":"b"}]}`, `{} {}`, `{"unknown":1}`, `{"version":`, strings.Repeat("[", 66) + strings.Repeat("]", 66), `{"a":]}`, `[}`} {
+		var s Snapshot
+		bad(t, decode(strings.NewReader(data), &s, MaxRegistryBytes, true))
+	}
+	var out any
+	if e := decode(strings.NewReader(`{"a":[1,true,null,{"b":"c"}]}`), &out, 1000, false); e != nil {
+		t.Fatal(e)
+	}
+	bad(t, decode(strings.NewReader("12345"), &out, 4, false))
+	bad(t, decode(failingReader{}, &out, 100, false))
+}

--- a/internal/instructions/store.go
+++ b/internal/instructions/store.go
@@ -1,0 +1,243 @@
+package instructions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+)
+
+var ErrConflict = errors.New("instruction registry revision changed")
+var ErrBusy = errors.New("instruction registry locked; retry or inspect a stale .lock directory after a crashed writer")
+
+// Store is the boundary for a future database backend. This implementation is
+// for bounded, rarely-written approved configuration, never a transcript store.
+type Store interface {
+	Load() (Snapshot, error)
+	Replace(expected uint64, next Snapshot) (Snapshot, error)
+}
+type FileStore struct{ Path string }
+
+func (f FileStore) Load() (Snapshot, error) {
+	var s Snapshot
+	if !absolutePath(f.Path) {
+		return s, fmt.Errorf("store must be a clean absolute path")
+	}
+	info, err := os.Lstat(f.Path)
+	if err != nil {
+		return s, err
+	}
+	if !info.Mode().IsRegular() {
+		return s, fmt.Errorf("store must be a regular file, not a symlink")
+	}
+	b, err := readBounded(f.Path, MaxRegistryBytes)
+	if err != nil {
+		return s, err
+	}
+	if err = decode(bytes.NewReader(b), &s, MaxRegistryBytes, true); err != nil {
+		return s, err
+	}
+	return s, s.Validate()
+}
+func (f FileStore) Replace(expected uint64, next Snapshot) (result Snapshot, err error) {
+	if !absolutePath(f.Path) {
+		return result, fmt.Errorf("store must be a clean absolute path")
+	}
+	if err = next.Validate(); err != nil {
+		return result, err
+	}
+	if next.Revision != expected {
+		return result, fmt.Errorf("input revision must equal --expect")
+	}
+	if expected == ^uint64(0) {
+		return result, fmt.Errorf("registry revision exhausted")
+	}
+	if err = os.MkdirAll(filepath.Dir(f.Path), 0700); err != nil {
+		return result, err
+	}
+	lock := f.Path + ".lock"
+	if err = os.Mkdir(lock, 0700); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return result, ErrBusy
+		}
+		return result, err
+	}
+	defer func() { err = errors.Join(err, os.Remove(lock)) }()
+	old, loadErr := f.Load()
+	if errors.Is(loadErr, os.ErrNotExist) {
+		old = Snapshot{Version: Version}
+	} else if loadErr != nil {
+		return result, loadErr
+	}
+	if old.Revision != expected {
+		return result, ErrConflict
+	}
+	incoming := make(map[string]Rule, len(next.Rules))
+	for _, r := range next.Rules {
+		incoming[r.ID] = r
+	}
+	for _, r := range old.Rules {
+		n, ok := incoming[r.ID]
+		if !ok {
+			return result, fmt.Errorf("cannot remove rule %q; revoke it with a new revision", r.ID)
+		}
+		if !reflect.DeepEqual(r, n) && (r.Revision == ^uint64(0) || n.Revision != r.Revision+1) {
+			return result, fmt.Errorf("changed rule %q must increment revision by one", r.ID)
+		}
+		delete(incoming, r.ID)
+	}
+	for _, r := range incoming {
+		if r.Revision != 1 {
+			return result, fmt.Errorf("new rule %q must start at revision 1", r.ID)
+		}
+	}
+	previous := make(map[string]Exception, len(old.Exceptions))
+	for _, e := range old.Exceptions {
+		previous[e.ID] = e
+	}
+	for _, e := range next.Exceptions {
+		if old, ok := previous[e.ID]; ok && !reflect.DeepEqual(old, e) {
+			return result, fmt.Errorf("exception %q is immutable; use a new id", e.ID)
+		}
+	}
+	next.Revision = expected + 1
+	data, err := json.MarshalIndent(next, "", "  ")
+	if err != nil {
+		return result, err
+	}
+	data = append(data, '\n')
+	if len(data) > MaxRegistryBytes {
+		return result, fmt.Errorf("registry exceeds %d bytes", MaxRegistryBytes)
+	}
+	history := f.Path + ".revisions"
+	if err = os.MkdirAll(history, 0700); err != nil {
+		return result, err
+	}
+	archive := filepath.Join(history, strconv.FormatUint(next.Revision, 10)+".json")
+	if b, e := readBounded(archive, MaxRegistryBytes); e == nil {
+		if !bytes.Equal(b, data) {
+			return result, fmt.Errorf("revision archive differs; inspect %s", archive)
+		}
+	} else if !errors.Is(e, os.ErrNotExist) {
+		return result, e
+	} else if err = atomicWrite(archive, data); err != nil {
+		return result, err
+	}
+	if err = atomicWrite(f.Path, data); err != nil {
+		return result, err
+	}
+	return next, nil
+}
+
+// No unlink-before-rename fallback. Local filesystems only. File contents are
+// synced; directory entries are not fsynced in v0, so this is not a power-loss
+// durability guarantee. An interrupted archive write is inspectable/retryable.
+func atomicWrite(destination string, data []byte) (err error) {
+	t, err := os.CreateTemp(filepath.Dir(destination), ".instructions-*")
+	if err != nil {
+		return err
+	}
+	name := t.Name()
+	defer func() {
+		if e := t.Close(); e != nil && !errors.Is(e, os.ErrClosed) {
+			err = errors.Join(err, e)
+		}
+		if e := os.Remove(name); e != nil && !errors.Is(e, os.ErrNotExist) {
+			err = errors.Join(err, e)
+		}
+	}()
+	if _, err = t.Write(data); err != nil {
+		return err
+	}
+	if err = t.Sync(); err != nil {
+		return err
+	}
+	if err = t.Close(); err != nil {
+		return err
+	}
+	return os.Rename(name, destination)
+}
+func readBounded(name string, limit int64) ([]byte, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	b, e := io.ReadAll(io.LimitReader(f, limit+1))
+	err = errors.Join(e, f.Close())
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(b)) > limit {
+		return nil, fmt.Errorf("file exceeds %d bytes", limit)
+	}
+	return b, nil
+}
+func decode(r io.Reader, out any, limit int64, strict bool) error {
+	b, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(b)) > limit {
+		return fmt.Errorf("JSON exceeds %d bytes", limit)
+	}
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if err = uniqueKeys(d, 0); err != nil {
+		return err
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return fmt.Errorf("expected exactly one JSON value")
+	}
+	d = json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if strict {
+		d.DisallowUnknownFields()
+	}
+	return d.Decode(out)
+}
+func uniqueKeys(d *json.Decoder, depth int) error {
+	if depth > 64 {
+		return fmt.Errorf("JSON nesting exceeds 64 levels")
+	}
+	token, err := d.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		keys := make(map[string]bool)
+		for d.More() {
+			key, e := d.Token()
+			if e != nil {
+				return e
+			}
+			name, ok := key.(string)
+			if !ok || keys[name] {
+				return fmt.Errorf("duplicate or invalid JSON key %q", key)
+			}
+			keys[name] = true
+			if err = uniqueKeys(d, depth+1); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for d.More() {
+			if err = uniqueKeys(d, depth+1); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter")
+	}
+	_, err = d.Token()
+	return err
+}

--- a/internal/instructions/store_test.go
+++ b/internal/instructions/store_test.go
@@ -1,0 +1,246 @@
+package instructions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreCASAndHistory(t *testing.T) {
+	d := isolated(t)
+	store := FileStore{Path: filepath.Join(d, "registry.json")}
+	s := snapshot(rule("a"))
+	saved, e := store.Replace(0, s)
+	if e != nil || saved.Revision != 1 {
+		t.Fatal(saved, e)
+	}
+	got, e := store.Load()
+	if e != nil || !reflect.DeepEqual(got, saved) {
+		t.Fatal(got, e)
+	}
+	if _, e = store.Replace(0, s); !errors.Is(e, ErrConflict) {
+		t.Fatalf("lost update allowed: %v", e)
+	}
+	saved.Rules[0].Text = "Different approved text."
+	_, e = store.Replace(1, saved)
+	bad(t, e)
+	saved.Rules[0].Revision = 2
+	got, e = store.Replace(1, saved)
+	if e != nil || got.Revision != 2 {
+		t.Fatal(got, e)
+	}
+	archived, e := os.ReadFile(filepath.Join(store.Path+".revisions", "1.json"))
+	if e != nil || !bytes.Contains(archived, []byte("Preserve unrelated")) {
+		t.Fatal("prior approval lost", e)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*Snapshot)
+	}{{"delete", func(s *Snapshot) { s.Rules = nil }}, {"new revision", func(s *Snapshot) { r := rule("new"); r.Revision = 3; s.Rules = append(s.Rules, r) }}, {"input revision", func(s *Snapshot) { s.Revision = 0 }}, {"invalid", func(s *Snapshot) { s.Version = 99 }}} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, e := store.Load()
+			if e != nil {
+				t.Fatal(e)
+			}
+			tc.mutate(&s)
+			_, e = store.Replace(2, s)
+			bad(t, e)
+		})
+	}
+	got, e = store.Load()
+	if e != nil {
+		t.Fatal(e)
+	}
+	got.Rules[0].Revision++
+	got.Rules[0].Status = "revoked"
+	if _, e = store.Replace(2, got); e != nil {
+		t.Fatal(e)
+	}
+	got, e = store.Load()
+	if e != nil {
+		t.Fatal(e)
+	}
+	got.Exceptions = []Exception{{ID: "grant", RuleID: "a", RuleRevision: 3, Task: "T", ExpiresAt: instant.Add(time.Hour), ApprovedBy: "owner", Reason: "test"}}
+	got, e = store.Replace(3, got)
+	if e != nil {
+		t.Fatal(e)
+	}
+	got.Exceptions[0].Task = "other"
+	_, e = store.Replace(4, got)
+	bad(t, e)
+}
+func TestStoreFailures(t *testing.T) {
+	d := isolated(t)
+	p := filepath.Join(d, "registry.json")
+	store := FileStore{Path: p}
+	_, e := (FileStore{Path: "relative"}).Load()
+	bad(t, e)
+	_, e = (FileStore{Path: "relative"}).Replace(0, snapshot())
+	bad(t, e)
+	if _, e = store.Load(); !errors.Is(e, os.ErrNotExist) {
+		t.Fatal(e)
+	}
+	write(t, p, []byte("broken"))
+	_, e = store.Load()
+	bad(t, e)
+	_, e = store.Replace(0, snapshot())
+	bad(t, e)
+	if e = os.Remove(p); e != nil {
+		t.Fatal(e)
+	}
+	if e = os.Mkdir(p, 0700); e != nil {
+		t.Fatal(e)
+	}
+	_, e = store.Load()
+	bad(t, e)
+	if e = os.Remove(p); e != nil {
+		t.Fatal(e)
+	}
+	if e = os.Mkdir(p+".lock", 0700); e != nil {
+		t.Fatal(e)
+	}
+	if _, e = store.Replace(0, snapshot()); !errors.Is(e, ErrBusy) {
+		t.Fatal(e)
+	}
+	if e = os.Remove(p + ".lock"); e != nil {
+		t.Fatal(e)
+	}
+	write(t, p, bytes.Repeat([]byte("x"), MaxRegistryBytes+1))
+	_, e = store.Load()
+	bad(t, e)
+	if e = os.Remove(p); e != nil {
+		t.Fatal(e)
+	}
+	bad(t, atomicWrite(filepath.Join(d, "missing", "target"), []byte("x")))
+	dir := filepath.Join(d, "directory")
+	if e = os.Mkdir(dir, 0700); e != nil {
+		t.Fatal(e)
+	}
+	bad(t, atomicWrite(dir, []byte("x")))
+	_, e = readBounded(dir, 100)
+	bad(t, e)
+	write(t, p+".lock", []byte("locked"))
+	if _, e = store.Replace(0, snapshot()); !errors.Is(e, ErrBusy) {
+		t.Fatal(e)
+	}
+	if e = os.Remove(p + ".lock"); e != nil {
+		t.Fatal(e)
+	}
+	s := snapshot()
+	s.Revision = ^uint64(0)
+	_, e = store.Replace(s.Revision, s)
+	bad(t, e)
+	if runtime.GOOS != "windows" {
+		target := filepath.Join(d, "real")
+		write(t, target, encoded(t, snapshot()))
+		if e = os.Symlink(target, p); e != nil {
+			t.Fatal(e)
+		}
+		_, e = store.Load()
+		bad(t, e)
+		if e = os.Remove(p); e != nil {
+			t.Fatal(e)
+		}
+	}
+	if e = os.MkdirAll(p+".revisions", 0700); e != nil {
+		t.Fatal(e)
+	}
+	next := snapshot()
+	next.Revision = 1
+	b, e := json.MarshalIndent(next, "", "  ")
+	if e != nil {
+		t.Fatal(e)
+	}
+	write(t, filepath.Join(p+".revisions", "1.json"), append(b, '\n'))
+	_, e = store.Replace(0, snapshot(rule("different")))
+	bad(t, e)
+	if _, e = store.Replace(0, snapshot()); e != nil {
+		t.Fatal("interrupted same-draft retry failed", e)
+	}
+}
+func TestConcurrentWriters(t *testing.T) {
+	d := isolated(t)
+	store := FileStore{Path: filepath.Join(d, "registry.json")}
+	if _, e := store.Replace(0, snapshot()); e != nil {
+		t.Fatal(e)
+	}
+	var wg sync.WaitGroup
+	results := make(chan error, 12)
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s := snapshot(rule(fmt.Sprint("r", i)))
+			s.Revision = 1
+			_, e := store.Replace(1, s)
+			results <- e
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	success := 0
+	for e := range results {
+		if e == nil {
+			success++
+		} else if !errors.Is(e, ErrBusy) && !errors.Is(e, ErrConflict) {
+			t.Fatal(e)
+		}
+	}
+	if success != 1 {
+		t.Fatalf("expected one writer, got %d", success)
+	}
+}
+func TestProcessWriter(t *testing.T) {
+	if p := os.Getenv("DEJA_INSTRUCTION_TEST_WRITER"); p != "" {
+		s := snapshot(rule("child"))
+		s.Revision = 1
+		_, e := (FileStore{Path: p}).Replace(1, s)
+		if e != nil {
+			fmt.Fprintln(os.Stderr, e)
+			os.Exit(3)
+		}
+		os.Exit(0)
+	}
+	d := isolated(t)
+	p := filepath.Join(d, "registry.json")
+	if _, e := (FileStore{Path: p}).Replace(0, snapshot()); e != nil {
+		t.Fatal(e)
+	}
+	binary, e := os.Executable()
+	if e != nil {
+		t.Fatal(e)
+	}
+	var commands []*exec.Cmd
+	for i := 0; i < 4; i++ {
+		cmd := exec.Command(binary, "-test.run=^TestProcessWriter$")
+		cmd.Env = append(os.Environ(), "DEJA_INSTRUCTION_TEST_WRITER="+p)
+		if e = cmd.Start(); e != nil {
+			t.Fatal(e)
+		}
+		commands = append(commands, cmd)
+	}
+	success := 0
+	for _, cmd := range commands {
+		e = cmd.Wait()
+		if e == nil {
+			success++
+		} else {
+			var exit *exec.ExitError
+			if !errors.As(e, &exit) || exit.ExitCode() != 3 {
+				t.Fatal(e)
+			}
+		}
+	}
+	if success != 1 {
+		t.Fatalf("%d process writes succeeded, want one", success)
+	}
+}

--- a/tools/instruction-storage/compare.py
+++ b/tools/instruction-storage/compare.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Synthetic SQLite/DuckDB workload probe; never reads agent history.
+
+Run both engines on the same machine. Loader implementations differ and load
+seconds must not be read as an apples-to-apples engine comparison. Query results
+are verified. This is not a multi-process concurrency or Deja search benchmark.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib
+import json
+import platform
+import random
+import sqlite3
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+def measure(operation: Any, repeats: int) -> dict[str, float]:
+    durations = []
+    for _ in range(repeats):
+        start = time.perf_counter_ns()
+        operation()
+        durations.append((time.perf_counter_ns() - start) / 1_000_000)
+    durations.sort()
+    return {"median_ms": statistics.median(durations),
+            "p95_ms": durations[min(len(durations) - 1, int(len(durations) * .95))]}
+
+
+def probe(engine: str, directory: Path, csv_path: Path, rows: int,
+          samples: int, scans: int, commits: int) -> dict[str, Any]:
+    module = sqlite3 if engine == "sqlite" else importlib.import_module("duckdb")
+    db = directory / (engine + ".db")
+    connection = module.connect(str(db))
+    try:
+        if engine == "sqlite":
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=FULL")
+        else:
+            connection.execute("SET threads=1")
+        connection.execute("CREATE TABLE events (id BIGINT PRIMARY KEY, scope INTEGER, flag INTEGER, payload VARCHAR)")
+        start = time.perf_counter()
+        if engine == "sqlite":
+            with csv_path.open(newline="") as stream:
+                connection.executemany("INSERT INTO events VALUES (?, ?, ?, ?)", csv.reader(stream))
+            connection.commit()
+        else:
+            source = str(csv_path).replace("'", "''")
+            connection.execute(f"COPY events FROM '{source}' (HEADER FALSE, DELIMITER ',')")
+        load_seconds = time.perf_counter() - start
+        connection.execute("CREATE INDEX scope_index ON events(scope)")
+        connection.commit()
+        query = "SELECT scope, COUNT(*), SUM(flag) FROM events GROUP BY scope ORDER BY scope"
+        expected: dict[int, list[int]] = {}
+        for i in range(rows):
+            bucket = expected.setdefault(i % 256, [0, 0])
+            bucket[0] += 1
+            bucket[1] += i % 3
+        actual = [(int(g), int(n), int(s)) for g, n, s in connection.execute(query).fetchall()]
+        assert actual == [(g, *expected[g]) for g in sorted(expected)], "aggregation mismatch"
+        rng = random.Random(0)
+        ids = iter(rng.randrange(rows) for _ in range(samples))
+
+        def point() -> None:
+            identifier = next(ids)
+            result = connection.execute("SELECT payload FROM events WHERE id=?", [identifier]).fetchone()
+            assert result == (f"synthetic-event-{identifier}",), "point lookup mismatch"
+
+        points = measure(point, samples)
+        aggregations = measure(lambda: connection.execute(query).fetchall(), scans)
+
+        def update() -> None:
+            connection.execute("BEGIN TRANSACTION")
+            connection.execute("UPDATE events SET flag=flag+1 WHERE id=0")
+            connection.commit()
+
+        mutations = measure(update, commits)
+        assert connection.execute("SELECT flag FROM events WHERE id=0").fetchone()[0] == commits
+    finally:
+        connection.close()
+
+    def reopen() -> None:
+        handle = module.connect(str(db))
+        try:
+            assert handle.execute("SELECT COUNT(*) FROM events WHERE id=0").fetchone()[0] == 1
+        finally:
+            handle.close()
+
+    return {"engine": engine,
+            "version": sqlite3.sqlite_version if engine == "sqlite" else module.__version__,
+            "rows": rows, "load_seconds_not_comparable": load_seconds,
+            "warm_primary_key_lookup": points, "warm_grouped_scan": aggregations,
+            "single_row_commits": mutations, "reopen_and_lookup": measure(reopen, min(20, samples)),
+            "database_bytes_after_close": db.stat().st_size}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engines", nargs="+", choices=("sqlite", "duckdb"), default=["sqlite", "duckdb"])
+    parser.add_argument("--rows", type=int, default=100_000)
+    parser.add_argument("--samples", type=int, default=200)
+    parser.add_argument("--scans", type=int, default=5)
+    parser.add_argument("--commits", type=int, default=25)
+    args = parser.parse_args()
+    if min(args.rows, args.samples, args.scans, args.commits) < 1:
+        parser.error("all counts must be positive")
+    if "duckdb" in args.engines:
+        try:
+            importlib.import_module("duckdb")
+        except ImportError:
+            parser.error("DuckDB Python package is required for that engine; no dependencies are installed automatically")
+    with tempfile.TemporaryDirectory(prefix="deja-storage-probe-") as temporary:
+        directory = Path(temporary)
+        csv_path = directory / "synthetic.csv"
+        with csv_path.open("w", newline="") as stream:
+            csv.writer(stream).writerows((i, i % 256, i % 3, f"synthetic-event-{i}") for i in range(args.rows))
+        report = {"python": platform.python_version(), "platform": platform.system(),
+                  "notes": ["Synthetic warm-cache microbenchmarks; no agent history.",
+                            "Single-process measurements; concurrency and process startup are not measured.",
+                            "SQLite WAL/FULL and DuckDB defaults; DuckDB query threads fixed to one.",
+                            "Bulk loader implementations differ; compare query/commit timings separately."],
+                  "results": [probe(e, directory, csv_path, args.rows, args.samples, args.scans, args.commits)
+                              for e in dict.fromkeys(args.engines)]}
+        print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds experimental, opt-in instruction memory: approved rules are resolved separately from ranked conversation recall and delivered through Claude Code/Codex lifecycle hooks. This is the independent instruction subsystem split from https://github.com/vshulcz/deja-vu/pull/3436; it has no context-cache dependency.

- Independent `deja instructions` CLI, shell completion, and command reference.
- Versioned JSON registry with compare-and-swap snapshot replacement and revision archives; `apply` is not a merge.
- Repository, worktree, task, session, environment, tool and path scopes; mandatory accumulation, keyed conflicts, effective windows, expiry and revision-pinned exceptions.
- Explicit supersession with cycle/target validation and protected-rule checks; a successor cannot weaken absolute, mandatory, or owner-authored rules. Competing applicable successors remain an explicit conflict.
- Bounded instruction/runbook delivery through the existing `hook-context`, `hook-prompt`, and `hook-tool` process: one handler and one combined response per event. Opt-in installation migrates old separate handlers, preserves unrelated configuration and survives normal reinstall. `SubagentStart` retains its instruction-only handler.
- Usage documentation, storage assessment, reproducible SQLite/DuckDB microbenchmark probe, regression coverage, and a 90% instruction-package coverage floor.

The three follow-up documents describe proposed runtime work, not additional implemented capabilities: [runtime design](https://github.com/full-chaos/deja-vu/blob/feat/instructions-set/docs/instruction-runtime-design.md), [storage decision](https://github.com/full-chaos/deja-vu/blob/feat/instructions-set/docs/instruction-runtime-storage.md), and [implementation/acceptance plan](https://github.com/full-chaos/deja-vu/blob/feat/instructions-set/docs/instruction-runtime-plan.md).

## Scope and limits

This is advisory v0: it does not execute/certify runbooks or enforce actions. Approval fields are provenance, not authentication. The registry is separate from the history index, with no blanket SQLite-to-DuckDB migration. Proposed task state, safe capture, delivery deduplication and gates are not implemented. No new head-to-head database benchmark or live-agent delivery validation is claimed.

The timezone and SQLite fixture corrections address four existing portability failures so this PR can be tested independently of the context-cache PR.

## Validation

Fresh validation of the review fixes on macOS arm64 with Go 1.25.13 and the default temporary directory (no TMPDIR workaround):

- `go test ./internal/instructions -race -count=1 -cover` passed: **93.5%** statement coverage, above the 90% package floor.
- CLI shared-hook, installer, help-contract, plugin-parity and nudge regressions passed with `-race`. These cover both installation orders, ordinary versus opted-in matchers, old executable migration, shell-wrapper preservation, mandatory context budgets, and retrying recall/nudges/session starts omitted for budget.
- A built-executable smoke test exercised 16 event deliveries: Claude and Codex, both installation orders, and SessionStart/UserPromptSubmit/PreToolUse/SubagentStart. Each event had one Deja handler and delivered the synthetic approved rule exactly once.
- `go vet ./...`, `golangci-lint run ./...`, build, changed-Go formatting and `git diff --check` passed.
- All 15 GitHub Actions checks passed on `beedc77e`, including the full Linux and macOS race-test suites, Linux coverage thresholds, cross-compilation, lint, security checks and platform smoke tests. Live-agent/model-request delivery is not claimed by the synthetic hook smoke test.
