### PR TITLE
fix(blame): a row names a few touched files, not forty

### DIFF
--- a/cmd/deja/blame_touched_cap_test.go
+++ b/cmd/deja/blame_touched_cap_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/search"
+)
+
+// A blame row carried every file its session touched — up to the forty the
+// manifest holds. Measured on a real store, that was 3186 of an 8044-byte
+// answer, about files the question did not ask about, and the answer is trimmed
+// by dropping whole sessions to fit its budget: six real paths came back with 20
+// sessions and 9.9 KB of quoted history, and with the list bounded the same
+// budget carried 38 sessions and 15.7 KB.
+func TestABlameRowNamesAFewTouchedFilesNotForty(t *testing.T) {
+	var touched []string
+	for i := range 30 {
+		touched = append(touched, fmt.Sprintf("/work/app/internal/thing%02d.go", i))
+	}
+	hit := search.BlameHit{
+		Session: model.Session{
+			Harness: "claude", ID: "s1", Project: "app",
+			Title: "touched a great many files", Touched: touched,
+		},
+		Count: 1, Snippets: []string{"… internal/thing00.go …"},
+	}
+	body := mustMarshalBlame([]search.BlameHit{hit}, 0, false)
+
+	var rows []map[string]any
+	if err := json.Unmarshal(body, &rows); err != nil {
+		t.Fatal(err)
+	}
+	var got []any
+	for _, row := range rows {
+		sess, ok := row["session"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if list, ok := sess["touched"].([]any); ok {
+			got = list
+		}
+	}
+	if len(got) == 0 {
+		t.Fatal("the row names no touched file at all")
+	}
+	if len(got) > blameTouchedCap {
+		t.Errorf("the row names %d touched files, which is the manifest's list rather than a few", len(got))
+	}
+	// The head of the list is the most-touched end, so that is what survives.
+	if first, _ := got[0].(string); !strings.HasSuffix(first, "thing00.go") {
+		t.Errorf("the kept file is %q, not the one the session touched most", first)
+	}
+}

--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -850,6 +850,27 @@ func mustMarshalBlameNote(note string) []byte {
 	return b
 }
 
+// blameTouchedCap bounds the files a blame row names beside the one asked about.
+//
+// The manifest holds up to forty per session, ordered by how often the session
+// touched them, and the whole list was served: measured on a real store, that
+// was 3186 of an 8044-byte answer — 40% of the second most-called tool's
+// payload — about files the question did not ask about. Three is what the
+// documented field says it is, "the few files this session worked on most", and
+// the head of that list is the most-touched ones. A co-change line was weighed
+// instead and dropped: over eight real paths the recurring neighbour appeared
+// in one session of one.
+const blameTouchedCap = 3
+
+// fewestTouched keeps the head of the touched list, which is its most-touched
+// end.
+func fewestTouched(paths []string) []string {
+	if len(paths) <= blameTouchedCap {
+		return paths
+	}
+	return paths[:blameTouchedCap]
+}
+
 func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []byte {
 	out := make([]any, 0, len(hits)+3)
 	// What every other door says before handing an agent transcript text: the
@@ -873,7 +894,8 @@ func mustMarshalBlame(hits []search.BlameHit, omitted int, refreshing bool) []by
 			Session: blameSessionJSON{
 				ID: h.Session.ID, Harness: h.Session.Harness, Project: h.Session.Project,
 				Path: h.Session.Path, Title: search.SafeNoteTitle(h.Session.Title),
-				Started: h.Session.Started, Updated: h.Session.Updated, Touched: h.Session.Touched,
+				Started: h.Session.Started, Updated: h.Session.Updated,
+				Touched: fewestTouched(h.Session.Touched),
 			},
 			Title: search.SafeNoteTitle(h.Session.Title), Count: h.Count, Score: h.Score,
 			Specificity: h.Specificity,

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -802,6 +802,13 @@ Returns a JSON array of blame hits (same stability rules as exact search):
 ]
 ```
 
+Each row also carries the session's `touched` list, bounded to the three files
+it worked on most. The manifest holds up to forty, and serving all of them spent
+3186 of an 8044-byte answer on files the question did not ask about — and the
+answer is trimmed by dropping whole sessions to fit its budget, so those bytes
+cost history. Over six real paths the same budget went from 20 sessions and
+9.9 KB of quoted text to 38 sessions and 15.7 KB.
+
 `specificity` says whether the session wrote the file as a path or as a bare
 name. It orders the list ahead of `score`, so a session that spelled the path
 out comes before one that only mentioned the filename. It is deliberately


### PR DESCRIPTION
`blame` is the second most-called tool in this machine's usage log — 248 calls — and has the largest payload of them all at ~7 KB. Measured field by field on a real answer, 3186 of its 8044 bytes were the `touched` list: every file each session worked on, up to the forty the manifest holds, for a question about one file.

That is not merely waste. The answer is trimmed to its budget by dropping whole sessions, so those bytes were paid for in history. Over six real paths, at the same budget:

| | before | after |
| --- | --- | --- |
| sessions in the answer | 20 | 38 |
| bytes of quoted history | 9 915 | 15 666 |
| bytes served | 43 314 | 41 396 |

Bounded to three, which is what the documented field already says it is ("the few files this session worked on most"), and the manifest keeps its forty — `blame`'s own path matching reads those, not the payload. The head of the list is the most-touched end, so that is what survives.

A co-change line was weighed instead of the bound and dropped: over eight real paths the recurring neighbour appeared in one session of one, so "usually changed with X" would have been inventing a pattern.
