### PR TITLE
fix(search): excerpts start and end on whole words

### DIFF
--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -2019,6 +2019,7 @@ func snippet(s, q string, re *regexp.Regexp) string {
 			start = 0
 		}
 	}
+	start, end = snapToWords(r, start, end, idx)
 	out := strings.TrimSpace(string(r[start:end]))
 	out = strings.Trim(out, " ,.;:-\n\t")
 	if start > 0 {
@@ -2028,6 +2029,86 @@ func snippet(s, q string, re *regexp.Regexp) string {
 		out += " …"
 	}
 	return out
+}
+
+// snapToWords moves a window's edges off the middle of a word, and onto the
+// start of a sentence when one is within reach.
+//
+// The window is a fixed 100 runes before the match, which on a long line lands
+// wherever it lands: over 400 real messages the cut opened inside a word in 35%
+// of the excerpts and closed inside one in 62% — "… tigravity doctor rows report
+// correctly", "… ads from disk per invocation". The first words of an excerpt are
+// what a reader uses to decide whether to read the rest, and a fragment spends
+// them on nothing. With the snap that is 2% and 30%, and the share of excerpts
+// that open on a capital — the cheap sign of a sentence start — goes from 6% to
+// 38%.
+//
+// Moving the left edge forward shortens the excerpt, so the same number of runes
+// is given back at the other end. The match is the floor for both edges: a snap
+// never crosses it, which is what keeps a window that was clamped against the
+// end of the message from sliding off its own match.
+func snapToWords(r []rune, start, end, match int) (int, int) {
+	if start > 0 {
+		limit := start + sentenceSnapRunes
+		if limit > match {
+			limit = match
+		}
+		moved := start
+		// A sentence start is worth more than a word start, so look for one
+		// first across the whole budget.
+		for i := start; i < limit && i+1 < len(r); i++ {
+			if isSentenceEnd(r[i]) && isSpace(r[i+1]) {
+				moved = i + 2
+				break
+			}
+		}
+		if moved == start {
+			wordLimit := start + headWordSnapRunes
+			if wordLimit > limit {
+				wordLimit = limit
+			}
+			for i := start; i < wordLimit; i++ {
+				if isSpace(r[i]) {
+					moved = i + 1
+					break
+				}
+			}
+		}
+		if given := moved - start; given > 0 {
+			start = moved
+			if end += given; end > len(r) {
+				end = len(r)
+			}
+		}
+	}
+	if end < len(r) {
+		floor := end - tailWordSnapRunes
+		if floor < match+1 {
+			floor = match + 1
+		}
+		for i := end; i > floor; i-- {
+			if isSpace(r[i-1]) {
+				end = i - 1
+				break
+			}
+		}
+	}
+	return start, end
+}
+
+// How far an edge may move to find a boundary. A sentence is worth walking
+// further for; past a short word's length the excerpt loses more than the
+// ragged edge costs.
+const (
+	sentenceSnapRunes = 80
+	headWordSnapRunes = 40
+	tailWordSnapRunes = 20
+)
+
+func isSpace(r rune) bool { return r == ' ' || r == '\t' || r == '\n' || r == '\r' }
+
+func isSentenceEnd(r rune) bool {
+	return r == '.' || r == '!' || r == '?' || r == '。' || r == '！' || r == '？'
 }
 
 // densestMention is where in low the query is discussed rather than mentioned:

--- a/internal/search/snippet_edge_test.go
+++ b/internal/search/snippet_edge_test.go
@@ -1,0 +1,49 @@
+package search
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+// The excerpt window starts a fixed distance before the match, so on a long line
+// it used to open in the middle of whatever word sat there. Over 400 real
+// messages that was 35% of excerpts; the first words are the ones a reader uses
+// to decide whether to read on.
+func TestAnExcerptDoesNotOpenInTheMiddleOfAWord(t *testing.T) {
+	// A long line with no sentence break anywhere near the left edge, so the
+	// word snap is what has to do the work.
+	lead := strings.Repeat("configuration reconciliation telemetry ", 12)
+	text := lead + "the exporter retried without any backoff at all " + strings.Repeat("and more words after it ", 20)
+
+	sn := snippet(text, "backoff", nil)
+	body := strings.TrimSuffix(strings.TrimPrefix(sn, "… "), " …")
+	if !strings.Contains(body, "backoff") {
+		t.Fatalf("the excerpt lost its own match: %q", sn)
+	}
+	first := strings.Fields(body)[0]
+	if !strings.Contains(lead+" ", " "+first+" ") && !strings.HasPrefix(text, first) {
+		t.Errorf("the excerpt opened on a word fragment %q:\n%s", first, sn)
+	}
+	last := strings.Fields(body)[len(strings.Fields(body))-1]
+	if !strings.Contains(text, last+" ") {
+		t.Errorf("the excerpt closed on a word fragment %q:\n%s", last, sn)
+	}
+}
+
+// A sentence start within reach of the left edge is worth more than a word
+// start: it is where the thought begins.
+func TestAnExcerptPrefersToOpenOnASentence(t *testing.T) {
+	lead := "Вчера мы долго ходили вокруг этого места и ничего не поняли толком совсем. " +
+		"Причина оказалась в том, что бэкофф считался от нуля, поэтому четвёртая попытка шла сразу же после третьей."
+	text := lead + " " + strings.Repeat("дальше идёт ещё текст про другое ", 20)
+
+	sn := snippet(text, "четвёртая", nil)
+	body := strings.TrimSuffix(strings.TrimPrefix(sn, "… "), " …")
+	if !strings.HasPrefix(body, "Причина оказалась") {
+		t.Errorf("the excerpt did not open on the sentence that carries the answer:\n%s", sn)
+	}
+	if r := []rune(body); len(r) > 0 && !unicode.IsUpper(r[0]) {
+		t.Errorf("the excerpt opened mid-sentence: %q", body)
+	}
+}


### PR DESCRIPTION
Excerpt lines are most of what a recall answer hands an agent by volume, and the window that makes them starts a fixed 100 runes before the match — wherever that lands. In the 56 recall answers this machine really served, 56% of the excerpt lines open with an ellipsis and 37% open on a word fragment: `… tigravity doctor rows report correctly`, `… ads from disk per invocation`, `… l.go:429-439`)`. The first few words are what a reader uses to decide whether to read the rest, and a fragment spends them on nothing.

Measured exactly on 400 real messages (dump the messages, call `snippet`, compare the cut against the source runes):

| | head inside a word | tail inside a word | head on a capital |
|---|---|---|---|
| before | 35% | 62% | 6% |
| after | 2% | 30% | 38% |

The left edge now walks forward to a sentence start if one is within 80 runes, else to the next word boundary within 40, and the runes it gives up are handed back at the other end so the excerpt keeps its size. Neither edge ever crosses the match, which is what keeps a window clamped against the end of a message from sliding off the thing it matched. The remaining 30% of ragged tails are runs with no space in them — paths and code.

`bench prompt`, `bench recall`, `bench context` and `bench block` are identical before and after (same arms, same recall@k, same token counts): this changes where a line is cut, not which line is chosen.

Tests: one on a long line with no sentence break near the edge (word snap does the work), one where a sentence start sits within reach and the excerpt has to open on it. Reverting the call turns both red.
