### PR TITLE
an excerpt is what someone said

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2264,8 +2264,46 @@ func isRegexSpace(c byte) bool {
 	return false
 }
 
+// creditOpeners are how deja asks an agent to credit a recall it used. The
+// sentence reports what an earlier session said, so quoted back as an excerpt it
+// is deja citing itself through the agent's mouth.
+var creditOpeners = []string{"déjà vu:", "deja vu:", "deja-vu recalled:", "deja recalled:"}
+
+// withoutOwnCredit removes that sentence and leaves the rest of the paragraph.
+// It runs mid-text rather than per line because the credit is written into the
+// middle of a reply: "No files changed. No benchmarks run. deja-vu recalled: …".
+func withoutOwnCredit(text string) string {
+	low := strings.ToLower(text)
+	for _, opener := range creditOpeners {
+		for {
+			i := strings.Index(low, opener)
+			if i < 0 {
+				break
+			}
+			end := len(text)
+			// To the end of the sentence, or the line, whichever comes first.
+			if j := strings.IndexAny(text[i:], "\n"); j >= 0 {
+				end = i + j
+			}
+			if j := strings.Index(text[i:], ". "); j >= 0 && i+j < end {
+				end = i + j + 1
+			}
+			text = strings.TrimSpace(text[:i]) + " " + strings.TrimSpace(text[end:])
+			low = strings.ToLower(text)
+		}
+	}
+	return strings.TrimSpace(text)
+}
+
 func proseForSnippet(s string) string {
 	s = redact.SafeForDisplay(s)
+	// Neither the harness nor deja is a witness. An excerpt is offered as
+	// something someone said about the subject, and measured over twelve
+	// queries an agent would plausibly ask — 77 quoted lines — 6% were a
+	// `<teammate-message …>` envelope and 6% were deja's own credit sentence
+	// coming back as evidence. Both are stripped where they sit, so a message
+	// that carries a person's words around them keeps the words.
+	s = withoutOwnCredit(digest.StripClosedHarnessBlocks(s))
 	var keep []string
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)

--- a/internal/search/snippet_voice_test.go
+++ b/internal/search/snippet_voice_test.go
@@ -1,0 +1,51 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// An excerpt is offered as something someone said about the subject. Measured
+// over twelve queries an agent would plausibly ask — 77 quoted lines — 6% were
+// a `<teammate-message …>` envelope and 6% were deja's own credit sentence
+// coming back as evidence.
+func TestAnExcerptIsWhatSomeoneSaid(t *testing.T) {
+	withEnvelope := "the retry budget stays at four " +
+		`<teammate-message teammate_id="team-lead" summary="review">Review one commit</teammate-message>` +
+		" and the cold path warms the index first"
+	got := proseForSnippet(withEnvelope)
+	if strings.Contains(got, "teammate-message") {
+		t.Errorf("the harness's envelope is quoted as evidence:\n%s", got)
+	}
+	for _, want := range []string{"retry budget stays at four", "cold path warms the index"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the words around the envelope were lost: %q not in\n%s", want, got)
+		}
+	}
+}
+
+// The credit line deja asks an agent to write is written into the middle of a
+// reply — "No files changed. No benchmarks run. deja-vu recalled: …" — so it is
+// removed where it sits rather than by dropping the line it shares.
+func TestDejaIsNotItsOwnWitness(t *testing.T) {
+	text := "No files changed. No benchmarks run. deja-vu recalled: prior benchmark research. " +
+		"The suite runs with -p 1 because the fixture is shared."
+	got := proseForSnippet(text)
+	if strings.Contains(strings.ToLower(got), "deja-vu recalled") {
+		t.Errorf("deja is quoted back as evidence:\n%s", got)
+	}
+	if !strings.Contains(got, "-p 1 because the fixture is shared") {
+		t.Errorf("the sentence after the credit was lost:\n%s", got)
+	}
+	if !strings.Contains(got, "No files changed") {
+		t.Errorf("the sentence before the credit was lost:\n%s", got)
+	}
+}
+
+// A person writing about the tag is not the tag.
+func TestSomeoneNamingTheTagKeepsTheirSentence(t *testing.T) {
+	text := "I removed the <teammate-message> handling from the parser, is that right?"
+	if got := proseForSnippet(text); !strings.Contains(got, "removed the") {
+		t.Errorf("a sentence about the tag was cut:\n%s", got)
+	}
+}


### PR DESCRIPTION
An excerpt is offered as something someone said about the subject, and one line in eight was written by neither a person nor an agent.

Measured over twelve queries an agent would plausibly ask, against a store built from every harness on a real machine:

| | before | after |
| --- | --- | --- |
| quoted lines | 77 | 69 |
| words | 60 (78%) | 60 (87%) |
| an answer line | 7 (9%) | 7 (10%) |
| deja quoted back | 5 (6%) | 0 |
| harness plumbing | 5 (6%) | 2 (3%) |

The eight lines that went were the junk — the count of words is unchanged, so nothing real was lost.

Both are the same problem in different clothes. A `<teammate-message …>` envelope is the harness talking to itself, and the credit line deja asks an agent to write — "deja-vu recalled: … — reusing it" — is deja citing itself through the agent's mouth. Both are removed where they sit rather than by dropping the line they share, because the credit is written into the middle of a reply: "No files changed. No benchmarks run. deja-vu recalled: …".

Closed envelopes only, which is the softer of the two strippers this repo has: the strict one belongs to the prompt hook, where a truncated notification is still not the person. Here a sentence someone wrote about the tag — "I removed the `<teammate-message>` handling from the parser" — has to survive, and a test says so.

Two plumbing lines remain by choice. One is an agent writing "Another Claude session sent a message: `<teammate-message …`" — the tag sits inside a live sentence, and cutting it would take the sentence.
