### PR TITLE
fix(recall): the files line names the ones the question is about

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -1495,7 +1495,7 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 				// them an agent that has just learned "we solved this before"
 				// still has to search the tree for where — and that search
 				// costs far more context than naming the paths here does.
-				if paths := recallTouchedLine(dir, h.Session); paths != "" {
+				if paths := recallTouchedLine(dir, h.Session, query.Tokens(q)); paths != "" {
 					fmt.Fprintf(&hb, "  files it touched: %s\n", paths)
 				}
 			}

--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/index"
 	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/query"
 	"github.com/vshulcz/deja-vu/internal/search"
 )
 
@@ -89,7 +91,15 @@ const recallTouchedFiles = 4
 // recallTouchedLine renders the files the session worked on, from the manifest
 // rather than the hit (a hit carries only matching messages). Empty when the
 // session touched nothing recorded — a conversation with no file work.
-func recallTouchedLine(dir string, s model.Session) string {
+//
+// The files the question is about come first. The manifest keeps Touched sorted
+// by path, so a session that worked on many files named the same four — the ones
+// whose paths sort first — to every question that reached it: measured over
+// sixteen recall calls on a real store, 1 of the 10 lines served held any word of
+// the question, and one session answered four unrelated questions with the same
+// three paths. The line exists so an agent that has just learned "this was
+// solved here" knows where to look, and alphabetical order does not know that.
+func recallTouchedLine(dir string, s model.Session, terms []string) string {
 	metas, err := index.AllMeta(dir)
 	if err != nil {
 		return ""
@@ -98,7 +108,7 @@ func recallTouchedLine(dir string, s model.Session) string {
 		if m.ID != s.ID || len(m.Touched) == 0 {
 			continue
 		}
-		paths := m.Touched
+		paths := pathsAboutIt(m.Touched, terms)
 		extra := 0
 		if len(paths) > recallTouchedFiles {
 			extra = len(paths) - recallTouchedFiles
@@ -126,6 +136,45 @@ func recallTouchedLine(dir string, s model.Session) string {
 		return search.SafeLine(out)
 	}
 	return ""
+}
+
+// pathsAboutIt puts the paths a question names ahead of the rest, keeping both
+// groups in the order the manifest recorded them so nothing else about the line
+// moves.
+func pathsAboutIt(paths, terms []string) []string {
+	if len(terms) == 0 || len(paths) < 2 {
+		return paths
+	}
+	var want []string
+	for _, t := range terms {
+		t = strings.ToLower(t)
+		// Two letters name nothing in a path; "go" and "md" would put every
+		// file first.
+		if utf8.RuneCountInString(t) >= 4 && !query.IsStopWord(t) {
+			want = append(want, t)
+		}
+	}
+	if len(want) == 0 {
+		return paths
+	}
+	named := make([]string, 0, len(paths))
+	rest := make([]string, 0, len(paths))
+	for _, p := range paths {
+		low := strings.ToLower(p)
+		hit := false
+		for _, t := range want {
+			if strings.Contains(low, t) {
+				hit = true
+				break
+			}
+		}
+		if hit {
+			named = append(named, p)
+		} else {
+			rest = append(rest, p)
+		}
+	}
+	return append(named, rest...)
 }
 
 // commonDirPrefix returns the longest directory prefix every path shares,

--- a/cmd/deja/recall_touched_about_test.go
+++ b/cmd/deja/recall_touched_about_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line names four of the files a session touched, and Touched is kept in path
+// order, so a session that worked on many files named the same four — the ones
+// that sort first — to every question that reached it. Measured over sixteen
+// recall calls on a real store, 1 of the 10 lines served held any word of the
+// question; with this, 4.
+func TestTheFilesLineNamesTheOnesAskedAbout(t *testing.T) {
+	dir, s := touchedLineStore(t,
+		"/w/app/internal/store/alpha.go",
+		"/w/app/internal/store/beta.go",
+		"/w/app/internal/store/delta.go",
+		"/w/app/internal/store/gamma.go",
+		"/w/app/internal/store/omega.go",
+		// The file the question is about sorts last, so the four-path cut drops
+		// it: Touched is kept in path order, which is what made one session
+		// answer every question with the same three files.
+		"/w/app/internal/store/retry_backoff.go",
+	)
+	got := recallTouchedLine(dir, s, []string{"backoff", "retries"})
+	if !strings.Contains(got, "retry_backoff.go") {
+		t.Errorf("the file the question names is missing from the line: %q", got)
+	}
+	// And it leads: an agent reads the first path.
+	if i, j := strings.Index(got, "retry_backoff.go"), strings.Index(got, "alpha.go"); j >= 0 && i > j {
+		t.Errorf("a file unrelated to the question came first: %q", got)
+	}
+}
+
+// With nothing in the question to go on, the line is what it was: path order,
+// untouched. Short words are no signal either — "go" and "md" would promote
+// every file in a Go repo.
+func TestTheFilesLineKeepsItsOrderWithoutTerms(t *testing.T) {
+	paths := []string{
+		"/w/app/internal/store/alpha.go",
+		"/w/app/internal/store/walk.go",
+		"/w/app/internal/store/stat.go",
+	}
+	dir, s := touchedLineStore(t, paths...)
+	for _, terms := range [][]string{nil, {"the", "a", "of"}, {"go", "md"}} {
+		got := recallTouchedLine(dir, s, terms)
+		if i, j := strings.Index(got, "alpha.go"), strings.Index(got, "stat.go"); i < 0 || j < 0 || i > j {
+			t.Errorf("terms %v reordered the line: %q", terms, got)
+		}
+	}
+}

--- a/cmd/deja/recall_touched_line_test.go
+++ b/cmd/deja/recall_touched_line_test.go
@@ -55,7 +55,7 @@ func TestRecallNamesTheFilesUnderTheBestHit(t *testing.T) {
 		"/w/app/internal/queue/backoff.go",
 		"/w/app/internal/queue/jitter.go",
 	)
-	got := recallTouchedLine(dir, s)
+	got := recallTouchedLine(dir, s, nil)
 	if got == "" {
 		t.Fatal("no line for a session that edited three files")
 	}
@@ -107,7 +107,7 @@ func TestRecallCountsTheFilesItDidNotName(t *testing.T) {
 		t.Fatalf("the store kept %d paths, at or under the line's cap of %d: there is no overflow to check, so the fixture needs more paths or the manifest cap moved",
 			held, recallTouchedFiles)
 	}
-	got := recallTouchedLine(dir, s)
+	got := recallTouchedLine(dir, s, nil)
 	if got == "" {
 		t.Fatal("no line for a session that edited seven files")
 	}
@@ -138,7 +138,7 @@ func TestRecallCountsTheFilesItDidNotName(t *testing.T) {
 // inventing one would name a directory none of them are in.
 func TestRecallLeavesUnrelatedPathsWhole(t *testing.T) {
 	dir, s := touchedLineStore(t, "/one/alpha.go", "/two/beta.go")
-	got := recallTouchedLine(dir, s)
+	got := recallTouchedLine(dir, s, nil)
 	if got == "" {
 		t.Fatal("no line for a session that edited two files")
 	}


### PR DESCRIPTION
`files it touched:` exists so an agent that has just read "this was solved here" knows where to look. It names four of the session's files, and `Touched` is kept in path order — so the four are whichever paths sort first, the same four for every question that reaches that session. Over sixteen recall calls against a real store, 1 of the 10 lines served held any word of the question, and one session answered four unrelated questions (`blame rows per file`, `mcp dispatcher modes`, `connection pool exhausted`, `compaction summary clipped`) with the same three paths.

Paths that carry a word of the question now come first, the rest keep their order, and the four-path cut applies after. Same sixteen calls: 4 of 10, and the lines that changed are the ones you would want — a question about the prompt hook now names `cmd/deja/hook_prompt.go`, one about the recall pointer names `cmd/deja/recall_frame.go`.

Words shorter than four runes and stopwords are ignored, so `go` and `md` cannot promote every file in a Go repo; with nothing usable in the question the line is exactly what it was.

Tests: one session whose related file sorts last and is dropped by the cut, which has to lead afterwards; one that pins the unchanged order for no terms, stopwords and two-letter words. Reverting the call turns the first red. `bench prompt`, `bench context`, `bench block` unchanged.
