### PR TITLE
fix(hook): the weak-match pointer names what was asked about

### DIFF
--- a/cmd/deja/hook_prompt.go
+++ b/cmd/deja/hook_prompt.go
@@ -1576,10 +1576,24 @@ func weakRecallPointer(ss []model.Session, terms []string) string {
 		return ""
 	}
 	s := ss[0]
-	topic := dejaVuTopic(s)
+	// With the terms, which is the whole point of the line: the pointer's only
+	// content is the topic it names, because the agent has to turn that into a
+	// recall call. Called without them, dejaVuTopic falls through to the
+	// session's title — and on the one firing measured against a real store
+	// that answered "how is the block" with `"делай задачи в next.md"`, a title
+	// from a session that merely mentions the subject somewhere. The spoken
+	// déjà vu line has passed its terms since it was written (#2734); this
+	// path did not, so the cheaper payload was also the wronger one.
+	topic := dejaVuTopic(s, terms...)
 	if topic == "" {
 		topic = strings.Join(terms, " ")
 	}
+	// Bounded the way the spoken opener bounds the same kind of line. The
+	// matched line is a whole user turn, which on this store reaches a thousand
+	// characters — and the pointer exists because it is cheap: 290 bytes became
+	// 1234 with the line unclipped, which is a digest's price for a pointer's
+	// content.
+	topic = clipTopic(topic)
 	when := "earlier"
 	if !s.Updated.IsZero() {
 		when = search.RelativeDate(s.Updated)
@@ -1590,6 +1604,29 @@ func weakRecallPointer(ss []model.Session, terms []string) string {
 	}
 	return fmt.Sprintf("deja: this project has history on %q from %s%s — call recall with a specific token if it matters here.\n",
 		search.SafeLine(topic), when, more)
+}
+
+// pointerTopicRunes is how much of the matched line the pointer names. Sixty is
+// what the spoken opener uses for the same job, and the agent only needs enough
+// to write a recall call.
+const pointerTopicRunes = 60
+
+// clipTopic bounds a topic to one readable clause, ending at a word where it
+// can. Cutting mid-word leaves a fragment nobody can search for, which is the
+// one thing this line is for.
+func clipTopic(topic string) string {
+	topic = strings.Join(strings.Fields(topic), " ")
+	r := []rune(topic)
+	if len(r) <= pointerTopicRunes {
+		return topic
+	}
+	cut := string(r[:pointerTopicRunes])
+	// Back up to the last space when one is near, so the reader gets whole
+	// words; a long unbroken token keeps the hard cut.
+	if i := strings.LastIndexByte(cut, ' '); i > len(cut)-20 && i > 0 {
+		cut = cut[:i]
+	}
+	return strings.TrimRight(cut, " ,;:—-") + "…"
 }
 
 // hookseenPrefixed reports whether a key already carries one of the prefixes

--- a/cmd/deja/hook_prompt_pointer_test.go
+++ b/cmd/deja/hook_prompt_pointer_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The pointer's whole content is the topic it names, because the agent has to
+// turn that into a recall call. It was built without the query's terms, so
+// dejaVuTopic fell through to the session's title: measured against a real
+// store, "how is the block" was answered with `"делай задачи в next.md"` — a
+// title from a session that merely mentions the subject somewhere.
+func TestThePointerNamesWhatWasAskedAbout(t *testing.T) {
+	s := model.Session{
+		Harness: "claude", ID: "s1", Project: "org/app",
+		Title:   "делай задачи в next.md",
+		Updated: time.Now(),
+		// The title and the opening line are one thing; the line that matched
+		// the question is further down. Without the terms the topic comes from
+		// the top of the session, which is the bug.
+		Messages: []model.Message{
+			{Role: "user", Text: "делай задачи в next.md, там список на сегодня"},
+			{Role: "assistant", Text: "открыл список"},
+			{Role: "user", Text: "the exporter retry budget keeps hammering the server on failure"},
+			{Role: "assistant", Text: "capped it at three attempts"},
+		},
+	}
+	got := weakRecallPointer([]model.Session{s}, []string{"retry", "budget"})
+	if !strings.Contains(got, "retry budget") {
+		t.Errorf("the pointer does not name what was asked about: %q", got)
+	}
+	if strings.Contains(got, "next.md") {
+		t.Errorf("the pointer named the session's title instead: %q", got)
+	}
+}
+
+// And it stays a pointer. The matched line is a whole user turn, which on a real
+// store reaches a thousand characters: unclipped, the block went from 290 bytes
+// to 1234, which is a digest's price for a pointer's content.
+func TestThePointerStaysShort(t *testing.T) {
+	long := "Новый содержательный разбор — code-grounded review в Commonplace, где хвалят deja-vu " +
+		"как низкотрений слой операционного recall и отдельно отмечают редакцию до индексации, " +
+		"а ограничения формулируют через лексическое перекрытие поиска."
+	s := model.Session{
+		Harness: "claude", ID: "s1", Project: "org/app", Updated: time.Now(),
+		Messages: []model.Message{
+			{Role: "user", Text: long},
+			{Role: "assistant", Text: "прочитал"},
+		},
+	}
+	got := weakRecallPointer([]model.Session{s}, []string{"recall", "разбор"})
+	if len(got) > 260 {
+		t.Errorf("the pointer is %d bytes, which is a digest's price: %q", len(got), got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("a clipped topic does not say it was clipped: %q", got)
+	}
+	// Whole words, so the reader can search for what it names.
+	if strings.Contains(got, "code-groun\"") || strings.Contains(got, "Commonpl…") {
+		t.Errorf("the topic was cut mid-word: %q", got)
+	}
+}


### PR DESCRIPTION
When a question matches on one rare word rather than two informative ones, the per-prompt hook injects a pointer instead of a digest: 134 bytes saying history exists and asking for a recall call. Its whole content is the topic it names, because the agent has to turn that into the call.

It was built without the query's terms. `dejaVuTopic` takes them and falls through to the session's title when it has none, so the pointer named the wrong thing — measured against a real store, "how is the block" came back as `"делай задачи в next.md"`, the title of a session that mentions the subject somewhere further down. The spoken déjà vu line in the same file has passed its terms since it was written; this path never did, so the cheaper payload was also the wronger one.

With the terms it names the matched line, and that line is a whole user turn — on this store they reach a thousand characters, which took the block from 290 bytes to 1234. Bounded to 60 runes, the same figure the spoken opener uses for the same job, cut at a word boundary so what it names can be searched for. 321 bytes.

What I could not show, and it is the more interesting half: that the pointer works at all. On a local model, three questions whose answer sits in a session deja holds, counting `recall(...)` calls — no block 0/3, pointer with the old topic 0/3, pointer with this fix 1/3, full digest 0/3 because it simply answers. The raw replies say why: handed a pointer, the model says "I don't have any relevant history loaded for this question" and goes to read the code. It reads the line as confirmation that memory is absent.

So this is a bug fix, not a feature: the pointer should name the right thing whatever it is worth. Whether a weak match should serve a short block instead of a pointer is a separate question, with a cost on every message, and wants its own measurement.
