### PR TITLE
blame quotes a piece of evidence once

### DIFF
--- a/internal/search/blame.go
+++ b/internal/search/blame.go
@@ -216,7 +216,36 @@ func Blame(ss []model.Session, target BlameTarget, o BlameOptions) []BlameHit {
 	// many times, so scoring alone put the transcript above its own note on
 	// every blame (#2829).
 	liftNotesBy(hits, func(h BlameHit) model.Session { return h.Session })
+	dropRepeatedSnippets(hits)
 	return hits
+}
+
+// dropRepeatedSnippets removes a quote the answer has already shown.
+//
+// A fork, a resumed session and a subagent run each carry the transcript they
+// were forked from, so one piece of evidence arrives under several ids and the
+// answer says it several times. Read from a real store: `deja blame
+// internal/search/search.go` quoted the same two lines under four different
+// sessions, all four forks of one, and those eight lines were most of the
+// answer.
+//
+// Ordering is untouched — the sessions still rank as they did, and a session
+// left with nothing new to show keeps its row, because "this session worked on
+// the file too" is the other half of what blame answers.
+func dropRepeatedSnippets(hits []BlameHit) {
+	seen := map[string]bool{}
+	for i := range hits {
+		kept := hits[i].Snippets[:0]
+		for _, sn := range hits[i].Snippets {
+			key := strings.Join(strings.Fields(sn), " ")
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			kept = append(kept, sn)
+		}
+		hits[i].Snippets = kept
+	}
 }
 
 // namedAPath reports whether the session wrote the file as a path rather than

--- a/internal/search/blame_repeat_test.go
+++ b/internal/search/blame_repeat_test.go
@@ -1,0 +1,60 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A fork, a resumed session and a subagent run each carry the transcript they
+// came from, so one piece of evidence arrives under several ids. Read from a
+// real store, `deja blame internal/search/search.go` quoted the same two lines
+// under four sessions — all four forks of one — and those eight lines were most
+// of the answer. On that file the quoted lines went from 18 to 11.
+func TestBlameSaysAPieceOfEvidenceOnce(t *testing.T) {
+	now := time.Now().UTC()
+	shared := "internal/search/search.go carries the lifecycle field and the summary printed under it"
+	own := "internal/search/search.go got the freshness floor raised to keep a year-old session usable"
+	session := func(id, extra string, ago time.Duration) model.Session {
+		msgs := []model.Message{{Role: "assistant", Text: shared, Time: now.Add(-ago)}}
+		if extra != "" {
+			msgs = append(msgs, model.Message{Role: "assistant", Text: extra, Time: now.Add(-ago)})
+		}
+		return model.Session{Harness: "claude", ID: id, Project: "deja-vu",
+			Updated: now.Add(-ago), Messages: msgs}
+	}
+	ss := []model.Session{
+		session("fork-a", own, time.Hour),
+		session("fork-b", "", 2*time.Hour),
+		session("fork-c", "", 3*time.Hour),
+	}
+	hits := Blame(ss, BlameTarget{Base: "search.go", FullPath: "internal/search/search.go"}, BlameOptions{})
+	if len(hits) != 3 {
+		t.Fatalf("hits = %d, want every session that touched the file", len(hits))
+	}
+	seen := 0
+	for _, h := range hits {
+		for _, sn := range h.Snippets {
+			if strings.Contains(sn, "carries the lifecycle field") {
+				seen++
+			}
+		}
+	}
+	if seen != 1 {
+		t.Errorf("the same evidence is quoted %d times", seen)
+	}
+	// The session that had something of its own still says it.
+	var kept bool
+	for _, h := range hits {
+		for _, sn := range h.Snippets {
+			if strings.Contains(sn, "freshness floor") {
+				kept = true
+			}
+		}
+	}
+	if !kept {
+		t.Error("a session's own evidence was dropped with the duplicate")
+	}
+}


### PR DESCRIPTION
`deja blame` quoted the same evidence once per fork.

A fork, a resumed session and a subagent run each carry the transcript they came from, so one thing said once arrives under several session ids. Read from a real store, `deja blame internal/search/search.go` quoted the same two lines under four sessions — all four forks of one — and those eight lines were most of the answer. Quoted lines on that file: 18 before, 11 after.

Ordering is untouched and no session loses its row: "this one worked on the file too" is the other half of what blame answers, so a session left with nothing new to show still appears, without a quote.

Also measured, and deliberately not changed: 25 files an agent really edited, 154 quoted lines — 81% words, 10% grep or compiler shaped, 9% a standing decision, no log lines. Half of that 10% is an agent citing line ranges in its own analysis, which is real evidence about the file, so cutting on that shape would take more than it saves. It is the most-asked tool an agent has here — 248 calls in the sixteen days the usage log covers — and after the dedupe what it says is what someone said.
