### PR TITLE
pin the manifests to 0.19.5

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/claude-plugin/plugin.json
+++ b/claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -12,7 +12,7 @@ import (
 // only offers an update for a plugin it installed from its own marketplace, so
 // for a repository or zip install nothing tells the user their copy is behind.
 // deja knows both numbers, and doctor is where someone looks.
-const kimiPluginVersion = "0.19.4"
+const kimiPluginVersion = "0.19.5"
 
 // kimiPluginInstalledVersion returns the version of the installed copy, or ""
 // when the plugin is not there.

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Codex: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -50,7 +50,7 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.4"
+    "@vshulcz/deja-vu": "^0.19.5"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.4"
+    "@vshulcz/deja-vu": "^0.19.5"
   },
   "peerDependencies": {
     "openclaw": ">=2026.7.1"

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": ">=1.0.0",
-    "@vshulcz/deja-vu": "^0.19.4"
+    "@vshulcz/deja-vu": "^0.19.5"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.4"
+    "@vshulcz/deja-vu": "^0.19.5"
   },
   "pi": {
     "extensions": ["./index.ts"],

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and twenty more — searchable and recalled, including work from before it was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.4"
+    "@vshulcz/deja-vu": "^0.19.5"
   }
 }

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.4",
+    "version": "0.19.5",
     "description": "Search Claude Code, Codex and Cursor session history locally",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.4/deja-vu_0.19.4_windows_amd64.zip",
-            "hash": "5d990f31d9dc46ee48a9220dbe9e0e632e41cc1ae2e9df96e5a452ca6656314f"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_amd64.zip",
+            "hash": "59c071f22ec4d36a11513497f2d8eb8025aae0395447fce9df5f515ee69d7392"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.4/deja-vu_0.19.4_windows_arm64.zip",
-            "hash": "053a1105c5210477b4ff6310b408141dd51cc67a81ec472a419d39d9b53d31e9"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_arm64.zip",
+            "hash": "87d6514436c2ffa34757b703021ba94769d14dcb53f10735bb8ee7cf524c62ac"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.4
+PackageVersion: 0.19.5
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -10,10 +10,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.4/deja-vu_0.19.4_windows_amd64.zip
-  InstallerSha256: 5D990F31D9DC46EE48A9220DBE9E0E632E41CC1AE2E9DF96E5A452CA6656314F
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_amd64.zip
+  InstallerSha256: 59C071F22EC4D36A11513497F2D8EB8025AAE0395447FCE9DF5F515EE69D7392
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.4/deja-vu_0.19.4_windows_arm64.zip
-  InstallerSha256: 053A1105C5210477B4FF6310B408141DD51CC67A81EC472A419D39D9B53D31E9
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_arm64.zip
+  InstallerSha256: 87D6514436C2FFA34757B703021BA94769D14DCB53F10735BB8EE7CF524C62AC
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.4
+PackageVersion: 0.19.5
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.4/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.5/LICENSE
 ShortDescription: Search Claude Code, Codex and Cursor session history locally
 Tags:
 - aider
@@ -19,6 +19,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.4
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.5
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.4
+PackageVersion: 0.19.5
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and twenty-one more — including work from before it was installed.",
   "author": {
     "name": "vshulcz",


### PR DESCRIPTION
The release run regenerates these and attaches them to the release; the repository has to catch up separately, and until it does every PR fails the manifest check.