### PR TITLE
fix(recall): an unrelated conclusion is offered, not claimed

### DIFF
--- a/cmd/deja/mcp.go
+++ b/cmd/deja/mcp.go
@@ -967,7 +967,7 @@ func attachAnswers(dir string, hits []search.Hit) {
 // Excerpt words count as well as query words, which is what keeps a conclusion
 // worded nothing like the question — the case the list exists for (#1011): "the
 // backoff counted from zero" stays under an excerpt that says backoff.
-func conclusionsAboutIt(cs []string, q string, snippets []string) []string {
+func conclusionsAboutIt(cs []string, q string, snippets []string) ([]string, bool) {
 	about := contentWords(q)
 	for _, sn := range snippets {
 		for w := range contentWords(sn) {
@@ -977,7 +977,7 @@ func conclusionsAboutIt(cs []string, q string, snippets []string) []string {
 	if len(about) == 0 {
 		// Nothing to judge against: a query of common words alone, which the
 		// ranking answered on its own terms.
-		return cs
+		return cs, true
 	}
 	kept := make([]string, 0, len(cs))
 	for _, c := range cs {
@@ -991,9 +991,14 @@ func conclusionsAboutIt(cs []string, q string, snippets []string) []string {
 		// which this store is full of — still concluded something, and a
 		// conclusion nobody asked for is a memory that can still turn out to be
 		// the one. Three of them is wallpaper; one is an offer.
-		return cs[:1]
+		//
+		// And it is offered as one: the second return is false, so the line
+		// above it does not call it a conclusion about the question. On sixteen
+		// recall calls against a real store this is what four of the answers
+		// show, and an agent reads the label as the claim.
+		return cs[:1], false
 	}
-	return kept
+	return kept, true
 }
 
 // sharesAWord is word overlap that holds for identifiers: `ManifestBuiltAt`
@@ -1482,11 +1487,19 @@ func recallTextResultFrom(dir, q, harness string, limit, offset, budget int) (st
 				// showed one where three were available.
 				want := 3 + shownAnswers(h.Snippets) + conclusionGateSlack
 				cs := withoutShownAnswer(digest.Conclusions(whole, left, want), h.Snippets)
-				if cs = conclusionsAboutIt(cs, q, h.Snippets); len(cs) > 0 {
+				cs, aboutIt := conclusionsAboutIt(cs, q, h.Snippets)
+				if len(cs) > 0 {
 					if len(cs) > 3 {
 						cs = cs[:3]
 					}
-					fmt.Fprintln(&hb, "  what this session concluded:")
+					label := "  what this session concluded:"
+					if !aboutIt {
+						// Nothing it concluded is about the question, and this
+						// is the newest thing it settled instead. Said plainly,
+						// because the label is what an agent reads as the claim.
+						label = "  what this session concluded, about its own work:"
+					}
+					fmt.Fprintln(&hb, label)
 					for _, c := range cs {
 						fmt.Fprintf(&hb, "  → %s\n", recallListingLine(c))
 					}

--- a/cmd/deja/mcp_conclusion_gate_test.go
+++ b/cmd/deja/mcp_conclusion_gate_test.go
@@ -49,6 +49,38 @@ func seedMixedConclusions(t *testing.T, tail string) string {
 	return dir
 }
 
+// seedUnrelatedConclusions writes a session that matches the question on its
+// filler and concluded nothing about it — the shape a long session has when a
+// question reaches it through one passing mention.
+func seedUnrelatedConclusions(t *testing.T) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	store := filepath.Join(os.Getenv("DEJA_CLAUDE_ROOT"), "-proj")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := func(text, hour string) string {
+		return `{"type":"assistant","message":{"role":"assistant","content":"` + text +
+			`"},"timestamp":"2026-08-02T` + hour + `:00:00Z","sessionId":"csb","cwd":"/proj"}` + "\n"
+	}
+	var b strings.Builder
+	for i := range 20 {
+		b.WriteString(line(strings.Repeat("glimwrax polling window notes ", 8), "0"+string(rune('0'+i%10))))
+	}
+	b.WriteString(line("in the end we moved the invoice mailer onto the nightly queue, "+
+		strings.Repeat("so the morning batch stops competing with it ", 6), "11"))
+	b.WriteString(line("the cause was a stale etag on the partner avatars, "+
+		strings.Repeat("and the proxy kept serving it for an hour ", 6), "12"))
+	if err := os.WriteFile(filepath.Join(store, "csb.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(tmp, "index.db")
+	if err := index.Ensure(dir, "", false, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
 // Conclusions are read off the whole session and sorted by age, so a session
 // that worked on three things served its newest three to every question about
 // any of them: over sixteen recall calls on a real store, 42% of the conclusion
@@ -74,8 +106,8 @@ func TestTheConclusionsListLeavesOutOtherWork(t *testing.T) {
 // helps, and the store is full of sessions whose words are in another language
 // than the query — withholding all of them would cost more than it saves.
 func TestASessionWithNoRelatedConclusionStillOffersOne(t *testing.T) {
-	dir := seedMixedConclusions(t, "")
-	text, _, _, _, err := recallTextResult(dir, "flimsyshard discussion", "", 0, 0, 4096-recallFrameOverhead)
+	dir := seedUnrelatedConclusions(t)
+	text, _, _, _, err := recallTextResult(dir, "glimwrax polling window", "", 0, 0, 4096-recallFrameOverhead)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,5 +117,27 @@ func TestASessionWithNoRelatedConclusionStillOffersOne(t *testing.T) {
 	shown := strings.Count(text, "\n  → ")
 	if shown != 1 {
 		t.Errorf("offered %d conclusion lines; an unrelated session gets one, not a list:\n%s", shown, text)
+	}
+	// And it is offered rather than claimed: the label is what an agent reads as
+	// the claim, so a line about the session's other work must not arrive under
+	// one that says it answers the question.
+	if !strings.Contains(text, "concluded, about its own work:") {
+		t.Errorf("an unrelated conclusion was labelled as this question's:\n%s", text)
+	}
+}
+
+// And the label stays plain when the conclusion is the question's: the hedge is
+// for the fallback, not for every hit.
+func TestARelatedConclusionIsNotHedged(t *testing.T) {
+	dir := seedMixedConclusions(t, "")
+	text, _, _, _, err := recallTextResult(dir, "flimsyshard retry cap", "", 0, 0, 4096-recallFrameOverhead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(text, "what this session concluded:") {
+		t.Errorf("the plain label is missing:\n%s", text)
+	}
+	if strings.Contains(text, "about its own work") {
+		t.Errorf("a conclusion about the question was hedged:\n%s", text)
 	}
 }


### PR DESCRIPTION
#3476 gates the conclusions list on the question and, when nothing passes, still offers one line — a session that matched on words the gate cannot see has concluded something, and it can turn out to be the one. It arrived under `what this session concluded:`, the same label as a conclusion that *is* about the question. The label is what an agent reads as the claim, so the fallback was claiming more than it knows.

It now reads `what this session concluded, about its own work:`. Two of the sixteen recall answers measured on a real store show that label; the other fourteen are unchanged.

Tests: the unrelated-conclusion session has to get the hedged label and exactly one line; the related one has to keep the plain label and not be hedged. Reverting the branch turns the first red. The unrelated fixture is new — the old one shared a word with the question through its filler, so it exercised the filter rather than the fallback.
