### PR TITLE
fix(recall): the answer marks an abandoned approach only where it can be found

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1327,7 +1327,10 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 		// approach inside was abandoned, not that the whole session is a dead
 		// end: the tried-then-fixed session is the most useful one, and the
 		// excerpts show which path was dropped.
-		if h.Session.GaveUp && h.Lifecycle == "" {
+		// And only where "somewhere in this session" is a place the agent can
+		// look: the same rule the search screen got in #3474, from the same
+		// function so the two cannot drift.
+		if h.Session.GaveUp && h.Lifecycle == "" && search.AbandonmentWorthSaying(h) {
 			fmt.Fprintln(&hb, "[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]")
 		}
 		// Sync keeps both copies when a session id is on two machines, and

--- a/cmd/deja/mcp_gaveup_mark_test.go
+++ b/cmd/deja/mcp_gaveup_mark_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// seedGaveUpSessions writes two sessions that both backed an approach out: one a
+// reader can scan, one the size of this machine's marathons.
+func seedGaveUpSessions(t *testing.T) string {
+	t.Helper()
+	hermeticEnv(t)
+	proj := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-app")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(id string, filler int) {
+		var b strings.Builder
+		turn := func(role, text, stamp string) {
+			b.WriteString(`{"type":"` + role + `","sessionId":"` + id + `","timestamp":"` + stamp +
+				`","message":{"role":"` + role + `","content":"` + text + `"}}` + "\n")
+		}
+		turn("user", "the flimsyshard exporter retries too hard", "2026-03-01T10:00:00Z")
+		turn("assistant", "we backed out the jitter change and capped flimsyshard retries at three instead",
+			"2026-03-01T10:01:00Z")
+		for i := range filler {
+			turn("assistant", strings.Repeat("flimsyshard retry notes and more notes ", 60),
+				"2026-03-01T1"+string(rune('0'+i%10))+":0"+string(rune('0'+i%6))+":00Z")
+		}
+		if err := os.WriteFile(filepath.Join(proj, id+".jsonl"), []byte(b.String()), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Six words per filler phrase, sixty phrases per turn: a hundred turns is
+	// past the thirty thousand words where "somewhere in here" stops being a
+	// place.
+	write("short1", 2)
+	write("marathon1", 100)
+	dir := index.DefaultDir()
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The mark is a property of the whole session, so on a long one it says only
+// that something was dropped somewhere in it. On sixteen recall calls against a
+// real store the answer carried it 32 times — twice per page — and every one of
+// those sessions was far too long to scan. The search screen got this rule in
+// #3474; the answer an agent reads was still printing the mark on everything.
+func TestTheAnswerDoesNotMarkAMarathonAsHavingBackedOut(t *testing.T) {
+	dir := seedGaveUpSessions(t)
+	text, _, _, _, err := recallTextResult(dir, "flimsyshard exporter retries", "", 5, 0, 8192)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const mark = "abandoned one approach partway"
+	short := strings.Index(text, "short1")
+	long := strings.Index(text, "marathon1")
+	if short < 0 || long < 0 {
+		t.Fatalf("the page is missing one of the two sessions:\n%s", text)
+	}
+	marks := strings.Count(text, mark)
+	if marks != 1 {
+		t.Errorf("the mark appears %d times; only the session a reader can scan should carry it:\n%s", marks, text)
+	}
+	// And it is the short session's: the mark sits under its header, before the
+	// next one begins.
+	between := text[min(short, long):max(short, long)]
+	if short < long && !strings.Contains(between, mark) {
+		t.Errorf("the mark went to the marathon rather than the short session:\n%s", text)
+	}
+	if long < short && strings.Contains(between, mark) {
+		t.Errorf("the mark went to the marathon rather than the short session:\n%s", text)
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -995,8 +995,11 @@ func proximityBoost(window, queryTokenCount int) float64 {
 	return boost
 }
 
-// abandonmentWorthSaying reports whether the give-up mark tells a reader
-// something about this hit.
+// AbandonmentWorthSaying reports whether the give-up mark tells a reader
+// something about this hit. Exported because the MCP recall answer words the
+// same mark ("[this session abandoned one approach partway …]") and was asking
+// the same question with no rule behind it: over sixteen recall calls on a real
+// store it printed the mark 32 times in 16 answers, two per page.
 //
 // GaveUp is a property of the whole session: one line anywhere saying something
 // was dropped marks all of it. On a short session that is useful — "one path
@@ -1017,7 +1020,7 @@ func proximityBoost(window, queryTokenCount int) float64 {
 // above: two recognisers for one idea, and the narrower one wins by accident.
 // A session with no recorded length keeps the mark: an unknown is not a
 // marathon.
-func abandonmentWorthSaying(h Hit) bool {
+func AbandonmentWorthSaying(h Hit) bool {
 	return h.Session.Words == 0 || h.Session.Words <= abandonmentScannableWords
 }
 
@@ -1336,7 +1339,7 @@ func Print(w io.Writer, hits []Hit, o Options) {
 		// wording is deliberately mild: a session that tried one thing, dropped
 		// it and found another is the most useful kind, so this flags an
 		// abandoned approach inside it, not the whole session as a dead end.
-		if h.Session.GaveUp && h.Lifecycle == "" && abandonmentWorthSaying(h) {
+		if h.Session.GaveUp && h.Lifecycle == "" && AbandonmentWorthSaying(h) {
 			note := "  mentions backing an approach out — one path here was abandoned"
 			if color {
 				note = cDim + note + cReset


### PR DESCRIPTION
#3474 fixed this for the search screen and missed the surface that matters more: the MCP recall answer words the same mark itself — `[this session abandoned one approach partway — check the excerpts for which, the rest may still hold]` — on the bare `GaveUp` flag. Over sixteen recall calls against a real store it printed 32 times in 16 answers, two per page, every one on a session far too long for "check the excerpts for which" to name anything findable. Now 4.

`abandonmentWorthSaying` is exported rather than re-spelled here, so the two surfaces cannot drift — the same reason #3473 gave for not keeping a second copy of a recogniser.

Test seeds two sessions that both backed an approach out, one short and one past thirty thousand words, and pins the mark to the short one; reverting the guard turns it red.
