### PR TITLE
feat(log): the point of action records the session it spoke into

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -175,7 +175,13 @@ func runHookToolMode(dir string, stdin io.Reader, stdout io.Writer, shape hookTo
 	// Record the injection so deja's most frequent surface is not invisible to
 	// stats and the receipt. Deduped above, so this counts a distinct fact
 	// served, not every action.
-	usage.RecordResult(dir, usage.KindTool, len(out), 1, false)
+	//
+	// With the agent session it went to, the way the per-prompt hook has since
+	// #1494. Without it this surface could be counted and never followed:
+	// measured on this machine, 492 point-of-action injections and not one that
+	// could be paired with what the agent did next — which is the pairing any
+	// judgement about whether the line helped has to start from.
+	usage.RecordServedInto(dir, usage.KindTool, len(out), 1, input.SessionID)
 	switch shape {
 	case hookToolPlain:
 		fmt.Fprint(stdout, out)

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -143,7 +143,10 @@ func runHookToolAfterMode(dir string, stdin io.Reader, stdout io.Writer, plain b
 	}
 	rememberInjectedIDs(dir, input.SessionID, token)
 	payload := frameRecall(truncateToolLine(line, toolAfterMaxBytes))
-	usage.RecordResult(dir, usage.KindTool, len(payload), 1, false)
+	// The receiving session too: this is the repair delivered at the failure,
+	// the surface with the best evidence behind it, and it was the one that
+	// could not be followed (#1494 gave the per-prompt hook the same field).
+	usage.RecordServedInto(dir, usage.KindTool, len(payload), 1, input.SessionID)
 	if plain {
 		fmt.Fprint(stdout, payload)
 		return nil

--- a/cmd/deja/hook_tool_into_test.go
+++ b/cmd/deja/hook_tool_into_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// The point of action is the surface with the best evidence behind it, and it
+// was the one recorded without a receiver: 492 injections on this machine and
+// not one that could be paired with what the agent did next. The per-prompt
+// hook has carried the receiving session since #1494; these two now do too.
+func TestThePointOfActionRecordsWhoItWentTo(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	commandRunWithAnOutcome(t, "go test ./... -count=1", "a", "b")
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash",`+
+		`"tool_input":{"command":"go test ./... -count=1"},"session_id":"agent-7","cwd":"/work/app"}`)
+	if out == "" {
+		t.Fatal("the hook said nothing, so there is no injection to record")
+	}
+	if into := lastInjectionInto(t, dir); into != "agent-7" {
+		t.Errorf("the injection was recorded into %q, want the agent session", into)
+	}
+}
+
+func lastInjectionInto(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(usage.Path(dir))
+	if err != nil {
+		t.Fatalf("no usage log: %v", err)
+	}
+	last := ""
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var e struct {
+			Kind string `json:"kind"`
+			Into string `json:"into"`
+		}
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		if e.Kind == usage.KindTool {
+			last = e.Into
+		}
+	}
+	return last
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -230,8 +230,6 @@ func RecordResultRaw(indexDir, kind string, bytes, sessions int, empty bool, raw
 	recordFull(indexDir, kind, bytes, sessions, empty, raw, nil)
 }
 
-// RecordServedSessions is RecordResultRaw plus the ids of the sessions the
-// digest contained.
 // RecordServedInto records one injection and the agent session that received
 // it. The kinds that carry a digest have had this since #1494; the
 // point-of-action hooks recorded the event without a receiver, so nothing could
@@ -240,6 +238,8 @@ func RecordServedInto(indexDir, kind string, bytes, sessions int, into string) {
 	recordFullAt(indexDir, kind, bytes, sessions, sessions == 0, 0, nil, into, time.Now().UTC())
 }
 
+// RecordServedSessions is RecordResultRaw plus the ids of the sessions the
+// digest contained.
 func RecordServedSessions(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
 	recordFull(indexDir, kind, bytes, sessions, empty, raw, ids)
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -232,6 +232,14 @@ func RecordResultRaw(indexDir, kind string, bytes, sessions int, empty bool, raw
 
 // RecordServedSessions is RecordResultRaw plus the ids of the sessions the
 // digest contained.
+// RecordServedInto records one injection and the agent session that received
+// it. The kinds that carry a digest have had this since #1494; the
+// point-of-action hooks recorded the event without a receiver, so nothing could
+// be paired with what the agent did next.
+func RecordServedInto(indexDir, kind string, bytes, sessions int, into string) {
+	recordFullAt(indexDir, kind, bytes, sessions, sessions == 0, 0, nil, into, time.Now().UTC())
+}
+
 func RecordServedSessions(indexDir, kind string, bytes, sessions int, empty bool, raw int64, ids []string) {
 	recordFull(indexDir, kind, bytes, sessions, empty, raw, ids)
 }


### PR DESCRIPTION
Measured while asking whether deja's injections change what happens next: of 4538 recorded events on this machine, 1508 name the agent session they went to and **none of the 492 point-of-action injections do**. That surface — the line before an edit and the repair beside a failed command — is the one with the best evidence behind it (#1174 measured 0/6 to 6/6), and it is the one that cannot be followed.

Both hooks now record the receiver the way the per-prompt hook has since #1494. Nothing else changes: same dedupe, same counting, one more field on the event.

What it unlocks: pairing an injection with the turns that follow it in the receiving transcript, which is the only way to answer "did the line help" without asking anyone.