### PR TITLE
feat(bench): the recall corpus asks in Russian too

### DIFF
--- a/cmd/deja/bench_test.go
+++ b/cmd/deja/bench_test.go
@@ -43,7 +43,7 @@ func TestBenchRecallJSONAndIsolation(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &report); err != nil {
 		t.Fatalf("invalid benchmark JSON %q: %v", out, err)
 	}
-	if len(report.CorpusHash) != 64 || report.Sessions != 500 || report.Queries != 50 || report.Lexical.RecallAt5 < 0.85 || report.Lexical.RecallAt10 < report.Lexical.RecallAt5 || report.Lexical.MedianMS < 0 || report.HybridStatus == "" {
+	if len(report.CorpusHash) != 64 || report.Sessions != bench.SessionCount || report.Queries != bench.QueryCount || report.Lexical.RecallAt5 < 0.85 || report.Lexical.RecallAt10 < report.Lexical.RecallAt5 || report.Lexical.MedianMS < 0 || report.HybridStatus == "" {
 		t.Fatalf("unexpected benchmark report: %#v", report)
 	}
 	// The columns that see the order, pinned at the top rather than at a

--- a/internal/bench/corpus.go
+++ b/internal/bench/corpus.go
@@ -15,7 +15,9 @@ const Seed int64 = 1
 
 const (
 	SessionCount = 500
-	QueryCount   = 50
+	// Five variants for each topic in the table, which is what makes every
+	// query name one session (#3481).
+	QueryCount = 100
 )
 
 type Query struct {
@@ -36,6 +38,10 @@ type topic struct {
 	typo      string
 	phrase    string
 	code      string
+	// ru marks a topic written the way this store is mostly written. The
+	// occasions a query names are in the topic's own language; a question that
+	// mixes two is nobody's question.
+	ru bool
 }
 
 var topics = []topic{
@@ -49,6 +55,21 @@ var topics = []topic{
 	{name: "locking", exact: "file lock contention", rephrased: "writers waited on the same lock", typo: "contetion", phrase: "file lock contention", code: "internal/lock.go"},
 	{name: "redaction", exact: "credential redaction", rephrased: "secrets are removed before indexing", typo: "redacton", phrase: "credential redaction", code: "security/redact.go"},
 	{name: "recovery", exact: "crash recovery replay", rephrased: "rebuilding after an interrupted write", typo: "replai", phrase: "crash recovery replay", code: "index/recover.go"},
+	// The other half of the corpus, because the ranking it gates is used mostly
+	// on stores that read like this one: #2734 found the store Russian-dominant
+	// and changed the decision recogniser for it, while this bench stayed
+	// English — so a ranking regression on Cyrillic passed every column at 1.00.
+	// Invented subjects, not this machine's.
+	{name: "кэш", exact: "инвалидация кэша", rephrased: "сброс устаревших записей кэша", typo: "инвалидацяи", phrase: "инвалидация кэша", code: "store/cache.go", ru: true},
+	{name: "миграция", exact: "идемпотентная миграция", rephrased: "повторяемое обновление схемы", typo: "идемпотнетная", phrase: "идемпотентная миграция", code: "store/migrate.go", ru: true},
+	{name: "пул", exact: "пул соединений исчерпан", rephrased: "клиенты базы закончились", typo: "исчерапн", phrase: "пул соединений исчерпан", code: "store/pool.go", ru: true},
+	{name: "токен", exact: "ротация refresh-токена", rephrased: "обновление доступа после ротации", typo: "ротацяи", phrase: "ротация refresh-токена", code: "auth/refresh.go", ru: true},
+	{name: "очередь", exact: "повторная доставка задачи", rephrased: "воркер получил одну задачу дважды", typo: "достаква", phrase: "повторная доставка задачи", code: "queue/worker.go", ru: true},
+	{name: "парсер", exact: "ошибка на границе записи", rephrased: "декодер перешёл границу записи", typo: "граинце", phrase: "ошибка на границе записи", code: "parse/record.go", ru: true},
+	{name: "таймаут", exact: "превышен дедлайн запроса", rephrased: "апстрим не ответил в срок", typo: "дедлйан", phrase: "превышен дедлайн запроса", code: "net/deadline.go", ru: true},
+	{name: "блокировка", exact: "конкуренция за файловую блокировку", rephrased: "писатели ждали одну блокировку", typo: "конкуренцяи", phrase: "конкуренция за файловую блокировку", code: "lock/file.go", ru: true},
+	{name: "редакция", exact: "вырезание секретов", rephrased: "секреты убираются до индексации", typo: "вырезаине", phrase: "вырезание секретов", code: "redact/secrets.go", ru: true},
+	{name: "восстановление", exact: "проигрывание журнала после сбоя", rephrased: "пересборка после прерванной записи", typo: "проигрывнаие", phrase: "проигрывание журнала после сбоя", code: "recover/replay.go", ru: true},
 }
 
 // Generate is the benchmark fixture. Every value, including timestamps and
@@ -82,7 +103,7 @@ func Generate(seed int64) Corpus {
 			// exact-phrase query had five legitimate matches and the label named
 			// one of them. That capped recall@1 at 0.74 after #3481 removed the
 			// coarser tie, and the cap was invisible in the number.
-			occasion := occasions[variant]
+			occasion := occasionsFor(t)[variant]
 			switch variant {
 			case 0:
 				text = fmt.Sprintf("decision: investigate %s %s; code reference %s", t.exact, occasion, t.code)
@@ -125,17 +146,30 @@ var occasions = [5]string{
 	"in the nightly job", "on replica lag",
 }
 
+// ruOccasions are the same five, for the half of the table written in Russian.
+var ruOccasions = [5]string{
+	"на холодном старте", "после деплоя", "под нагрузкой",
+	"в ночном прогоне", "на лаге реплики",
+}
+
+func occasionsFor(t topic) [5]string {
+	if t.ru {
+		return ruOccasions
+	}
+	return occasions
+}
+
 func queryText(t topic, variant int) string {
 	switch variant {
 	case 0:
-		return t.exact + " " + occasions[0]
+		return t.exact + " " + occasionsFor(t)[0]
 	case 1:
-		return t.rephrased + " " + occasions[1]
+		return t.rephrased + " " + occasionsFor(t)[1]
 	case 2:
-		return t.typo + " " + occasions[2]
+		return t.typo + " " + occasionsFor(t)[2]
 	case 3:
-		return fmt.Sprintf("%q %s", t.phrase, occasions[3])
+		return fmt.Sprintf("%q %s", t.phrase, occasionsFor(t)[3])
 	default:
-		return t.code + " " + occasions[4]
+		return t.code + " " + occasionsFor(t)[4]
 	}
 }

--- a/internal/bench/recall_gold_test.go
+++ b/internal/bench/recall_gold_test.go
@@ -97,3 +97,38 @@ func holdsAll(text string, words []string) bool {
 	}
 	return true
 }
+
+// The ranking this corpus gates is used mostly on stores that do not read like
+// the first half of the topic table. #2734 found the store Russian-dominant and
+// changed the decision recogniser for it; the bench stayed English, so a
+// regression on Cyrillic passed every column at 1.00. Both halves ask, and each
+// asks in its own language — a query that mixes two is nobody's question.
+func TestTheRecallCorpusAsksInBothLanguages(t *testing.T) {
+	c := Generate(Seed)
+	cyrillic := func(s string) bool {
+		for _, r := range s {
+			if r >= 0x400 && r <= 0x4FF {
+				return true
+			}
+		}
+		return false
+	}
+	ru, en := 0, 0
+	for _, q := range c.Queries {
+		if cyrillic(q.Text) {
+			ru++
+			// The occasion travels with the subject: "под нагрузкой", never
+			// "under load" after three Russian words.
+			for _, word := range []string{"under load", "after a deploy", "on cold start", "nightly job", "replica lag"} {
+				if strings.Contains(q.Text, word) {
+					t.Errorf("%q asks in two languages at once", q.Text)
+				}
+			}
+			continue
+		}
+		en++
+	}
+	if ru < QueryCount/4 || en < QueryCount/4 {
+		t.Errorf("the corpus asks %d queries in Russian and %d in English; both halves have to be there", ru, en)
+	}
+}


### PR DESCRIPTION
`bench recall` is the gate on ranking, and after #3481 and #3482 it sits at 1.00 on every column — in English only. The store this ranking actually runs on is mostly not English: #2734 found it Russian-dominant and changed the decision recogniser for that reason, while this corpus kept ten English topics, so a regression on Cyrillic passed all four columns untouched.

Ten Russian topics join the table — invented subjects, their own code paths, their own occasions ("под нагрузкой", not "under load" after three Russian words) — so the corpus is 100 queries, half of them Cyrillic, still one session per query. Same ranker: recall@1 and MRR stay 1.00, which is the finding. The shapes all work on Cyrillic today; what changes is that a change which breaks them now fails CI.

Tests: both halves have to be present and no query may ask in two languages at once; and the singular-answer invariant from #3482 now covers twice as many queries. Putting the English occasion back on the Russian texts turns it red, naming the queries two sessions answer.

`bench prompt`, `bench context`, `bench block` unchanged. The sizes in `bench_test.go` come from `bench.SessionCount` and `bench.QueryCount` now rather than literals, so the corpus can grow without the assertion drifting.
