### PR TITLE
fix(bench): a recall query names the occasion, so one session answers it

### DIFF
--- a/cmd/deja/bench.go
+++ b/cmd/deja/bench.go
@@ -27,7 +27,10 @@ type benchMetric struct {
 	//
 	// They only started moving once each query named one session: while five
 	// queries shared a string and five sessions shared a text, a perfect ranker
-	// scored 0.20 and 0.457, which is what this printed for a long time.
+	// scored 0.20 and 0.457, which is what this printed for a long time. With
+	// the subject plus the occasion naming one session, all four columns sit at
+	// 1.00 and the bench is a regression gate: the test asserts the top, so a
+	// ranking change that moves one answer off first place fails CI.
 	RecallAt1             float64 `json:"recall_at_1"`
 	MRR                   float64 `json:"mrr"`
 	RecallAt5             float64 `json:"recall_at_5"`

--- a/cmd/deja/bench_test.go
+++ b/cmd/deja/bench_test.go
@@ -46,17 +46,21 @@ func TestBenchRecallJSONAndIsolation(t *testing.T) {
 	if len(report.CorpusHash) != 64 || report.Sessions != 500 || report.Queries != 50 || report.Lexical.RecallAt5 < 0.85 || report.Lexical.RecallAt10 < report.Lexical.RecallAt5 || report.Lexical.MedianMS < 0 || report.HybridStatus == "" {
 		t.Fatalf("unexpected benchmark report: %#v", report)
 	}
-	// The columns that can see the order. Every query on this corpus returns
-	// exactly five hits, so recall@5 answers "did it come back" and recall@10
-	// cannot differ from it — a ranking that put every answer last scored the
-	// same 1.00 (#2933). recall@1 and MRR are what move: they must be reported,
-	// and they must be below the saturated column, or the bench is measuring
-	// presence again under new names.
-	if report.Lexical.MRR <= 0 || report.Lexical.MRR >= report.Lexical.RecallAt5 {
-		t.Errorf("MRR %.3f says nothing recall@5 %.2f does not", report.Lexical.MRR, report.Lexical.RecallAt5)
+	// The columns that see the order, pinned at the top rather than at a
+	// fraction. Each of the fifty queries names one session and that session is
+	// the only one carrying its words (#3481 and the occasions after it), so the
+	// ranker putting every answer first is the pass mark: a drop here is a
+	// ranking regression and nothing else.
+	//
+	// These used to be asserted below recall@5, which was right while they were
+	// capped by ties — recall@1 could not exceed 0.20 and MRR 0.457 whatever the
+	// ranker did, and the bench printed exactly those two numbers. The cap was
+	// the thing that made them look like measurements.
+	if report.Lexical.RecallAt1 < 1 {
+		t.Errorf("recall@1 %.2f: a query whose one answer is the only session that says it was not ranked first", report.Lexical.RecallAt1)
 	}
-	if report.Lexical.RecallAt1 <= 0 || report.Lexical.RecallAt1 >= report.Lexical.RecallAt5 {
-		t.Errorf("recall@1 %.2f says nothing recall@5 %.2f does not", report.Lexical.RecallAt1, report.Lexical.RecallAt5)
+	if report.Lexical.MRR < 1 {
+		t.Errorf("MRR %.3f: the answer was not first for every query", report.Lexical.MRR)
 	}
 	entries, err := os.ReadDir(outside)
 	if err != nil {

--- a/internal/bench/corpus.go
+++ b/internal/bench/corpus.go
@@ -75,17 +75,25 @@ func Generate(seed int64) Corpus {
 			// distinct pairs.
 			t = topics[i/5]
 			variant := i % 5
+			// The occasion, which is what tells one session about a subject from
+			// the next four. Without it the topic's phrase sat in four of the
+			// five texts — "cache invalidation" is in the exact session, the
+			// typo's correction, the quoted one and the code review — so the
+			// exact-phrase query had five legitimate matches and the label named
+			// one of them. That capped recall@1 at 0.74 after #3481 removed the
+			// coarser tie, and the cap was invisible in the number.
+			occasion := occasions[variant]
 			switch variant {
 			case 0:
-				text = fmt.Sprintf("decision: investigate %s; code reference %s", t.exact, t.code)
+				text = fmt.Sprintf("decision: investigate %s %s; code reference %s", t.exact, occasion, t.code)
 			case 1:
-				text = fmt.Sprintf("error log: %s; decision: %s", t.exact, t.rephrased)
+				text = fmt.Sprintf("error log: %s %s; decision: %s", t.exact, occasion, t.rephrased)
 			case 2:
-				text = fmt.Sprintf("error log mentions %s; the correct term is %s", t.typo, t.exact)
+				text = fmt.Sprintf("error log mentions %s %s; the correct term is %s", t.typo, occasion, t.exact)
 			case 3:
-				text = fmt.Sprintf("decision recorded for %q in %s", t.phrase, t.code)
+				text = fmt.Sprintf("decision recorded for %q %s in %s", t.phrase, occasion, t.code)
 			case 4:
-				text = fmt.Sprintf("code review for %s found the %s behavior", t.code, t.exact)
+				text = fmt.Sprintf("code review for %s %s found the %s behavior", t.code, occasion, t.exact)
 			}
 			queries = append(queries, Query{Text: queryText(t, variant), Relevant: []string{id}})
 		}
@@ -108,17 +116,26 @@ func Generate(seed int64) Corpus {
 	return Corpus{Sessions: sessions, Queries: queries, Hash: hex.EncodeToString(h[:])}
 }
 
+// occasions are what a person adds when they actually ask: not "connection pool
+// exhausted" but "connection pool exhausted under load". One per variant, shared
+// across topics, so every query still competes with nine sessions that name the
+// same occasion and ten that name the same subject.
+var occasions = [5]string{
+	"on cold start", "after a deploy", "under load",
+	"in the nightly job", "on replica lag",
+}
+
 func queryText(t topic, variant int) string {
 	switch variant {
 	case 0:
-		return t.exact
+		return t.exact + " " + occasions[0]
 	case 1:
-		return t.rephrased
+		return t.rephrased + " " + occasions[1]
 	case 2:
-		return t.typo
+		return t.typo + " " + occasions[2]
 	case 3:
-		return fmt.Sprintf("%q", t.phrase)
+		return fmt.Sprintf("%q %s", t.phrase, occasions[3])
 	default:
-		return t.code
+		return t.code + " " + occasions[4]
 	}
 }

--- a/internal/bench/recall_gold_test.go
+++ b/internal/bench/recall_gold_test.go
@@ -1,6 +1,9 @@
 package bench
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // A query the corpus answers five times over is a tie, not a ranking question.
 //
@@ -43,4 +46,54 @@ func TestEachBenchQueryNamesOneSession(t *testing.T) {
 			}
 		}
 	}
+}
+
+// And one session, not five, holds the words the query asks with. The subject
+// alone sat in four of a topic's five texts, so the exact-phrase query matched
+// all four and the label named one: recall@1 could not pass 0.74 however the
+// ranker behaved. The occasion in the query is what makes the answer singular.
+func TestOneSessionHoldsEachQuerysWords(t *testing.T) {
+	c := Generate(Seed)
+	for _, q := range c.Queries {
+		want := queryWords(q.Text)
+		var holders []string
+		for _, s := range c.Sessions {
+			if len(s.Messages) == 0 {
+				continue
+			}
+			if holdsAll(s.Messages[0].Text, want) {
+				holders = append(holders, s.ID)
+			}
+		}
+		if len(holders) != 1 {
+			t.Errorf("%q is carried by %d sessions (%v); the metric credits one", q.Text, len(holders), holders)
+			continue
+		}
+		if holders[0] != q.Relevant[0] {
+			t.Errorf("%q is carried by %s but credited to %s", q.Text, holders[0], q.Relevant[0])
+		}
+	}
+}
+
+// queryWords are the words a query has to be found by, with the quoting and the
+// punctuation a phrase query carries taken off.
+func queryWords(text string) []string {
+	var out []string
+	for _, w := range strings.Fields(strings.ToLower(text)) {
+		w = strings.Trim(w, `"'.,;:`)
+		if len(w) > 2 {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func holdsAll(text string, words []string) bool {
+	low := strings.ToLower(text)
+	for _, w := range words {
+		if !strings.Contains(low, w) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Follow-up to #3481, which removed the coarse tie (five queries sharing one string) and left a finer one: the topic's phrase sat in four of its five session texts — `cache invalidation` is in the exact session, in the typo session's correction, in the quoted one and in the code review — so the exact-phrase query had four legitimate matches and the label named one. recall@1 could not pass 0.74 whatever the ranker did, and nothing in the number said so.

Each gold session now carries an occasion as well as a subject (`connection pool exhausted under load`, `refresh token rotation in the nightly job`) and each query asks with both. Five occasions across ten topics, so every query still competes with nine sessions naming the same occasion and four naming the same subject — plus the 450 noise sessions. Same ranker, same seed: recall@1 0.74 → 1.00, MRR 0.857 → 1.00.

All four columns now sit at the top, which is what the bench is for after this: a gate. The test asserts recall@1 and MRR are 1.00, so any change that moves one of the fifty answers off first place fails CI — where the old assertion ("recall@1 must be below recall@5") was right only while the cap existed.

Tests: the new invariant is that exactly one session holds the words of each query, and that it is the one credited; dropping the occasion turns it red, naming the queries no session answers, and the bench gate red with it.

`bench prompt`, `bench context` and `bench block` unchanged.
