### PR TITLE
perf(redact): the multilingual pattern runs on its own words

### DIFF
--- a/internal/redact/intl_gate_test.go
+++ b/internal/redact/intl_gate_test.go
@@ -1,0 +1,64 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// The international key=value pattern is an alternation of Cyrillic, Chinese,
+// Japanese and Korean words, and it was gated on the whole hint list — so an
+// English transcript that says "token" ran it over every message. Measured
+// over 6.1 MB of real transcript text, that was 2227 ms of the 4523 ms
+// redaction spends, on text the pattern cannot match a byte of.
+func TestTheInternationalPatternRunsOnItsOwnWords(t *testing.T) {
+	// Still redacted, in each script the pattern is written for.
+	for _, secret := range []string{
+		"пароль: hunter2secretvalue123",
+		"токен = abcdefghijklmnopqrstuvwx",
+		"密码: supersecretvalue1234",
+		"contraseña: supersecretvalue1234",
+		"비밀번호: supersecretvalue1234",
+	} {
+		got, counts := Text(secret)
+		if strings.Contains(got, "supersecretvalue1234") || strings.Contains(got, "hunter2secretvalue123") ||
+			strings.Contains(got, "abcdefghijklmnopqrstuvwx") {
+			t.Errorf("%q was stored in the clear: %q", secret, got)
+		}
+		if counts.Total() == 0 {
+			t.Errorf("%q was not counted as a redaction", secret)
+		}
+	}
+	// And the English gate still catches the English shapes, which is what the
+	// other patterns are for.
+	got, _ := Text("api_key: abcdefghijklmnopqrstuvwx")
+	if strings.Contains(got, "abcdefghijklmnopqrstuvwx") {
+		t.Errorf("an English assignment was stored in the clear: %q", got)
+	}
+}
+
+// The gate is a necessary condition, so a text with none of those words does
+// not reach the pattern at all — and one that has the word without an
+// assignment still does not.
+func TestTheInternationalPatternIsNotRunOnEnglishText(t *testing.T) {
+	before := intlPatternRuns.Load()
+	Text("api_key: abcdefghijklmnopqrstuvwx and a token: abcdefghijklmnopqrstuvwx")
+	if intlPatternRuns.Load() != before {
+		t.Error("an English assignment ran the Cyrillic, Chinese, Japanese and Korean alternation")
+	}
+	Text("пароль: hunter2secretvalue123")
+	if intlPatternRuns.Load() == before {
+		t.Error("a Russian assignment did not reach the pattern written for it")
+	}
+}
+
+func TestTheInternationalGateNeedsBothWordAndAssignment(t *testing.T) {
+	if kvAssignmentNearbyHints(strings.ToLower("we spent the whole token budget on this"), kvIntlHints) {
+		t.Error("an English sentence opened the international gate")
+	}
+	if kvAssignmentNearbyHints(strings.ToLower("пароль от вина был простой"), kvIntlHints) {
+		t.Error("a sentence with no assignment opened the gate")
+	}
+	if !kvAssignmentNearbyHints(strings.ToLower("пароль: hunter2secretvalue123"), kvIntlHints) {
+		t.Error("a real assignment did not open the gate")
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -2,6 +2,7 @@ package redact
 
 import (
 	"math"
+	"sync/atomic"
 
 	"github.com/vshulcz/deja-vu/internal/query"
 	"os"
@@ -101,7 +102,12 @@ func Disabled() bool { return os.Getenv("DEJA_NO_REDACT") == "1" }
 // chatter it cost 289µs, which was the single largest item in index-time
 // redaction.
 func kvAssignmentNearby(lower string) bool {
-	for _, hint := range kvHints {
+	return kvAssignmentNearbyHints(lower, kvHints)
+}
+
+// kvAssignmentNearbyHints is kvAssignmentNearby for one pattern's own words.
+func kvAssignmentNearbyHints(lower string, hints []string) bool {
+	for _, hint := range hints {
 		for at := 0; ; {
 			i := strings.Index(lower[at:], hint)
 			if i < 0 {
@@ -156,6 +162,24 @@ var kvHints = []string{
 	"key", "secret", "token", "passw", "authorization",
 	"пароль", "парол", "токен", "секрет", "ключ",
 	"contraseña", "senha", "mot de passe", "passwort",
+	"密码", "密碼", "パスワード", "비밀번호",
+}
+
+// intlPatternRuns counts how often the international pattern is actually run.
+// The gate below cannot be checked by what comes back — text the pattern cannot
+// match reads the same whether it ran or not — and the whole point of the gate
+// is that it does not run, so the count is what a test can hold on to.
+var intlPatternRuns atomic.Int64
+
+// kvIntlHints are the words genericKVIntlRE itself is written from. It was
+// gated on the whole list above, so an English transcript that says "token"
+// ran a case-insensitive alternation of Cyrillic, Chinese, Japanese and Korean
+// words over every message — measured over 6.1 MB of real transcript text,
+// 2227 ms of the 4523 ms redaction spends, and the pattern cannot match a byte
+// of it.
+var kvIntlHints = []string{
+	"пароль", "парол", "токен", "секрет", "ключ",
+	"contraseña", "senha", "passwort",
 	"密码", "密碼", "パスワード", "비밀번호",
 }
 
@@ -227,6 +251,9 @@ func Text(s string) (string, Counts) {
 		s = replaceSubmatch(s, envKeyRE, "credential", counts, func(m []string) string {
 			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
 		})
+	}
+	if kvAssignmentNearbyHints(lower, kvIntlHints) {
+		intlPatternRuns.Add(1)
 		s = replaceSubmatch(s, genericKVIntlRE, "credential", counts, func(m []string) string {
 			return m[1] + m[2] + m[3] + "[redacted:credential]" + closingQuote(m[3], m[5])
 		})


### PR DESCRIPTION
Redaction is 30% of a rebuild's CPU on a real store, and half of that is one pattern: `genericKVIntlRE`, the case-insensitive alternation of Cyrillic, Chinese, Japanese and Korean secret words. It was gated on the whole hint list, so an English transcript that mentions "token" or "key" ran it over every message — 2227 ms of the 4523 ms redaction spends over 6.1 MB of this machine's own transcript text, on text the pattern cannot match a byte of.

Gated on its own words now. Same secrets redacted — a test covers each script the pattern is written for — and the gate stays a necessary condition, so nothing it skips could have matched. The counter the test reads exists because the effect is invisible in the output: text that cannot match reads the same whether the pattern ran or not.

Redaction over the same 6.1 MB: 4523 ms → 2828 ms on a Russian-heavy corpus; an English-only store skips the pattern entirely. A full rebuild's CPU falls from 95.7 s to 90.8 s, wall clock unchanged — the rebuild's wall time is bounded by something else, which is worth its own look.
