### PR TITLE
fix(bench): refuse to measure a corpus the ignore rule hides

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vshulcz/deja-vu/internal/embed"
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -326,11 +327,30 @@ func benchmarkTempDir() (string, error) {
 		return "", err
 	}
 	parent := filepath.Join(workingDir, ".deja-bench")
+	if err := benchCorpusVisible(parent); err != nil {
+		return "", err
+	}
 	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return "", err
 	}
 	sweepStaleBenchRuns(parent, time.Now())
 	return os.MkdirTemp(parent, "run-")
+}
+
+// benchCorpusVisible refuses to measure a corpus deja cannot see.
+//
+// The corpus is written under the working directory, and the ignore rule is a
+// property of paths rather than of configuration — so a bench run from a
+// directory the rule covers indexes its corpus and then finds none of it. Every
+// arm reads zero, which is indistinguishable from a surface that has stopped
+// working: `deja bench prompt` printed 0 of 13 real questions from a tree under
+// `~/.claude/jobs/`, and 13 of 13 from a directory beside it.
+func benchCorpusVisible(parent string) error {
+	pol := policy.Load()
+	if !pol.Ignored(parent, "") {
+		return nil
+	}
+	return fmt.Errorf("bench: the corpus would sit in %s, which deja's ignore rule hides, so every arm would read zero — run the bench from a directory the rule does not cover", parent)
 }
 
 // sweepStaleBenchRuns removes what interrupted runs left behind.

--- a/cmd/deja/bench_ignored_cwd_test.go
+++ b/cmd/deja/bench_ignored_cwd_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The bench writes its corpus under the working directory, and the ignore rule
+// covers paths rather than configuration — so a run from a covered tree indexes
+// its corpus and then finds none of it. Every arm reads zero, which is what a
+// dead surface looks like: `deja bench prompt` printed 0 of 13 real questions
+// from a directory under `~/.claude/jobs/`, and 13 of 13 from one beside it.
+func TestBenchRefusesToMeasureACorpusItCannotSee(t *testing.T) {
+	work := filepath.Join(t.TempDir(), "home", ".claude", "jobs", "job-1", "tmp")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// t.Chdir rather than a cleanup of our own: cleanups run last-registered
+	// first, so a manual restore would race t.TempDir's removal.
+	t.Chdir(work)
+
+	got, err := benchmarkTempDir()
+	if err == nil {
+		t.Fatalf("the bench prepared %q inside a tree the ignore rule hides", got)
+	}
+	for _, want := range []string{"ignore rule", "read zero"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not say %q: %v", want, err)
+		}
+	}
+	if entries, rerr := os.ReadDir(work); rerr == nil && len(entries) > 0 {
+		t.Errorf("a refused run still left %d entries behind", len(entries))
+	}
+}
+
+// Anywhere else it prepares the run tree as before.
+func TestBenchPreparesItsRunTreeElsewhere(t *testing.T) {
+	work := t.TempDir()
+	t.Chdir(work)
+	got, err := benchmarkTempDir()
+	if err != nil {
+		t.Fatalf("bench refused an ordinary directory: %v", err)
+	}
+	if !strings.HasPrefix(got, work) {
+		t.Errorf("run tree %q is not under the working directory %q", got, work)
+	}
+}


### PR DESCRIPTION
`deja bench` writes its corpus under the working directory, and the ignore rule covers paths rather than configuration — so a run from a covered tree indexes its corpus and then finds none of it. Every arm reads zero, which is exactly what a dead surface looks like.

Found it while trying to score the per-prompt hook: `deja bench prompt` printed 0 of 13 real questions from a directory under `~/.claude/jobs/`, and 13 of 13 with precision 1.00 from a directory beside it. The package test has always passed, because it runs in its own temp HOME.

Now it refuses with the reason instead of printing zeros. Nothing is created before the refusal, and a run from anywhere else is unchanged.
