### PR TITLE
fix(recall): the conclusions list leaves out the session's other work

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -953,6 +953,87 @@ func attachAnswers(dir string, hits []search.Hit) {
 	}
 }
 
+// conclusionsAboutIt keeps the conclusions that have something to do with what
+// was asked.
+//
+// "what this session concluded" is read off the whole session, and a session
+// that ran for days concluded things about everything it touched. Measured on
+// sixteen recall calls against a real store, 42% of the conclusion lines served
+// shared no word with the query or with the excerpts they sat under — and a long
+// session served the same three lines to a question about blame rows, one about
+// the MCP dispatcher and one about a connection pool, because those were simply
+// the newest things it had concluded.
+//
+// Excerpt words count as well as query words, which is what keeps a conclusion
+// worded nothing like the question — the case the list exists for (#1011): "the
+// backoff counted from zero" stays under an excerpt that says backoff.
+func conclusionsAboutIt(cs []string, q string, snippets []string) []string {
+	about := contentWords(q)
+	for _, sn := range snippets {
+		for w := range contentWords(sn) {
+			about[w] = true
+		}
+	}
+	if len(about) == 0 {
+		// Nothing to judge against: a query of common words alone, which the
+		// ranking answered on its own terms.
+		return cs
+	}
+	kept := make([]string, 0, len(cs))
+	for _, c := range cs {
+		if sharesAWord(contentWords(c), about) {
+			kept = append(kept, c)
+		}
+	}
+	if len(kept) == 0 && len(cs) > 0 {
+		// One line rather than none. A session that matched on words this gate
+		// cannot see — a query in one language against a transcript in another,
+		// which this store is full of — still concluded something, and a
+		// conclusion nobody asked for is a memory that can still turn out to be
+		// the one. Three of them is wallpaper; one is an offer.
+		return cs[:1]
+	}
+	return kept
+}
+
+// sharesAWord is word overlap that holds for identifiers: `ManifestBuiltAt`
+// lowercases to one token, so a question about the manifest shares nothing with
+// it on equality alone, and the conclusion that named it was dropped for a query
+// plainly about it.
+func sharesAWord(words, about map[string]bool) bool {
+	for w := range words {
+		if about[w] {
+			return true
+		}
+		for a := range about {
+			if len(a) >= 5 && strings.Contains(w, a) {
+				return true
+			}
+			if len(w) >= 5 && strings.Contains(a, w) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// conclusionGateSlack is how many extra conclusions to ask for, so the list can
+// still show three after the gate above has dropped the ones about other work.
+const conclusionGateSlack = 3
+
+// contentWords are the words of a text that carry its subject: long enough to
+// mean something and not a word every session holds.
+func contentWords(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, tok := range query.Tokens(s) {
+		if utf8.RuneCountInString(tok) < 4 || query.IsStopWord(tok) {
+			continue
+		}
+		out[tok] = true
+	}
+	return out
+}
+
 // shownAnswers counts the excerpts that are answer lines rather than matched
 // text, which is how many conclusions the drop below can take.
 func shownAnswers(snippets []string) int {
@@ -1393,8 +1474,12 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 				// Ask for as many extra as there are answer lines above: the
 				// drop below can take any of them, and asking for a fixed one
 				// more still showed two where three were available.
-				want := 3 + shownAnswers(h.Snippets)
-				if cs := withoutShownAnswer(digest.Conclusions(whole, left, want), h.Snippets); len(cs) > 0 {
+				// Three more than the list can show: the gate below drops the
+				// ones about something else, and asking for exactly three
+				// showed one where three were available.
+				want := 3 + shownAnswers(h.Snippets) + conclusionGateSlack
+				cs := withoutShownAnswer(digest.Conclusions(whole, left, want), h.Snippets)
+				if cs = conclusionsAboutIt(cs, q, h.Snippets); len(cs) > 0 {
 					if len(cs) > 3 {
 						cs = cs[:3]
 					}

--- a/cmd/deja/mcp_conclusion_gate_test.go
+++ b/cmd/deja/mcp_conclusion_gate_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedMixedConclusions writes one long session that concluded two things: one
+// about the subject of the query, and a newer one about unrelated work. A real
+// session that ran for days looks like this, and "what this session concluded"
+// reads the whole of it.
+func seedMixedConclusions(t *testing.T, tail string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(text, hour string) string {
+		return `{"type":"assistant","message":{"role":"assistant","content":"` + text +
+			`"},"timestamp":"2026-08-02T` + hour + `:00:00Z","sessionId":"csa","cwd":"/proj"}` + "\n"
+	}
+	var b strings.Builder
+	for i := range 20 {
+		b.WriteString(line(strings.Repeat("flimsyshard retry cap discussion ", 8), "0"+string(rune('0'+i%10))))
+	}
+	b.WriteString(line("so we decided to cap flimsyshard retries at three and log the fourth, "+
+		strings.Repeat("because the queue drains slower than it fills ", 6), "11"))
+	// Newer, and about something else entirely: this is what the list shows
+	// first when it is only going by age.
+	b.WriteString(line("in the end we moved the invoice mailer onto the nightly queue, "+
+		strings.Repeat("so the morning batch stops competing with it ", 6), "12"))
+	b.WriteString(line("the cause was a stale etag on the partner avatars, "+
+		strings.Repeat("and the proxy kept serving it for an hour ", 6), "13"))
+	if tail != "" {
+		b.WriteString(line(tail, "14"))
+	}
+	if err := os.WriteFile(filepath.Join(store, "csa.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Conclusions are read off the whole session and sorted by age, so a session
+// that worked on three things served its newest three to every question about
+// any of them: over sixteen recall calls on a real store, 42% of the conclusion
+// lines shared no word with the query or with the excerpts under them.
+func TestTheConclusionsListLeavesOutOtherWork(t *testing.T) {
+	dir := seedMixedConclusions(t, "")
+	text, _, _, _, err := recallTextResult(dir, "flimsyshard retry cap", "", 0, 0, 4096-recallFrameOverhead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "cap flimsyshard retries") {
+		t.Errorf("the conclusion about what was asked is missing:\n%s", text)
+	}
+	for _, other := range []string{"invoice mailer", "partner avatars"} {
+		if strings.Contains(text, other) {
+			t.Errorf("a conclusion about other work (%q) was served as this session's conclusion:\n%s", other, text)
+		}
+	}
+}
+
+// And when a session concluded nothing the gate can tie to the question, it
+// still offers one line. A conclusion nobody asked for can be the one that
+// helps, and the store is full of sessions whose words are in another language
+// than the query — withholding all of them would cost more than it saves.
+func TestASessionWithNoRelatedConclusionStillOffersOne(t *testing.T) {
+	dir := seedMixedConclusions(t, "")
+	text, _, _, _, err := recallTextResult(dir, "flimsyshard discussion", "", 0, 0, 4096-recallFrameOverhead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "what this session concluded") {
+		t.Errorf("the session offered no conclusion at all:\n%s", text)
+	}
+	shown := strings.Count(text, "\n  → ")
+	if shown != 1 {
+		t.Errorf("offered %d conclusion lines; an unrelated session gets one, not a list:\n%s", shown, text)
+	}
+}

--- a/cmd/deja/recall_no_repeat_test.go
+++ b/cmd/deja/recall_no_repeat_test.go
@@ -110,12 +110,17 @@ func TestTheFreedSlotIsFilled(t *testing.T) {
 	turns := []struct{ role, text string }{
 		// The matched question comes last, so its answer is also the newest
 		// conclusion — which is the case where the repeat costs a slot.
+		//
+		// Every turn is about the retry queue: the list only carries what the
+		// question is about, so a session whose other conclusions were about
+		// other work would show one line here for that reason rather than this
+		// one.
 		{"user", "the timeouts"},
-		{"assistant", "TIMEOUTS: the read timeout stays at thirty seconds for now."},
+		{"assistant", "TIMEOUTS: the retry queue read timeout stays at thirty seconds for now."},
 		{"user", "the pool"},
-		{"assistant", "POOL: capped the connection pool at sixteen per worker."},
+		{"assistant", "POOL: capped the retry queue workers at sixteen each."},
 		{"user", "the alerts"},
-		{"assistant", "ALERTS: page only on the second consecutive failure."},
+		{"assistant", "ALERTS: page only on the second consecutive retry queue failure."},
 		{"user", "what did we decide about the retry queue backoff in the end"},
 		{"assistant", "ANSWER: we settled on full jitter with three attempts, then give up."},
 	}


### PR DESCRIPTION
`what this session concluded` is read off the whole session and sorted by age, so a session that worked on several things serves its newest three to any question about any of them. Over sixteen recall calls against a real store, 16 of the 38 conclusion lines served (42%) shared no word with the query or with the excerpts they sat under — and one long session handed the same three lines to a question about blame rows, one about the MCP dispatcher and one about a connection pool, because those happened to be the last things it concluded.

An agent reads those lines as the answer, so a line about other work is worse than no line: the excerpt stays either way, and the excerpt is the memory.

Each line now has to share a content word with the query or with the excerpts under it (substring too, so a question about the manifest matches a conclusion naming `ManifestBuiltAt` — word equality alone dropped that one). When nothing passes, the list still offers one line rather than none: the store is full of sessions whose words are in a different language than the query, and an unasked-for conclusion can be the one that helps. Three of them is wallpaper; one is an offer.

On the same sixteen calls: 38 conclusion lines → 27, and off-topic ones 16 → 4, all four being that single-line fallback. Page size is unchanged (63266 → 63172 bytes over the sixteen answers) because the page refills with excerpts — this buys content, not tokens. `bench context` (deja-recall 1096 tokens, coverage 1.00), `bench block`, `bench prompt` and `bench recall` are identical.

Two tests: one session that concluded both the thing asked about and two unrelated things, and one where nothing relates and a single line still has to come back. Reverting the gate turns both red.
