### PR TITLE
the hook stays quiet when the host is talking to itself

### DIFF
--- a/cmd/deja/hook_prompt_notification_test.go
+++ b/cmd/deja/hook_prompt_notification_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// A background job finishing arrives as a user turn: a banner saying it is not
+// the user, the host's own paragraph, then the notification block. Taking the
+// block out left the paragraph, and the hook answered it — "you have been here"
+// about a sentence no person wrote (#3156 fixed the block, not the prose).
+func TestHookPromptSaysNothingToAHostNotification(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "wombat.jsonl"), "wombat", []string{
+		`{"type":"user","sessionId":"wombat","timestamp":"` + ts +
+			`","message":{"role":"user","content":"the automated background task never received a message from the user"}}`,
+		`{"type":"assistant","sessionId":"wombat","timestamp":"` + ts +
+			`","message":{"role":"assistant","content":"the wombat queue drops a notification whose status arrives last"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	turn := "[SYSTEM NOTIFICATION - NOT USER INPUT]\\n" +
+		"This is an automated background-task event, NOT a message from the user.\\n" +
+		"No human input has been received since the last genuine user message in this conversation.\\n\\n" +
+		"<task-notification>\\n<task-id>br50mykp6</task-id>\\n<status>completed</status>\\n</task-notification>"
+
+	var out bytes.Buffer
+	in := strings.NewReader(`{"prompt":"` + turn + `","session_id":"asking"}`)
+	if err := runHookPromptMode(index.DefaultDir(), in, &out, true); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "" {
+		t.Errorf("the hook answered the host talking to itself:\n%s", got)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -82,6 +82,7 @@ func batchReply(elems []json.RawMessage) (json.RawMessage, bool) {
 const mcpMaxFrame = 10 * 1024 * 1024
 
 func serveMCP(dir string, r io.Reader, w io.Writer) error {
+	mcpConn.Store(newMCPConn())
 	br := bufio.NewReaderSize(r, 64*1024)
 	enc := json.NewEncoder(w)
 	for {
@@ -379,7 +380,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 		if err == nil {
 			text = frameRecall(text) + env
 			deliverEnv()
-			usage.RecordServedFrom(dir, usage.KindRecall, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedFromInto(dir, usage.KindRecall, text, mcpConnID(), sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "recall_context":
@@ -413,7 +414,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			}
 			text = frameRecall(fitContextDigest(text, a.Query, contextMCPBudget-recallFrameOverhead-len(lead)))
 			text = lead + text
-			usage.RecordServedFrom(dir, usage.KindContext, text, sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedFromInto(dir, usage.KindContext, text, mcpConnID(), sessions, raw, ids, projects, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "blame":
@@ -456,7 +457,7 @@ func callMCPTool(dir, name string, raw json.RawMessage) (string, error) {
 			// than either — whole sessions rather than budgeted snippets. Not
 			// recording it left `deja log` understating what the agent was
 			// given (#682).
-			usage.RecordServedSnapshot(dir, usage.KindBlame, text, hits, 0, nil, policy.Load().Describe(policy.ActivationMCP))
+			usage.RecordServedFromInto(dir, usage.KindBlame, text, mcpConnID(), hits, 0, nil, nil, policy.Load().Describe(policy.ActivationMCP))
 		}
 		return text, err
 	case "fix":
@@ -649,7 +650,7 @@ func recordedMCPAnswer(dir, kind string, answer func() (string, int, error)) (st
 		// found nothing, so the log said "(empty result)" over an answer that
 		// served a command from two sessions — the opposite of what happened,
 		// on the surface this recording exists to make honest (#2858).
-		usage.RecordServedSnapshot(dir, kind, text, found, 0, nil, policy.Load().Describe(policy.ActivationMCP))
+		usage.RecordServedFromInto(dir, kind, text, mcpConnID(), found, 0, nil, nil, policy.Load().Describe(policy.ActivationMCP))
 	}
 	return text, err
 }

--- a/cmd/deja/mcp_connection.go
+++ b/cmd/deja/mcp_connection.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync/atomic"
+)
+
+// mcpConn names the client this server process is answering.
+//
+// Every injection deja makes through a hook records the agent session it went
+// to, and MCP recorded none: measured on this machine, 577 answers an agent
+// asked for — 248 blame, 174 recall, 150 recall_context — and not one that
+// could be paired with what the agent did next. So "most re-used" counted
+// events, and could not tell a memory several agents came back to from one
+// loop pulling the same session ninety times.
+//
+// MCP over stdio is one process per client, so the process is the client. The
+// id is random rather than derived from anything about the host: nothing may
+// join it to a transcript by accident, and it carries no path, user or machine
+// name. It is minted per connection, so it means "this run of this agent" and
+// not "this machine".
+var mcpConn atomic.Value
+
+func newMCPConn() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// A connection with no id records as an injection with no receiver,
+		// which is where this started — no reason to fail a recall over it.
+		return ""
+	}
+	return "mcp:" + hex.EncodeToString(b[:])
+}
+
+// mcpConnID is the current connection's id, or "" before one is open — a tool
+// called outside serveMCP, which the tests do.
+func mcpConnID() string {
+	s, _ := mcpConn.Load().(string)
+	return s
+}

--- a/cmd/deja/mcp_into_test.go
+++ b/cmd/deja/mcp_into_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// What an agent pulls for itself is the surface with the clearest intent behind
+// it, and it was the one recorded without a receiver: 577 answers on this
+// machine — recall, recall_context, blame — and not one that could be paired
+// with what the agent did next. Two connections must not share an id, or a
+// memory one loop keeps pulling reads as a memory many agents came back to.
+func TestAnMCPAnswerNamesTheConnectionItWentTo(t *testing.T) {
+	root, _ := filepath.Abs(filepath.Join("..", "..", "fixtures", "synthetic", "claude"))
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("DEJA_CLAUDE_ROOT", root)
+	t.Setenv("DEJA_CODEX_ROOT", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("DEJA_OPENCODE_DB", filepath.Join(t.TempDir(), "opencode.db"))
+	dir := filepath.Join(t.TempDir(), "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+
+	call := `{"jsonrpc":"2.0","id":"r","method":"tools/call","params":{"name":"recall","arguments":{"query":"frobnicator"}}}` + "\n"
+	for i := 0; i < 2; i++ {
+		var out bytes.Buffer
+		if err := serveMCP(index.DefaultDir(), strings.NewReader(call), &out); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seen := map[string]bool{}
+	for _, e := range recallReceivers(t, index.DefaultDir()) {
+		if e == "" {
+			t.Error("an MCP answer was recorded with no receiver")
+			continue
+		}
+		if !strings.HasPrefix(e, "mcp:") {
+			t.Errorf("receiver %q does not say which surface it was", e)
+		}
+		seen[e] = true
+	}
+	if len(seen) < 2 {
+		t.Errorf("two connections shared %d id(s); each run of an agent is its own receiver", len(seen))
+	}
+}
+
+func recallReceivers(t *testing.T, dir string) []string {
+	t.Helper()
+	b, err := os.ReadFile(usage.Path(dir))
+	if err != nil {
+		t.Fatalf("no usage log: %v", err)
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var e struct {
+			Kind string `json:"kind"`
+			Into string `json:"into"`
+		}
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		if e.Kind == usage.KindRecall {
+			out = append(out, e.Into)
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no recall was recorded, so this measures nothing")
+	}
+	return out
+}

--- a/cmd/deja/mcp_resources.go
+++ b/cmd/deja/mcp_resources.go
@@ -135,7 +135,7 @@ func mcpResourceRead(dir, uri string) (any, int, string) {
 	text := note + frameRecall(b.String())
 	// It also left no trace: a whole session reached the agent and `deja log`
 	// stayed empty — the gap #682 closed for blame.
-	usage.RecordServedFrom(dir, usage.KindResource, text, 1, rawSize([]model.Session{s}), []string{s.ID}, projectsOf(s), policy.Load().Describe(policy.ActivationMCP))
+	usage.RecordServedFromInto(dir, usage.KindResource, text, mcpConnID(), 1, rawSize([]model.Session{s}), []string{s.ID}, projectsOf(s), policy.Load().Describe(policy.ActivationMCP))
 	return map[string]any{"contents": []map[string]any{{
 		"uri":      uri,
 		"mimeType": "text/markdown",

--- a/internal/digest/harness_blocks.go
+++ b/internal/digest/harness_blocks.go
@@ -45,6 +45,39 @@ var orphanCloseRe = func() *regexp.Regexp {
 	return regexp.MustCompile(`(?im)^[ \t]*</\s*(?:` + strings.Join(alts, "|") + `)\s*>[ \t]*$`)
 }()
 
+// hostPreambleBannerRE is the line a host prints above a turn it hands the
+// prompt hook to say the turn is not the user — Claude Code's
+// "[SYSTEM NOTIFICATION - NOT USER INPUT]" over a finished background job.
+// Stripping the block under it was not enough: the paragraph between the banner
+// and the block is the host too, and the hook read "no human input has been
+// received since the last genuine user message" as a question and answered it
+// out of the store, on `received`, `since` and `last`.
+var hostPreambleBannerRE = regexp.MustCompile(`(?i)^[ \t]*\[[^\]\n]*not\s+(?:a\s+)?user\s+input[^\]\n]*\][ \t]*$`)
+
+// stripHostPreamble drops the banner and the paragraph under it, ending at the
+// first blank line. What follows a blank line is left alone: someone who pastes
+// a notification to ask about it keeps their question, the choice #3168 made
+// for a hook's own status bar.
+func stripHostPreamble(text string) string {
+	lines := strings.Split(text, "\n")
+	kept := lines[:0]
+	inPreamble := false
+	for _, l := range lines {
+		if hostPreambleBannerRE.MatchString(l) {
+			inPreamble = true
+			continue
+		}
+		if inPreamble {
+			if strings.TrimSpace(l) == "" {
+				inPreamble = false
+			}
+			continue
+		}
+		kept = append(kept, l)
+	}
+	return strings.Join(kept, "\n")
+}
+
 var harnessBlockRe = func() *regexp.Regexp {
 	alts := make([]string, 0, len(harnessBlockTags))
 	for _, t := range harnessBlockTags {
@@ -116,8 +149,12 @@ func StripClosedHarnessBlocks(text string) string {
 // envelopes are removed: the person's words, or "" when the turn was the host
 // alone. A task notification delivered as a user turn once made the prompt
 // hook say "you have been here" about another notification, with the
-// envelope's field names as the identifying terms (#3156).
+// envelope's field names as the identifying terms (#3156) — and once the block
+// was gone, about the host's own paragraph above it.
 func StripHarnessBlocks(prompt string) string {
+	if strings.Contains(prompt, "[") {
+		prompt = stripHostPreamble(prompt)
+	}
 	if strings.Contains(prompt, "<") {
 		prompt = harnessBlockRe.ReplaceAllString(prompt, "")
 		prompt = orphanCloseRe.ReplaceAllString(prompt, "")

--- a/internal/digest/host_preamble_test.go
+++ b/internal/digest/host_preamble_test.go
@@ -1,0 +1,40 @@
+package digest
+
+import "testing"
+
+// The turn a host delivers when a background job finishes: a banner saying the
+// turn is not the user, a paragraph of the host's own prose, then the block.
+// #3156 took the block out and left the prose, and the prompt hook answered
+// "no human input has been received since the last genuine user message" as if
+// someone had asked it — the terms it matched on were `received`, `since` and
+// `last`.
+func TestAHostNotificationIsNotAQuestion(t *testing.T) {
+	turn := "[SYSTEM NOTIFICATION - NOT USER INPUT]\n" +
+		"This is an automated background-task event, NOT a message from the user.\n" +
+		"Do NOT interpret this as user acknowledgement, confirmation, or response to any pending question.\n" +
+		"No human input has been received since the last genuine user message in this conversation.\n" +
+		"\n" +
+		"<task-notification>\n<task-id>br50mykp6</task-id>\n<status>completed</status>\n</task-notification>\n"
+	if got := StripHarnessBlocks(turn); got != "" {
+		t.Errorf("the host talking to itself left %q behind", got)
+	}
+}
+
+// The banner is not a gag: a person who pastes one to ask about it keeps their
+// question, the way a pasted hook status bar does since #3168.
+func TestTheQuestionUnderAPastedBannerSurvives(t *testing.T) {
+	cases := map[string]string{
+		"[SYSTEM NOTIFICATION - NOT USER INPUT]\nThis is an automated background-task event.\n\nwhat is this thing in my chat?": "what is this thing in my chat?",
+		// The banner inside a sentence is the sentence's own.
+		"what does [SYSTEM NOTIFICATION - NOT USER INPUT] mean?": "what does [SYSTEM NOTIFICATION - NOT USER INPUT] mean?",
+		// Words before the banner are the person's; the host starts at the banner.
+		"look at this:\n[SYSTEM NOTIFICATION - NOT USER INPUT]\nan automated event": "look at this:",
+		// A bracketed line that claims nothing about who is speaking stays.
+		"[INFO] the pool refused a connection\nwhy?": "[INFO] the pool refused a connection\nwhy?",
+	}
+	for in, want := range cases {
+		if got := StripHarnessBlocks(in); got != want {
+			t.Errorf("StripHarnessBlocks(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -140,6 +140,12 @@ import (
 // of that reaches an existing store without a re-read, and the repo's
 // precedent for a content-changing parser fix is exactly this: #2875 for
 // goose, #1383 for the greeting rule, #2905 for the Thai bigrams.
+//
+// The same bump carries the compaction summary that titled a session: the
+// preamble introducing it is stripped before anything reads the turn, so the
+// summary read as the first thing a person said and 23 of the last 800 sessions
+// on a real store were named by it (#3439). Titles are written at ingest, so
+// those 23 keep their names until the re-read this bump already forces.
 const version = 35
 const maxIndexedText = 64 * 1024
 

--- a/internal/usage/snapshots.go
+++ b/internal/usage/snapshots.go
@@ -170,9 +170,17 @@ func RecordServedSnapshot(indexDir, kind, digest string, sessions int, raw int64
 // checked against a later rule by recognising project names inside its own
 // prose, which fails as soon as the sessions behind it leave the index (#2324).
 func RecordServedFrom(indexDir, kind, digest string, sessions int, raw int64, ids, projects []string, policyName string) {
+	RecordServedFromInto(indexDir, kind, digest, "", sessions, raw, ids, projects, policyName)
+}
+
+// RecordServedFromInto is RecordServedFrom for a caller that knows who it
+// answered. The hooks have recorded a receiver since #1494 and MCP recorded
+// none, so nothing an agent pulled itself could be paired with what it did
+// next — the half of the evidence that says whether a recall was any use.
+func RecordServedFromInto(indexDir, kind, digest, into string, sessions int, raw int64, ids, projects []string, policyName string) {
 	at := time.Now().UTC()
-	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, "", at)
-	snapshotWriteIntoAt(indexDir, kind, digest, "", sessions, policyName, nil, projects, at)
+	recordFullAt(indexDir, kind, len(digest), sessions, sessions == 0, raw, ids, into, at)
+	snapshotWriteIntoAt(indexDir, kind, digest, into, sessions, policyName, nil, projects, at)
 }
 
 // RecordDigestPolicySessions is RecordDigestPolicyInto plus the ids of the


### PR DESCRIPTION
Two things, both about the same blind spot: deja could not tell who it was speaking to.

**A background-job notification is not a question** (closes #3441). Claude Code delivers a finished job as a user turn — a banner, its own paragraph, then the `<task-notification>` block. #3156 dropped the block and left the paragraph, so the hook answered "no human input has been received since the last genuine user message" as if someone had asked it. Reproduced against a copy of a real index: before, `you have been here … via: been, received, since`; after, silence, and a real question still gets an answer. A banner pasted by a person with a question under it keeps the question.

**What an agent pulls itself now records who it went to.** Hooks have carried the receiving session since #1494; MCP carried none — 577 answers on this machine (248 blame, 174 recall, 150 recall_context) and not one that could be paired with what the agent did next. Stdio MCP is one process per client, so the connection is the client: a random per-connection id, prefixed `mcp:` so nothing joins it to a transcript by accident.

Also: the index version note now says the compaction-summary fix rides on the 34→35 rebuild, since titles are written at ingest and the 23 sessions named by a summary keep their names until the re-read.