### PR TITLE
perf(index): the neighbour map is mined on all cores

### DIFF
--- a/internal/index/cooccur.go
+++ b/internal/index/cooccur.go
@@ -51,25 +51,36 @@ func buildCooccur(tmp string, ss []model.Session) {
 		toks = append(toks, t)
 		return v
 	}
-	var df []int
-	perSession := make([][]uint32, 0, len(ss))
-	seen := map[uint32]bool{}
-	for _, s := range ss {
-		clear(seen)
-		for _, m := range s.Messages {
+	// Tokenising every message of every session is what this pass costs — 6.0 s
+	// of a build on a real store, and the only single-threaded thing left in
+	// the sidecar phase. Each session's distinct tokens are collected in
+	// parallel and interned afterwards in session order, so the ids, the
+	// document frequencies and everything downstream are what one core
+	// produced.
+	uniquePerSession := make([][]string, len(ss))
+	parallelForRanked(len(ss), func(i int) {
+		seen := make(map[string]bool, 256)
+		var out []string
+		for _, m := range ss[i].Messages {
 			for _, tok := range tokens(m.Text) {
 				if len(tok) < 4 || query.IsStopWord(tok) {
 					continue
 				}
-				v := id(tok)
-				if seen[v] {
+				if seen[tok] {
 					continue
 				}
-				seen[v] = true
+				seen[tok] = true
+				out = append(out, tok)
 			}
 		}
-		list := make([]uint32, 0, len(seen))
-		for v := range seen {
+		uniquePerSession[i] = out
+	})
+	var df []int
+	perSession := make([][]uint32, 0, len(ss))
+	for _, unique := range uniquePerSession {
+		list := make([]uint32, 0, len(unique))
+		for _, tok := range unique {
+			v := id(tok)
 			list = append(list, v)
 			for len(df) <= int(v) {
 				df = append(df, 0)

--- a/internal/index/cooccur_parallel_test.go
+++ b/internal/index/cooccur_parallel_test.go
@@ -1,0 +1,62 @@
+package index
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// Tokenising every message of every session was 6 s of a build and the last
+// single-threaded pass in the sidecar phase. Each session's distinct tokens are
+// collected in parallel and interned afterwards in session order, so the ids,
+// the document frequencies and the neighbour map are what one core produced.
+func TestNeighbourMapIsTheSameOnOneCoreAndMany(t *testing.T) {
+	// A word has to appear in at least three sessions and in at most a quarter
+	// of them to be banded at all, so the corpus is twelve clusters of five
+	// sessions, each cluster with its own pair of words.
+	var ss []model.Session
+	for cluster := range 12 {
+		for n := range 5 {
+			ss = append(ss, model.Session{
+				Harness: "claude", ID: fmt.Sprintf("s%02d-%d", cluster, n), Project: "app",
+				Messages: []model.Message{
+					{Role: "user", Text: fmt.Sprintf("quokkabloom%02d keeps losing rows", cluster)},
+					{Role: "assistant", Text: fmt.Sprintf("snorblewidget%02d rotation fixed quokkabloom%02d for good", cluster, cluster)},
+					{Role: "assistant", Text: fmt.Sprintf("run %d of the same routine", n)},
+				},
+			})
+		}
+	}
+
+	build := func(workers int) map[string][]string {
+		rerankWorkers = func() int { return workers }
+		dir := t.TempDir()
+		buildCooccur(dir, ss)
+		return readCooccur(dir)
+	}
+	one := build(1)
+	many := build(8)
+	t.Cleanup(func() { rerankWorkers = defaultRerankWorkers })
+
+	if len(one) == 0 {
+		t.Fatal("no neighbours were mined, so the comparison proves nothing")
+	}
+	if len(one) != len(many) {
+		t.Fatalf("one core mined %d tokens, eight mined %d", len(one), len(many))
+	}
+	for tok, want := range one {
+		got, ok := many[tok]
+		if !ok {
+			t.Fatalf("%q has neighbours on one core and none on eight", tok)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%q: %d neighbours on one core, %d on eight", tok, len(want), len(got))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%q neighbour %d: one core says %q, eight say %q", tok, i, want[i], got[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
The neighbour map's first pass tokenises every message of every session to count document frequencies. It was the last single-threaded thing in the sidecar phase — 6.0 s of a build on a 2721-session store.

Each session's distinct tokens are collected in parallel and interned afterwards in session order, so the ids, the frequencies and the neighbour lists are what one core produced. A test builds the map on one core and on eight over the same corpus and compares the lists token by token.

Rebuild 29.3 s → 26.9 s, and the sidecar phase from 6.0 s to under 2 s. Race detector clean.

With this the rebuild's phases stand at: reading transcripts 10.8 s, redaction 7.3 s, records and spill 3.9 s, sidecars 2.0 s, buckets 1.5 s. Reading is next, and it is already parallel per store and per file — 16.3 s of CPU in 10.8 s of wall, so what is left there is one enormous transcript being parsed by one worker.
