### PR TITLE
fix(search): drop the abandonment mark on sessions too long to scan

### DIFF
--- a/internal/search/abandonment_marker_test.go
+++ b/internal/search/abandonment_marker_test.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
+)
+
+// GaveUp is a property of a whole session: one line anywhere saying something
+// was dropped marks all of it. On a session someone can scan, "one path here was
+// abandoned — check the excerpts" names a real thing to look for. On a marathon
+// it is certain and therefore empty: measured over twelve real queries, the mark
+// sat on 23 of 60 hits, and the sessions carrying it were this machine's longest
+// — 4.2 million words, 3.1 million, 2.0 million.
+func TestTheAbandonmentMarkIsNotPutOnAMarathon(t *testing.T) {
+	hit := func(words int) Hit {
+		return Hit{
+			Session: model.Session{
+				Harness: "claude", ID: "s1", Project: "app", GaveUp: true, Words: words,
+				Messages: []model.Message{{Role: "user", Text: "the exporter retries too hard"}},
+			},
+			Count:    1,
+			Snippets: []string{"the exporter retries too hard"},
+		}
+	}
+	render := func(h Hit) string {
+		var b bytes.Buffer
+		Print(&b, []Hit{h}, query.Options{Query: "exporter"})
+		return b.String()
+	}
+
+	const mark = "mentions backing an approach out"
+	if got := render(hit(2000)); !strings.Contains(got, mark) {
+		t.Errorf("a session a reader can scan lost the mark:\n%s", got)
+	}
+	if got := render(hit(4_264_226)); strings.Contains(got, mark) {
+		t.Errorf("a 4.2-million-word session was marked as having abandoned one path:\n%s", got)
+	}
+	// A session whose length was never recorded keeps it: an unknown is not a
+	// marathon.
+	if got := render(hit(0)); !strings.Contains(got, mark) {
+		t.Errorf("a session with no recorded length lost the mark:\n%s", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -995,6 +995,38 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	return boost
 }
 
+// abandonmentWorthSaying reports whether the give-up mark tells a reader
+// something about this hit.
+//
+// GaveUp is a property of the whole session: one line anywhere saying something
+// was dropped marks all of it. On a short session that is useful — "one path
+// here was abandoned, check the excerpts for which" names a real thing to look
+// for. On a marathon it is certain and therefore empty: measured over twelve
+// real queries, the mark sat on 23 of 60 hits, and the sessions carrying it were
+// this machine's longest — 4.2 million words, 3.1 million, 2.0 million. Of
+// course something was dropped somewhere in four million words.
+//
+// The same reasoning the rest of this file applies to a haystack: the claim has
+// to be about something the reader can act on. So the mark stands on a session
+// small enough to scan and goes on one where "somewhere in here" names no place.
+//
+// Size is the whole test on purpose. The sharper rule — does a give-up line sit
+// in the excerpts this hit shows — needs the phrase list that recognises one,
+// and that list lives in internal/index, which cannot be imported here.
+// Re-spelling it in this package is the mistake #3473 just fixed in the line
+// above: two recognisers for one idea, and the narrower one wins by accident.
+// A session with no recorded length keeps the mark: an unknown is not a
+// marathon.
+func abandonmentWorthSaying(h Hit) bool {
+	return h.Session.Words == 0 || h.Session.Words <= abandonmentScannableWords
+}
+
+// abandonmentScannableWords is how long a session can be before "somewhere in
+// here" stops being a place. Thirty thousand words is a long working session and
+// still a thing a reader can search; this machine's marathons are two orders
+// above it.
+const abandonmentScannableWords = 30000
+
 // lifecycleSummary words a hit's recorded state for a person. It says what
 // happened rather than naming the state: "superseded" is our vocabulary, not
 // the reader's.
@@ -1304,7 +1336,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		// wording is deliberately mild: a session that tried one thing, dropped
 		// it and found another is the most useful kind, so this flags an
 		// abandoned approach inside it, not the whole session as a dead end.
-		if h.Session.GaveUp && h.Lifecycle == "" {
+		if h.Session.GaveUp && h.Lifecycle == "" && abandonmentWorthSaying(h) {
 			note := "  mentions backing an approach out — one path here was abandoned"
 			if color {
 				note = cDim + note + cReset


### PR DESCRIPTION
A marker that fires on most hits is wallpaper. `GaveUp` is a session-wide flag — one line anywhere saying something was dropped marks the whole transcript — and on twelve real queries against a copied store it put "mentions backing an approach out" on 23 of 60 hits. The sessions carrying it were the longest ones in the store: 4.2M words, 3.1M, 2.0M. Of course something was abandoned somewhere in four million words; the line tells a reader nothing they can look for.

Now it stands only where the reader can act on it: a session small enough to scan (≤30k words), or one whose length was never recorded. Short sessions — where "one path here was abandoned, check the excerpts" points at something findable — keep it.

The test is size only, on purpose: the sharper check (does a give-up line sit in the excerpts this hit shows) needs the phrase list from `internal/index`, which `internal/search` can't import, and re-spelling it here is exactly what #3473 just fixed one function above.

Test keeps the mark at 2k words and at 0, drops it at 4,264,226; reverting the guard turns it red. `bench prompt`, `bench recall`, `bench context`, `bench block` unchanged.

For the threshold: of 2416 sessions in that store 47 carry a give-up line, and they skew long (median 7k words against 638 for all sessions). 25 of the 47 are under 30k and keep the mark; going up to 100k would add nine sessions of 100k–660k words, where "somewhere in here" is not a place.
