### PR TITLE
the missing program is named before the command runs

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -331,6 +331,13 @@ func commandHookLine(dir, cwd, cmd string) string {
 	// and reaches the ones that matter (#2924). It is also the more useful of
 	// the two: knowing a command has been run says nothing about whether to
 	// run it now.
+	// Before either: a program that is not here. It is the most certain thing
+	// deja can say about a command that has not run yet, and the session-start
+	// block that says it is measurably not heard — nine of the ten sessions
+	// told about a missing command ran it anyway.
+	if line := missingProgramLine(dir, cmd); line != "" {
+		return line
+	}
 	if line := commandFailureLine(dir, cmd); line != "" {
 		return line
 	}

--- a/cmd/deja/missing_program.go
+++ b/cmd/deja/missing_program.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/policy"
+)
+
+// A program this machine does not have is the one thing deja can say for
+// certain before a command runs, and it was the one thing it did not say.
+//
+// The session-start block has carried it for a long time — "18 separate
+// sessions hit `command not found: timeout`" — and measured on this machine's
+// own transcripts, of the ten sessions that were told, nine went on to run the
+// command anyway and got the same refusal. `timeout` alone: named at the start
+// of ten sessions, run in nine of them. A fact stated at the start does not
+// survive to the moment it matters.
+//
+// This is that fact, moved to the moment. The pre-tool hook already fires
+// before the command runs and was silent here, because what it looks up is the
+// shape of the whole command — `timeout 30 go test ./...` shares no shape with
+// `timeout 600 python3 build.py`, so nothing matched. A missing program is not
+// about the shape. It is about the first word.
+const (
+	// missingProgramMinSessions is how many separate sessions have to have been
+	// refused before deja says so. One is a machine that has changed since;
+	// deja does not check whether the program is there now, and must not turn
+	// a stale sighting into an instruction.
+	missingProgramMinSessions = 2
+	// missingProgramMaxTokens bounds how much of a compound is examined. Every
+	// segment after the first ran in a state the ones before it made, but a
+	// missing program refuses the same way wherever it stands.
+	missingProgramMaxTokens = 12
+)
+
+// missingProgramLine says that a program in this command is not on this
+// machine, or "" when every program in it has run here.
+func missingProgramLine(dir, cmd string) string {
+	pol := policy.Load()
+	allow := func(project string) bool { return pol.Allows(policy.ActivationAuto, project) }
+	for _, prog := range commandPrograms(cmd) {
+		_, sig, ok := index.FrictionSignature("command not found: " + prog)
+		if !ok {
+			continue
+		}
+		if n := index.FrictionSessions(dir, sig, allow); n >= missingProgramMinSessions {
+			return fmt.Sprintf("%s is not on this machine — %s ran into that.",
+				prog, toolSessionCount(n))
+		}
+	}
+	return ""
+}
+
+// commandPrograms lists what a command line invokes: the first word of each
+// segment, without the environment assignments and wrappers in front of it.
+// A wrapper is listed too — `sudo` and `timeout` are programs that can be
+// missing themselves, and `timeout` is the one this machine is missing most.
+func commandPrograms(cmd string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, seg := range splitCommandSegments(cmd) {
+		fields := strings.Fields(seg)
+		if len(fields) > missingProgramMaxTokens {
+			fields = fields[:missingProgramMaxTokens]
+		}
+		for _, f := range fields {
+			if strings.Contains(f, "=") {
+				continue
+			}
+			// A path is a program the machine either has or does not have at
+			// that path, which is a different claim from "not installed", and
+			// the wall is recorded under the bare name a shell reports.
+			if strings.ContainsAny(f, "/$\"'`(){}<>") {
+				break
+			}
+			if !seen[f] {
+				seen[f] = true
+				out = append(out, f)
+			}
+			break
+		}
+	}
+	return out
+}
+
+// splitCommandSegments cuts a command line at the separators that start a new
+// command: a pipe, a semicolon, and the two boolean joiners.
+func splitCommandSegments(cmd string) []string {
+	fields := strings.FieldsFunc(cmd, func(r rune) bool {
+		return r == '|' || r == ';' || r == '&' || r == '\n'
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/cmd/deja/missing_program_test.go
+++ b/cmd/deja/missing_program_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The one thing deja can say for certain before a command runs. It has been in
+// the session-start block for a long time and it is measurably not heard: of
+// the ten sessions on this machine that were told a command was missing, nine
+// ran it anyway and got the same refusal.
+func TestTheHookNamesAProgramThisMachineDoesNotHave(t *testing.T) {
+	dir := storeThatKeepsMissing(t, "zonkotool", 3)
+	line := commandHookLine(dir, "/work/app", "zonkotool --check ./src")
+	if line == "" {
+		t.Fatal("the hook said nothing about a command this machine has never had")
+	}
+	if !strings.Contains(line, "zonkotool") || !strings.Contains(line, "3 sessions") {
+		t.Errorf("the line does not name the program and how often: %q", line)
+	}
+}
+
+// One sighting is a machine that may have changed since. deja does not check
+// whether the program is there now, so it must not turn a single refusal into
+// an instruction.
+func TestOneRefusalIsNotEnough(t *testing.T) {
+	dir := storeThatKeepsMissing(t, "zonkotool", 1)
+	if line := commandHookLine(dir, "/work/app", "zonkotool --check ./src"); line != "" {
+		t.Errorf("one sighting was enough to warn: %q", line)
+	}
+}
+
+// The wrapper is a program too, and it is the one this machine is missing most.
+func TestAMissingWrapperIsFound(t *testing.T) {
+	dir := storeThatKeepsMissing(t, "zonkotool", 3)
+	line := commandHookLine(dir, "/work/app", "zonkotool 30 go test ./... -count=1")
+	if !strings.Contains(line, "zonkotool") {
+		t.Errorf("a missing wrapper in front of a real command was not named: %q", line)
+	}
+}
+
+// storeThatKeepsMissing builds a store where n separate sessions were refused
+// the same program.
+func storeThatKeepsMissing(t *testing.T, prog string, n int) string {
+	t.Helper()
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	ts := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	for i := 0; i < n; i++ {
+		id := "s" + string(rune('a'+i))
+		writeClaudeFixture(t, filepath.Join(claudeRoot, "app", id+".jsonl"), id, []string{
+			`{"type":"assistant","sessionId":"` + id + `","timestamp":"` + ts +
+				`","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"` + prog + ` --check ./src"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","timestamp":"` + ts +
+				`","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","is_error":true,"content":"zsh:1: command not found: ` + prog + `"}]}}`,
+		})
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}


### PR DESCRIPTION
Closes #3448.

The session-start block has carried this for a long time — "18 separate sessions hit `command not found: timeout`". Measured on real transcripts: of the ten sessions that were told a command was missing, nine ran it anyway and got the same refusal. `timeout` was named at the start of ten sessions and run in nine of them. A fact stated at the start does not survive to the moment it matters.

The pre-tool hook fires at that moment and was silent, because what it looks up is the shape of the whole command: `timeout 30 go test ./...` shares no shape with `timeout 600 python3 build.py`, so nothing matched. A missing program is not about the shape — it is about the first word.

Against a store built from real sessions, before and after:

```
$ timeout 30 go test ./internal/index -count=1
  before: silent
  after:  timeout is not on this machine — 20 sessions ran into that.

$ shellcheck scripts/release.sh
  before: silent
  after:  shellcheck is not on this machine — 4 sessions ran into that.
```

A command whose programs have all run here is unchanged, and `gtimeout` — the one that works — stays silent.

Two sessions is the floor: one refusal is a machine that may have changed since, and deja does not check whether the program is there now, so it must not turn a single sighting into an instruction. Wrappers count as programs, because `timeout` is one and it is the one this machine is missing most.
