### PR TITLE
the point of action keeps what it said

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -203,7 +203,13 @@ func runHookToolMode(dir string, stdin io.Reader, stdout io.Writer, shape hookTo
 	// measured on this machine, 492 point-of-action injections and not one that
 	// could be paired with what the agent did next — which is the pairing any
 	// judgement about whether the line helped has to start from.
-	usage.RecordServedInto(dir, usage.KindTool, len(out), 1, input.SessionID)
+	// The text, not only the count. The injections file holds a snapshot for
+	// every session-start and per-prompt block and held none for this surface:
+	// 507 point-of-action injections on a real machine and not one whose content
+	// could be read back. So what deja says at the moment with the best evidence
+	// behind it could not be audited, replayed, or compared against what the
+	// agent did next — and `deja log --last` had nothing to print for it.
+	usage.RecordDigestInto(dir, usage.KindTool, out, input.SessionID, 1, 0, nil)
 	switch shape {
 	case hookToolPlain:
 		fmt.Fprint(stdout, out)

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -146,7 +146,9 @@ func runHookToolAfterMode(dir string, stdin io.Reader, stdout io.Writer, plain b
 	// The receiving session too: this is the repair delivered at the failure,
 	// the surface with the best evidence behind it, and it was the one that
 	// could not be followed (#1494 gave the per-prompt hook the same field).
-	usage.RecordServedInto(dir, usage.KindTool, len(payload), 1, input.SessionID)
+	// The text too, for the reason the pre-tool hook keeps it: a fix pair
+	// delivered at a failure is the one injection worth reading back.
+	usage.RecordDigestInto(dir, usage.KindTool, payload, input.SessionID, 1, 0, nil)
 	if plain {
 		fmt.Fprint(stdout, payload)
 		return nil

--- a/cmd/deja/tool_snapshot_test.go
+++ b/cmd/deja/tool_snapshot_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/usage"
+)
+
+// Every session-start and per-prompt block leaves a snapshot of its text; the
+// point of action left only a count. Read from a real machine: 507 injections
+// there and not one whose content could be read back, so the surface with the
+// best evidence behind it was the one that could not be audited, replayed, or
+// compared against what the agent did next — and `deja log --last` had nothing
+// to print for it.
+func TestThePointOfActionKeepsWhatItSaid(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := tmp + "/index.db"
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	commandRunWithAnOutcome(t, "go test ./... -count=1", "a", "b")
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	out := toolHookRun(t, `{"hook_event_name":"PreToolUse","tool_name":"Bash",`+
+		`"tool_input":{"command":"go test ./... -count=1"},"session_id":"agent-9","cwd":"/work/app"}`)
+	if out == "" {
+		t.Fatal("the hook said nothing, so there is no injection to record")
+	}
+
+	b, err := os.ReadFile(usage.SnapshotPath(dir))
+	if err != nil {
+		t.Fatalf("no injections file: %v", err)
+	}
+	var kept, into string
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		var row struct {
+			Kind   string `json:"kind"`
+			Digest string `json:"digest"`
+			Text   string `json:"text"`
+			Into   string `json:"into"`
+		}
+		if json.Unmarshal([]byte(line), &row) != nil || row.Kind != usage.KindTool {
+			continue
+		}
+		kept = row.Digest + row.Text
+		into = row.Into
+	}
+	if kept == "" {
+		t.Fatalf("the point-of-action injection left no text:\n%s", b)
+	}
+	// The line itself, whatever it said: this fixture's is the command's own
+	// history, and what matters is that the text reached the file.
+	if !strings.Contains(kept, "has run that command") {
+		t.Errorf("the snapshot does not hold what was said: %q", kept)
+	}
+	if into != "agent-9" {
+		t.Errorf("the snapshot was recorded into %q, want the agent session", into)
+	}
+}


### PR DESCRIPTION
The point of action recorded a byte count and nothing else, so what it actually said could not be read back.

Counted on a real machine: 507 point-of-action injections in the sixteen days the usage log covers, and the injections file holds a snapshot for none of them — 102 for the per-prompt block and 9 for session start. `deja log --last` has nothing to print for the surface, and the one measurement worth taking here — whether the agent used what deja named — cannot be joined at all, because half the pair is missing.

Both tool hooks now write the text beside the event, through the same writer the other surfaces use, so one instant stamps both. The receiver was already recorded (#3440), and this is the other half of that pair.

Cost is a line per injection in a file that already rotates. What it buys is that a line delivered before a command or after a failure can be audited, replayed, and compared against what the agent did next.
