### PR TITLE
fix: two release blockers — a summary that named sessions, and a memo that missed a rewrite

### DIFF
--- a/internal/index/compaction_title_test.go
+++ b/internal/index/compaction_title_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A compaction summary is the harness handing a conversation back to itself.
+// The preamble that introduced it is stripped as an injected line, so what is
+// left starts at the summary — and 23 of the last 800 sessions on a real store
+// were named after it, which is what the recall block then quoted back.
+func TestACompactionSummaryDoesNotNameASession(t *testing.T) {
+	tmp := t.TempDir()
+	setHome(t, tmp)
+	t.Setenv("USERPROFILE", tmp)
+	claude := filepath.Join(tmp, "claude")
+	t.Setenv("DEJA_CLAUDE_ROOT", claude)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(tmp, "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(tmp, "none.db"))
+	t.Setenv("DEJA_NOTES_FILE", filepath.Join(tmp, "notes.jsonl"))
+	proj := filepath.Join(claude, "-work-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := "This session is being continued from a previous conversation.\\n\\n" +
+		"Summary:\\n1. Primary Request and Intent:\\n   The user asked for the retry budget.\\n" +
+		"2. Key Technical Concepts:\\n   the quokkabloom fetcher\\n"
+	lines := `{"type":"user","sessionId":"s1","cwd":"/work/app","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"` + summary + `"}}
+{"type":"user","sessionId":"s1","cwd":"/work/app","timestamp":"2026-01-02T03:05:05Z","message":{"role":"user","content":"why does the quokkabloom fetcher time out"}}
+{"type":"assistant","sessionId":"s1","cwd":"/work/app","timestamp":"2026-01-02T03:06:05Z","message":{"role":"assistant","content":"the retry budget is capped at four"}}
+`
+	if err := os.WriteFile(filepath.Join(proj, "s1.jsonl"), []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Sessions) == 0 {
+		t.Fatal("nothing indexed, so this measures nothing")
+	}
+	for _, meta := range m.Sessions {
+		if strings.HasPrefix(strings.ToLower(meta.Title), "summary:") {
+			t.Errorf("a session is named by its compaction summary: %q", meta.Title)
+		}
+		if !strings.Contains(meta.Title, "quokkabloom") {
+			t.Errorf("the question under the summary did not name the session: %q", meta.Title)
+		}
+	}
+}
+
+// And a person's own "Summary:" is theirs.
+func TestAPersonsSummaryStillNamesTheirSession(t *testing.T) {
+	if compactionSummary("Summary: we moved the retry budget to four and closed the ticket") {
+		t.Error("a sentence a person wrote was read as a compaction")
+	}
+	if !compactionSummary("Summary:\n1. Primary Request and Intent:\n   the retry budget") {
+		t.Error("the compaction template was not recognised")
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -1826,6 +1826,38 @@ func harnessPreamble(text string) bool {
 			return true
 		}
 	}
+	return compactionSummary(t)
+}
+
+// compactionSummary reports the summary a harness writes when it compacts a
+// conversation and hands the rest back to itself.
+//
+// The preamble that introduced it — "This session is being continued…" — is
+// stripped as an injected line before anything reads the turn, so what is left
+// starts at the summary and no longer looks like the harness's. 23 of the last
+// 800 sessions on a real store were named after it: "Summary: 1. Primary
+// Request and Intent: …" reached `deja last`, the recall block and the
+// repeated-question counter as if a person had typed it.
+//
+// Matched on the template rather than on the word: someone writing "Summary: we
+// moved the retry budget" is naming their own session, and the headings below
+// are the ones a compaction writes.
+func compactionSummary(t string) bool {
+	if !strings.HasPrefix(strings.ToLower(t), "summary:") {
+		return false
+	}
+	head := t
+	if len(head) > 600 {
+		head = head[:600]
+	}
+	for _, heading := range []string{
+		"Primary Request", "Key Technical Concepts", "Files and Code Sections",
+		"Pending Tasks", "Current Work",
+	} {
+		if strings.Contains(head, heading) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/sources/lifecycle.go
+++ b/internal/sources/lifecycle.go
@@ -46,6 +46,7 @@ func PromotedLifecycles() map[string]Lifecycle {
 	if statOK {
 		if !notesFresh(path, size, mod, statOK) {
 			notesMemo.path, notesMemo.size, notesMemo.mod = path, size, mod
+			notesMemo.sum, _ = notesSum(path)
 			notesMemo.stamped, notesMemo.notes = true, nil
 		}
 		notesMemo.states = out

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -627,8 +627,8 @@ func notesSum(path string) ([32]byte, bool) {
 // notesFresh reports whether the memo still describes the file, and takes the
 // lock's word for it — callers hold the lock.
 func notesFresh(path string, size int64, mod time.Time, ok bool) bool {
-	if !(ok && notesMemo.stamped && notesMemo.path == path &&
-		notesMemo.size == size && notesMemo.mod.Equal(mod)) {
+	if !ok || !notesMemo.stamped || notesMemo.path != path ||
+		notesMemo.size != size || !notesMemo.mod.Equal(mod) {
 		return false
 	}
 	if time.Since(mod) > notesFreshWindow {

--- a/internal/sources/notes.go
+++ b/internal/sources/notes.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -571,22 +572,28 @@ type PromotedNote struct {
 // Keyed on size and modification time, so a promotion made in one MCP call is
 // visible in the next; the manifest is remembered the same way.
 //
-// What that key cannot see: a hand edit that changes no byte count — swapping
-// `accepted` for `rejected` is the same eight characters — on a filesystem
-// whose modification times are whole seconds, read again by the same
-// long-lived process inside that second. Every write deja makes is an append,
-// so this needs a person editing the file by hand at exactly that moment; the
-// next read after that second sees it.
+// Size and time alone cannot see a rewrite that changes no byte count —
+// swapping `accepted` for `rejected` is the same eight characters — on a
+// filesystem whose modification times are coarse, read again inside that tick.
+// It is not only a hand edit: the windows leg of CI hit it on every run. So a
+// stamp younger than the clock's own resolution is confirmed by hashing the
+// file, which is a read of a few kilobytes against the parse it saves.
 var notesMemo struct {
 	sync.Mutex
 	path    string
 	size    int64
 	mod     time.Time
+	sum     [32]byte
 	notes   []PromotedNote
 	states  map[string]Lifecycle
 	parses  int
 	stamped bool
 }
+
+// notesFreshWindow is how young a modification time has to be before the stamp
+// stops being evidence on its own. Two seconds covers a filesystem that records
+// whole seconds and a write that lands just after the memo was taken.
+const notesFreshWindow = 2 * time.Second
 
 // notesParses counts the parses that actually read the file, for the test that
 // pins the memo.
@@ -607,11 +614,28 @@ func notesStamp(path string) (int64, time.Time, bool) {
 	return fi.Size(), fi.ModTime(), true
 }
 
+// notesSum is the file's content, hashed. Read only inside the window where the
+// stamp cannot be trusted, and never on the hot path of an unchanged file.
+func notesSum(path string) ([32]byte, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return [32]byte{}, false
+	}
+	return sha256.Sum256(b), true
+}
+
 // notesFresh reports whether the memo still describes the file, and takes the
 // lock's word for it — callers hold the lock.
 func notesFresh(path string, size int64, mod time.Time, ok bool) bool {
-	return ok && notesMemo.stamped && notesMemo.path == path &&
-		notesMemo.size == size && notesMemo.mod.Equal(mod)
+	if !(ok && notesMemo.stamped && notesMemo.path == path &&
+		notesMemo.size == size && notesMemo.mod.Equal(mod)) {
+		return false
+	}
+	if time.Since(mod) > notesFreshWindow {
+		return true
+	}
+	sum, read := notesSum(path)
+	return read && sum == notesMemo.sum
 }
 
 // LoadPromotedNotes returns the latest state per promoted source session.
@@ -634,6 +658,7 @@ func LoadPromotedNotes() []PromotedNote {
 	if statOK {
 		if !notesFresh(path, size, mod, statOK) {
 			notesMemo.path, notesMemo.size, notesMemo.mod = path, size, mod
+			notesMemo.sum, _ = notesSum(path)
 			notesMemo.stamped, notesMemo.states = true, nil
 		}
 		// The memo keeps its own array for the same reason the read above

--- a/internal/sources/notes_memo_rewrite_test.go
+++ b/internal/sources/notes_memo_rewrite_test.go
@@ -1,0 +1,48 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A rewrite that changes no byte count — `accepted` for `rejected` is the same
+// eight characters — was invisible to a memo keyed on size and modification
+// time, on a filesystem whose times are coarse. The windows leg hit it on every
+// run; a promotion made in one MCP call was then answered stale in the next.
+func TestARewriteOfTheSameLengthIsSeen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.jsonl")
+	t.Setenv("DEJA_NOTES_FILE", path)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	line := func(state string) string {
+		return `{"kind":"promoted","session":"claude:a","project":"app","state":"` + state +
+			`","title":"t","text":"keep the pool","ts":"` + now + `"}` + "\n"
+	}
+	if err := os.WriteFile(path, []byte(line("accepted")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadPromotedNotes(); len(got) != 1 || got[0].State != "accepted" {
+		t.Fatalf("first read: %+v", got)
+	}
+
+	// Same length and, once the stamp is put back, the same modification time —
+	// which is what a coarse clock hands the memo on its own.
+	if err := os.WriteFile(path, []byte(line("rejected")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, fi.ModTime(), fi.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadPromotedNotes(); len(got) != 1 || got[0].State != "rejected" {
+		t.Errorf("the rewrite was answered from the memo: %+v", got)
+	}
+	if got := PromotedLifecycles(); got["claude:a"].State != "rejected" {
+		t.Errorf("the lifecycle came from the memo: %+v", got)
+	}
+}


### PR DESCRIPTION
Both found while cutting 0.19.5.

**A compaction summary named the session.** The preamble that introduces it — "This session is being continued…" — is stripped as an injected line before anything reads the turn, so what was left started at `Summary: 1. Primary Request and Intent:` and looked like something a person typed. Measured on this machine: 23 of the last 800 sessions were named that way, and the recall block quoted them back under that name. The template is now read as the harness's own, so the question under it names the session; someone writing "Summary: we moved the retry budget" still names their own.

**The notes memo missed a rewrite of the same length.** `accepted` and `rejected` are eight characters each, so size and modification time say nothing on a filesystem whose times are coarse — the windows leg failed on it every run, and in the field a promotion made in one MCP call could be answered stale in the next. A stamp younger than two seconds is now confirmed by hashing the file; an older one still costs a single stat.

Verified on a copy of a real 2,500-session index: `Summary: …` titles 23 → 0, and the sessions are named by their first real question.