### PR TITLE
fix(recall): the answer line picks the outcome, not the first reply

### DIFF
--- a/internal/search/answer.go
+++ b/internal/search/answer.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"github.com/vshulcz/deja-vu/internal/digest"
 	"strings"
 	"unicode/utf8"
 
@@ -18,21 +19,33 @@ import (
 // returns only the messages that matched, so the reply does not exist in memory
 // at scoring time and has to be read back from the index.
 func AnswerAfter(messages []model.Message, i int) string {
+	// A reply that records an outcome wins over an earlier one that does not.
+	// DecisionText never comes back empty for a reply with words in it — it
+	// falls through to the opening — so taking the first non-empty answer
+	// returned whatever the agent said first, and what it says first is usually
+	// what it is about to do: "Проверяю, что экспортер теперь перестал
+	// ретраить" was attached as the answer while the reply under it held
+	// "Причина найдена: бэкофф считался от нуля". The same mistake #3470 fixed
+	// where a plan led a block, on the line an agent reads as the answer.
+	first := ""
 	for j := i + 1; j < len(messages) && j <= i+3; j++ {
 		m := messages[j]
 		if m.Role == "user" {
-			// The user spoke again before any answer; there is no reply to
-			// attach, and reaching further would attach someone else's.
-			return ""
+			// The user spoke again; there is no further reply to attach, and
+			// reaching past them would attach someone else's.
+			break
 		}
 		if m.Role != "assistant" {
 			continue
 		}
-		if text := DecisionText(m.Text); text != "" {
+		if text, ok := decisionSentence(m.Text); ok {
 			return text
 		}
+		if first == "" {
+			first = DecisionText(m.Text)
+		}
 	}
-	return ""
+	return first
 }
 
 // decisionPhrases mark the sentence a reader actually wants. They are the
@@ -43,6 +56,32 @@ var decisionPhrases = []string{
 	"decision:", "fixed by", "fixed it by", "the fix", "root cause",
 	"turned out", "traced it to", "instead of", "the cause was",
 	"resolved by", "worked around", "we set", "we added",
+}
+
+// carriesDecisionSentence is the shared recogniser, applied to one sentence.
+//
+// decisionPhrases below is English and was the whole test, while the blocks deja
+// injects have used digest.CarriesDecision — both languages, and the
+// plan-versus-outcome rules — since the store turned out to be Russian-dominant
+// (#2734). So the one structured thing a recall answer adds, the "→ " line under
+// a hit, was picked by the narrower of the two recognisers deja owns. Counted
+// over 1265 distinct assistant lines on a real store: the phrase list marks 34,
+// the shared recogniser 60, and 59 of those are lines the list never sees —
+// "Причина в конфиге: …", "состояние стало пустым".
+//
+// The phrase list stays as a second opinion: it holds shapes the shared rule
+// deliberately leaves out ("we pinned", "we set", "we added"), and on the same
+// sample it alone marks 33 lines.
+func carriesDecisionSentence(low string) bool {
+	if digest.CarriesDecision(low) {
+		return true
+	}
+	for _, phrase := range decisionPhrases {
+		if strings.Contains(low, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // decisionText picks the sentence that records the outcome, falling back to the
@@ -58,20 +97,41 @@ func DecisionText(text string) string {
 	for i, s := range sentences {
 		low[i] = strings.ToLower(s)
 	}
+	if out, ok := decisionSentence(text); ok {
+		return out
+	}
+	return clip(text)
+}
+
+// decisionSentence is the sentence of a reply that records an outcome, and
+// whether there is one at all. DecisionText answers with the reply's opening
+// when there is none, which is a reasonable thing to show and a useless thing
+// to decide on — every caller that has to choose between replies needs the
+// second return value.
+func decisionSentence(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", false
+	}
+	sentences := splitSentences(text)
+	low := make([]string, len(sentences))
+	for i, s := range sentences {
+		low[i] = strings.ToLower(s)
+	}
 	for i, s := range low {
-		for _, phrase := range decisionPhrases {
-			if strings.Contains(s, phrase) {
+		if carriesDecisionSentence(s) {
+			{
 				out := sentences[i]
 				// A decision often needs the sentence after it to make sense
 				// ("We pinned pgx to 5.4.3. Revisit when 1.24 ships.").
 				if i+1 < len(sentences) && len(out)+len(sentences[i+1]) < answerCap {
 					out += " " + sentences[i+1]
 				}
-				return clip(out)
+				return clip(out), true
 			}
 		}
 	}
-	return clip(text)
+	return "", false
 }
 
 const answerCap = 260

--- a/internal/search/answer_shared_decision_test.go
+++ b/internal/search/answer_shared_decision_test.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The "→ " line under a recall hit is the one structured thing the answer adds,
+// and it picked its sentence with an English phrase list while every block deja
+// injects used the shared recogniser — which knows both languages and tells a
+// plan from an outcome. Counted over 1265 distinct assistant lines on a real
+// store: the list marks 34, the shared rule 60, and 59 of those are lines the
+// list never sees.
+func TestTheAnswerLineUsesTheSharedRecogniser(t *testing.T) {
+	// Each reply opens with chatter and records its outcome in a later
+	// sentence, so picking the sentence and falling through to the whole reply
+	// are told apart: the fallback would carry the wanted words too.
+	for _, c := range []struct{ reply, want, notWant string }{
+		{"Смотрю дальше по логам и жду ответа. Причина в конфиге: `my.aeza.net` не подпадает ни под одно правило.",
+			"Причина в конфиге", "Смотрю дальше"},
+		{"Проверил оба пути входа и перезагрузил демон. Состояние стало пустым после повторного off.",
+			"стало пустым", "Проверил оба пути"},
+		{"Долго искал и перебрал три гипотезы. В итоге решили держать single-writer.",
+			"решили держать single-writer", "Долго искал"},
+		// The English shapes the phrase list holds on its own still work.
+		{"Looked at the options and weighed them. We pinned pgx to 5.4.3 for now.",
+			"We pinned pgx", "Looked at the options"},
+		{"Dug through the handler for a while. Root cause was the stale etag reuse.",
+			"Root cause", "Dug through"},
+	} {
+		got := DecisionText(c.reply)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("the answer line picked %q, which does not carry %q", got, c.want)
+		}
+		if strings.Contains(got, c.notWant) {
+			t.Errorf("the answer line quoted the whole reply rather than its outcome: %q", got)
+		}
+	}
+}
+
+// And a reply that only announces what it is about to do is not an answer: the
+// shared recogniser rejects it, which the phrase list could not see either way.
+func TestTheAnswerLineDoesNotQuoteAPlanAsAnOutcome(t *testing.T) {
+	msgs := []model.Message{
+		{Role: "user", Text: "why does the exporter retry so hard"},
+		{Role: "assistant", Text: "Проверяю, что экспортер теперь перестал ретраить без паузы."},
+		{Role: "assistant", Text: "Причина найдена: бэкофф считался от нуля, поэтому четвёртая попытка шла сразу."},
+	}
+	got := AnswerAfter(msgs, 0)
+	if strings.Contains(got, "Проверяю") {
+		t.Errorf("a plan was attached as the answer: %q", got)
+	}
+	if !strings.Contains(got, "Причина найдена") {
+		t.Errorf("the outcome was not attached: %q", got)
+	}
+}


### PR DESCRIPTION
Agents call `recall` and essentially nothing else — 49 of the 56 deja calls in this machine's 326 transcripts, with `blame`, `fix` and `how` at zero, because the hooks answer those before the tool is reached. So the one structured thing a recall answer adds, the `→ ` line under a hit, is worth looking at closely. Two defects in it, both of a family this repo has fixed elsewhere.

**It used its own phrase list, and that list is English.** `decisionPhrases` in answer.go holds "we pinned", "root cause", "turned out". Every block deja injects has used `digest.CarriesDecision` — both languages, plus the plan-versus-outcome rules — since the store turned out to be Russian-dominant (#2734 says so in as many words). Counted over 1265 distinct assistant lines from a real store: the phrase list marks 34, the shared recogniser 60, and 59 of those are lines the list never sees — `Причина в конфиге: …`, `состояние стало пустым`. The list stays as a second opinion, since it holds shapes the shared rule deliberately leaves out ("we set", "we added") and alone marks 33.

**And it attached whatever the agent said first.** `DecisionText` never comes back empty for a reply with words in it — it falls through to the opening — so `AnswerAfter` returned the first reply in its window whatever was in it, and what an agent says first is usually what it is about to do. On a two-reply window it attached "Проверяю, что экспортер теперь перестал ретраить" as the answer while the reply under it held "Причина найдена: бэкофф считался от нуля". That is exactly the mistake #3470 fixed where a plan led a block; here it is the line an agent reads as *the answer*.

`decisionSentence` now reports whether it found an outcome at all, which is what any caller choosing between replies needs; `DecisionText` keeps its contract of always showing something.

Tests: one over five replies that open with chatter and record the outcome later, so picking the sentence is told apart from falling through to the whole reply (the first version of that test passed for the wrong reason — the fallback carried the wanted words too); one over a window where a plan precedes the outcome. Reverting either half turns one red. `bench prompt`, `bench context`, `bench block` and `bench recall` unchanged.
