### PR TITLE
fix(ctx): a compaction summary does not fill the context window

### DIFF
--- a/internal/search/context_summary_test.go
+++ b/internal/search/context_summary_test.go
@@ -1,0 +1,80 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// summarySession is a session whose window holds a compaction summary — the
+// longest message a session ever has, naming everything it did — beside the
+// turns that actually discussed the subject.
+func summarySession() model.Session {
+	summary := "Summary:\n1. **Primary Request and Intent:**\n\n" +
+		"   The standing instruction is to keep improving the tool.\n" +
+		"2. **Key Technical Concepts:**\n   - the retry budget, the scheduler, the failover\n" +
+		strings.Repeat("   - a line about something else entirely\n", 120)
+	now := time.Now()
+	return model.Session{
+		Harness: "claude", ID: "s1", Project: "app", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: summary, Time: now},
+			{Role: "user", Text: "what did we settle about the retry budget?", Time: now.Add(time.Minute)},
+			{Role: "assistant", Text: "We capped the retry budget at three attempts and let the fourth fail loudly.", Time: now.Add(2 * time.Minute)},
+		},
+	}
+}
+
+// A compaction summary names everything the session did, so it matches almost
+// any question and then fills the window on its own. Measured over eight
+// questions an agent would ask, on a real store: three answers came back
+// carrying one, at 95% of the answer each — 44% of every byte recall_context
+// served, none of it an answer.
+func TestAContextWindowIsNotFilledByACompactionSummary(t *testing.T) {
+	var b bytes.Buffer
+	PrintContext(&b, summarySession(), "retry budget")
+	got := b.String()
+
+	if !strings.Contains(got, "capped the retry budget at three") {
+		t.Errorf("the turn that answers is missing:\n%s", got)
+	}
+	if strings.Contains(got, "a line about something else entirely") {
+		t.Errorf("the summary was printed whole (%d bytes):\n%s", len(got), got[:min(len(got), 400)])
+	}
+	if !strings.Contains(got, "compaction summary") {
+		t.Errorf("nothing says the summary was cut:\n%s", got)
+	}
+	// The lines of it that do carry the query are what it contributes.
+	if !strings.Contains(got, "the retry budget, the scheduler, the failover") {
+		t.Errorf("the matching line of the summary is missing:\n%s", got)
+	}
+}
+
+// Asked nothing — `deja ctx <id>`, the MCP resource read — there is nothing to
+// match, and the summary is the best account of the session there is.
+func TestWithNoQueryTheSummaryIsKept(t *testing.T) {
+	var b bytes.Buffer
+	PrintContext(&b, summarySession(), "")
+	if !strings.Contains(b.String(), "a line about something else entirely") {
+		t.Error("a session read with no query lost its summary")
+	}
+}
+
+// A turn that merely opens with the word is a person writing, not a harness.
+func TestAnOrdinaryTurnCalledSummaryIsUntouched(t *testing.T) {
+	now := time.Now()
+	s := model.Session{
+		Harness: "claude", ID: "s2", Project: "app", Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "Summary: the retry budget is three and the scheduler is single-writer, which is what we agreed.", Time: now},
+		},
+	}
+	var b bytes.Buffer
+	PrintContext(&b, s, "retry budget")
+	if got := b.String(); !strings.Contains(got, "single-writer") {
+		t.Errorf("an ordinary turn was clipped as a compaction summary:\n%s", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1575,7 +1575,7 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 		keep := carries || m.Role == "user" || (m.Role == "assistant" && prevKept)
 		prevKept = keep
 		return keep, hits
-	})
+	}, func(m model.Message) string { return clipCompactionSummary(m.Text, parts) })
 	if written > 0 {
 		return
 	}
@@ -1584,7 +1584,86 @@ func PrintContext(w io.Writer, s model.Session, query string) {
 	if qlow != "" {
 		fmt.Fprintf(w, "\nNo single message contains the full query; showing the session's opening exchange.\n")
 	}
-	printContextChunks(w, s, budget, func(m model.Message) (bool, []int) { return true, nil })
+	printContextChunks(w, s, budget, func(m model.Message) (bool, []int) { return true, nil },
+		func(m model.Message) string { return clipCompactionSummary(m.Text, parts) })
+}
+
+// compactionSummaryLineCap and compactionSummaryByteCap bound what a compaction
+// summary contributes to a context window.
+const (
+	compactionSummaryLineCap = 8
+	compactionSummaryByteCap = 700
+)
+
+// compactionSummaryLead says what was cut and why, so the lines below are not
+// read as the whole turn.
+const compactionSummaryLead = "[compaction summary of an earlier part of this session — the matching lines only]"
+
+// clipCompactionSummary reduces a compaction summary to the lines that carry
+// the query, or returns "" for a turn that is not one.
+//
+// A summary is the longest message a session ever holds and it names everything
+// the session did, so it matches almost any question and then fills the window
+// on its own. Measured over eight questions an agent would ask, on a real
+// store: three answers came back carrying one, and it was 95% of each of them —
+// 44% of every byte `recall_context` served. None of it answered the question.
+func clipCompactionSummary(text string, parts []string) string {
+	if !digest.IsCompactionSummary(text) {
+		return ""
+	}
+	// Nothing was asked, so nothing can be matched: `deja ctx <id>` and the MCP
+	// resource read a session with no query, and there the summary is the best
+	// account of it there is.
+	if len(parts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(compactionSummaryLead)
+	lines := 0
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || contextPartHits(line, parts) == nil {
+			continue
+		}
+		carries := false
+		for _, h := range contextPartHits(line, parts) {
+			if h > 0 {
+				carries = true
+				break
+			}
+		}
+		if !carries {
+			continue
+		}
+		b.WriteString("\n")
+		b.WriteString(line)
+		lines++
+		if lines >= compactionSummaryLineCap || b.Len() >= compactionSummaryByteCap {
+			break
+		}
+	}
+	if lines == 0 {
+		// It matched as a whole and no single line does — a query whose words
+		// are spread through it. Name the subject and stop: the summary is
+		// there, and it is not what was asked about.
+		return compactionSummaryLead + "\n" + firstLines(text, 2)
+	}
+	return b.String()
+}
+
+// firstLines is the first n non-empty lines, for naming what a clipped turn was
+// about.
+func firstLines(text string, n int) string {
+	var out []string
+	for _, raw := range strings.Split(text, "\n") {
+		if line := strings.TrimSpace(raw); line != "" {
+			out = append(out, line)
+			if len(out) == n {
+				break
+			}
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // contextQueryParts is what the digest weighs a turn against: the query's terms
@@ -1719,7 +1798,7 @@ func renderContextTurns(turns []contextTurn) []string {
 	return out
 }
 
-func printContextChunks(w io.Writer, s model.Session, budget int, include func(m model.Message) (ok bool, hits []int)) int {
+func printContextChunks(w io.Writer, s model.Session, budget int, include func(m model.Message) (ok bool, hits []int), clip func(m model.Message) string) int {
 	// A digest is what someone pipes into a prompt, so it carries the
 	// conversation. The work records — tool output, the files a turn touched, the
 	// commands it ran, the spans it replaced — are indexed and searchable by role
@@ -1755,7 +1834,13 @@ func printContextChunks(w io.Writer, s model.Session, budget int, include func(m
 		if len(hits) > parts {
 			parts = len(hits)
 		}
-		kept = append(kept, contextTurn{role: m.Role, raw: m.Text, hits: hits})
+		raw := m.Text
+		if clip != nil {
+			if short := clip(m); short != "" {
+				raw = short
+			}
+		}
+		kept = append(kept, contextTurn{role: m.Role, raw: raw, hits: hits})
 	}
 	weights := contextTurnWeights(kept, parts)
 	rendered := renderContextTurns(kept)


### PR DESCRIPTION
A compaction summary names everything a session did, so it matches almost any question and then fills the window on its own. Measured over eight questions an agent would plausibly ask, against a store built from every harness on a real machine: three answers came back carrying one, at ~95% of the answer each — 7128 of 7528 bytes, 7388 of 7793, 7538 of 7938 — which is 44% of every byte `recall_context` served, and none of it an answer to the question.

Clipped to the lines that carry the query, with a marker saying so. After: 0 of 8, and the freed budget goes to turns that were being crowded out. Asked nothing — `deja ctx <id>`, the MCP resource read — nothing can be matched and the summary stays whole; `deja show` is unchanged either way. A turn that merely opens with the word "Summary:" is a person writing, and a test says so.

`recall` snippets were measured for the same defect and have it at 0 of 44 quoted lines, so nothing there needed changing.
