### PR TITLE
fix: the failure path says what it knows

### DIFF
--- a/cmd/deja/fix.go
+++ b/cmd/deja/fix.go
@@ -127,6 +127,11 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "deja: no session on this machine ran a command after that error")
 		return nil
 	}
+	return printFixPairs(stdout, pairs)
+}
+
+// printFixPairs writes the pairs in the prose form, one remedy per pair.
+func printFixPairs(stdout io.Writer, pairs []index.FixPair) error {
 	for _, p := range pairs {
 		when := ""
 		if !p.When.IsZero() {
@@ -151,6 +156,14 @@ func runFix(dir string, args []string, stdout io.Writer) error {
 			ran = "ran next, unconfirmed"
 		}
 		fmt.Fprintf(stdout, "  %s: %s\n", ran, search.SafeCommand(p.Command))
+		// A repaired remedy is the failing command corrected, and on its own it
+		// reads as an unrelated line — 107 of the 360 pairs served on a real
+		// store share no word with the error they answer, because what ties
+		// them is the command before, not the words. Shown, the reader sees the
+		// correction instead of a long command to trust.
+		if p.Failed != "" {
+			fmt.Fprintf(stdout, "  after this failed: %s\n", search.SafeCommand(p.Failed))
+		}
 	}
 	return nil
 }
@@ -202,6 +215,10 @@ type fixRowJSON struct {
 	// omitted when the remedy was a command. It reached the prose only, and a
 	// script read an empty command (#3261).
 	Edit string `json:"edit,omitempty"`
+	// Failed is the command that produced the error, present when the remedy
+	// is that command corrected. The prose shows it as "after this failed",
+	// and a script wanting to apply the correction needs the same two halves.
+	Failed string `json:"failed,omitempty"`
 	// Candidate is the half-evidence flag the prose renders as "ran next,
 	// unconfirmed": one session ran this after the error and nothing has
 	// confirmed it worked. A caller acting on a fix needs to know which it has.
@@ -218,6 +235,7 @@ func writeFixJSON(stdout io.Writer, pairs []index.FixPair) error {
 			Error:     search.SafeLine(p.Error),
 			Command:   search.SafeCommand(p.Command),
 			Edit:      search.SafePath(p.Edit),
+			Failed:    search.SafeCommand(p.Failed),
 			Candidate: p.Candidate,
 		}
 		if !p.When.IsZero() {

--- a/cmd/deja/fix_repaired_voice_test.go
+++ b/cmd/deja/fix_repaired_voice_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The remedy for a wall the shell put up is the command that hit it, corrected,
+// and it names nothing the error named — 107 of the 360 pairs served from a real
+// store are that shape. Offered alone it reads as an unrelated command to trust.
+func TestFixShowsWhatTheRepairedCommandRepaired(t *testing.T) {
+	p := index.FixPair{
+		Error:    "zsh:1: no matches found: --include=*.go",
+		Command:  `grep -rn "quokkabloom" --include="*.go" internal`,
+		Failed:   `grep -rn "quokkabloom" --include=*.go internal`,
+		Repaired: true,
+		When:     time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	}
+	var out bytes.Buffer
+	if err := printFixPairs(&out, []index.FixPair{p}); err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"ran next: " + p.Command, "after this failed: " + p.Failed} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output %q lacks %q", got, want)
+		}
+	}
+}
+
+// A script applying a correction needs the same two halves the prose shows.
+func TestFixJSONCarriesTheCommandThatFailed(t *testing.T) {
+	p := index.FixPair{
+		Error:    "zsh:1: no matches found: --include=*.go",
+		Command:  `grep -rn "quokkabloom" --include="*.go" internal`,
+		Failed:   `grep -rn "quokkabloom" --include=*.go internal`,
+		Repaired: true,
+	}
+	var out bytes.Buffer
+	if err := writeFixJSON(&out, []index.FixPair{p}); err != nil {
+		t.Fatal(err)
+	}
+	var got fixJSON
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Fixes) != 1 || got.Fixes[0].Failed == "" {
+		t.Fatalf("the row does not carry what was repaired: %s", out.String())
+	}
+	p.Failed, p.Repaired = "", false
+	out.Reset()
+	if err := writeFixJSON(&out, []index.FixPair{p}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), "failed") {
+		t.Errorf("an ordinary remedy carries a repair field: %s", out.String())
+	}
+}
+
+// At the moment of the failure the reader has just run the failing command, so
+// the line names the relationship instead of repeating it.
+func TestFixLineSaysTheSameCommandWorked(t *testing.T) {
+	p := index.FixPair{
+		Error:    "zsh:1: no matches found: --include=*.go",
+		Command:  `grep -rn "quokkabloom" --include="*.go" internal`,
+		Failed:   `grep -rn "quokkabloom" --include=*.go internal`,
+		Repaired: true,
+		Project:  "deja-vu",
+		When:     time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+	}
+	got := fixLine(p, 3)
+	if !strings.Contains(got, "the same command worked as: "+p.Command) {
+		t.Errorf("line %q does not say the command is the reader's own, corrected", got)
+	}
+	if strings.Contains(got, "what followed it") {
+		t.Errorf("a repair is offered as the next thing someone happened to run: %q", got)
+	}
+	p.Failed, p.Repaired = "", false
+	if got := fixLine(p, 3); !strings.Contains(got, "what followed it") {
+		t.Errorf("an ordinary remedy lost its wording: %q", got)
+	}
+}

--- a/cmd/deja/hook_tool_after.go
+++ b/cmd/deja/hook_tool_after.go
@@ -507,6 +507,14 @@ func fixLine(p index.FixPair, sessions int) string {
 		return "deja: this error came up" + how + " " + where + " before" + when +
 			" — one session ran this after it, and nothing confirms it worked: " + cmd
 	}
+	// A repaired remedy is not "what followed it", it is the command the reader
+	// has just run, corrected — and this is the one surface where they already
+	// know what they ran, so the line names the relationship and not the command
+	// twice. Of the 360 pairs served on a real store, 107 name nothing their
+	// error names for exactly this reason.
+	if p.Failed != "" {
+		return "deja: this error came up" + how + " " + where + " before" + when + " — the same command worked as: " + cmd
+	}
 	return "deja: this error came up" + how + " " + where + " before" + when + " — what followed it: " + cmd
 }
 

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -716,6 +716,12 @@ func mcpFix(dir, name string, raw json.RawMessage) (string, int, error) {
 		}
 		fmt.Fprintf(&fb, "%s%s\n  %s: %s\n", recallListingLine(p.Error), when, ran,
 			commandListingLine(p.Command))
+		// What makes a repaired remedy the answer is the command before it, so
+		// the surface that hands it over shows both — otherwise the agent is
+		// asked to trust a long line that names nothing of its error.
+		if p.Failed != "" {
+			fmt.Fprintf(&fb, "  after this failed: %s\n", commandListingLine(p.Failed))
+		}
 	}
 	// Framed like `how` (#2844) and for a sharper reason: this hands an agent a
 	// command at the moment it has just hit an error, which is the moment it is

--- a/cmd/deja/mcp_fix_repaired_test.go
+++ b/cmd/deja/mcp_fix_repaired_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The MCP tool is where an agent reads a remedy with no person in between, so
+// it carries the same two halves the CLI does: a repaired remedy is the command
+// that failed, corrected, and what makes it the answer is that command.
+func TestMCPFixShowsWhatTheRepairedCommandRepaired(t *testing.T) {
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-r")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"r1","cwd":"/w/r","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the migration keeps failing"}}` + "\n" +
+		`{"type":"assistant","sessionId":"r1","cwd":"/w/r","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -f migrate.sql"}}]}}` + "\n" +
+		`{"type":"user","sessionId":"r1","cwd":"/w/r","timestamp":"2026-07-20T10:02:00Z","message":{"role":"user","content":[{"type":"tool_result","content":"psql: FATAL: role app_user does not exist"}]}}` + "\n" +
+		`{"type":"assistant","sessionId":"r1","cwd":"/w/r","timestamp":"2026-07-20T10:03:00Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"psql -f migrate.sql --username postgres"}}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "r1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := callMCPTool(dir, "fix", json.RawMessage(`{"error":"psql: FATAL: role app_user does not exist"}`))
+	if err != nil {
+		t.Fatalf("fix: %v", err)
+	}
+	if !strings.Contains(got, "--username postgres") {
+		t.Fatalf("the corrected command is missing:\n%s", got)
+	}
+	if !strings.Contains(got, "after this failed: $ psql -f migrate.sql") {
+		t.Errorf("the answer does not say what the command repaired:\n%s", got)
+	}
+}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -550,6 +550,22 @@ when the remedy was a command.
 }
 ```
 
+A row carries `failed` when the remedy is the command that produced the error,
+corrected — a missing `timeout` dropped, a flag the shell refused rewritten. That
+remedy usually shares no word with the error, since what ties them is the command
+before it, so the prose shows both and prints the second as *"after this
+failed"*. `failed` is omitted for every other remedy.
+
+```json
+{
+  "error": "no matches found: --include=*.go",
+  "command": "grep -rn \"deja\" --include=\\*.go .",
+  "failed": "grep -rn \"deja\" --include=*.go .",
+  "candidate": false,
+  "when": "2026-08-29T18:02:44Z"
+}
+```
+
 As with `friction`, an empty result keeps the envelope and returns `fixes: []`.
 The prose path distinguishes "held but unconfirmed", "nothing recorded for that
 line" and "no session ran a command after that error" in three different

--- a/internal/index/fix_own_wording_test.go
+++ b/internal/index/fix_own_wording_test.go
@@ -1,0 +1,47 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A line deja stored is a line deja can look up. The shell-position rule reads
+// `zsh:1: no matches found: …` and stores the line without the marker, and the
+// stored line is not friction on its own — so `deja fix` was handed a line out
+// of its own table, answered "nothing recorded for that line", and offered as
+// the closest thing it held the line it had just been given. 106 of the 1,310
+// error lines on a real store are that shape.
+func TestAStoredErrorLineIsFoundByItsOwnText(t *testing.T) {
+	now := time.Now().UTC()
+	s := model.Session{
+		Harness: "claude", ID: "s1",
+		Messages: []model.Message{
+			{Role: "command", Text: `grep -rn "quokkabloom" --include=*.go internal`, Time: now},
+			{Role: "tool-output", Text: "zsh:1: no matches found: --include=*.go", Time: now.Add(time.Second)},
+			{Role: "command", Text: `grep -rn "quokkabloom" --include="*.go" internal`, Time: now.Add(2 * time.Second)},
+		},
+	}
+	dir := t.TempDir()
+	buildFixes(dir, []model.Session{s}, func(m model.Session) string { return m.Harness + ":" + m.ID })
+
+	stored := ReadFixes(dir)
+	if len(stored) != 1 {
+		t.Fatalf("want one pair, got %+v", stored)
+	}
+	if got := FixesFor(dir, stored[0].Error, 3, nil); len(got) != 1 {
+		t.Fatalf("the stored line %q found nothing: %+v", stored[0].Error, got)
+	}
+	// The marker the shell printed still works, and so does the whole line with
+	// other output around it.
+	if got := FixesFor(dir, "make check\nzsh:1: no matches found: --include=*.go\nexit 1", 3, nil); len(got) != 1 {
+		t.Errorf("the pasted output stopped matching: %+v", got)
+	}
+	// The fallback is deja recognising its own wording, not a search: a line
+	// that only contains the stored one is still a miss, which is what the
+	// "closest it holds" hint is for.
+	if got := FixesFor(dir, "no matches found", 3, nil); len(got) != 0 {
+		t.Errorf("a partial line matched: %+v", got)
+	}
+}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -79,6 +79,12 @@ type FixPair struct {
 	// different kind than the word rules: the pair is not a command that
 	// happened to follow the error, it is the command that caused it, working.
 	Repaired bool `json:",omitempty"`
+	// Failed is the command that produced the error, stored for a repaired
+	// remedy so the reader can see what the correction was. Without it the
+	// remedy reads as an unrelated line: 107 of the 360 pairs served on a real
+	// store name nothing the error names, because they are not a command about
+	// the error, they are the command that caused it, working.
+	Failed string `json:",omitempty"`
 	// Candidate marks a sighting that is not a pair yet: the remedy named
 	// nothing the error named, and no other session has done the same thing
 	// after the same error. Evidence of the second kind accumulates across
@@ -444,8 +450,15 @@ func fixPairsIn(ms []model.Message, key, project string) []FixPair {
 			if namesAnEphemeralPath(cmd) {
 				continue
 			}
+			// The failing command travels with the remedy that corrects it, and
+			// only then: it is there to explain the remedy, and the same bound
+			// the remedy has applies — a pasted script is not something to show.
+			failed := ""
+			if repaired && len(failedCmd) <= fixCommandMax {
+				failed = failedCmd
+			}
 			out = append(out, FixPair{Sig: sig, Error: line, Command: cmd, Key: key,
-				When: ms[j].Time, Project: project, Repaired: repaired})
+				When: ms[j].Time, Project: project, Repaired: repaired, Failed: failed})
 			paired = true
 			break
 		}
@@ -633,6 +646,9 @@ func mergeFixes(dir, tmp string, replacements []model.Session, replaced map[stri
 		}
 		if c, counts := redact.Text(p.Command); len(counts) > 0 {
 			p.Command, dirty = c, true
+		}
+		if f, counts := redact.Text(p.Failed); len(counts) > 0 {
+			p.Failed, dirty = f, true
 		}
 		kept = append(kept, p)
 	}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -679,6 +679,44 @@ func ReadFixes(dir string) []FixPair {
 	return out
 }
 
+// fixSignaturesFor is the set of error signatures the text asks about.
+//
+// Ordinarily every line is hashed the way it was at ingest. The fallback is for
+// a line deja stored and could not read back: the shell-position rule (#3445)
+// recognises `zsh:1: no matches found: …` and stores the normalised line
+// without the marker, so the stored line is not friction on its own — and 106
+// of the 1,310 error lines on a real store are that shape. `deja fix` then
+// answered "nothing recorded for that line" and suggested, as the closest it
+// held, the very line it had just been given.
+func fixSignaturesFor(dir, text string) map[uint64]bool {
+	sigs := map[uint64]bool{}
+	for _, raw := range strings.Split(text, "\n") {
+		if line, ok := FrictionLine(raw); ok {
+			sigs[frictionHash(line)] = true
+		}
+	}
+	if len(sigs) > 0 {
+		return sigs
+	}
+	// Exact lines only, and only after nothing hashed: this is deja recognising
+	// its own wording, not a search for something like it.
+	want := map[string]bool{}
+	for _, raw := range strings.Split(text, "\n") {
+		if l := strings.ToLower(strings.TrimSpace(raw)); l != "" {
+			want[l] = true
+		}
+	}
+	if len(want) == 0 {
+		return sigs
+	}
+	for _, p := range ReadFixes(dir) {
+		if want[strings.ToLower(strings.TrimSpace(p.Error))] {
+			sigs[p.Sig] = true
+		}
+	}
+	return sigs
+}
+
 // FixesFor returns the commands that followed this error before, newest first.
 // The text can be a whole pasted stack trace: every line is tried, so the
 // caller does not have to know which one carries the signature. allow, when
@@ -688,12 +726,7 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 	if limit <= 0 {
 		limit = 3
 	}
-	sigs := map[uint64]bool{}
-	for _, raw := range strings.Split(text, "\n") {
-		if line, ok := FrictionLine(raw); ok {
-			sigs[frictionHash(line)] = true
-		}
-	}
+	sigs := fixSignaturesFor(dir, text)
 	if len(sigs) == 0 {
 		return nil
 	}
@@ -770,12 +803,7 @@ func FixesFor(dir, text string, limit int, allow func(project string) bool) []Fi
 // it worked. The command that says "nothing ran after that error" asks first,
 // so it does not deny holding what it is holding (#2282).
 func FixCandidateSeen(dir, text string, allow func(project string) bool) bool {
-	sigs := map[uint64]bool{}
-	for _, raw := range strings.Split(text, "\n") {
-		if line, ok := FrictionLine(raw); ok {
-			sigs[frictionHash(line)] = true
-		}
-	}
+	sigs := fixSignaturesFor(dir, text)
 	if len(sigs) == 0 {
 		return false
 	}

--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -114,7 +114,7 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 	}
 	var out []FixPair
 	for _, p := range all {
-		if p.Repaired || sharesTerm(p.Error, p.Command) || repeats[fixKey(p)] >= 2 {
+		if selfEvidentPair(p) || (repetitionConfirms(p) && repeats[fixKey(p)] >= 2) {
 			out = append(out, p)
 			continue
 		}
@@ -163,6 +163,38 @@ func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string
 		}
 	}
 	_ = writeGob(fixesPath(tmp), kept)
+}
+
+// selfEvidentPair reports whether a remedy stands on what it is rather than on
+// having happened before. An edit is never self-evident the way a command that
+// names what the error named is: the error names a test, the remedy names a
+// file, and nothing ties them but a second session doing the same thing.
+func selfEvidentPair(p FixPair) bool {
+	if p.Edit != "" {
+		return false
+	}
+	return p.Repaired || sharesTerm(p.Error, p.Command)
+}
+
+// repetitionConfirms reports whether a second sighting is evidence for this
+// remedy at all.
+//
+// A failing test is repaired by editing the code, so a bare command that
+// followed one is the session moving on, and on a machine where the same
+// routine runs every day it moves on the same way twice. Read off a real store:
+// of the 360 pairs `deja fix` serves, 69 rest on repetition alone; the 48 edits
+// among them mostly name the file the failing test lives in, and of the 21
+// commands eleven answer a red test with `gh pr merge 2532`,
+// `git checkout -q -b work477` or `git status`.
+//
+// Only that shape is refused. `brew services start postgresql` after
+// `psql: connection refused` is a command nothing but a second session ties to
+// the error, and it is still the answer.
+func repetitionConfirms(p FixPair) bool {
+	if p.Edit != "" {
+		return true
+	}
+	return !namedTestFailure(p.Error)
 }
 
 // fixKey identifies one remedy for one error, so the same pair arriving from
@@ -525,11 +557,7 @@ func mergeFixPairs(kept, fresh []FixPair) []FixPair {
 	promoted := map[string]bool{}
 	for _, p := range fresh {
 		k := fixKey(p)
-		// An edit is never self-evident the way a command that names what the
-		// error named is: the error names a test, the remedy names a file, and
-		// nothing ties them but a second session doing the same thing.
-		selfEvident := p.Edit == "" && (p.Repaired || sharesTerm(p.Error, p.Command))
-		if selfEvident || repeats[k]+seen[k] >= 2 {
+		if selfEvidentPair(p) || (repetitionConfirms(p) && repeats[k]+seen[k] >= 2) {
 			p.Candidate = false
 			kept = append(kept, p)
 			promoted[k] = true

--- a/internal/index/fixpair_failed_test.go
+++ b/internal/index/fixpair_failed_test.go
@@ -1,0 +1,49 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A repaired remedy is the failing command corrected, so what makes it the
+// answer is the command before it. Without that command stored the remedy is a
+// long line naming nothing of the error: 107 of the 360 pairs served on a real
+// store are that shape.
+func TestARepairedPairCarriesTheCommandThatFailed(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "command", Text: `grep -rn "deja" --include=*.go .`, Time: now},
+		{Role: "tool-output", Text: "zsh:1: no matches found: --include=*.go", Time: now.Add(time.Second)},
+		{Role: "command", Text: `grep -rn "deja" --include=\*.go .`, Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "3 matches", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 || !pairs[0].Repaired {
+		t.Fatalf("want one repaired pair, got %+v", pairs)
+	}
+	if pairs[0].Failed != `grep -rn "deja" --include=*.go .` {
+		t.Errorf("the pair does not say what it repaired: %q", pairs[0].Failed)
+	}
+}
+
+// Every other remedy is a command someone ran after the error, not that
+// command corrected, and saying "after this failed" about it would be a claim
+// the store cannot make.
+func TestAnOrdinaryPairCarriesNoFailingCommand(t *testing.T) {
+	now := time.Now()
+	ms := []model.Message{
+		{Role: "command", Text: "make build", Time: now},
+		{Role: "tool-output", Text: "zsh: command not found: shellcheck", Time: now.Add(time.Second)},
+		{Role: "command", Text: "brew install shellcheck", Time: now.Add(time.Minute)},
+		{Role: "tool-output", Text: "installed", Time: now.Add(2 * time.Minute)},
+	}
+	pairs := fixPairsIn(ms, "claude:s1", "p")
+	if len(pairs) != 1 || pairs[0].Repaired {
+		t.Fatalf("want one ordinary pair, got %+v", pairs)
+	}
+	if pairs[0].Failed != "" {
+		t.Errorf("an ordinary remedy claims to repair %q", pairs[0].Failed)
+	}
+}

--- a/internal/index/fixpair_testfail_test.go
+++ b/internal/index/fixpair_testfail_test.go
@@ -1,0 +1,66 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A failing test is repaired by an edit, so the command that followed one is
+// the session moving on — and the work moves on the same way every day, which
+// used to be enough to call it a fix. `deja fix` answered eleven red tests on
+// this machine with `gh pr merge`, `git checkout -b` and `git status`.
+func TestACommandAfterARedTestIsNotConfirmedByRepetition(t *testing.T) {
+	now := time.Now()
+	session := func(id string) []FixPair {
+		return fixPairsIn([]model.Message{
+			{Role: "tool-output", Text: "--- FAIL: TestBillingRoundsHalfUp (0.09s)", Time: now},
+			{Role: "command", Text: "gh pr merge 2532 --squash --delete-branch", Time: now.Add(time.Minute)},
+		}, "claude:"+id, "p")
+	}
+	first := mergeFixPairs(nil, session("s1"))
+	if len(first) != 1 || !first[0].Candidate {
+		t.Fatalf("one sighting is a candidate: %+v", first)
+	}
+	second := mergeFixPairs(first, session("s2"))
+	if len(second) != 1 {
+		t.Fatalf("the sighting is kept, not dropped: %+v", second)
+	}
+	if !second[0].Candidate {
+		t.Errorf("a second session running the same command after the same red test confirmed nothing: %+v", second[0])
+	}
+}
+
+// The rule is about that shape only. `brew services start postgresql` names
+// nothing `psql: connection refused` names either, and a second session running
+// it is still the answer.
+func TestARepeatedCommandAfterAnOrdinaryFailureStillConfirms(t *testing.T) {
+	now := time.Now()
+	session := func(id string) []FixPair {
+		return fixPairsIn([]model.Message{
+			{Role: "tool-output", Text: "psql: connection refused on port 5432", Time: now},
+			{Role: "command", Text: "brew services start postgresql", Time: now.Add(time.Minute)},
+		}, "claude:"+id, "p")
+	}
+	second := mergeFixPairs(mergeFixPairs(nil, session("s1")), session("s2"))
+	if len(second) != 1 || second[0].Candidate {
+		t.Fatalf("a repeated remedy for an ordinary failure must be a pair: %+v", second)
+	}
+}
+
+// And an edit after a red test is exactly what a repair looks like, so the
+// second sighting confirms it.
+func TestAnEditAfterARedTestIsStillConfirmedByRepetition(t *testing.T) {
+	now := time.Now()
+	session := func(id string) []FixPair {
+		return fixPairsIn([]model.Message{
+			{Role: "tool-output", Text: "--- FAIL: TestBillingRoundsHalfUp (0.09s)", Time: now},
+			{Role: "edit", Text: "internal/billing/round.go\n-\tmath.Round(v)\n+\tmath.Floor(v + 0.5)", Time: now.Add(time.Minute)},
+		}, "claude:"+id, "p")
+	}
+	second := mergeFixPairs(mergeFixPairs(nil, session("s1")), session("s2"))
+	if len(second) != 1 || second[0].Candidate {
+		t.Fatalf("a repeated edit after a red test must be a pair: %+v", second)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -165,7 +165,13 @@ import (
 // Pairs are a sidecar written at build time, so an existing store keeps the
 // ones it has until the bump forces the re-read (#3445 carries the other half:
 // the errors those pairs answer).
-const version = 36
+// 37 narrows what a second sighting proves. A red test is repaired by an edit,
+// so a bare command that followed one is the session moving on, and the same
+// routine runs the same way every day — which was enough to promote it. On a
+// real store 11 of the 360 pairs served answered a named test failure with
+// `gh pr merge 2532`, `git checkout -q -b work477` or `git status`. They are
+// sightings again, and the pairs already on file only re-mine on this bump.
+const version = 37
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -171,6 +171,11 @@ import (
 // real store 11 of the 360 pairs served answered a named test failure with
 // `gh pr merge 2532`, `git checkout -q -b work477` or `git status`. They are
 // sightings again, and the pairs already on file only re-mine on this bump.
+//
+// The same bump stores the failing command beside the remedy that corrects it.
+// 107 of those 360 answers share no word with the error they answer — they are
+// not a command about the error, they are the command that caused it, working —
+// and shown alone they read as an unrelated line to trust.
 const version = 37
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -176,6 +176,13 @@ import (
 // 107 of those 360 answers share no word with the error they answer — they are
 // not a command about the error, they are the command that caused it, working —
 // and shown alone they read as an unrelated line to trust.
+//
+// Storing it showed the rule that mines them comparing the wrong thing. The
+// commands carry the shell prompt a harness stored with them, so `$` was the
+// program of both sides, the same-program test passed for any two lines and the
+// navigation guard guarded nothing: 36 of 163 such answers were a different
+// program or `cd` elsewhere. The wrapper the shell could not find is now
+// transparent too, so `timeout 12 launchctl …` is repaired by `launchctl …`.
 const version = 37
 const maxIndexedText = 64 * 1024
 

--- a/internal/index/repaired.go
+++ b/internal/index/repaired.go
@@ -63,18 +63,42 @@ var navigationCommands = map[string]bool{
 }
 
 // commandTokens splits a command into the words a comparison can be made on.
-func commandTokens(cmd string) []string { return strings.Fields(cmd) }
+//
+// The shell prompt some harnesses store with the command goes first. Left in,
+// it is the program of every command ever recorded: `$` equals `$`, so the
+// same-program test below passed for any two lines and the navigation guard
+// guarded nothing — measured on a real store, 21 of the 163 repaired pairs
+// served ran a different program (`go test` answered by `rm`, `git` by `go`)
+// and three more were `cd` somewhere else.
+func commandTokens(cmd string) []string {
+	f := strings.Fields(cmd)
+	if len(f) > 0 && f[0] == "$" {
+		return f[1:]
+	}
+	return f
+}
 
 // commandProgram is what the command runs, without the path it was found at
 // and without the environment assignments and wrappers in front of it.
 func commandProgram(tokens []string) string {
-	for _, t := range tokens {
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
 		if strings.Contains(t, "=") {
 			continue
 		}
 		switch t {
 		case "sudo", "env", "time", "nohup", "exec", "command":
 			continue
+		case "timeout", "gtimeout", "stdbuf", "nice":
+			// The wrapper takes a duration before the command it runs, and
+			// `timeout 90 ssh …` runs ssh — dropping a wrapper the shell cannot
+			// find is the repair for the wall this machine hits most, so both
+			// sides have to name the program that does the work. With no
+			// duration after it the wrapper is the program itself.
+			if i+1 < len(tokens) && isDurationToken(tokens[i+1]) {
+				i++
+				continue
+			}
 		}
 		if i := strings.LastIndex(t, "/"); i >= 0 {
 			t = t[i+1:]
@@ -82,6 +106,21 @@ func commandProgram(tokens []string) string {
 		return t
 	}
 	return ""
+}
+
+// isDurationToken reports whether the token is a plain duration — the argument
+// `timeout` and its kin take before the command they run.
+func isDurationToken(t string) bool {
+	t = strings.TrimRight(t, "smhd")
+	if t == "" {
+		return false
+	}
+	for _, r := range t {
+		if (r < '0' || r > '9') && r != '.' {
+			return false
+		}
+	}
+	return true
 }
 
 // tokenOverlap is how much of the two commands is the same words, counted as

--- a/internal/index/repaired_prefix_test.go
+++ b/internal/index/repaired_prefix_test.go
@@ -1,0 +1,38 @@
+package index
+
+import "testing"
+
+// The commands come out of a transcript with the shell prompt some harnesses
+// store in front of them, and with it in place `$` was the program of every
+// command ever recorded — so the same-program test compared `$` with `$` and
+// passed for any two lines. On a real store 21 of the 163 repaired answers ran
+// a different program and three were `cd` somewhere else.
+func TestAPromptPrefixDoesNotMakeEveryCommandTheSameProgram(t *testing.T) {
+	if repairedVariant("$ go test ./cmd/deja -run TestPasses", "$ rm cmd/deja/zz_probe_test.go; go test ./cmd/deja") {
+		t.Error("removing a probe file counts as a repair of a failing test")
+	}
+	if repairedVariant("$ cd ~/one-place && make check", "$ cd ~/another-place && make check") {
+		t.Error("going somewhere else counts as a repair")
+	}
+	// And the shape the bound was chosen for still holds with the prompt there.
+	if !repairedVariant(`$ grep -rn "quokkabloom" --include=*.go internal`, `$ grep -rn "quokkabloom" --include="*.go" internal`) {
+		t.Error("the corrected glob is no longer a repair")
+	}
+}
+
+// Dropping the wrapper the shell could not find is the repair for the wall this
+// machine hits most: 19 sessions have run into a missing `timeout`.
+func TestDroppingAMissingWrapperIsARepair(t *testing.T) {
+	if !repairedVariant("$ timeout 12 launchctl kickstart -k system/dev.example.svc",
+		"$ launchctl kickstart -k system/dev.example.svc") {
+		t.Error("the same command without the missing wrapper is not recognised as the repair")
+	}
+	if got := commandProgram(commandTokens("$ timeout 90 ssh -o ConnectTimeout=10 host uptime")); got != "ssh" {
+		t.Errorf("the program behind the wrapper is %q", got)
+	}
+	// A duration is what timeout takes; a command that happens to be named
+	// after it is still the program.
+	if got := commandProgram(commandTokens("$ timeout --help")); got != "timeout" {
+		t.Errorf("timeout with no command after it is %q", got)
+	}
+}


### PR DESCRIPTION
Four things about what the failure path claims, read off a real store where `deja fix` serves 360 pairs.

**A command after a red test is not confirmed by repetition.** A pair is promoted on a second sighting — another session ran the same thing after the same error — and on a machine where the same routine runs every day that counts the routine. 69 of the 360 rest on repetition alone, and 11 of those answer a named test failure with `gh pr merge 2532`, `git checkout -q -b work477` or `git status`. A red test is repaired by an edit, so a bare command that followed one is the session moving on. Repetition still confirms everything else, including an edit after a red test and `brew services start postgresql` after `psql: connection refused`. The 11 go back to being sightings, which callers still serve as unconfirmed once the pairs run out.

**A repaired remedy says what it repaired.** 107 of the 360 share no word with the error they answer, because they are not a command about the error — they are the command that caused it, working: a missing `timeout` dropped, a glob the shell refused quoted. Alone they read as a long unrelated line to trust. The pair now carries the failing command, `deja fix` and the MCP tool print it as *"after this failed"*, `--json` carries `failed`, and the hook at the point of the failure says *"the same command worked as"* — there the reader has just run the failing command, so the line names the relationship rather than repeating it.

**Storing it showed the mining rule comparing the wrong thing.** Commands come out of a transcript with the shell prompt a harness stored in front of them, so `$` was the program of both sides: the same-program test passed for any two lines and the navigation guard guarded nothing. 36 of those 163 answers ran a different program or `cd` elsewhere — `go test ./cmd/deja` answered by `rm cmd/deja/zz_probe_test.go`, `git` by `go`. Ten of the 36 stay pairs on a shared term. The wrapper the shell could not find is transparent now, so `timeout 12 launchctl kickstart …` is still repaired by `launchctl kickstart …`, which is what 19 sessions of missing `timeout` want.

**A line deja stored is a line deja can look up.** The shell-position rule reads `zsh:1: no matches found: --include=*.go` and stores the line without the marker, and that stored line is not friction on its own: 106 of the 1,310 error lines on file could not be found by their own text, so `fix` answered "nothing recorded for that line" and then offered, as the closest thing it held, the line it had just been given. Exact lines only, and only after nothing hashed — deja recognising its own wording, not a search for something like it.

Index version 37: pairs are a build-time sidecar, so what is already on file only re-mines on the bump.
