### PR TITLE
perf(index): a record's role sits outside its compressed body

### DIFF
--- a/internal/index/coverage_extra_test.go
+++ b/internal/index/coverage_extra_test.go
@@ -564,11 +564,15 @@ func TestCurrentFilesAllHarnessesAndRecordEdgeCases(t *testing.T) {
 	}
 	buf = binary.AppendUvarint(buf, rtbl.intern("src"))
 	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("decode missing role err=%v", err)
+	}
+	buf = binary.AppendUvarint(buf, rtbl.intern("role"))
+	if _, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("decode missing encoding flag err=%v", err)
 	}
 	buf = append(buf, recordRaw)
-	buf = appendField(buf, "role")
-	if rec, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) || rec.Key != "k" || rec.SourcePath != "src" {
+	if rec, err := decodeRecord(buf, rtbl); !errors.Is(err, io.ErrUnexpectedEOF) ||
+		rec.Key != "k" || rec.SourcePath != "src" || rec.Role != "role" {
 		t.Fatalf("decode missing time rec=%#v err=%v", rec, err)
 	}
 	buf = binary.LittleEndian.AppendUint64(buf, uint64(time.Now().UnixNano()))
@@ -854,14 +858,15 @@ func TestRequestedCodecLineAndSubstringBranches(t *testing.T) {
 	for _, data := range [][]byte{
 		{0x80},
 		{1, 1},
-		{1, 1, recordRaw},
+		{1, 1, 1},
+		{1, 1, 1, recordRaw},
 	} {
 		if _, err := decodeRecord(data, newRecordTables()); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("decodeRecord(%v) err=%v", data, err)
 		}
 	}
 	// An encoding byte the reader does not know is corruption, not EOF.
-	if _, err := decodeRecord([]byte{1, 1, 9}, newRecordTables()); !IsCorrupt(err) {
+	if _, err := decodeRecord([]byte{1, 1, 1, 9}, newRecordTables()); !IsCorrupt(err) {
 		t.Fatalf("unknown encoding flag err=%v, want a corruption error", err)
 	}
 	recPath := filepath.Join(tmp, "records.bin")

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -183,7 +183,13 @@ import (
 // navigation guard guarded nothing: 36 of 163 such answers were a different
 // program or `cd` elsewhere. The wrapper the shell could not find is now
 // transparent too, so `timeout 12 launchctl …` is repaired by `launchctl …`.
-const version = 37
+// 38 moves a record's role out of its compressed body. Scanning for one kind
+// of record — every command in the store, which is what `deja how` asks —
+// inflated all 280,000 records to read the 20,000 it wanted, and 53% of that
+// command's time was flate. The role is interned beside the session key now, so
+// the scan reads a prefix and skips the rest. Records are the store itself, so
+// the layout change is what forces this bump.
+const version = 38
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message

--- a/internal/index/records_corrupt_test.go
+++ b/internal/index/records_corrupt_test.go
@@ -64,8 +64,12 @@ func TestFirstMatchSurfacesCorruption(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// [size][keyID][pathID][roleID][flag]: past the three interned ids is the
+	// encoding byte, and an unknown one is corruption.
 	off := 4
 	_, k := binary.Uvarint(b[off:])
+	off += k
+	_, k = binary.Uvarint(b[off:])
 	off += k
 	_, k = binary.Uvarint(b[off:])
 	off += k
@@ -101,8 +105,12 @@ func TestEachRecordAtSurfacesCorruption(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Flip the first record's encoding flag (after the two leading varints).
+	// [size][keyID][pathID][roleID][flag]: past the three interned ids is the
+	// encoding byte, and an unknown one is corruption.
 	off := 4
 	_, k := binary.Uvarint(b[off:])
+	off += k
+	_, k = binary.Uvarint(b[off:])
 	off += k
 	_, k = binary.Uvarint(b[off:])
 	off += k

--- a/internal/index/role_scan_test.go
+++ b/internal/index/role_scan_test.go
@@ -1,0 +1,89 @@
+package index
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A record's role sits outside its compressed body, so a scan for one kind of
+// record reads a prefix and skips the rest instead of inflating all of them:
+// `deja how` asks for every command in the store and was decompressing all
+// 280,000 records to read 20,000, which was 53% of its time. What it hands back
+// has to be exactly what filtering after a full decode gives.
+func TestARoleScanReturnsWhatAFullScanWouldFilter(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "role-index")
+	now := time.Now().UTC().Truncate(time.Second)
+	var ss []model.Session
+	for i := range 12 {
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: fmt.Sprintf("s%02d", i), Project: "app", Updated: now,
+			Messages: []model.Message{
+				{Role: "user", Text: fmt.Sprintf("session %d asks about the retry budget", i), Time: now},
+				{Role: "command", Text: fmt.Sprintf("go test ./internal/pool -run TestDrain%d", i), Time: now.Add(time.Second)},
+				{Role: "tool-output", Text: strings.Repeat("output line that compresses well\n", 8), Time: now.Add(2 * time.Second)},
+				{Role: "edit", Text: fmt.Sprintf("internal/pool/pool%d.go\n-\tone\n+\ttwo", i), Time: now.Add(3 * time.Second)},
+				{Role: "assistant", Text: "capped the retry budget at three", Time: now.Add(4 * time.Second)},
+			},
+		})
+	}
+	if err := os.MkdirAll(filepath.Join(dir+".tmp", "buckets"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSessions(dir+".tmp", dir, ss, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	m, err := readManifest(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tables := tablesFromManifest(m)
+	recs := filepath.Join(dir, "records.bin")
+
+	for _, role := range []string{"command", "edit", "user", "assistant", "tool-output"} {
+		var want, got []Record
+		if err := eachRecord(recs, tables, func(r Record) {
+			if r.Role == role {
+				want = append(want, r)
+			}
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := eachRecordInRoles(recs, tables, map[string]bool{role: true}, func(r Record) {
+			got = append(got, r)
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if len(want) == 0 {
+			t.Fatalf("no %s records were written, so the comparison proves nothing", role)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s: the role scan returned %d records, the full scan %d", role, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s record %d differs:\n scan: %+v\n full: %+v", role, i, got[i], want[i])
+			}
+		}
+	}
+
+	// Two roles at once keep the order they were written in, which is what a
+	// caller pairing a command with its output depends on.
+	var pairs []string
+	if err := eachRecordInRoles(recs, tables, map[string]bool{"command": true, "tool-output": true}, func(r Record) {
+		pairs = append(pairs, r.Role)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		if pairs[i] != "command" || pairs[i+1] != "tool-output" {
+			t.Fatalf("the two roles came back out of order: %v", pairs[:min(8, len(pairs))])
+		}
+	}
+}

--- a/internal/index/store_io.go
+++ b/internal/index/store_io.go
@@ -216,6 +216,65 @@ func eachRecordUntil(path string, t *recordTables, fn func(Record) bool) error {
 	}
 }
 
+// recordRoleIn reads only what a record's prefix says: whose session it is and
+// what kind of record it is. Nothing is inflated, which is the point.
+func recordRoleIn(b []byte, t *recordTables) (key, role string, ok bool) {
+	kid, n := binary.Uvarint(b)
+	if n <= 0 {
+		return "", "", false
+	}
+	b = b[n:]
+	_, n = binary.Uvarint(b)
+	if n <= 0 {
+		return "", "", false
+	}
+	b = b[n:]
+	rid, n := binary.Uvarint(b)
+	if n <= 0 {
+		return "", "", false
+	}
+	return t.lookup(kid), t.lookup(rid), true
+}
+
+// eachRecordInRoles streams the records whose role is wanted, reading the
+// prefix of every record and the body of only those. Same order and same
+// records as filtering after a full decode, at a fraction of the work.
+func eachRecordInRoles(path string, t *recordTables, want map[string]bool, fn func(Record)) error {
+	f, err := openIndexFile(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	r := bufio.NewReaderSize(f, 1024*1024)
+	var hdr [4]byte
+	buf := make([]byte, 0, 64*1024)
+	for {
+		if _, err := io.ReadFull(r, hdr[:]); err != nil {
+			return nil
+		}
+		size := binary.LittleEndian.Uint32(hdr[:])
+		if size > maxRecordSize {
+			return fmt.Errorf("%w: record length %d exceeds cap", errCorruptIndex, size)
+		}
+		if cap(buf) < int(size) {
+			buf = make([]byte, size)
+		}
+		payload := buf[:size]
+		if _, err := io.ReadFull(r, payload); err != nil {
+			return nil
+		}
+		_, role, ok := recordRoleIn(payload, t)
+		if !ok || !want[role] {
+			continue
+		}
+		rec, err := decodeRecord(payload, t)
+		if err != nil {
+			return err
+		}
+		fn(rec)
+	}
+}
+
 func eachRecord(path string, t *recordTables, fn func(Record)) error {
 	f, err := openIndexFile(path)
 	if err != nil {
@@ -433,14 +492,19 @@ var inflateReaders = sync.Pool{New: func() any { return flate.NewReader(nil) }}
 // payload so a walk can peek the key and skip the record without inflating
 // anything — that path never touches a compressed byte.
 func encodeRecord(r Record, t *recordTables) []byte {
-	body := make([]byte, 0, len(r.Role)+len(r.Text)+24)
-	body = appendField(body, r.Role)
+	body := make([]byte, 0, len(r.Text)+24)
 	body = binary.LittleEndian.AppendUint64(body, uint64(recordNanos(r.Time)))
 	body = appendField(body, r.Text)
 
 	b := make([]byte, 0, len(body)+16)
 	b = binary.AppendUvarint(b, t.intern(r.Key))
 	b = binary.AppendUvarint(b, t.intern(r.SourcePath))
+	// The role sits outside the compressed body so a scan for one kind of
+	// record can skip the rest without inflating them. It used to be the first
+	// field inside the body, which made "every command in the store" — what
+	// `deja how` asks — decompress all 280,000 records to read 20,000 of them:
+	// 53% of that command's time was flate.
+	b = binary.AppendUvarint(b, t.intern(r.Role))
 	if len(body) < compressFloor {
 		return append(append(b, recordRaw), body...)
 	}
@@ -479,8 +543,14 @@ func decodeRecord(b []byte, t *recordTables) (Record, error) {
 		return rec, io.ErrUnexpectedEOF
 	}
 	b = b[n:]
+	rid, n := binary.Uvarint(b)
+	if n <= 0 {
+		return rec, io.ErrUnexpectedEOF
+	}
+	b = b[n:]
 	rec.Key = t.lookup(kid)
 	rec.SourcePath = t.lookup(pid)
+	rec.Role = t.lookup(rid)
 	if len(b) < 1 {
 		return rec, io.ErrUnexpectedEOF
 	}
@@ -500,9 +570,6 @@ func decodeRecord(b []byte, t *recordTables) (Record, error) {
 		b = body
 	} else if flag != recordRaw {
 		return rec, fmt.Errorf("%w: unknown record encoding %d", errCorruptIndex, flag)
-	}
-	if rec.Role, b, ok = consumeField(b); !ok {
-		return rec, io.ErrUnexpectedEOF
 	}
 	if len(b) < 8 {
 		return rec, io.ErrUnexpectedEOF
@@ -1291,14 +1358,12 @@ func eachRecordOfRoles(dir string, roles map[string]bool, fn func(SessionMeta, R
 		dir = DefaultDir()
 	}
 	return walkRecordsStable(dir, func(m Manifest) error {
-		return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
-			if !roles[r.Role] {
-				return
-			}
-			if meta, ok := m.Sessions[r.Key]; ok {
-				fn(meta, r)
-			}
-		})
+		return eachRecordInRoles(filepath.Join(dir, "records.bin"), tablesFromManifest(m), roles,
+			func(r Record) {
+				if meta, ok := m.Sessions[r.Key]; ok {
+					fn(meta, r)
+				}
+			})
 	})
 }
 
@@ -1311,14 +1376,12 @@ func EachRecordOfRole(dir, role string, fn func(SessionMeta, Record)) error {
 		dir = DefaultDir()
 	}
 	return walkRecordsStable(dir, func(m Manifest) error {
-		return eachRecord(filepath.Join(dir, "records.bin"), tablesFromManifest(m), func(r Record) {
-			if r.Role != role {
-				return
-			}
-			if meta, ok := m.Sessions[r.Key]; ok {
-				fn(meta, r)
-			}
-		})
+		return eachRecordInRoles(filepath.Join(dir, "records.bin"), tablesFromManifest(m),
+			map[string]bool{role: true}, func(r Record) {
+				if meta, ok := m.Sessions[r.Key]; ok {
+					fn(meta, r)
+				}
+			})
 	})
 }
 


### PR DESCRIPTION
`deja how` asks for every command in the store. The role was the first field inside a record's deflated body, so answering that meant inflating all 280,000 records to read the 20,000 wanted — profiled, 53% of the command's time was flate.

The role is interned beside the session key and the source path now, in the prefix, so a role-scoped scan reads a few varints per record and inflates only the matches. `EachRecordOfRole` and its two-role sibling go through the new walker; `deja restore`'s span inventory and the command/output pairing get the same skip for free.

On a 2721-session store, both indexes freshly built: `how` 286 ms → 96 ms. Every other surface is unchanged (recall 629→627 ms, blame 272→271 ms), and `how`'s output is identical line for line.

Index version 38 — records are the store, so the layout change forces the rebuild. A test writes an index and compares a role scan against filtering after a full decode, role by role, and checks that two roles asked for together still come back in written order.
