### PR TITLE
fix(copilot-chat): a turn VS Code raised itself is not the person's words

### DIFF
--- a/internal/sources/copilot_chat.go
+++ b/internal/sources/copilot_chat.go
@@ -577,7 +577,16 @@ func copilotChatAppendRequest(s *model.Session, req map[string]any) {
 	t := parseTimeAny(req["timestamp"])
 	if user := copilotChatUserText(req["message"]); strings.TrimSpace(user) != "" {
 		s.Touch(t)
-		s.Messages = append(s.Messages, model.Message{Role: "user", Text: user, Time: t})
+		system, _ := req["isSystemInitiated"].(bool)
+		confirmation, _ := req["confirmation"].(string)
+		// Some turns VS Code raises itself: a background terminal completion
+		// carries the terminal's output as the message, and a confirmation
+		// carries the button's own label. The turn happened, so it still
+		// times the session and its work is still recorded, but nobody typed
+		// the text and recall must not quote it back as though someone had.
+		if !system && strings.TrimSpace(confirmation) == "" {
+			s.Messages = append(s.Messages, model.Message{Role: "user", Text: user, Time: t})
+		}
 	}
 	at := parseTimeAny(req["responseTimestamp"])
 	if at.IsZero() {

--- a/internal/sources/copilot_chat_hosttext_test.go
+++ b/internal/sources/copilot_chat_hosttext_test.go
@@ -1,0 +1,180 @@
+package sources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+func copilotChatHostTextSession(t *testing.T, body, ext string) model.Session {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "session"+ext)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := ParseCopilotChatFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1 (%#v)", len(sessions), sessions)
+	}
+	return sessions[0]
+}
+
+func copilotChatRoleTexts(messages []model.Message, role string) []string {
+	var texts []string
+	for _, message := range messages {
+		if message.Role == role {
+			texts = append(texts, message.Text)
+		}
+	}
+	return texts
+}
+
+func TestCopilotChatDoesNotCallVSCodeRequestTextThePersons(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   string
+		wantUser bool
+	}{
+		{
+			name:   "system initiated",
+			fields: `,"isSystemInitiated":true`,
+		},
+		{
+			name:   "confirmation",
+			fields: `,"confirmation":"Accept"`,
+		},
+		{
+			name:     "ordinary request",
+			wantUser: true,
+		},
+		{
+			name:     "false and empty",
+			fields:   `,"isSystemInitiated":false,"confirmation":""`,
+			wantUser: true,
+		},
+		{
+			name:     "null markers",
+			fields:   `,"isSystemInitiated":null,"confirmation":null`,
+			wantUser: true,
+		},
+		{
+			name:     "wrong marker types",
+			fields:   `,"isSystemInitiated":"true","confirmation":true`,
+			wantUser: true,
+		},
+		{
+			name:     "whitespace confirmation",
+			fields:   `,"confirmation":"  "`,
+			wantUser: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"version":3,"sessionId":"flat","creationDate":1763727100000,"requests":[{` +
+				`"timestamp":1763727104742` + tc.fields + `,` +
+				`"message":{"text":"request text"},` +
+				`"response":[{"value":"assistant reply"}],` +
+				`"responseTimestamp":1763727400000}]}`
+
+			session := copilotChatHostTextSession(t, body, ".json")
+			messages := session.Messages
+			users := copilotChatRoleTexts(messages, "user")
+			if tc.wantUser {
+				if len(users) != 1 || users[0] != "request text" {
+					t.Fatalf("users = %#v, want the ordinary request", users)
+				}
+			} else if len(users) != 0 {
+				t.Fatalf("users = %#v, want none", users)
+			}
+			assistants := copilotChatRoleTexts(messages, "assistant")
+			if len(assistants) != 1 || assistants[0] != "assistant reply" {
+				t.Fatalf("assistants = %#v, want the response", assistants)
+			}
+			if got := session.Started.UnixMilli(); got != 1763727100000 {
+				t.Fatalf("started = %d, want 1763727100000", got)
+			}
+			if got := session.Updated.UnixMilli(); got != 1763727400000 {
+				t.Fatalf("updated = %d, want 1763727400000", got)
+			}
+		})
+	}
+}
+
+func TestCopilotChatReplaysAHostMarkerBeforeIndexing(t *testing.T) {
+	body := `{"kind":0,"v":{"version":3,"sessionId":"replayed","creationDate":1763727100000,` +
+		`"requests":[{"timestamp":1763727104742,"message":{"text":"host notification"},` +
+		`"response":[{"value":"work completed"}],"responseTimestamp":1763727400000}]}}` + "\n" +
+		`{"kind":1,"k":["requests",0,"isSystemInitiated"],"v":true}` + "\n"
+
+	messages := copilotChatHostTextSession(t, body, ".jsonl").Messages
+	if users := copilotChatRoleTexts(messages, "user"); len(users) != 0 {
+		t.Fatalf("users = %#v, want none after replayed marker", users)
+	}
+	assistants := copilotChatRoleTexts(messages, "assistant")
+	if len(assistants) != 1 || assistants[0] != "work completed" {
+		t.Fatalf("assistants = %#v, want the response", assistants)
+	}
+}
+
+func TestCopilotChatHostRequestKeepsCommandWork(t *testing.T) {
+	t.Setenv("DEJA_INDEX_COMMANDS", "1")
+	body := `{"version":3,"sessionId":"command","creationDate":1763727100000,"requests":[{` +
+		`"timestamp":1763727104742,"isSystemInitiated":true,` +
+		`"message":{"text":"terminal completion notification"},` +
+		`"response":[{"kind":"toolInvocationSerialized","toolId":"runInTerminal",` +
+		`"toolSpecificData":{"kind":"terminal","commandLine":{"original":"go test ./..."}}}],` +
+		`"responseTimestamp":1763727400000}]}`
+
+	messages := copilotChatHostTextSession(t, body, ".json").Messages
+	if users := copilotChatRoleTexts(messages, "user"); len(users) != 0 {
+		t.Fatalf("users = %#v, want none", users)
+	}
+	commands := copilotChatRoleTexts(messages, RoleCommand)
+	if len(commands) != 1 || commands[0] != "$ go test ./..." {
+		t.Fatalf("commands = %#v, want the terminal work record", commands)
+	}
+}
+
+// A confirmation can arrive the same way, so the guard has to see it after the
+// log is replayed rather than only on the entry the log opened with.
+func TestCopilotChatReplaysAConfirmationBeforeIndexing(t *testing.T) {
+	body := `{"kind":0,"v":{"version":3,"sessionId":"confirmed","creationDate":1763727100000,` +
+		`"requests":[{"timestamp":1763727104742,"message":{"text":"Accept: \"Run go test?\""},` +
+		`"response":[{"value":"ran it"}],"responseTimestamp":1763727400000}]}}` + "\n" +
+		`{"kind":1,"k":["requests",0,"confirmation"],"v":"Accept"}` + "\n"
+
+	messages := copilotChatHostTextSession(t, body, ".jsonl").Messages
+	if users := copilotChatRoleTexts(messages, "user"); len(users) != 0 {
+		t.Fatalf("users = %#v, want none after the replayed confirmation", users)
+	}
+	assistants := copilotChatRoleTexts(messages, "assistant")
+	if len(assistants) != 1 || assistants[0] != "ran it" {
+		t.Fatalf("assistants = %#v, want the response", assistants)
+	}
+}
+
+// Dropping the text does not drop the turn. A background completion is when the
+// session was last active, so it still has to move Updated: the second request
+// here carries no response, so the only thing that can advance the session is
+// the request itself.
+func TestCopilotChatHostRequestStillTimesTheSession(t *testing.T) {
+	body := `{"version":3,"sessionId":"timing","creationDate":1763727100000,"requests":[` +
+		`{"timestamp":1763727104742,"message":{"text":"typed question"},` +
+		`"response":[{"value":"answer"}],"responseTimestamp":1763727200000},` +
+		`{"timestamp":1763727900000,"isSystemInitiated":true,` +
+		`"message":{"text":"terminal finished"}}]}`
+
+	session := copilotChatHostTextSession(t, body, ".json")
+	users := copilotChatRoleTexts(session.Messages, "user")
+	if len(users) != 1 || users[0] != "typed question" {
+		t.Fatalf("users = %#v, want only the typed one", users)
+	}
+	if got := session.Updated.UnixMilli(); got != 1763727900000 {
+		t.Fatalf("updated = %d, want the host turn at 1763727900000", got)
+	}
+}


### PR DESCRIPTION
## Summary

v0.19.5 took the harness's own text out of the user role across the parsers, but copilot-chat was
not in that pass. It still indexes every request as the person's words, including the ones VS Code
wrote itself.

Two markers say so, both on the request object and both preserved into the transcript:

- **`isSystemInitiated`** is set when the editor raises the turn rather than the person. The
  producer that ships today is the terminal tool's background-completion notification, and its
  message text is the terminal's own output. A search for what someone asked came back holding a
  command's stdout. The producer is described in microsoft/vscode#330561.
- **`confirmation`** is set when someone clicks a confirmation button. The text is the IDE's own
  wording, assembled from the button's label and the confirmation title, so a click was stored as a
  sentence someone typed.

Only the user text is dropped. The turn still times the session, the response is still indexed, and
the work records are untouched: a background completion did real work and that work is worth
finding. What goes is the claim about who wrote the text.

Both markers are ordinary fields of the request, so a `.jsonl` mutation log can add one with a later
`kind:1` Set. The guard runs after replay rather than only on the entry the log opened with, and a
test covers each marker arriving that way.

Same shape as the fixes this release already merged for the other harnesses: #3268 and #3334 for
Claude Code, #3306 for Copilot CLI, #3256 for Roo and Cline, #3300 for opencode, #3327 for
Antigravity, #3249 for aider. The guard mirrors `internal/sources/claude.go:195-199`.

## Test plan

New file `internal/sources/copilot_chat_hosttext_test.go`, ten cases:

- flat `.json` with `isSystemInitiated: true`, and with `confirmation: "Accept"`: no user message,
  and the assistant reply from the same request is still there
- an ordinary request, `false` with an empty confirmation, `null` markers, markers of the wrong JSON
  type, and a whitespace-only confirmation: the user message is kept. These are the controls, and
  they fail if the guard is written too broadly
- a `.jsonl` log where `isSystemInitiated` arrives as a later Set, and one where `confirmation` does
- a system-initiated turn whose response carries a terminal `toolInvocationSerialized`: the
  `RoleCommand` work record survives
- a session whose second request is host-authored, later, and carries no response: it still advances
  `Updated`. Moving the `Touch` inside the guard makes that case fail, which is how the decision to
  time the session from a dropped turn is pinned rather than just written down.

Measured here:

| | |
|---|---|
| the new tests against the parser at `main` | 3 fail, each reporting host text stored as a user message |
| after the change, `go test ./internal/sources/ -run CopilotChat` | 45 pass |
| full `internal/sources` package | failure set identical to `main` on this machine |
| `go vet ./...`, `git diff --check` | clean |

## Notes

The three Copilot Chat sessions on this machine all have `requests: []`, so I cannot put a
before-and-after count from a real store next to this. The fixtures are built from the serialized
shapes in the VS Code source rather than captured from a populated transcript, and the marker
semantics come from the same place.

`systemInitiatedLabel` is deliberately ignored. It supplies optional display text and falls back to
the message; `isSystemInitiated` is the field that says who raised the turn.

Two other defects in this file came out of the same reading and are deliberately left out of this
change, since they belong to the sidecar reader rather than the request loop. I will send them as
one follow-up: `chatResourcePath` never percent-decodes what `entries[].resource` writes as a URI
string, and the `workingSet` field is typed as a list of objects where the storage format writes a
list of pairs, so a non-empty one makes the whole sidecar read return early. Happy to file them as
an issue first if you would rather decide the legacy-format question before any code moves.
