### PR TITLE
what counts as a wall, and what counts as a remedy

### DIFF
--- a/internal/index/errors_agents_hit_test.go
+++ b/internal/index/errors_agents_hit_test.go
@@ -1,0 +1,56 @@
+package index
+
+import "testing"
+
+// Counted over 102,735 commands and 2,951 failures in real transcripts: two
+// thirds of the failures repeat an error the store has already seen, and 44% of
+// those were first seen in a different session. The walls below are the ones
+// that dominate that count and that nothing here recognised, so `deja friction`
+// listed other errors, `deja fix` returned nothing, and the hook at the failure
+// stayed silent through 89 sightings of the same shell mistake.
+func TestTheWallsThatDominateTheCount(t *testing.T) {
+	walls := []string{
+		// zsh answering `[ "$a" == "$b" ]`. Twelve characters once the shell's
+		// position marker is stripped, and the length bound dropped it.
+		"(eval):1: == not found",
+		"zsh:1: === not found",
+		// A command that ran out of time. The wording is the harness's, and
+		// "connection timed out" never covered it.
+		"Command timed out after 10m 0s",
+		// The harness refusing the agent's own call.
+		"<tool_use_error>InputValidationError: [ { expected: string }]",
+		"Error: File has been modified since read, either by the user or by a linter",
+		"Error: No such tool available: Write. Write is disabled for this session",
+		// The tail of a Python traceback, beyond the four exception names that
+		// were listed.
+		"json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)",
+		"ValueError: invalid literal for int() with base 10",
+		"FileNotFoundError: [Errno 2] No such file",
+	}
+	for _, w := range walls {
+		if _, ok := FrictionLine(w); !ok {
+			t.Errorf("not recognised as a wall: %q", w)
+		}
+	}
+}
+
+// The shell marker says an error follows, not that everything after it is one.
+func TestTheShellMarkerDoesNotLetJunkThrough(t *testing.T) {
+	notWalls := []string{
+		// deja quoting itself: its own report comes back as tool output in the
+		// next session, and this is exactly the shape that taught it about
+		// itself before.
+		"zsh:1: command not found: timeout · 2026-01-02",
+		// Source that talks about a shell error.
+		`zsh:1: echo "command not found: $BIN"`,
+		// Too little left to recognise.
+		"zsh:1: killed",
+		// A colon and a number, but not a shell.
+		"config:1: retries not found",
+	}
+	for _, l := range notWalls {
+		if _, ok := FrictionLine(l); ok {
+			t.Errorf("read as a wall: %q", l)
+		}
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -74,6 +74,11 @@ type FixPair struct {
 	// Command, never beside it: an edit is evidence of what was changed, not
 	// something a reader can run.
 	Edit string `json:",omitempty"`
+	// Repaired marks the remedy as the failing command corrected — same
+	// program, most of the same words. That is evidence on its own, and of a
+	// different kind than the word rules: the pair is not a command that
+	// happened to follow the error, it is the command that caused it, working.
+	Repaired bool `json:",omitempty"`
 	// Candidate marks a sighting that is not a pair yet: the remedy named
 	// nothing the error named, and no other session has done the same thing
 	// after the same error. Evidence of the second kind accumulates across
@@ -109,7 +114,7 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 	}
 	var out []FixPair
 	for _, p := range all {
-		if sharesTerm(p.Error, p.Command) || repeats[fixKey(p)] >= 2 {
+		if p.Repaired || sharesTerm(p.Error, p.Command) || repeats[fixKey(p)] >= 2 {
 			out = append(out, p)
 			continue
 		}
@@ -312,6 +317,22 @@ func outputFailed(ms []model.Message, cmd int) bool {
 	return false
 }
 
+// commandBefore is the command whose output the error at i came out of: the
+// nearest command record above it, with nothing but its own output in between.
+// A session that printed an error without running anything — a build step the
+// harness ran itself — has none, and gets "".
+func commandBefore(ms []model.Message, i int) string {
+	for k := i - 1; k >= 0 && k >= i-fixOutputWindow; k-- {
+		if ms[k].Role == roleCommand {
+			return strings.TrimSpace(firstLineOf(ms[k].Text))
+		}
+		if ms[k].Role != roleToolOutput {
+			return ""
+		}
+	}
+	return ""
+}
+
 // fixPairsIn mines one session.
 func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 	var out []FixPair
@@ -324,6 +345,9 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 		if !ok {
 			continue
 		}
+		// The command that produced this error, for the remedy that is that
+		// same command corrected.
+		failedCmd := commandBefore(ms, i)
 		// The first file the session changed after the error, kept in case the
 		// window holds no command that answers it.
 		edited := ""
@@ -368,7 +392,15 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			// construction when the command greps for the symbol the compiler
 			// complained about, so the table filled with the step an agent
 			// takes between hitting an error and solving it.
-			if investigationCommand(cmd) {
+			//
+			// Unless the command is the failing one corrected. Then what it
+			// does is beside the point: the agent wanted to run exactly this,
+			// the shell would not let it, and the corrected line is the whole
+			// remedy. The wall this was found on is zsh refusing
+			// `--include=*.go` — a grep, rejected here as investigation, and
+			// one of the most repeated walls on the machine that mined it.
+			repaired := repairedVariant(failedCmd, cmd)
+			if !repaired && investigationCommand(cmd) {
 				continue
 			}
 			// A command that names a scratch file is not a remedy anyone can
@@ -380,7 +412,8 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			if namesAnEphemeralPath(cmd) {
 				continue
 			}
-			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key, When: ms[j].Time, Project: project})
+			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key,
+				When: ms[j].Time, Project: project, Repaired: repaired})
 			paired = true
 			break
 		}
@@ -495,7 +528,7 @@ func mergeFixPairs(kept, fresh []FixPair) []FixPair {
 		// An edit is never self-evident the way a command that names what the
 		// error named is: the error names a test, the remedy names a file, and
 		// nothing ties them but a second session doing the same thing.
-		selfEvident := p.Edit == "" && sharesTerm(p.Error, p.Command)
+		selfEvident := p.Edit == "" && (p.Repaired || sharesTerm(p.Error, p.Command))
 		if selfEvident || repeats[k]+seen[k] >= 2 {
 			p.Candidate = false
 			kept = append(kept, p)

--- a/internal/index/friction.go
+++ b/internal/index/friction.go
@@ -68,8 +68,49 @@ func FrictionSignature(l string) (string, uint64, bool) {
 // FrictionLine reports whether a line of tool output names something specific
 // that went wrong, and returns it in the form two sessions can be compared on.
 func FrictionLine(l string) (string, bool) {
+	shell := shellErrorPrefix(l)
 	l = normalizeFriction(l)
+	// A shell only prints its position marker in front of something it could
+	// not do, so the marker is the signal and what follows may be short. This
+	// machine's transcripts hold 89 sightings of `(eval):1: == not found` —
+	// zsh's answer to `[ "$a" == "$b" ]` — and every one was dropped for
+	// length before any phrase was consulted, so `deja friction`, `deja fix`
+	// and the hook at the failure all had nothing to say about a wall the
+	// agent walked into every few days for months.
+	if shell && utf8.RuneCountInString(l) >= shellErrorMin &&
+		utf8.RuneCountInString(l) <= frictionLineMax &&
+		!looksLikeSource(l) && !isDejaOwnReport(l) {
+		return l, true
+	}
 	return l, isFriction(l)
+}
+
+// shellErrorMin is how much has to be left of a shell's complaint for it to be
+// worth remembering. `== not found` is twelve characters; a bare `killed` is
+// not a wall anyone recognises.
+const shellErrorMin = 8
+
+// shellErrorPrefix reports whether the line opens with a shell's position
+// marker — `zsh:1:`, `(eval):2:`, `sh:12:`. normalizeFriction strips it so the
+// same complaint from two shells counts once; this asks whether it was there.
+func shellErrorPrefix(l string) bool {
+	l = strings.TrimSpace(l)
+	first := strings.Index(l, ":")
+	if first <= 0 || first > 16 {
+		return false
+	}
+	switch strings.ToLower(l[:first]) {
+	case "zsh", "bash", "sh", "dash", "ksh", "fish", "(eval)", "(anon)":
+	default:
+		return false
+	}
+	rest := l[first+1:]
+	second := strings.Index(rest, ": ")
+	if second <= 0 {
+		return false
+	}
+	_, err := strconv.Atoi(rest[:second])
+	return err == nil
 }
 
 // normalizeFriction strips the shell's position prefix so the same missing
@@ -259,6 +300,65 @@ var dejaFixReport = regexp.MustCompile(` · \d{4}-\d{2}-\d{2}$`)
 
 var leadingTimestamp = regexp.MustCompile(`^\[?\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\]?\s+`)
 
+// looksLikeSource reports whether the line is code that talks about an error
+// rather than an error. Tool output carries source as often as it carries
+// results — a `cat` of a script, a diff, a heredoc — and an
+// `echo "App not found: $APP"` inside a deploy script reached second place the
+// first time this was measured.
+//
+// A bare double quote used to stand for most of this and cost more than it
+// caught: tools quote the thing they could not find — `relation "orders" does
+// not exist`, `pull access denied for "acme/api"` — so the same psql failure
+// was friction without its quotes and invisible with them (#2431). What is left
+// is the punctuation source puts around a quote — an assignment, a call, a
+// struct field, a code span — none of which appears in what a tool prints:
+// 130 of the 192 lines of this repo's own source that read as friction (#2436).
+func looksLikeSource(l string) bool {
+	for _, source := range []string{"echo ", "printf ", "$(", "=~", "print("} {
+		if strings.Contains(l, source) {
+			return true
+		}
+	}
+	if strings.HasPrefix(l, "\"") || strings.Contains(l, "\": \"") {
+		return true
+	}
+	if strings.Contains(l, `("`) || strings.Contains(l, `, "`) ||
+		strings.Contains(l, `:= "`) || strings.Contains(l, `= "`) ||
+		strings.Contains(l, `: "`) && strings.HasSuffix(l, `"},`) ||
+		strings.HasPrefix(l, "`") {
+		return true
+	}
+	// A comment about an error is source too, and the wider marker list in
+	// #729 made these reachable: `// panic: this is a comment about panics`
+	// became the top wall on a store of shell snippets.
+	for _, comment := range []string{"//", "#", "/*", "*", "--"} {
+		// normalizeFriction has already trimmed the line.
+		if strings.HasPrefix(l, comment) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDejaOwnReport reports whether the line is something deja printed. Its own
+// output is tool output in the next session, and every line of it contains an
+// error by construction, so without this running the command slowly teaches
+// deja about itself.
+//
+// `deja friction` writes a count and the error; `deja fix` writes the error
+// with the date of the session it came from and the command underneath. Both
+// came back as a fresh sighting of the error they were quoting, and the command
+// `fix` printed became a candidate remedy for it — found on a real store as the
+// pair `command not found: python · 2026-05-18`.
+func isDejaOwnReport(l string) bool {
+	if i := strings.Index(l, " sessions  "); i > 0 {
+		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
+			return true
+		}
+	}
+	return dejaFixReport.MatchString(l) || strings.HasPrefix(l, "ran next: ")
+}
+
 // isFriction keeps the error shapes that name something specific. The generic
 // ones carry no information — every Python failure prints `Traceback (most
 // recent call last):`, and clustering those put an empty line at the top of
@@ -290,62 +390,10 @@ func isFriction(l string) bool {
 	// `Cannot find module ./config` was kept (#2432). Nothing is needed in its
 	// place — a line with only a generic opening matches no phrase below and
 	// falls through to false, which is where it belonged.
-	// Tool output carries source as often as it carries results — a `cat` of a
-	// script, a diff, a heredoc. An `echo "App not found: $APP"` inside a
-	// deploy script reached second place on the first run: it is a line about
-	// an error, not an error.
-	for _, source := range []string{"echo ", "printf ", "$(", "=~", "print("} {
-		if strings.Contains(l, source) {
-			return false
-		}
-	}
-	// A bare double quote used to be on that list, and it cost more than it
-	// caught: tools quote the thing they could not find — `relation "orders"
-	// does not exist`, `repository "…" not found`, `pull access denied for
-	// "acme/api"` — so the same psql failure was friction without its quotes
-	// and invisible with them (#2431). What the quote was there to reject is
-	// still rejected by the markers above and by the two shapes below: a line
-	// that opens with a quoted string, and a JSON pair, which is what a
-	// payload printed into tool output looks like.
-	if strings.HasPrefix(l, "\"") || strings.Contains(l, "\": \"") {
+	if looksLikeSource(l) {
 		return false
 	}
-	// Source that carries an error string is a line about an error, not one.
-	// A bare quote used to stand for this and cost far more than it caught
-	// (#2430): what is left is the punctuation source puts around the quote —
-	// an assignment, a call, a struct field, a code span — none of which
-	// appears in the output a tool prints. Measured over this repo: 130 of the
-	// 192 lines of its own docs and source that read as friction (#2436).
-	if strings.Contains(l, `("`) || strings.Contains(l, `, "`) ||
-		strings.Contains(l, `:= "`) || strings.Contains(l, `= "`) ||
-		strings.Contains(l, `: "`) && strings.HasSuffix(l, `"},`) ||
-		strings.HasPrefix(l, "`") {
-		return false
-	}
-	// A comment about an error is source too, and the wider marker list in
-	// #729 made these reachable: `// panic: this is a comment about panics`
-	// became the top wall on a store of shell snippets.
-	for _, comment := range []string{"//", "#", "/*", "*", "--"} {
-		// normalizeFriction has already trimmed the line.
-		if strings.HasPrefix(l, comment) {
-			return false
-		}
-	}
-	// deja's own report is tool output in the next session, and every line of
-	// it contains an error by construction. Drop the report shape so running
-	// the command does not slowly teach it about itself.
-	if i := strings.Index(l, " sessions  "); i > 0 {
-		if _, err := strconv.Atoi(strings.TrimSpace(l[:i])); err == nil {
-			return false
-		}
-	}
-	// `deja fix` prints the error it answers with the date beside it, and the
-	// command underneath. Both come back as tool output in the next session:
-	// the first is read as a fresh sighting of the error it is quoting, so
-	// asking deja about an error taught deja that the error happened again,
-	// and the command it printed became a candidate remedy for it. Found on a
-	// real store as the pair `command not found: python · 2026-05-18`.
-	if dejaFixReport.MatchString(l) || strings.HasPrefix(l, "ran next: ") {
+	if isDejaOwnReport(l) {
 		return false
 	}
 	// The list was nine phrases about things not being found or permitted, and
@@ -384,6 +432,28 @@ func isFriction(l string) bool {
 		// "no such file or directory" was already here; its sibling was not
 		// (#3373).
 		"go.mod file not found", "does not contain main module",
+		// The walls an agent hits that none of the above reached, counted over
+		// 102,735 commands and 2,951 failures in this machine's transcripts.
+		//
+		// A command that ran out of time is the commonest of them — 144
+		// sightings — and the wording is the harness's, not a server's, so
+		// "connection timed out" above never covered it. What memory has to
+		// say about it is worth the line: the same command timed out here
+		// before, and either it wants a longer budget or it wants the
+		// background.
+		"timed out after",
+		// The harness refusing the agent's own call: a file edited without
+		// being read again, an argument the tool would not take, a tool that
+		// is off in this session. 32 sightings, and every one is the agent's
+		// own mistake rather than the machine's, which is the kind a memory
+		// can actually stop.
+		"tool_use_error", "inputvalidationerror",
+		"has been modified since read", "no such tool available",
+		// The tail of a Python traceback names the failure; only four of these
+		// were listed and the rest fell through. 30 sightings of the JSON one
+		// alone.
+		"jsondecodeerror", "valueerror:", "runtimeerror:", "oserror:",
+		"filenotfounderror:", "importerror:", "unicodedecodeerror:",
 	} {
 		if strings.Contains(low, p) {
 			return true

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -146,7 +146,17 @@ import (
 // summary read as the first thing a person said and 23 of the last 800 sessions
 // on a real store were named by it (#3439). Titles are written at ingest, so
 // those 23 keep their names until the re-read this bump already forces.
-// 36 re-mines the fix pairs. The miner asked two things of a candidate — does
+// 36 is about what happens when something goes wrong, in two halves.
+//
+// The first is what counts as a wall at all. A shell's position marker is
+// itself the error signal, and timeouts, the harness's own tool errors and the
+// rest of the Python traceback tails join the phrase list (#3445). A session's
+// friction hashes are written into the manifest at ingest — the same shape as
+// 31 — so `deja friction` reads the records and sees the difference while the
+// hook at the failure and the environment block read the manifest and stay
+// silent. The bump is what ends that.
+//
+// The second re-mines the fix pairs. The miner asked two things of a candidate — does
 // the remedy name what the error named, did another session do the same thing —
 // and both are about words, so it missed the commonest repair there is: the
 // failing command, corrected. Counted over 2,953 failed commands, 16% are

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -146,7 +146,16 @@ import (
 // summary read as the first thing a person said and 23 of the last 800 sessions
 // on a real store were named by it (#3439). Titles are written at ingest, so
 // those 23 keep their names until the re-read this bump already forces.
-const version = 35
+// 36 re-mines the fix pairs. The miner asked two things of a candidate — does
+// the remedy name what the error named, did another session do the same thing —
+// and both are about words, so it missed the commonest repair there is: the
+// failing command, corrected. Counted over 2,953 failed commands, 16% are
+// followed by the same program with most of the same words and no failure,
+// against the 112 confirmed pairs the word rules mine from the same corpus.
+// Pairs are a sidecar written at build time, so an existing store keeps the
+// ones it has until the bump forces the re-read (#3445 carries the other half:
+// the errors those pairs answer).
+const version = 36
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/repaired.go
+++ b/internal/index/repaired.go
@@ -1,0 +1,110 @@
+package index
+
+import "strings"
+
+// A remedy is usually the failing command, corrected.
+//
+// The miner asks two things of a candidate pair: does the remedy name something
+// the error named, or did another session do the same thing after the same
+// error. Both are about words, and both miss the commonest shape there is —
+// the agent runs a command, it fails, and the next thing it runs is that same
+// command with the glob quoted, the flag dropped or the path fixed.
+//
+// Counted over 2,953 failed commands in real transcripts: 4% were followed by
+// the identical command working (a retry of a flake, median zero steps in
+// between), 64% by a changed command running the same program, and 16% by one
+// that also kept most of the failing command. That last group is 479 pairs on
+// one machine, against the 112 confirmed pairs the word rules mine from the
+// same corpus — and it is better evidence, because the remedy is not a command
+// that happened to follow, it is the command that failed, working.
+const (
+	// repairedOverlap is how much of the failing command has to survive. At
+	// 0.6 a quoted glob, a dropped flag and a corrected path all still count,
+	// while `cd one-place` after `cd another` does not — that pair shares a
+	// program and nothing else, and it was the single most common shape below
+	// this bound.
+	repairedOverlap = 0.6
+	// repairedMinTokens keeps one-word commands out. `make` after `make` is
+	// the identical command, and `ls` after `pwd` is not a repair of anything.
+	repairedMinTokens = 2
+)
+
+// repairedVariant reports whether cmd is failed, corrected: the same program,
+// most of the same words, and not the same line over again.
+func repairedVariant(failed, cmd string) bool {
+	failed, cmd = strings.TrimSpace(failed), strings.TrimSpace(cmd)
+	if failed == "" || cmd == "" || failed == cmd {
+		return false
+	}
+	a, b := commandTokens(failed), commandTokens(cmd)
+	if len(a) < repairedMinTokens || len(b) < repairedMinTokens {
+		return false
+	}
+	prog := commandProgram(a)
+	if prog == "" || prog != commandProgram(b) {
+		return false
+	}
+	// Going somewhere else is not a repair of not being able to go here, and
+	// this is where the noise was: `cd` alone is 705 of the 1,892 same-program
+	// successes, the largest single source. The commands below carry no work,
+	// so a corrected one of them is nothing to hand an agent even when it is
+	// genuinely the fix.
+	if navigationCommands[prog] {
+		return false
+	}
+	return tokenOverlap(a, b) >= repairedOverlap
+}
+
+// navigationCommands are the ones that move around or print something rather
+// than do anything. A remedy has to be worth running.
+var navigationCommands = map[string]bool{
+	"cd": true, "ls": true, "pwd": true, "cat": true, "echo": true,
+	"head": true, "tail": true, "which": true, "less": true, "more": true,
+}
+
+// commandTokens splits a command into the words a comparison can be made on.
+func commandTokens(cmd string) []string { return strings.Fields(cmd) }
+
+// commandProgram is what the command runs, without the path it was found at
+// and without the environment assignments and wrappers in front of it.
+func commandProgram(tokens []string) string {
+	for _, t := range tokens {
+		if strings.Contains(t, "=") {
+			continue
+		}
+		switch t {
+		case "sudo", "env", "time", "nohup", "exec", "command":
+			continue
+		}
+		if i := strings.LastIndex(t, "/"); i >= 0 {
+			t = t[i+1:]
+		}
+		return t
+	}
+	return ""
+}
+
+// tokenOverlap is how much of the two commands is the same words, counted as
+// the shared multiset over the longer side. Multiset rather than set: a command
+// that repeats a flag is not more similar for repeating it.
+func tokenOverlap(a, b []string) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	counts := make(map[string]int, len(a))
+	for _, t := range a {
+		counts[t]++
+	}
+	shared := 0
+	for _, t := range b {
+		if counts[t] > 0 {
+			counts[t]--
+			shared++
+		}
+	}
+	longer := len(a)
+	if len(b) > longer {
+		longer = len(b)
+	}
+	return float64(shared) / float64(longer)
+}

--- a/internal/index/repaired_pair_test.go
+++ b/internal/index/repaired_pair_test.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The remedy that is the failing command corrected stands on its own. Before
+// this it did not: the corrected line names nothing the error named — zsh says
+// `no matches found` and the fix is a pair of quotes — so it was filed as a
+// candidate and never served until some other session happened to run the same
+// line after the same error.
+func TestTheCorrectedCommandIsServedAtOnce(t *testing.T) {
+	now := time.Now().UTC()
+	s := model.Session{
+		Harness: "claude", ID: "s1",
+		Messages: []model.Message{
+			{Role: "command", Text: `grep -rn "quokkabloom" --include=*.go internal`, Time: now},
+			{Role: "tool-output", Text: "zsh:1: no matches found: --include=*.go", Time: now.Add(time.Second)},
+			{Role: "command", Text: `grep -rn "quokkabloom" --include="*.go" internal`, Time: now.Add(2 * time.Second)},
+		},
+	}
+	dir := t.TempDir()
+	buildFixes(dir, []model.Session{s}, func(m model.Session) string { return m.Harness + ":" + m.ID })
+
+	served := FixesFor(dir, "zsh:1: no matches found: --include=*.go", 3, nil)
+	if len(served) != 1 {
+		t.Fatalf("the corrected command was not served: %+v", ReadFixes(dir))
+	}
+	if !served[0].Repaired {
+		t.Errorf("served without being recognised as a repair: %+v", served[0])
+	}
+	if served[0].Command != `grep -rn "quokkabloom" --include="*.go" internal` {
+		t.Errorf("served the wrong command: %q", served[0].Command)
+	}
+}
+
+// A session that hits an error and goes on to unrelated work still yields
+// nothing on its own.
+func TestMovingOnStillWaitsForASecondSession(t *testing.T) {
+	now := time.Now().UTC()
+	s := model.Session{
+		Harness: "claude", ID: "s1",
+		Messages: []model.Message{
+			{Role: "command", Text: `psql -c "select 1"`, Time: now},
+			{Role: "tool-output", Text: "psql: connection refused on port 5432", Time: now.Add(time.Second)},
+			{Role: "command", Text: "git status --short", Time: now.Add(2 * time.Second)},
+		},
+	}
+	dir := t.TempDir()
+	buildFixes(dir, []model.Session{s}, func(m model.Session) string { return m.Harness + ":" + m.ID })
+	if got := FixesFor(dir, "psql: connection refused on port 5432", 3, nil); len(got) != 0 {
+		t.Errorf("unrelated work was served as a remedy: %+v", got)
+	}
+}

--- a/internal/index/repaired_test.go
+++ b/internal/index/repaired_test.go
@@ -1,0 +1,48 @@
+package index
+
+import "testing"
+
+// The shapes a repair actually takes, counted over 2,953 failed commands: a
+// glob that needed quoting, a flag that had to go, a path that was wrong. Each
+// is the failing command with a small correction, which is why it is evidence
+// on its own — unlike "the command that ran next", which named nothing in 87%
+// of cases.
+func TestARepairIsTheFailingCommandCorrected(t *testing.T) {
+	repairs := [][2]string{
+		// zsh will not expand the glob; quoting it is the whole fix.
+		{`grep -rn "hookDigest" --include=*.go internal`, `grep -rn "hookDigest" --include="*.go" internal`},
+		// The flag the tool does not take.
+		{`go test ./internal/index -run TestFix -count=1 -race -json`, `go test ./internal/index -run TestFix -count=1 -race`},
+		// The path that was wrong.
+		{`python3 scripts/report.py --out /var/reports`, `python3 scripts/report.py --out ./reports`},
+		// A wrapper in front does not change what is being run.
+		{`sudo systemctl restart deja-sync.service --now`, `systemctl restart deja-sync.service --now`},
+	}
+	for _, r := range repairs {
+		if !repairedVariant(r[0], r[1]) {
+			t.Errorf("not read as a repair:\n  was: %s\n  now: %s", r[0], r[1])
+		}
+	}
+}
+
+// What the bound is for. The most common shape below it was one program run
+// twice on unrelated arguments, which says nothing about the error.
+func TestMovingOnIsNotARepair(t *testing.T) {
+	notRepairs := [][2]string{
+		// Going somewhere else carries no work, whether or not it was the fix.
+		// `cd` is 705 of the 1,892 same-program successes, the largest single
+		// source of noise in the shape.
+		{`cd /work/api && ls`, `cd /work/web && ls`},
+		// A different program entirely.
+		{`go build ./...`, `npm run build`},
+		// The identical command again is a retry, not a repair.
+		{`go test ./internal/index -count=1`, `go test ./internal/index -count=1`},
+		// One word is not enough to compare.
+		{`make`, `ninja`},
+	}
+	for _, r := range notRepairs {
+		if repairedVariant(r[0], r[1]) {
+			t.Errorf("read as a repair when it is not:\n  was: %s\n  now: %s", r[0], r[1])
+		}
+	}
+}


### PR DESCRIPTION
Closes #3445.

Two thirds of the failures in real transcripts repeat an error the store has already seen, a median of 19 days apart. deja spoke on 5 of the 319 repeats in the window the usage log covers. Two reasons, one on each side of the pair.

**What counts as a wall.** A shell's position marker — `zsh:1:`, `(eval):2:` — is itself the error signal: a shell prints one only in front of something it could not do, so what follows may be short, which is what `== not found` needs (twelve characters after the marker is stripped, against a floor of twenty; 89 sightings dropped on length). `timed out after`, the harness's own tool errors (`<tool_use_error>`, `InputValidationError`, `file has been modified since read`, `no such tool available`) and the rest of the Python traceback tails join the phrase list. The guards still apply on the new path — source that talks about an error, and deja quoting its own report, which an existing test caught the first time round.

Replayed over every repeating error on a real store, both stores rebuilt from the same sources: `deja fix` had an answer for 12% before and 24% after. `deja friction` goes from naming two of the machine's top eight walls to naming seven.

**What counts as a remedy.** The miner asked whether the remedy named something the error named, or whether another session did the same thing — both about words, so it missed the commonest repair there is: the failing command, corrected. Counted over 2,953 failed commands, 4% are followed by the identical command working (a retry, median zero steps in between), 64% by a changed command running the same program, and 16% by one that also keeps most of the failing command. Navigation is excluded — `cd` alone was 705 of that 1,892 and a corrected `cd` is nothing to hand anyone — and a corrected command is no longer rejected as investigation, which is what kept a re-quoted `grep` out.

Over the same errors, remedies deja will stand behind rather than caveat go from 6 to 9.

Index version 36: friction hashes are written into the manifest at ingest and the pairs are a sidecar written at build time, so neither half reaches a store that already exists without the re-read.
