### PR TITLE
fix(search): the width cut ends on a whole word

### DIFF
--- a/internal/search/fit_line_word_test.go
+++ b/internal/search/fit_line_word_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+// The width cut is a second cut, after the excerpt window: on 400 real messages
+// rendered at 118 columns it ended inside a word in 56% of the lines it
+// shortened, even with the window's own edges snapped.
+func TestTheWidthCutEndsOnAWholeWord(t *testing.T) {
+	line := "the exporter retried without any backoff at all, and the fourth attempt went out immediately after the third one"
+	got := fitLine(line, 60)
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("the line was not cut at all: %q", got)
+	}
+	body := strings.TrimSuffix(got, "…")
+	last := strings.Fields(body)[len(strings.Fields(body))-1]
+	if !strings.Contains(line, last+" ") && !strings.Contains(line, last+",") {
+		t.Errorf("the line ended on the fragment %q: %q", last, got)
+	}
+}
+
+// A word longer than the walk keeps its prefix: a path or an identifier is worth
+// more cut than dropped, and dropping it would spend a third of the line on
+// nothing.
+func TestALongTokenIsCutRatherThanDropped(t *testing.T) {
+	line := "the chart is kube-prometheus-stack-prometheus-operator-admission-webhook-patch"
+	got := fitLine(line, 50)
+	if !strings.Contains(got, "kube-prometheus") {
+		t.Errorf("the long token was dropped instead of cut: %q", got)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1410,8 +1410,22 @@ func fitLine(s string, width int) string {
 		return s
 	}
 	// One column short of the width, for the ellipsis.
-	return strings.TrimRight(termwidth.Cut(s, width-1), " ") + "…"
+	cut := strings.TrimRight(termwidth.Cut(s, width-1), " ")
+	// And back to the end of a word, the same reason the excerpt window snaps
+	// its own edges: over sixteen real searches rendered at 120 columns, 118 of
+	// the 150 lines this cut shortened (79%) ended inside a word —
+	// "kube-prometheus-stack-prome…". The walk is short so a line of unbroken
+	// path or code keeps the columns instead.
+	if at := strings.LastIndexAny(cut, " \t"); at > 0 && utf8.RuneCountInString(cut[at:]) <= lineSnapRunes {
+		cut = strings.TrimRight(cut[:at], " \t")
+	}
+	return cut + "…"
 }
+
+// lineSnapRunes is how much of the last word may be given up to end the line on
+// a whole one. A word longer than this is a path or an identifier, where the
+// prefix is worth more than the tidy edge.
+const lineSnapRunes = 14
 
 func tierLabel(h Hit) string {
 	if h.Tier == "" || h.Tier == TierExact {


### PR DESCRIPTION
Second cut, same problem as #3475. After the excerpt window picks its text, `fitLine` trims it to the terminal width and appends an ellipsis wherever the column budget runs out: on 400 real messages rendered at 118 columns, 56% of the lines it shortened ended inside a word — `kube-prometheus-stack-prome…` — even with the window's own edges snapped. Now 11%.

The walk back is at most 14 runes, so a long path or identifier keeps its prefix instead of being dropped: a cut `kube-prometheus-stack-prome…` still tells the reader which chart, and giving up a third of the line to end tidily would not.

Terminal rendering only — a pipe gets width 0 and no cut, so nothing an agent reads over MCP or in a script changes. Tests: one line cut mid-word that has to come back whole, one long token that has to survive as a prefix; reverting the walk turns the first red.
