### PR TITLE
fix(bench): each recall query names one session

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -24,6 +24,10 @@ type benchMetric struct {
 	// every query returns exactly five hits, so recall@5 says only whether the
 	// session came back at all and recall@10 cannot differ from it — reversing
 	// the ranking left both at 1.00 (#2933).
+	//
+	// They only started moving once each query named one session: while five
+	// queries shared a string and five sessions shared a text, a perfect ranker
+	// scored 0.20 and 0.457, which is what this printed for a long time.
 	RecallAt1             float64 `json:"recall_at_1"`
 	MRR                   float64 `json:"mrr"`
 	RecallAt5             float64 `json:"recall_at_5"`

--- a/internal/bench/corpus.go
+++ b/internal/bench/corpus.go
@@ -64,6 +64,16 @@ func Generate(seed int64) Corpus {
 		project := fmt.Sprintf("project-%02d", i%25)
 		text := fmt.Sprintf("routine %s session %d recorded a harmless status update", t.name, i)
 		if i < QueryCount {
+			// One query, one session. The topic used to come from i%10 and the
+			// variant from i%5, which makes the variant a function of the topic:
+			// all five gold sessions of a topic got the same text, and the five
+			// queries built from them were the same string with five different
+			// "correct" answers. A perfect ranker scored recall@1 0.20 and MRR
+			// 0.457 — (1 + 1/2 + 1/3 + 1/4 + 1/5)/5 to three places, which is
+			// what the bench reported — so the headline ranking numbers measured
+			// the tie and could not move. Ten topics and five variants make fifty
+			// distinct pairs.
+			t = topics[i/5]
 			variant := i % 5
 			switch variant {
 			case 0:

--- a/internal/bench/recall_gold_test.go
+++ b/internal/bench/recall_gold_test.go
@@ -1,0 +1,46 @@
+package bench
+
+import "testing"
+
+// A query the corpus answers five times over is a tie, not a ranking question.
+//
+// The topic came from i%10 and the variant from i%5, which made the variant a
+// function of the topic: each topic's five gold sessions carried the same text,
+// and the five queries built from them were one string with five different
+// "correct" answers. recall@1 was then capped at 0.20 and MRR at
+// (1 + 1/2 + 1/3 + 1/4 + 1/5)/5 = 0.457 — the numbers the bench printed — so the
+// two columns that exist to see the order could not move.
+func TestEachBenchQueryNamesOneSession(t *testing.T) {
+	c := Generate(Seed)
+	asked := map[string][]string{}
+	for _, q := range c.Queries {
+		if len(q.Relevant) != 1 {
+			t.Fatalf("query %q names %d sessions; the metric assumes one", q.Text, len(q.Relevant))
+		}
+		asked[q.Text] = append(asked[q.Text], q.Relevant[0])
+	}
+	for text, gold := range asked {
+		if len(gold) > 1 {
+			t.Errorf("%q is asked %d times with a different answer each time: %v", text, len(gold), gold)
+		}
+	}
+
+	// And the session it names has to be the only one that says it: a second
+	// session with the same text is the same tie one level down.
+	text := map[string]int{}
+	for _, s := range c.Sessions {
+		if len(s.Messages) > 0 {
+			text[s.Messages[0].Text]++
+		}
+	}
+	for _, q := range c.Queries {
+		for _, s := range c.Sessions {
+			if s.ID != q.Relevant[0] || len(s.Messages) == 0 {
+				continue
+			}
+			if n := text[s.Messages[0].Text]; n > 1 {
+				t.Errorf("%d sessions carry the text of %s, the answer to %q", n, s.ID, q.Text)
+			}
+		}
+	}
+}


### PR DESCRIPTION
`bench recall` printed recall@1 0.20 and MRR 0.457 for a long time, and those were not measurements of the ranking — they were the ceiling. The corpus took the topic from `i%10` and the variant from `i%5`, so the variant is a function of the topic: each topic's five gold sessions got identical text, and the five queries built from them were *one string with five different single correct answers*. A perfect ranker scores 1/5 on that, and MRR (1 + 1/2 + 1/3 + 1/4 + 1/5)/5 = 0.4567 — the number printed, to three places.

Ten topics and five variants make fifty distinct pairs, so each query now names one session and each answer is the only session that says it. Same ranker, same seed: recall@1 0.20 → 0.74, MRR 0.457 → 0.857. The 13 queries that still miss are ranking work someone can now do and see.

recall@5 and recall@10 stay saturated for the reason #2933 recorded — five hits per query — and the comment on `benchMetric` now says which two columns can move and why they couldn't.

Test asserts what was missing: every query string distinct, one relevant session each, and that session the only one carrying its text. Reverting the corpus line turns it red with the five repeated queries named.
