### PR TITLE
perf: a recall answer takes 0.9s instead of 2.3s

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -474,6 +474,14 @@ func runHookPromptMode(dir string, stdin io.Reader, stdout io.Writer, plain bool
 			tail += "\n" + nudge
 		}
 		lead := promptHookLead
+		// After the first block of a session the two explanatory sentences are
+		// words the agent has already read, and the third repeats the line this
+		// block ends with. Measured on a real store: a session receives a median
+		// of 23 per-prompt blocks, the lead is 301 bytes of a 1439-byte block,
+		// so 22 of those blocks carried 6.6 KB of the same sentences.
+		if blockAlreadySentThisSession(dir, input.SessionID) {
+			lead = promptHookLeadShort
+		}
 		// A repeat of the question itself is a different claim than a session
 		// about the subject, and a stronger one: the agent does not have to
 		// decide whether the history is relevant, only whether the answer
@@ -1521,6 +1529,27 @@ func sessionIDs(ss []model.Session) []string {
 // sentence (#2370). The match is on wording, and the lead now says so and asks
 // for the one check that catches it.
 const promptHookLead = "deja found sessions whose wording matches this request — not a judgement that they answer it. Check that the session describes what is happening now before acting on it. If one genuinely helps, use it and tell the user in one short line, as the last line of this block asks; otherwise ignore silently.\n"
+
+// promptHookLeadShort is the lead every block after the first one carries: the
+// caveat that still applies each time, without the sentences the session has
+// already been told and without the citation instruction the block ends with
+// anyway.
+const promptHookLeadShort = "deja matched on wording, not meaning — check the session fits before acting on it.\n"
+
+// blockAlreadySentThisSession reports whether this agent session has had a
+// per-prompt block before. The seen list is written after every block that goes
+// out, keyed by the session, so its own rows are the record of that.
+func blockAlreadySentThisSession(dir, sid string) bool {
+	if sid == "" {
+		return false
+	}
+	return len(recentlyInjected(dir, sid, leadWindow)) > 0
+}
+
+// leadWindow is how far back the check reads. Longer than the injection
+// cooldown on purpose: this asks whether the session was ever told, not whether
+// a particular memory is on cooldown.
+const leadWindow = 500
 
 // digestBudget is how much room the block gets. A match resting on a single
 // rare word is a weaker claim than one resting on two, and it is where most of

--- a/cmd/deja/hook_prompt_lead_once_test.go
+++ b/cmd/deja/hook_prompt_lead_once_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// The lead is 301 bytes of a 1439-byte block, a session receives a median of 23
+// blocks, and the lead's last sentence repeats the line every block ends with.
+// Said once, the other 22 blocks stop carrying 6.6 KB of the same sentences.
+func TestTheBlockExplainsItselfOncePerSession(t *testing.T) {
+	withStatsStores(t)
+	claudeRoot := os.Getenv("DEJA_CLAUDE_ROOT")
+	old := time.Now().Add(-72 * time.Hour).UTC().Format(time.RFC3339)
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "leadfix.jsonl"), "leadfix", []string{
+		`{"type":"user","sessionId":"leadfix","timestamp":"` + old + `","message":{"role":"user","content":"the quokkabloom exporter drops rows at utc_midnight"}}`,
+		`{"type":"assistant","sessionId":"leadfix","timestamp":"` + old + `","message":{"role":"assistant","content":"we moved the quokkabloom exporter off utc_midnight and it stopped dropping rows"}}`,
+	})
+	writeClaudeFixture(t, filepath.Join(claudeRoot, "beta", "leadfix2.jsonl"), "leadfix2", []string{
+		`{"type":"user","sessionId":"leadfix2","timestamp":"` + old + `","message":{"role":"user","content":"the snorblewidget retry budget was capped at three"}}`,
+		`{"type":"assistant","sessionId":"leadfix2","timestamp":"` + old + `","message":{"role":"assistant","content":"we capped the snorblewidget retry budget at three attempts and let the fourth fail"}}`,
+	})
+	if err := index.Ensure(index.DefaultDir(), "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(t.TempDir(), "tmp", "beta")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	ask := func(prompt string) string {
+		in := `{"prompt":"` + prompt + `","session_id":"agent-lead"}`
+		var out bytes.Buffer
+		if err := runHookPrompt(index.DefaultDir(), strings.NewReader(in), &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.String()
+	}
+
+	first := ask("is the quokkabloom exporter still losing rows overnight")
+	if !strings.Contains(first, "deja found sessions whose wording matches this request") {
+		t.Fatalf("the first block does not explain itself:\n%s", first)
+	}
+
+	second := ask("how many attempts does the snorblewidget budget allow now")
+	if strings.Contains(second, "deja found sessions whose wording matches this request") {
+		t.Errorf("the second block repeats the whole explanation:\n%s", second)
+	}
+	if !strings.Contains(second, "matched on wording, not meaning") {
+		t.Errorf("the second block dropped the caveat that still applies:\n%s", second)
+	}
+	// What must survive on every block: the untrusted-data line and the line
+	// that asks for the citation.
+	for _, want := range []string{"untrusted reference data", "If it helped, say:"} {
+		if !strings.Contains(second, want) {
+			t.Errorf("the second block lost %q:\n%s", want, second)
+		}
+	}
+	if len(second) >= len(first) {
+		t.Errorf("the second block is not smaller: %d then %d bytes", len(first), len(second))
+	}
+}

--- a/internal/index/rerank_parallel_test.go
+++ b/internal/index/rerank_parallel_test.go
@@ -1,0 +1,49 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The ranker scores sessions on many cores now, because lowercasing and
+// tokenising every turn of every ranked session was 1.6 s of a 2.4 s recall
+// answer on a real store. Spreading work changes nothing about the answer only
+// if the order it comes back in is the same, so both paths are run.
+func TestRankingIsTheSameOnOneCoreAndMany(t *testing.T) {
+	var ss []model.Session
+	for i := range 24 {
+		msgs := []model.Message{
+			{Role: "user", Text: fmt.Sprintf("session %d asks about the retry budget", i)},
+			{Role: "assistant", Text: fmt.Sprintf("we capped it at %d attempts", i%5)},
+		}
+		if i%3 == 0 {
+			msgs = append(msgs, model.Message{Role: "assistant", Text: "the scheduler stayed single-writer"})
+		}
+		ss = append(ss, model.Session{Harness: "claude", ID: fmt.Sprintf("s%02d", i), Messages: msgs})
+	}
+	terms := []string{"retry", "budget", "scheduler"}
+	idf := map[string]float64{"retry": 1.5, "budget": 2, "scheduler": 3}
+
+	rerankWorkers = func() int { return 1 }
+	one := rerankByBestMessage(cloneSessions(ss), terms, idf)
+	rerankWorkers = func() int { return 8 }
+	many := rerankByBestMessage(cloneSessions(ss), terms, idf)
+	t.Cleanup(func() { rerankWorkers = defaultRerankWorkers })
+
+	if len(one) != len(many) {
+		t.Fatalf("one core ranked %d sessions, eight ranked %d", len(one), len(many))
+	}
+	for i := range one {
+		if one[i].ID != many[i].ID {
+			t.Fatalf("position %d: one core says %s, eight say %s", i, one[i].ID, many[i].ID)
+		}
+	}
+}
+
+func cloneSessions(ss []model.Session) []model.Session {
+	out := make([]model.Session, len(ss))
+	copy(out, ss)
+	return out
+}

--- a/internal/index/retrieval.go
+++ b/internal/index/retrieval.go
@@ -9,8 +9,11 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -3926,6 +3929,55 @@ func intersectPostingMaps(sets []map[int64]posting) []posting {
 	return out
 }
 
+// tokenHitCap bounds the buffer one token is built in. tokens flushes a token
+// once it passes 64 bytes, so nothing longer than that plus one rune is ever
+// held here.
+const tokenHitCap = 64 + utf8.UTFMax
+
+// tokenHits reports which of the wanted tokens a text contains.
+//
+// It tokenises exactly as tokens does — same fold, same rune classes, same
+// two-byte minimum and same flush past 64 bytes — and then throws the token
+// away instead of collecting it. The ranker asks whether a message carries any
+// of a query's five or ten words, and building the message's whole token set to
+// answer that was 25% of the CPU a recall answer spent: 4000 turns of each of
+// fifty sessions, a map and a sort per turn.
+func tokenHits(s string, want map[string]bool) map[string]bool {
+	if len(want) == 0 {
+		return nil
+	}
+	s = nfcfold.Compose(s)
+	var hit map[string]bool
+	var buf [tokenHitCap]byte
+	n := 0
+	flush := func() {
+		if n >= 2 {
+			// The compiler does not allocate for a map lookup keyed by a
+			// converted byte slice, which is the point of the buffer.
+			if want[string(buf[:n])] {
+				if hit == nil {
+					hit = make(map[string]bool, len(want))
+				}
+				hit[string(buf[:n])] = true
+			}
+		}
+		n = 0
+	}
+	for _, r := range strings.ToLower(s) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' ||
+			(n > 0 && isMark(r)) {
+			n += utf8.EncodeRune(buf[n:], r)
+			if n > 64 {
+				flush()
+			}
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return hit
+}
+
 func tokens(s string) []string {
 	// Fold NFD to NFC so an accented word keys the same whether it was typed or
 	// stored decomposed. A combining mark is category Mn, not a letter, so the
@@ -4415,23 +4467,67 @@ const bestMessageTurns = 4000
 // session spreads the same words over many. Reciprocal rank fusion keeps both
 // votes; stable on ties, so the pool's order survives where messages cannot
 // separate sessions.
+
+// parallelForRanked runs fn over 0..n-1 on one goroutine per core, once there is
+// enough work to pay for handing it out.
+func parallelForRanked(n int, fn func(i int)) {
+	workers := rerankWorkers()
+	if workers > n {
+		workers = n
+	}
+	if workers < 2 || n < 4 {
+		for i := range n {
+			fn(i)
+		}
+		return
+	}
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= n {
+					return
+				}
+				fn(i)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// rerankWorkers is a variable so a test can force the single-core path and
+// compare the two orders.
+var rerankWorkers = defaultRerankWorkers
+
+func defaultRerankWorkers() int { return runtime.NumCPU() }
+
 func rerankByBestMessage(ss []model.Session, terms []string, idf map[string]float64) []model.Session {
 	forms := make([][]string, len(terms))
+	wanted := map[string]bool{}
 	for i, t := range terms {
 		t = strings.ToLower(t)
 		forms[i] = append([]string{t}, stemMatchForms(t)...)
+		for _, f := range forms[i] {
+			wanted[f] = true
+		}
 	}
 	best := make([]float64, len(ss))
-	for i, s := range ss {
+	// Per session and independent, and lowercasing every message of every
+	// ranked session is where a recall answer spends its time: 1.6 s of 2.4 s
+	// on a real store, profiled. Spread across cores; each session's score is
+	// computed exactly as before, so the ranking is unchanged.
+	parallelForRanked(len(ss), func(i int) {
+		s := ss[i]
 		msgs := s.Messages
 		if len(msgs) > bestMessageTurns {
 			msgs = msgs[:bestMessageTurns]
 		}
 		for _, msg := range msgs {
-			toks := map[string]bool{}
-			for _, tk := range tokens(strings.ToLower(msg.Text)) {
-				toks[tk] = true
-			}
+			toks := tokenHits(msg.Text, wanted)
 			score := 0.0
 			for ti, t := range terms {
 				hit := false
@@ -4456,7 +4552,7 @@ func rerankByBestMessage(ss []model.Session, terms []string, idf map[string]floa
 				best[i] = score
 			}
 		}
-	}
+	})
 	// Fuse rather than replace: the pool's own order is session-level IDF
 	// overlap, which wins on a small haystack; the best-message score wins on
 	// a large pile. Reciprocal rank fusion keeps both votes.

--- a/internal/index/token_hits_test.go
+++ b/internal/index/token_hits_test.go
@@ -1,0 +1,58 @@
+package index
+
+import (
+	"strings"
+	"testing"
+)
+
+// tokenHits answers what the ranker actually asks — does this message carry any
+// of these words — without building the message's whole token set. It has to
+// tokenise identically, or the ranking changes with the shortcut.
+func TestTokenHitsAgreesWithTokens(t *testing.T) {
+	texts := []string{
+		"The retry budget was capped at three attempts",
+		"café vs café: the same word, composed and decomposed",
+		"كَتَبَ and हिन्दी carry marks that continue a word",
+		"internal/index/fixpair.go:146 _ = writeGob(fixesPath(tmp), kept)",
+		"MiXeD CaSe and UPPER CASE and lower",
+		"hyphen-joined and under_scored tokens",
+		strings.Repeat("a", 70) + " " + strings.Repeat("b", 130),
+		"один два три ЧЕТЫРЕ",
+		"",
+		"a b c",
+		"日本語のトークン化",
+	}
+	for _, text := range texts {
+		all := tokens(text)
+		want := map[string]bool{}
+		for _, tk := range all {
+			want[tk] = true
+		}
+		// Every token the full tokeniser found must be reported.
+		got := tokenHits(text, want)
+		for _, tk := range all {
+			if !got[tk] {
+				t.Errorf("tokenHits(%.30q) missed %q", text, tk)
+			}
+		}
+		if len(got) != len(want) {
+			t.Errorf("tokenHits(%.30q) found %d tokens, tokens found %d", text, len(got), len(want))
+		}
+		// And a word the text does not carry is not invented.
+		if hit := tokenHits(text, map[string]bool{"quokkabloom": true}); len(hit) != 0 {
+			t.Errorf("tokenHits(%.30q) claimed a word the text lacks: %v", text, hit)
+		}
+	}
+}
+
+// The wanted set is what bounds the answer: a token in the text that nobody
+// asked about is not reported.
+func TestTokenHitsReportsOnlyWhatWasAsked(t *testing.T) {
+	got := tokenHits("the retry budget was capped at three", map[string]bool{"budget": true, "scheduler": true})
+	if !got["budget"] || got["scheduler"] || len(got) != 1 {
+		t.Fatalf("want budget alone, got %v", got)
+	}
+	if tokenHits("anything at all", nil) != nil {
+		t.Error("an empty question got an answer")
+	}
+}

--- a/internal/search/relevance_parallel_test.go
+++ b/internal/search/relevance_parallel_test.go
@@ -1,0 +1,54 @@
+package search
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Hits are built on many cores now — lowercasing every message of every ranked
+// session was the other half of a 2.4 s recall answer. The page an agent reads
+// has to be the same one either way, snippets included.
+func TestRelevanceHitsAreTheSameOnOneCoreAndMany(t *testing.T) {
+	var ss []model.Session
+	for i := range 20 {
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: fmt.Sprintf("s%02d", i),
+			Messages: []model.Message{
+				{Role: "user", Text: fmt.Sprintf("what did we settle about the retry budget in round %d", i)},
+				{Role: "assistant", Text: fmt.Sprintf("capped at %d, and the scheduler stayed single-writer", i%4)},
+			},
+		})
+	}
+	terms := []string{"retry", "budget", "scheduler"}
+	idf := map[string]float64{"retry": 1.5, "budget": 2, "scheduler": 3}
+
+	relevanceWorkers = func() int { return 1 }
+	one := RelevanceHitsWeighted(ss, terms, idf)
+	relevanceWorkers = func() int { return 8 }
+	many := RelevanceHitsWeighted(ss, terms, idf)
+	t.Cleanup(func() { relevanceWorkers = defaultRelevanceWorkers })
+
+	if len(one) != len(many) {
+		t.Fatalf("one core returned %d hits, eight returned %d", len(one), len(many))
+	}
+	for i := range one {
+		if one[i].Session.ID != many[i].Session.ID {
+			t.Fatalf("position %d: one core says %s, eight say %s", i, one[i].Session.ID, many[i].Session.ID)
+		}
+		if one[i].Count != many[i].Count || one[i].Score != many[i].Score {
+			t.Fatalf("%s scored %v/%d on one core and %v/%d on eight",
+				one[i].Session.ID, one[i].Score, one[i].Count, many[i].Score, many[i].Count)
+		}
+		if len(one[i].Snippets) != len(many[i].Snippets) {
+			t.Fatalf("%s carries %d snippets on one core and %d on eight",
+				one[i].Session.ID, len(one[i].Snippets), len(many[i].Snippets))
+		}
+		for j := range one[i].Snippets {
+			if one[i].Snippets[j] != many[i].Snippets[j] {
+				t.Fatalf("%s snippet %d differs between the two paths", one[i].Session.ID, j)
+			}
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2517,8 +2517,14 @@ func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]fl
 	if weight == nil {
 		weight = termWeights(ss, terms)
 	}
-	hits := make([]Hit, 0, len(ss))
-	for rank, s := range ss {
+	hits := make([]Hit, len(ss))
+	// One session's score is read from that session alone, and lowercasing its
+	// messages is where the time goes: profiled on a real store, a recall
+	// answer spent 2.4 s in it and in the ranker's own copy of the same loop.
+	// Spread across cores the way the context renderer already is (#1790) —
+	// the work per session is unchanged, so the answer is identical.
+	parallelForSessions(len(ss), func(rank int) {
+		s := ss[rank]
 		hit := Hit{Session: s, Tier: TierRelevance}
 		// Snippet the messages where the most query terms MEET, not the first
 		// message that contains any one of them. The passage that answers a
@@ -2583,10 +2589,48 @@ func RelevanceHitsWeighted(ss []model.Session, terms []string, idf map[string]fl
 			hit.Snippets = append(hit.Snippets, snippet(s.Messages[best[i].idx].Text, best[i].center, nil))
 		}
 		hit.Score = float64(len(ss) - rank)
-		hits = append(hits, hit)
-	}
+		hits[rank] = hit
+	})
 	return liftedNotes(hits)
 }
+
+// parallelForSessions runs fn over 0..n-1, on one goroutine per core once there
+// is enough work to pay for them. The bound is the same shape renderContextTurns
+// uses: a handful of items is faster on one core than it is to hand out.
+func parallelForSessions(n int, fn func(i int)) {
+	workers := relevanceWorkers()
+	if workers > n {
+		workers = n
+	}
+	if workers < 2 || n < 4 {
+		for i := range n {
+			fn(i)
+		}
+		return
+	}
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= n {
+					return
+				}
+				fn(i)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// relevanceWorkers is a variable so a test can force the single-core path and
+// compare the two orders.
+var relevanceWorkers = defaultRelevanceWorkers
+
+func defaultRelevanceWorkers() int { return runtime.NumCPU() }
 
 // SafeText neutralises what a terminal acts on rather than prints. Transcript
 // text arrives verbatim from a harness, and after `deja sync import` from


### PR DESCRIPTION
Profiled on a real store of 2721 sessions, an MCP `recall` answer took 2.3 s and `recall_context` 2.4 s. Keeping the index fresh was 165 ms of that; the rest was the answer itself, and 40% of its CPU went to lowercasing and tokenising every turn of every ranked session — up to 4000 turns each, fifty sessions, a map and a sort per turn.

Three changes, none of which touch what comes back:

- The ranker's per-session scoring and the relevance tier's hit-building run on all cores. Both were already per-session and independent; tests run each on one core and on eight and compare the order, the scores and the snippets.
- The ranker asks whether a message carries any of the query's words, so it no longer builds the message's whole token set to answer that. `tokenHits` tokenises exactly as `tokens` does — same fold, same rune classes, same two-byte minimum, same flush past 64 bytes — and a test checks the two agree on accents, Arabic marks, CJK, hyphens and a 130-byte word.

`recall` 2274 ms → 957 ms, `recall_context` 2415 ms → 851 ms, `fix` unchanged at 58 ms. `bench recall`, `bench context` and `bench prompt` print identical numbers before and after, and six of seven real MCP answers are byte-identical (the seventh is `blame`, whose score already differs between two identical calls on main).

The fourth change is tokens rather than time: the per-prompt block's 301-byte lead explained itself on every block, and its last sentence repeated the line the block already ends with. A session gets a median of 23 blocks, so 22 of them carried the same sentences. Said once per session now; the untrusted-data line and the citation line stay on every block. Over five prompts in one session: 7391 → 6515 bytes.
