### PR TITLE
fix(digest): an announcement of intent is not a decision

### DIFF
--- a/internal/digest/decision_plan_opener_test.go
+++ b/internal/digest/decision_plan_opener_test.go
@@ -1,0 +1,43 @@
+package digest
+
+import "testing"
+
+// A line that opens by saying what is about to happen is a plan, whatever
+// decision word sits inside the thing being planned. Counted over 985 distinct
+// assistant opening lines from a real store, 54 read as decisions and 7 of them
+// were announcements of intent — and a block that leads with one of those is the
+// case a model answers "there is no decision on record" to.
+func TestAnAnnouncementOfIntentIsNotADecision(t *testing.T) {
+	for _, line := range []string{
+		"Проверяю, что видео теперь играет дольше трёх секунд.",
+		"Проверяю: смотрю, писал ли mpv в терминал раньше, и что теперь этого нет.",
+		"I'll look at the git history for the Gemini extension to find the fix.",
+		`I'll search the repo for any discussion of a "checkout worker" to see what was actually decided.`,
+		"I'm going to stop here rather than give you a diagnosis, because I can't trust the working tree.",
+		"Let me check why the exporter retries, then we decide.",
+		"Ищу существующий тест на conclusions-блок, добавлю пин на новое поведение.",
+	} {
+		if CarriesDecision(line) {
+			t.Errorf("an announcement of intent reads as a decision: %q", line)
+		}
+	}
+}
+
+// And the outcomes the rule exists for are untouched, including the ones whose
+// wording overlaps a plan's.
+func TestOutcomesStillCarryTheirDecision(t *testing.T) {
+	for _, line := range []string{
+		"Both window paths now use event time, so the April root cause is genuinely fixed.",
+		"прод-пины теперь ложатся на релиз-ветку, а не на main",
+		"we capped the retry budget at three attempts because retrying past that spread the outage",
+		"решили оставить single-writer: вторая запись ломала failover",
+		"The June 9 finding still holds, and the fix is still in the tree.",
+		"оказалось, что таймаут рубил ТСПУ по сигнатуре, а не провайдер",
+		// An outcome that happens to name a plan later in the line.
+		"Кэш переехал на generation-ключи; теперь давай посмотрим на экспортер.",
+	} {
+		if !CarriesDecision(line) {
+			t.Errorf("an outcome stopped reading as a decision: %q", line)
+		}
+	}
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1075,6 +1075,9 @@ func CarriesDecisionExcept(text string, asked []string) bool {
 	if quotesDeja(low) {
 		return false
 	}
+	if announcesItself(low) {
+		return false
+	}
 	for _, p := range planAfterMarker {
 		// A plan may still report an outcome elsewhere in the line, so this
 		// blanks the plan wording rather than disqualifying the whole line.
@@ -1093,6 +1096,37 @@ func CarriesDecisionExcept(text string, asked []string) bool {
 			}
 		}
 		if !skip {
+			return true
+		}
+	}
+	return false
+}
+
+// planOpeners are how a line announces what is about to happen rather than
+// reporting what came of it. planAfterMarker handles the same idea mid-sentence
+// ("готово. теперь давай"); this is its sibling for the opening clause, where
+// the marker the decision rule fires on sits inside the thing being planned:
+// "Проверяю, что видео теперь играет" fires on "теперь", "I'll look at the git
+// history for the Gemini extension to find the fix" on "the fix".
+//
+// Counted over 985 distinct assistant opening lines from a real store, 54 were
+// read as decisions and 7 of those — 13% — were announcements of intent. None of
+// the seven also reported an outcome, which is why the opener disqualifies the
+// line rather than being blanked out of it.
+var planOpeners = []string{
+	"i'll ", "i will ", "i'm going to", "i am going to", "let me ", "let's ",
+	"going to ", "about to ",
+	"ищу", "проверяю", "смотрю", "читаю", "реализую", "добавляю", "пишу ",
+	"делаю", "начинаю", "перемеряю", "спавню", "запускаю", "собираю", "сейчас ",
+}
+
+// announcesItself reports whether the line opens by saying what the speaker is
+// about to do. Only at the opening: a plan mentioned later in a line that
+// reports an outcome is what planAfterMarker is for.
+func announcesItself(low string) bool {
+	trimmed := strings.TrimLeft(low, "*#->•· \t")
+	for _, opener := range planOpeners {
+		if strings.HasPrefix(trimmed, opener) {
 			return true
 		}
 	}

--- a/internal/search/recall_plan_lead_test.go
+++ b/internal/search/recall_plan_lead_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The start block leads with the session that settled something, and what counts
+// as settled is one predicate. A session whose newest line only announces what it
+// is about to do — "Проверяю, что видео теперь играет", which fires on the state
+// word inside the thing being checked — used to qualify, and then it led the
+// block with a plan while the session holding the outcome waited behind it.
+func TestAPlanDoesNotLeadTheStartBlock(t *testing.T) {
+	now := time.Now()
+	planning := model.Session{
+		Harness: "claude", ID: "planning", Project: "org/app",
+		Updated: now,
+		Messages: []model.Message{
+			{Role: "user", Text: "the exporter retries are hammering the server"},
+			{Role: "assistant", Text: "Проверяю, что экспортер теперь перестал ретраить без паузы."},
+		},
+	}
+	settled := model.Session{
+		Harness: "claude", ID: "settled", Project: "org/app",
+		Updated: now.Add(-12 * time.Hour),
+		Messages: []model.Message{
+			{Role: "user", Text: "what do we do about the exporter retries"},
+			{Role: "assistant", Text: "we capped the retry budget at three attempts because retrying past that spread the outage"},
+		},
+	}
+
+	got := BuildAutoRecall([]model.Session{planning, settled}, AutoRecallOptions{
+		Mode: RecallSafe, ProjectNames: []string{"org/app"}, Now: now,
+	})
+	if got.Sessions == 0 {
+		t.Fatal("the digest served nothing")
+	}
+	if len(got.IDs) == 0 || got.IDs[0] != "settled" {
+		t.Errorf("the block opened on %v rather than on the session that settled something", got.IDs)
+	}
+	if !strings.Contains(got.Text, "capped the retry budget at three") {
+		t.Errorf("the block lost the outcome:\n%s", got.Text)
+	}
+}


### PR DESCRIPTION
Every block deja injects rests on one predicate: does this line carry a decision. The start block orders by it (#3468), the per-prompt hook leads with it (#1475), the compaction handover picks its conclusion by it.

Counted over 985 distinct assistant opening lines from a real store, 54 read as decisions — and 7 of those, 13%, were announcements of intent:

```
Проверяю, что видео теперь играет дольше трёх секунд.                   fires on "теперь"
I'll look at the git history for the Gemini extension to find the fix.  fires on "the fix"
Ищу существующий тест на conclusions-блок, добавлю пин.                 fires on the decision wording inside the plan
```

The marker is inside the thing being planned. `planAfterMarker` already handles this mid-sentence — "готово. теперь давай" — and this is its sibling for the opening clause, where the whole line is the plan. None of the seven also reported an outcome, so the opener disqualifies the line rather than being blanked out of it.

It matters because of what a block that leads with a plan does to a reader. Measured on a local model, a block whose sessions settled nothing does not merely fall silent — it answers "there is no decision on record" and "not stated", which reads as an answer rather than as a gap.

Outcomes are untouched, including the ones whose wording overlaps a plan's ("Кэш переехал на generation-ключи; теперь давай посмотрим на экспортер" still carries its decision), and `bench prompt`, `bench context`, `bench block` and `bench recall` print what they printed before. Two tests: one over the seven real shapes, one at the block level showing the plan no longer leads.

What this does not claim: on this machine's own store the blocks come back byte-identical — 8 of 8 projects at session start, 12 of 12 real questions through the per-prompt hook. Every candidate those blocks ranked already had a genuine outcome to lead with, so the guard changes nothing there. It bites where a session's newest line is a plan and an older one holds the answer, which is the shape the 7 of 54 came from.
