### PR TITLE
fix(hook): the command warning names the project the failure happened in

### DIFF
--- a/cmd/deja/hook_tool.go
+++ b/cmd/deja/hook_tool.go
@@ -331,7 +331,7 @@ func applyPatchFiles(patch string) []string {
 // That rule exists so deja cannot endorse a command it half recognises; a
 // warning cannot endorse anything, and its cost when wrong is a line the
 // reader ignores.
-func commandFailureLine(dir, cmd string) string {
+func commandFailureLine(dir, cwd, cmd string) string {
 	pol := policy.Load()
 	fail, ok := index.CommandFailedBefore(dir, cmd, func(project string) bool {
 		return pol.Allows(policy.ActivationAuto, project)
@@ -339,8 +339,33 @@ func commandFailureLine(dir, cmd string) string {
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("Last time this machine ran %s it ended with: %s (in %s)",
-		search.SafeCommand(fail.Head), search.SafeLine(fail.Line), toolSessionCount(fail.Sessions))
+	// Where it happened, when that is not here. The line is keyed on the shape
+	// of the command, and the shape travels: `go test ./...` is every Go
+	// checkout on the machine. In a directory deja has never seen, 2 of 15
+	// ordinary build and test commands drew a warning and both were another
+	// repository's own failure — a named test, a ten-minute timeout — read as
+	// if this project's suite were broken. The fix pair says "in <project>" for
+	// the same reason (#2363); this said "this machine" and stopped there.
+	where := ""
+	if project := strings.TrimSpace(search.SafeLine(fail.Project)); project != "" && !hookProjectIs(cwd, fail.Project) {
+		where = " in " + project
+	}
+	return fmt.Sprintf("Last time this machine ran %s%s it ended with: %s (in %s)",
+		search.SafeCommand(fail.Head), where, search.SafeLine(fail.Line), toolSessionCount(fail.Sessions))
+}
+
+// hookProjectIs reports whether a recorded project is the one the agent is
+// working in, by the same names the rest of the hook ranks with.
+func hookProjectIs(cwd, project string) bool {
+	if project == "" {
+		return false
+	}
+	for _, name := range digest.ProjectNameCandidates(cwd) {
+		if strings.EqualFold(name, project) {
+			return true
+		}
+	}
+	return false
 }
 
 func commandHookLine(dir, cwd, cmd string) string {
@@ -366,7 +391,7 @@ func commandHookLine(dir, cwd, cmd string) string {
 	if line := missingProgramLine(dir, cmd); line != "" {
 		return line
 	}
-	if line := commandFailureLine(dir, cmd); line != "" {
+	if line := commandFailureLine(dir, cwd, cmd); line != "" {
 		return line
 	}
 	use, ok := index.CommandHistory(dir, cmd)

--- a/cmd/deja/hook_tool_fail_where_test.go
+++ b/cmd/deja/hook_tool_fail_where_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The warning is keyed on the shape of the command, and a shape travels: `go
+// test ./...` is every Go checkout on the machine. In a directory deja had
+// never seen, 2 of 15 ordinary build and test commands drew a warning and both
+// were another repository's own failure — a named test, a ten-minute timeout —
+// with nothing in the line to say so.
+func TestTheCommandWarningNamesTheProjectItHappenedIn(t *testing.T) {
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	// Two sessions in one project where the suite ended on a named test.
+	for _, id := range []string{"f1", "f2"} {
+		writeClaudeFixture(t, filepath.Join(root, "-work-payments", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/payments","timestamp":"2026-01-02T03:04:05Z","message":{"role":"user","content":"run the suite"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/payments","timestamp":"2026-01-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/payments","timestamp":"2026-01-02T03:04:07Z","toolUseResult":{"stdout":"--- FAIL: TestLedgerRollsBack\nFAIL\n","stderr":""},"message":{"role":"user","content":[{"type":"tool_result","content":"--- FAIL: TestLedgerRollsBack\nFAIL\n"}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Asked from the project it happened in: the line says what happened and
+	// does not spend words saying where.
+	here := commandFailureLine(dir, "/work/payments", "go test ./...")
+	if !strings.Contains(here, "TestLedgerRollsBack") {
+		t.Fatalf("the failure did not reach the line at home: %q", here)
+	}
+	if strings.Contains(here, " in work/payments") || strings.Contains(here, " in payments") {
+		t.Errorf("the line named the project the agent is already in: %q", here)
+	}
+
+	// Asked from a checkout deja has never seen: the same failure, and where it
+	// belongs — otherwise it reads as this project's suite being broken.
+	away := commandFailureLine(dir, "/work/warehouse", "go test ./...")
+	if !strings.Contains(away, "TestLedgerRollsBack") {
+		t.Fatalf("the failure did not reach the line away from home: %q", away)
+	}
+	if !strings.Contains(away, "payments") {
+		t.Errorf("another project's failure was reported without naming it: %q", away)
+	}
+}


### PR DESCRIPTION
`hook-tool` warns before a command with "Last time this machine ran `go test ./...` it ended with: …". The warning is keyed on the shape of the command, and a shape travels between checkouts — `go test ./...` is every Go project on the machine. Asked from a directory deja has never seen, 2 of 15 ordinary build and test commands drew a warning, and both were another repository's own failure: a named test (`--- FAIL: TestDocCommentsNameWhatTheyDocument`) and a ten-minute timeout. Read in a fresh checkout, that says this project's suite is broken.

The line names where it happened when that is not here:

```
Last time this machine ran go test ./... in goprojects/deja-vu it ended with: --- FAIL: TestDocCommentsNameWhatTheyDocument (in 2 sessions)
```

Asked inside that project, the wording is unchanged — no words spent saying what the agent already knows. `CommandFailure` already carries the project (it is what the trust policy filters on), and the fix-pair line says "in <project>" for the same reason (#2363); this one said "this machine" and stopped.

Test: one project whose suite ends on a named test, asked from that project (no "in", failure present) and from another (failure present, project named). Reverting the clause turns the second half red. `bench prompt` arms and `bench block` unchanged.
