### PR TITLE
fix(hook): the start block leads with what was settled

### DIFF
--- a/internal/bench/context.go
+++ b/internal/bench/context.go
@@ -15,15 +15,18 @@ import (
 const (
 	ContextChainCount    = 30
 	ContextNegativeCount = 5
-	// Seven, not three: with one fact per session and the rest naming the
-	// chain without settling anything, the block has to choose what to quote.
-	// At three every arm scored 1.00 whatever the digest did, which is what
-	// made the coverage column unable to move (#2931, #2933).
-	ContextPriorCount = 7
-	// contextFactEvery spreads the three facts over the prior sessions instead
-	// of filing them in the first three: with ContextPriorCount at 7 they land
-	// in the first, fourth and seventh (#2931).
-	contextFactEvery = 3
+	// Fourteen priors and eight facts, the facts in the oldest eight sessions
+	// and the six newest settling nothing. Two properties the column needs: a
+	// block that reads the newest sessions finds nothing, and a block that
+	// prefers the sessions which settled something still cannot carry all eight
+	// within its budget — so the coverage can move in both directions and
+	// saturation is out of reach. At seven priors and three facts it reached two
+	// by recency and the third by choosing well, and once the choosing was
+	// fixed every arm scored 1.00 with nowhere left for a regression to show
+	// (#2931, #2933).
+	ContextPriorCount = 14
+	// contextFactEvery spreads the facts one per session over the oldest eight.
+	contextFactEvery = 1
 )
 
 type ContextChain struct {
@@ -58,6 +61,11 @@ func GenerateContext(seed int64) ContextCorpus {
 				fmt.Sprintf("%s fact: error fixed by replacing stale etag reuse with generation checks", id),
 				fmt.Sprintf("%s fact: option chosen was bounded refresh with jitter because retries must spread load", id),
 				fmt.Sprintf("%s fact: config value settled at context_ttl=%dm", id, 10+i%7),
+				fmt.Sprintf("%s fact: we decided the retry budget stops at three attempts", id),
+				fmt.Sprintf("%s fact: the scheduler stays single-writer, so the failover drains first", id),
+				fmt.Sprintf("%s fact: agreed to key the cache on generation rather than on mtime", id),
+				fmt.Sprintf("%s fact: settled that the nightly compaction runs after the export", id),
+				fmt.Sprintf("%s fact: chose to drop the second index instead of widening the first", id),
 			}
 			chain.Task = fmt.Sprintf("Handle %s using the prior error, chosen option, and settled context_ttl value.", id)
 			chain.Terms = []string{id}

--- a/internal/bench/prompt.go
+++ b/internal/bench/prompt.go
@@ -339,6 +339,12 @@ func promptShapeChain(rng *rand.Rand, i int, kind string, topic promptTopic, sta
 	return chain
 }
 
+// PromptPriorCount is how many prior sessions each prompt chain holds. It was
+// the context corpus's constant, so raising that one to make the block's
+// coverage column movable silently doubled this corpus and moved a negative
+// control with it.
+const PromptPriorCount = 7
+
 // GeneratePrompt builds one chain per topic: three prior sessions carrying the
 // fact under working noise, and no task session — the question comes from the
 // caller, the way a prompt does.
@@ -358,7 +364,7 @@ func GeneratePrompt(seed int64) PromptCorpus {
 			Question:   topic.question,
 			Paraphrase: topic.paraphrase,
 		}
-		for j := 0; j < ContextPriorCount; j++ {
+		for j := 0; j < PromptPriorCount; j++ {
 			t := base.Add(time.Duration(i*10+j) * time.Minute)
 			msgs := []model.Message{{Role: "user", Text: fmt.Sprintf("we decided %s", topic.fact), Time: t}}
 			for k := 0; k < 4+rng.Intn(6); k++ {

--- a/internal/search/recall.go
+++ b/internal/search/recall.go
@@ -111,6 +111,11 @@ func AutoRecallDigestShowing(ss []model.Session, budget int, terms []string, ask
 	return strings.TrimSpace(b.String()), shown
 }
 
+// settledProbeBudget is how much of a session the ordering reads to ask whether
+// it concluded anything. The same budget the block itself renders with, so the
+// question is about the lines that would be shown.
+const settledProbeBudget = 400
+
 // BuildAutoRecall applies the session-start recall policy while constructing
 // the digest. Unknown modes use the safe policy.
 func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
@@ -125,6 +130,19 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 		o.Now = time.Now()
 	}
 	candidates := append([]model.Session(nil), ss...)
+	// A session that settled something beats one that did not, whatever their
+	// dates. Measured on the context benchmark: the block served six sessions
+	// newest-first, four of them carrying "routine update, nothing settled
+	// here", and the session holding how the error was fixed never got a slot —
+	// a third of the corpus's facts, present in the per-hit digest and missing
+	// from the block an agent is handed at session start. The per-prompt hook
+	// has led with the concluding session since #1475; this is the same rule on
+	// the other surface.
+	settled := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		lines := digest.Conclusions(c, settledProbeBudget, 1)
+		settled[c.Harness+":"+c.ID] = len(lines) > 0 && digest.CarriesDecision(lines[0])
+	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		ti := o.TaskScores[candidates[i].Harness+":"+candidates[i].ID]
 		tj := o.TaskScores[candidates[j].Harness+":"+candidates[j].ID]
@@ -136,6 +154,11 @@ func BuildAutoRecall(ss []model.Session, o AutoRecallOptions) AutoRecallResult {
 			if iNew != jNew {
 				return iNew
 			}
+		}
+		iSet := settled[candidates[i].Harness+":"+candidates[i].ID]
+		jSet := settled[candidates[j].Harness+":"+candidates[j].ID]
+		if iSet != jSet {
+			return iSet
 		}
 		iRecent := !candidates[i].Updated.Before(o.Now.AddDate(0, 0, -90))
 		jRecent := !candidates[j].Updated.Before(o.Now.AddDate(0, 0, -90))

--- a/internal/search/recall_settled_test.go
+++ b/internal/search/recall_settled_test.go
@@ -1,0 +1,64 @@
+package search
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The block handed over at session start served the newest sessions, and on the
+// context benchmark four of its six slots carried "routine update, nothing
+// settled here" while the session holding how the error was fixed never got
+// one — a third of that corpus's facts, present in the per-hit digest and
+// missing from the block. A session that settled something now beats one that
+// did not, whatever their dates.
+func TestTheStartBlockPrefersSessionsThatSettledSomething(t *testing.T) {
+	now := time.Now()
+	var ss []model.Session
+	// Newest first: four that settled nothing, then the two that did.
+	for i := range 4 {
+		ss = append(ss, model.Session{
+			Harness: "claude", ID: fmt.Sprintf("idle-%d", i), Project: "org/app",
+			Updated: now.Add(-time.Duration(i) * time.Hour),
+			Messages: []model.Message{
+				{Role: "user", Text: "routine update on the etag cache, nothing settled here"},
+				{Role: "assistant", Text: "looked at the etag cache and the refresh path, still reading"},
+			},
+		})
+	}
+	ss = append(ss, model.Session{
+		Harness: "claude", ID: "decided", Project: "org/app",
+		Updated: now.Add(-10 * time.Hour),
+		Messages: []model.Message{
+			{Role: "user", Text: "what do we do about the etag cache refresh"},
+			{Role: "assistant", Text: "we decided to use bounded refresh with jitter because retries must spread load"},
+		},
+	})
+	ss = append(ss, model.Session{
+		Harness: "claude", ID: "fixed", Project: "org/app",
+		Updated: now.Add(-20 * time.Hour),
+		Messages: []model.Message{
+			{Role: "user", Text: "the etag reuse keeps serving stale bodies"},
+			{Role: "assistant", Text: "fixed it by replacing stale etag reuse with generation checks"},
+		},
+	})
+
+	got := BuildAutoRecall(ss, AutoRecallOptions{
+		Mode: RecallSafe, ProjectNames: []string{"org/app"}, Now: now,
+	})
+	if got.Sessions == 0 {
+		t.Fatal("the digest served nothing")
+	}
+	for _, want := range []string{"bounded refresh with jitter", "replacing stale etag reuse"} {
+		if !strings.Contains(got.Text, want) {
+			t.Errorf("the block dropped what was settled (%q):\n%s", want, got.Text)
+		}
+	}
+	// And the sessions it led with are those two, not the four newer ones.
+	if len(got.IDs) < 2 || (got.IDs[0] != "decided" && got.IDs[0] != "fixed") {
+		t.Errorf("the block opened on %v, not on a session that settled something", got.IDs)
+	}
+}


### PR DESCRIPTION
The block handed over at session start served the newest sessions. On the context benchmark that meant six slots, four of them carrying "routine update, nothing settled here", while the session holding how the error was fixed never got one: a third of the corpus's facts, present in the per-hit digest and missing from the block. The per-prompt hook has led with the concluding session since #1475; this is the same rule on the other surface, applied after the task score and the novelty ordering so neither loses its say.

That exposed a second thing. The coverage column was only movable because the block chose badly — with the choosing fixed, every arm scored 1.00 and a regression in the block had nowhere to show, which is the state #2931 and #2933 exist to prevent. The context corpus now holds eight facts in its eight oldest prior sessions and six newer ones that settle nothing, so the column cannot saturate (eight facts, six slots, a budget that carries four) and it moves in both directions:

| | before | after |
| --- | --- | --- |
| deja-block coverage, old ordering | 0.67 | 0.00 |
| deja-block coverage, new ordering | 1.00 (saturated) | 0.50 |
| deja-recall (the union) | 1.00 | 1.00 |

The corpus hash moves with this, and the prompt corpus does not: it was reading the context corpus's session-count constant, so raising that one silently doubled it and moved a negative control. It has its own constant now, and `bench prompt`, `bench recall` and `bench block` print what they printed before.

What this does not show: on a real store the block is byte-identical before and after across eight of this machine's projects. Every candidate those blocks were built from already carried a conclusion, so the new tiebreak never fires. It bites where recent sessions settled nothing and older ones did — the shape the corpus holds, and the shape the per-prompt hook already guards against.
