### PR TITLE
fix(recall): one stray path no longer makes the files line absolute

### DIFF
--- a/cmd/deja/recall_frame.go
+++ b/cmd/deja/recall_frame.go
@@ -118,11 +118,13 @@ func recallTouchedLine(dir string, s model.Session, terms []string) string {
 		// under one repo repeat its absolute prefix four times, which is most
 		// of the line's cost and none of its meaning. Relative paths are also
 		// what the agent will type next.
-		root := commonDirPrefix(paths)
+		root := majorityDirPrefix(paths)
 		shown := paths
 		if root != "" {
 			shown = make([]string, len(paths))
 			for i, p := range paths {
+				// A path outside the root keeps its own: the root is named for
+				// the ones under it, not claimed over all of them.
 				shown[i] = strings.TrimPrefix(p, root)
 			}
 		}
@@ -175,6 +177,38 @@ func pathsAboutIt(paths, terms []string) []string {
 		}
 	}
 	return append(named, rest...)
+}
+
+// majorityDirPrefix is commonDirPrefix for a real session: the directory most of
+// these paths share, even when one of them sits somewhere else entirely.
+//
+// Requiring every path to share it made one outlier cost the whole line: a
+// session that edited three files in one repo and ran one script in /private/tmp
+// printed four absolute paths — 255 bytes where 90 say the same thing, on a line
+// whose whole job is to be short. Measured across sixteen recall calls on a real
+// store, four of the ten lines served were absolute for this reason.
+//
+// Majority, not "all but one": a line of four paths from four different trees has
+// no root to name, and saying one would be a claim about paths that are not under
+// it.
+func majorityDirPrefix(paths []string) string {
+	if root := commonDirPrefix(paths); root != "" {
+		return root
+	}
+	if len(paths) < 3 {
+		return ""
+	}
+	best := ""
+	for i := range paths {
+		// Leave one out and ask the same question of the rest.
+		rest := make([]string, 0, len(paths)-1)
+		rest = append(rest, paths[:i]...)
+		rest = append(rest, paths[i+1:]...)
+		if root := commonDirPrefix(rest); len(root) > len(best) {
+			best = root
+		}
+	}
+	return best
 }
 
 // commonDirPrefix returns the longest directory prefix every path shares,

--- a/cmd/deja/recall_touched_root_test.go
+++ b/cmd/deja/recall_touched_root_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// The line says the shared directory once and lists names under it, which only
+// worked when every path shared one. A session that edited files in a repo and
+// ran one script in /private/tmp printed four absolute paths instead — 255 bytes
+// where 90 say the same thing. Across sixteen recall calls on a real store, 5 of
+// the 10 lines served were absolute for that reason, and the ten lines together
+// cost 2258 bytes against 1808 with the root named for the majority.
+func TestOneStrayPathDoesNotMakeTheWholeLineAbsolute(t *testing.T) {
+	dir, s := touchedLineStore(t,
+		"/w/app/internal/queue/backoff.go",
+		"/w/app/internal/queue/retry.go",
+		"/w/app/internal/queue/jitter.go",
+		"/private/tmp/probe/run3.sh",
+	)
+	got := recallTouchedLine(dir, s, nil)
+	if strings.Count(got, "/w/app/internal/queue") != 1 {
+		t.Errorf("the repo the three files share is not named once: %q", got)
+	}
+	// The stray path is still there in full: it is not under the root, and
+	// trimming a prefix it does not have would name a file that does not exist.
+	if !strings.Contains(got, "/private/tmp/probe/run3.sh") {
+		t.Errorf("the path outside the root was lost or mangled: %q", got)
+	}
+}
+
+// Four paths from four trees have no root to name: saying one would claim it
+// over paths that are not under it.
+func TestPathsFromDifferentTreesClaimNoRoot(t *testing.T) {
+	dir, s := touchedLineStore(t,
+		"/w/one/alpha.go",
+		"/x/two/beta.go",
+		"/y/three/gamma.go",
+		"/z/four/delta.go",
+	)
+	got := recallTouchedLine(dir, s, nil)
+	if strings.Contains(got, " in /") {
+		t.Errorf("a root was named over paths that do not share it: %q", got)
+	}
+	for _, want := range []string{"/w/one/alpha.go", "/x/two/beta.go"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%s is missing: %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
The files line says the shared directory once and lists names under it, which needed *every* path to share it. A session that edited three files in one repo and ran one script in `/private/tmp` therefore printed four absolute paths: 255 bytes where 90 say the same thing, on a line whose whole job is to be short. Over sixteen recall calls against a real store, 5 of the 10 lines served were absolute for that reason; the ten together cost 2258 bytes, now 1808 (−20%), and none of them opens on an absolute path.

The root is now the directory the majority share — leave-one-out, not "all but one", so four paths from four trees still claim no root, and a path outside the root keeps its own in full rather than having a prefix trimmed it never had.

Tests: the three-plus-stray session, where the repo has to be named once and the stray survives whole; and four unrelated trees, where no root may be claimed. Reverting the call turns the first red.
