### PR TITLE
fix(mcp): a stale content version still answers

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1978,6 +1978,16 @@ func buildingNowForAgent(dir string) string {
 			return rebuildRefusedForAgent(dir)
 		}
 		requestWarmup(dir)
+		// A stale content version is not an unreadable store. When the layout is
+		// the one this build writes, answer from the snapshot and let the
+		// detached rebuild catch up — the same choice #1733 made for a refresh,
+		// for the same reason: measured on this machine, 8 of the 56 recalls an
+		// agent actually made landed in this sentence, and an agent does not ask
+		// again, it concludes there is no history. Of the last four upgrades,
+		// three changed only what deja derives from a transcript.
+		if !index.Damaged(dir) && index.ReadableSnapshot(dir) {
+			return ""
+		}
 		return "deja is rebuilding its index for this version of deja. Recall comes online shortly; ask again then."
 	}
 	// Nothing indexed yet and nothing building: this is a first run, and

--- a/cmd/deja/mcp_stale_version_test.go
+++ b/cmd/deja/mcp_stale_version_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// staleStore is a store holding one answer, so the two states an upgrade can
+// leave behind can be put on it in turn.
+func staleStore(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	root := filepath.Join(tmp, "claude", "proj-stale")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DEJA_CLAUDE_ROOT", filepath.Join(tmp, "claude"))
+	body := `{"type":"user","sessionId":"st1","cwd":"/w/s","timestamp":"2026-07-20T10:00:00Z","message":{"role":"user","content":"the quokkabloom exporter keeps dropping rows"}}` + "\n" +
+		`{"type":"assistant","sessionId":"st1","cwd":"/w/s","timestamp":"2026-07-20T10:01:00Z","message":{"role":"assistant","content":"we capped the quokkabloom retry budget at three attempts"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "st1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The premise: the answer is there while the store is current.
+	got, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"quokkabloom retry budget"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "quokkabloom") {
+		t.Fatalf("the fixture does not answer at all:\n%s", got)
+	}
+	return dir
+}
+
+// A version bump forces a rebuild, and during it recall used to send the agent
+// away: "deja is rebuilding its index for this version — ask again then."
+// Measured on a real store, 8 of the 56 recalls an agent actually made landed in
+// that sentence, and an agent does not ask again — it concludes there is no
+// history (#1733 says exactly that about the refresh case).
+//
+// A stale content version is not an unreadable store: three of the last four
+// bumps changed only what deja derives from a transcript.
+func TestRecallAnswersFromAStaleVersionItCanRead(t *testing.T) {
+	dir := staleStore(t)
+	if err := index.SetManifestVersionForTest(dir, index.CurrentVersionForTest()-1); err != nil {
+		t.Fatal(err)
+	}
+	if !indexNeedsRebuild(dir) || !index.ReadableSnapshot(dir) {
+		t.Fatalf("premise: needsRebuild=%v readable=%v, want a stale store this build can read",
+			indexNeedsRebuild(dir), index.ReadableSnapshot(dir))
+	}
+	got, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"quokkabloom retry budget"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "ask again then") {
+		t.Errorf("recall sent the agent away over a content version it can read:\n%s", got)
+	}
+	if !strings.Contains(got, "quokkabloom") {
+		t.Errorf("recall answered nothing from a readable snapshot:\n%s", got)
+	}
+}
+
+// And a layout this build cannot be sure of is still a decline: there is nothing
+// to trust. Zero is what a store written before the field existed carries.
+func TestRecallDeclinesALayoutItCannotRead(t *testing.T) {
+	dir := staleStore(t)
+	if err := index.SetManifestFormatForTest(dir, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := index.SetManifestVersionForTest(dir, index.CurrentVersionForTest()-1); err != nil {
+		t.Fatal(err)
+	}
+	if !indexNeedsRebuild(dir) || index.ReadableSnapshot(dir) {
+		t.Fatalf("premise: needsRebuild=%v readable=%v, want a stale store this build cannot read",
+			indexNeedsRebuild(dir), index.ReadableSnapshot(dir))
+	}
+	got, err := callMCPTool(dir, "recall", json.RawMessage(`{"query":"quokkabloom retry budget"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "ask again then") {
+		t.Errorf("an unreadable layout was served as an answer:\n%s", got)
+	}
+}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -190,6 +190,21 @@ import (
 // the scan reads a prefix and skips the rest. Records are the store itself, so
 // the layout change is what forces this bump.
 const version = 38
+
+// onDiskFormat is how the store is laid out on disk — the record encoding, the
+// bucket encoding, the manifest's own shape. It moves only when a reader of an
+// older store would mis-read it, which is rarer than version: of the last four
+// bumps, 35, 36 and 37 changed what deja derives from a transcript and left
+// every byte's meaning alone, and only 38 moved a field.
+//
+// The distinction is what a reader needs during the rebuild a bump forces. A
+// store whose content rules are stale still answers correctly under the old
+// rules; a store whose layout this build cannot read answers nothing. Measured
+// on a real machine: 8 of 56 recalls an agent actually made came back with
+// "deja is rebuilding its index for this version — ask again then", and an
+// agent does not ask again (#1733 says so about the refresh case). Three of the
+// last four upgrades could have kept answering.
+const onDiskFormat = 2
 const maxIndexedText = 64 * 1024
 
 // maxRecordSize bounds a single serialized record. A record is one message
@@ -414,7 +429,11 @@ const askedQuestionCap = 8
 const askedMaxRunes = 240
 
 type Manifest struct {
-	Version          int                    `json:"version"`
+	Version int `json:"version"`
+	// Format is the on-disk layout this store was written with. Absent on a
+	// store written before the field existed, which reads as unknown: a reader
+	// that cannot tell declines rather than guessing.
+	Format           int                    `json:"format,omitempty"`
 	Files            map[string]FileState   `json:"files"`
 	Sessions         map[string]SessionMeta `json:"sessions"`
 	BuiltAt          time.Time              `json:"built_at"`
@@ -495,7 +514,10 @@ type FileIngest struct {
 }
 
 type manifestCore struct {
-	Version          int
+	Version int
+	// Format: see Manifest. Written since onDiskFormat existed; absent on an
+	// older store, which reads as zero and means "cannot say".
+	Format           int
 	Files            map[string]FileState
 	BuiltAt          time.Time
 	Generation       string

--- a/internal/index/ingest.go
+++ b/internal/index/ingest.go
@@ -512,7 +512,7 @@ func rebuildWithTombstones(dir string, harness string, scope string, files map[s
 	// incremental build carries the old stamp forward: it keeps records it
 	// wrote under the previous patterns, which is why `deja index` has to ask
 	// for a rebuild rather than quietly declaring the new list in force (#1307).
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
+	m := Manifest{Version: version, Format: onDiskFormat, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imported.watermarks, ExportBoundary: imported.boundary, ImportedRecords: imported.dedupe,
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
 		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
@@ -1086,7 +1086,7 @@ func writeSessionsWithSync(tmp, dir string, ss []model.Session, files map[string
 	writtenMessages := 0
 	lastIngestFiles = len(files)
 	parsedThisPass(files)
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
+	m := Manifest{Version: version, Format: onDiskFormat, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: imp.watermarks, ExportBoundary: imp.boundary, ImportedRecords: imp.dedupe,
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
 		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
@@ -3034,7 +3034,7 @@ func updateIndex(dir, harness, scope string, files map[string]FileState, force b
 	// keyed on it — the embedding sidecar — that the file it measured was still
 	// there (#1357). Only appendIncremental, which appends in place, may keep a
 	// generation.
-	m := Manifest{Version: version, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(),
+	m := Manifest{Version: version, Format: onDiskFormat, Files: files, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(),
 		Generation: time.Now().UTC().Format(time.RFC3339Nano), Scope: scope,
 		ExportWatermarks: old.ExportWatermarks, ExportBoundary: old.ExportBoundary, ImportedRecords: old.ImportedRecords,
 		// Kept from the old index: this build reuses records written under
@@ -3375,6 +3375,7 @@ func appendIncremental(dir, harness, scope string, old Manifest, files map[strin
 	}
 	m := old
 	m.Version = version
+	m.Format = onDiskFormat
 	m.Scope = scope
 	m.BuiltAt = time.Now()
 	m.Files = files

--- a/internal/index/manifest.go
+++ b/internal/index/manifest.go
@@ -12,6 +12,29 @@ import (
 	"github.com/vshulcz/deja-vu/internal/policy"
 )
 
+// ReadableSnapshot reports whether the store on disk can be read by this build
+// even though its content rules are stale.
+//
+// A version bump forces a rebuild, and during it every reading surface has to
+// choose between an answer under the old rules and no answer at all. When the
+// on-disk layout is the one this build writes, the first is strictly better:
+// records decode, postings resolve, and what is missing is only whatever the new
+// rules would re-derive. When the layout differs — or the store predates the
+// field and cannot say — there is nothing a reader can trust.
+//
+// Damage is not staleness and is the caller's check: a torn record log is
+// unreadable whatever its format says.
+func ReadableSnapshot(dir string) bool {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	m, err := readManifestCached(dir)
+	if err != nil {
+		return false
+	}
+	return m.Format == onDiskFormat
+}
+
 // IsCurrentVersion reports whether the index on disk was written by this
 // build's format. Hook paths never call Ensure, so after an upgrade that
 // changes the layout they would read the old store directly — for version 12
@@ -273,7 +296,7 @@ func readManifest(dir string) (Manifest, error) {
 	if err := readGob(filepath.Join(dir, "manifest.gob"), &core); err != nil {
 		return Manifest{}, err
 	}
-	m := Manifest{Version: core.Version, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, IngestFiles: core.IngestFiles, ExcludeFingerprint: core.ExcludeFingerprint, ToolFingerprint: core.ToolFingerprint, Sessions: map[string]SessionMeta{}}
+	m := Manifest{Version: core.Version, Format: core.Format, Files: core.Files, BuiltAt: core.BuiltAt, Generation: core.Generation, Scope: core.Scope, Redacted: core.Redacted, RedactionRules: core.RedactionRules, ExportWatermarks: core.ExportWatermarks, ExportBoundary: core.ExportBoundary, ImportedRecords: core.ImportedRecords, RecordStrings: core.RecordStrings, RecordsSize: core.RecordsSize, BucketFiles: core.BucketFiles, IngestHealth: core.IngestHealth, IngestFiles: core.IngestFiles, ExcludeFingerprint: core.ExcludeFingerprint, ToolFingerprint: core.ToolFingerprint, Sessions: map[string]SessionMeta{}}
 	if err := readGob(filepath.Join(dir, "sessions.gob"), &m.Sessions); err != nil {
 		return Manifest{}, err
 	}
@@ -284,7 +307,7 @@ func readManifest(dir string) (Manifest, error) {
 // for updates that change only core fields (e.g. export watermarks) where the
 // caller has not loaded sessions and must not clobber them.
 func writeManifestOnly(dir string, m Manifest) error {
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
+	core := manifestCore{Version: m.Version, Format: m.Format, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}
@@ -300,7 +323,7 @@ func writeManifestOnly(dir string, m Manifest) error {
 // rather than serving a fresh-looking index whose sessions are stale.
 func writeManifest(dir string, m Manifest) error {
 	mergeIngestDiag(&m)
-	core := manifestCore{Version: m.Version, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
+	core := manifestCore{Version: m.Version, Format: m.Format, Files: m.Files, BuiltAt: m.BuiltAt, Generation: m.Generation, Scope: m.Scope, Redacted: m.Redacted, RedactionRules: m.RedactionRules, ExportWatermarks: m.ExportWatermarks, ExportBoundary: m.ExportBoundary, ImportedRecords: m.ImportedRecords, RecordStrings: m.RecordStrings, IngestHealth: m.IngestHealth, IngestFiles: m.IngestFiles, ExcludeFingerprint: m.ExcludeFingerprint, ToolFingerprint: m.ToolFingerprint}
 	if fi, err := os.Stat(filepath.Join(dir, "records.bin")); err == nil {
 		core.RecordsSize = fi.Size()
 	}

--- a/internal/index/manifest_testhooks.go
+++ b/internal/index/manifest_testhooks.go
@@ -1,0 +1,51 @@
+package index
+
+// The states a reader has to handle are written by an upgrade, not by a test, so
+// a test needs a way to put a store into one. These three are the smallest way
+// to do that without a test reaching into the manifest's encoding itself.
+
+// CurrentVersionForTest is the content version this build writes.
+func CurrentVersionForTest() int { return version }
+
+// SetManifestVersionForTest rewrites the stored content version, which is what
+// an upgrade leaves behind: the store is this build's layout, and its derived
+// content is one version old.
+func SetManifestVersionForTest(dir string, v int) error {
+	m, err := readManifest(dir)
+	if err != nil {
+		return err
+	}
+	m.Version = v
+	// The cache keys on the file's mtime and size, and a rewrite of the same
+	// manifest can land inside one filesystem timestamp tick — so clear it
+	// rather than trusting the stat to differ.
+	if err := writeManifest(dir, m); err != nil {
+		return err
+	}
+	clearManifestCacheForTest()
+	return nil
+}
+
+// SetManifestFormatForTest rewrites the stored on-disk format, for the state a
+// reader must decline: a layout it cannot be sure of. Zero is what a store
+// written before the field existed carries.
+func SetManifestFormatForTest(dir string, f int) error {
+	m, err := readManifest(dir)
+	if err != nil {
+		return err
+	}
+	m.Format = f
+	if err := writeManifest(dir, m); err != nil {
+		return err
+	}
+	clearManifestCacheForTest()
+	return nil
+}
+
+// clearManifestCacheForTest drops the cached manifest so the next read sees what
+// was just written.
+func clearManifestCacheForTest() {
+	manifestCache.mu.Lock()
+	manifestCache.ok = false
+	manifestCache.mu.Unlock()
+}

--- a/internal/index/readable_snapshot_test.go
+++ b/internal/index/readable_snapshot_test.go
@@ -1,0 +1,50 @@
+package index
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// A version bump forces a rebuild, and during it every reading surface chooses
+// between an answer under the old rules and no answer at all. ReadableSnapshot
+// is that choice: the layout this build writes can be read, a layout it cannot
+// be sure of cannot.
+func TestReadableSnapshotSeparatesLayoutFromContent(t *testing.T) {
+	tmp := hermeticIndexEnv(t)
+	dir := filepath.Join(tmp, "readable")
+	if err := Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if !ReadableSnapshot(dir) {
+		t.Fatal("a store this build just wrote reads as unreadable")
+	}
+	// What an upgrade leaves behind: stale content, this build's layout.
+	if err := SetManifestVersionForTest(dir, CurrentVersionForTest()-1); err != nil {
+		t.Fatal(err)
+	}
+	if IsCurrentVersion(dir) {
+		t.Fatal("the fixture is not one version behind")
+	}
+	if !ReadableSnapshot(dir) {
+		t.Error("a stale content version made the layout unreadable")
+	}
+	// What a store written before the field existed carries.
+	if err := SetManifestFormatForTest(dir, 0); err != nil {
+		t.Fatal(err)
+	}
+	if ReadableSnapshot(dir) {
+		t.Error("a store that cannot say its layout was read anyway")
+	}
+	// And a layout from some future build is equally not this one's.
+	if err := SetManifestFormatForTest(dir, 999); err != nil {
+		t.Fatal(err)
+	}
+	if ReadableSnapshot(dir) {
+		t.Error("a layout this build does not write was read anyway")
+	}
+	// A directory with no manifest at all has nothing to read.
+	if ReadableSnapshot(filepath.Join(tmp, "absent")) {
+		t.Error("a missing store reads as readable")
+	}
+}

--- a/internal/index/sync.go
+++ b/internal/index/sync.go
@@ -839,7 +839,7 @@ func initEmptyIndex(dir string) error {
 	// Same reasoning for the tools this build could use: blank reads as "an
 	// older deja wrote this", and a store skipped for a missing CLI would then
 	// never be re-read once it was installed (#1760).
-	m := Manifest{Version: version, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{},
+	m := Manifest{Version: version, Format: onDiskFormat, Files: map[string]FileState{}, Sessions: map[string]SessionMeta{}, BuiltAt: time.Now(), ExportWatermarks: map[string]int64{}, ImportedRecords: map[string]bool{},
 		ExcludeFingerprint: sources.ExclusionFingerprint(),
 		ToolFingerprint:    mergedToolFingerprint(priorToolFingerprint(dir))}
 	return writeManifest(dir, m)


### PR DESCRIPTION
I read what the agent on this machine actually did with deja, across 326 transcripts: 56 recall-family calls, and 8 of them — 14% — came back with

```
deja is rebuilding its index for this version of deja. Recall comes online shortly; ask again then.
```

The agent did not ask again. `buildingNowForAgent` already says why in its own comment, about the refresh case: "an agent does not ask again, it concludes there is none" (#1733). A version bump was still declining.

The mistake is that one number carried two meanings. `version` moves when deja changes what it *derives* from a transcript — a friction rule, a title rule, which pairs count — and also when it changes the *bytes on disk*. Of the last four bumps, 35, 36 and 37 changed only the former and left every byte's meaning alone; only 38 moved a field. During the rebuild those three forced, the store was perfectly readable, and recall refused to read it.

So the on-disk layout gets its own number, `onDiskFormat`, stamped into the manifest and bumped only when a reader of an older store would mis-read it. A stale content version with a layout this build writes now answers from the snapshot — under the old rules, which is what "answering from the index as it was" has always meant on the CLI — while the detached rebuild catches up. A layout this build cannot be sure of still declines, and a store written before the field existed cannot say, so it declines too: one more upgrade and it starts working.

Two tests, one per state, each asserting its premise before it asks (the first version of the second test passed for the wrong reason — the warmup the first call requested had already made the store current again). Reverting the serve branch turns the first red; making the format check always true turns the second red. `bench prompt`, `bench context`, `bench block` and `bench recall` unchanged.

Worth saying plainly: this is the second time today that reading what the agent actually invoked beat reasoning about what it should invoke. The same pass found that agents call `recall` 49 times and `blame`, `fix` and `how` zero times on this machine — the hooks answer those before the tool is reached — which is a finding about the product's shape rather than a defect, and not something I am changing here.
