### PR TITLE
test(bench): the off-topic arms ask through the hook

### DIFF
--- a/cmd/deja/bench_prompt.go
+++ b/cmd/deja/bench_prompt.go
@@ -613,10 +613,16 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Marathon, nil)
 	finishPromptArm(&report.Fresh, nil)
 	finishPromptArm(&report.Bucket, nil)
-	// Asked against the project that holds every one of its words.
+	// Asked against the project that holds every one of its words, and asked
+	// through the hook rather than through the bar alone: the hook has gates the
+	// bar does not — whether anyone spoke the subject, whether the block was
+	// already delivered — and an arm that stops before them cannot see a change
+	// to them. Measured both ways on this corpus the two agree (3 of 3 fire, and
+	// 2 of 3 on the absent subjects below), so this costs nothing today and
+	// stops the arm reporting a bar the product does not apply alone.
 	for _, q := range offTopicQuestions() {
 		report.OffTopic.Cases++
-		if fired, _ := promptBenchProbe(indexDir, bench.PromptHaystackProject, "no-such-chain", prompt.Terms(q)); fired {
+		if fired, _ := hookEndToEndAs(indexDir, bench.PromptHaystackProject, q, "", "", "zz-offtopic"); fired {
 			report.OffTopic.Fired++
 			report.OffTopic.FalseFires++
 		}
@@ -628,7 +634,7 @@ func measurePrompt(seed int64) (promptReport, error) {
 	finishPromptArm(&report.Tied, nil)
 	for _, q := range absentSubjectQuestions() {
 		report.AbsentSubject.Cases++
-		if fired, _ := promptBenchProbe(indexDir, bench.PromptHaystackProject, "no-such-chain", prompt.Terms(q)); fired {
+		if fired, _ := hookEndToEndAs(indexDir, bench.PromptHaystackProject, q, "", "", "zz-absent"); fired {
 			report.AbsentSubject.Fired++
 			report.AbsentSubject.FalseFires++
 		}


### PR DESCRIPTION
The two arms that exist to catch noise — `off_topic` (every word is in the project, the question never was) and `absent_subject` (the subject belongs to another project) — stopped at `RecallWorthShowingNaming`. The hook has gates after that bar: whether anyone actually spoke the subject, whether the block was already delivered to this reader. An arm that stops before them reports on a rule the product does not apply on its own, and a change to those gates cannot move it.

They go through `hookEndToEndAs` now, like the chain arms. Measured both ways on this corpus the numbers agree — 3 of 3 off-topic questions fire, 2 of 3 absent subjects — so nothing in the report moves today; what changes is that a hook-level gate now shows up there.

This came out of trying exactly such a gate: requiring two of the question's words in one message, or in a message and its neighbour, before a session may answer. Both forms silence the absent-subject arm (2 false fires → 0) and both cost the end-to-end arm its content (fired 2 of 3 → 0 of 3), so neither is worth having — but with the arms as they were, only the first half of that was visible.
