### PR TITLE
perf(index): a rebuild takes 30s instead of 51s

### DIFF
--- a/internal/index/fixpair.go
+++ b/internal/index/fixpair.go
@@ -101,9 +101,18 @@ func fixesPath(dir string) string { return filepath.Join(dir, fixesFile) }
 // sidecar here, failures are swallowed: this is an extra, never a reason to
 // fail an index build.
 func buildFixes(tmp string, ss []model.Session, keyOf func(model.Session) string) {
+	// Mining is per session and reads nothing shared, and it was 9.4 s of a
+	// 51 s build on a real store — the longest of the four sidecars, with the
+	// rest of the machine idle. Collected per session and flattened in session
+	// order, so what lands on file does not depend on which worker finished
+	// first.
+	perSession := make([][]FixPair, len(ss))
+	parallelForRanked(len(ss), func(i int) {
+		perSession[i] = fixPairsIn(ss[i].Messages, keyOf(ss[i]), ss[i].Project)
+	})
 	var all []FixPair
-	for _, s := range ss {
-		all = append(all, fixPairsIn(s.Messages, keyOf(s), s.Project)...)
+	for _, pairs := range perSession {
+		all = append(all, pairs...)
 	}
 	if len(all) == 0 {
 		return

--- a/internal/index/fixpair_parallel_test.go
+++ b/internal/index/fixpair_parallel_test.go
@@ -1,0 +1,55 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Mining runs per session on all cores now — it was 9.4 s of a 51 s build, the
+// longest of the four sidecars. What lands on file must not depend on which
+// worker finished first, so the same corpus is mined on one core and on eight
+// and the tables are compared row by row.
+func TestMinedPairsAreTheSameOnOneCoreAndMany(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	var ss []model.Session
+	for i := range 40 {
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: fmt.Sprintf("s%02d", i), Project: "app", Updated: now,
+			Messages: []model.Message{
+				{Role: "command", Text: fmt.Sprintf("grep -rn \"quokkabloom%d\" --include=*.go internal", i), Time: now},
+				{Role: "tool-output", Text: "zsh:1: no matches found: --include=*.go", Time: now.Add(time.Second)},
+				{Role: "command", Text: fmt.Sprintf("grep -rn \"quokkabloom%d\" --include=\"*.go\" internal", i), Time: now.Add(2 * time.Second)},
+				{Role: "tool-output", Text: "3 matches", Time: now.Add(3 * time.Second)},
+				{Role: "command", Text: "make check", Time: now.Add(4 * time.Second)},
+				{Role: "tool-output", Text: fmt.Sprintf("--- FAIL: TestSnorbleWidget%d", i), Time: now.Add(5 * time.Second)},
+				{Role: "edit", Text: fmt.Sprintf("internal/widget/snorble%d.go\n-\tone\n+\ttwo", i), Time: now.Add(6 * time.Second)},
+			},
+		})
+	}
+	keyOf := func(s model.Session) string { return s.Harness + ":" + s.ID }
+
+	build := func(workers int) []FixPair {
+		rerankWorkers = func() int { return workers }
+		dir := t.TempDir()
+		buildFixes(dir, ss, keyOf)
+		return ReadFixes(dir)
+	}
+	one := build(1)
+	many := build(8)
+	t.Cleanup(func() { rerankWorkers = defaultRerankWorkers })
+
+	if len(one) == 0 {
+		t.Fatal("nothing was mined, so the comparison proves nothing")
+	}
+	if len(one) != len(many) {
+		t.Fatalf("one core mined %d pairs, eight mined %d", len(one), len(many))
+	}
+	for i := range one {
+		if one[i] != many[i] {
+			t.Fatalf("row %d differs:\n one core: %+v\n eight:    %+v", i, one[i], many[i])
+		}
+	}
+}

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -613,14 +613,25 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// under the previous phase's last percentage, so the bar sat still through
 	// it (#3372).
 	reportPhase("mining fixes and commands", 4)
-	buildCooccur(tmp, ss)
-	reportAdvance(1)
-	buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID })
-	reportAdvance(1)
-	buildCommands(tmp, ss)
-	reportAdvance(1)
-	buildCommandFails(tmp, ss)
-	reportAdvance(1)
+	// Four passes over the same sessions, each writing its own file and reading
+	// nothing the others write, so they run together rather than one after the
+	// other. Profiled on a real store, they were 9.4 s (fixes) and 6.0 s
+	// (co-occurrence) of a 51 s build, with the whole machine idle beside them.
+	var sidecars sync.WaitGroup
+	for _, build := range []func(){
+		func() { buildCooccur(tmp, ss) },
+		func() { buildFixes(tmp, ss, func(s model.Session) string { return s.Harness + ":" + s.ID }) },
+		func() { buildCommands(tmp, ss) },
+		func() { buildCommandFails(tmp, ss) },
+	} {
+		sidecars.Add(1)
+		go func() {
+			defer sidecars.Done()
+			build()
+			reportAdvance(1)
+		}()
+	}
+	sidecars.Wait()
 	reportPhase("writing index", sp.bucketCount())
 	if err := sp.writeBuckets(filepath.Join(tmp, "buckets")); err != nil {
 		return err


### PR DESCRIPTION
A full rebuild of a 2721-session store took 51 s of wall clock and 91 s of CPU — 1.8 cores of ten. Profiled, the idle part was the sidecar phase: four passes over the same sessions, one after another, each single-threaded. Fix mining alone was 9.4 s and co-occurrence 6.0 s.

The four run together now — each reads the sessions and writes its own file, and none reads what another writes — and fix mining runs per session across cores. Mined pairs are collected per session and flattened in session order, so the table does not depend on which worker finished first; a test mines the same corpus on one core and on eight and compares the rows.

51.5 s → 29.6 s wall, 90.8 s → 67.4 s CPU on the same store. Race detector clean on the package.

Co-occurrence is now the longest of the four at 6 s. It interns tokens into one shared map, so spreading it needs per-worker tables and a merge — worth its own change.
