### PR TITLE
feat(hook): the missing-program line says the command ran without it

### DIFF
--- a/cmd/deja/missing_program.go
+++ b/cmd/deja/missing_program.go
@@ -46,11 +46,89 @@ func missingProgramLine(dir, cmd string) string {
 			continue
 		}
 		if n := index.FrictionSessions(dir, sig, allow); n >= missingProgramMinSessions {
-			return fmt.Sprintf("%s is not on this machine — %s ran into that.",
+			line := fmt.Sprintf("%s is not on this machine — %s ran into that.",
 				prog, toolSessionCount(n))
+			return line + missingProgramRemedy(dir, prog, allow)
 		}
 	}
 	return ""
+}
+
+// missingProgramRemedy adds what this machine did instead, when what it did was
+// simply to leave the program out.
+//
+// The line above states a fact and recommends nothing, and the note on this file
+// says what that is worth: of the ten sessions told at session start that
+// `timeout` was missing, nine ran it anyway. The store knows more than the fact.
+// Both pairs recorded for `timeout` on this machine are the same command with
+// the wrapper taken out — `timeout 12 launchctl kickstart …` followed by
+// `launchctl kickstart …` — which is a remedy an agent can apply without reading
+// another project's command line.
+//
+// Only that shape. A pair whose remedy is a different program ("use python3") is
+// a claim about this machine's toolchain that one recorded run does not support,
+// and a pair whose remedy is a diagnostic (`docker info | grep …`, which is what
+// the store holds for docker) is not a remedy at all.
+func missingProgramRemedy(dir, prog string, allow func(project string) bool) string {
+	for _, p := range index.FixesFor(dir, "command not found: "+prog, 4, allow) {
+		if sameCommandWithout(p.Failed, p.Command, prog) {
+			return " The same command ran without it."
+		}
+	}
+	return ""
+}
+
+// sameCommandWithout reports whether worked is failed with the program — and the
+// argument a wrapper takes, like `timeout 90` — removed and nothing else
+// changed.
+func sameCommandWithout(failed, worked, prog string) bool {
+	if failed == "" || worked == "" {
+		return false
+	}
+	var kept []string
+	dropNext := false
+	found := false
+	for _, f := range strings.Fields(strings.TrimPrefix(strings.TrimSpace(failed), "$ ")) {
+		if dropNext {
+			dropNext = false
+			// A wrapper's first argument is its own — `timeout 90` — and the
+			// next token after the program is dropped with it only when it is
+			// not part of the work.
+			if isWrapperArgument(f) {
+				continue
+			}
+		}
+		if f == prog {
+			found = true
+			dropNext = true
+			continue
+		}
+		kept = append(kept, f)
+	}
+	if !found {
+		return false
+	}
+	return strings.Join(kept, " ") == strings.Join(strings.Fields(strings.TrimPrefix(strings.TrimSpace(worked), "$ ")), " ")
+}
+
+// isWrapperArgument reports whether a token is the kind of argument a wrapper
+// takes rather than part of the command it wraps: a duration, a signal, a
+// number.
+func isWrapperArgument(tok string) bool {
+	if tok == "" || strings.HasPrefix(tok, "-") {
+		return false
+	}
+	for i, r := range tok {
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		// A trailing unit is part of a duration: 90s, 2m, 1h.
+		if i > 0 && (r == 's' || r == 'm' || r == 'h' || r == '.') && i == len(tok)-1 {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // commandPrograms lists what a command line invokes: the first word of each

--- a/cmd/deja/missing_program_remedy_test.go
+++ b/cmd/deja/missing_program_remedy_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedMissingProgram writes two sessions that ran a wrapped command, were told
+// the wrapper does not exist, and then ran the same command without it.
+//
+// The wrapper is `timeout` because that is what the mining recognises as a
+// wrapper (`commandProgram` skips timeout, gtimeout, stdbuf and nice), and it is
+// the program this machine is missing most.
+func seedMissingProgram(t *testing.T, remedy string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for _, id := range []string{"m1", "m2"} {
+		writeClaudeFixture(t, filepath.Join(root, "-work-app", id+".jsonl"), id, []string{
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-02-02T03:04:05Z","message":{"role":"user","content":"restart the worker"}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-02-02T03:04:06Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"timeout 12 launchctl kickstart -k system/app.worker"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-02-02T03:04:07Z","message":{"role":"user","content":[{"type":"tool_result","content":"zsh:1: command not found: timeout"}]}}`,
+			`{"type":"assistant","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-02-02T03:04:08Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"` + remedy + `"}}]}}`,
+			`{"type":"user","sessionId":"` + id + `","cwd":"/work/app","timestamp":"2026-02-02T03:04:09Z","message":{"role":"user","content":[{"type":"tool_result","content":"done"}]}}`,
+		})
+	}
+	if _, err := captureRun(t, "index"); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The line states a fact and recommends nothing, and the note on missing_program.go
+// says what that is worth: of the ten sessions told at session start that
+// `timeout` was missing, nine ran it anyway. When the store holds the remedy —
+// and for `timeout` on a real store both recorded pairs are the same command with
+// the wrapper taken out — the line can say so.
+func TestTheMissingProgramLineSaysTheCommandRanWithoutIt(t *testing.T) {
+	dir := seedMissingProgram(t, "launchctl kickstart -k system/app.worker")
+	got := missingProgramLine(dir, "timeout 30 launchctl kickstart -k system/app.worker")
+	if !strings.Contains(got, "is not on this machine") {
+		t.Fatalf("the missing program was not named at all: %q", got)
+	}
+	if !strings.Contains(got, "ran without it") {
+		t.Errorf("the recorded remedy did not reach the line: %q", got)
+	}
+}
+
+// A remedy that is a different command is a claim one recorded run does not
+// support, and a diagnostic is not a remedy at all: the line stays a fact.
+func TestADifferentCommandIsNotOfferedAsTheRemedy(t *testing.T) {
+	dir := seedMissingProgram(t, "launchctl print system/app.worker | grep state")
+	got := missingProgramLine(dir, "timeout 30 launchctl kickstart -k system/app.worker")
+	if !strings.Contains(got, "is not on this machine") {
+		t.Fatalf("the missing program was not named at all: %q", got)
+	}
+	if strings.Contains(got, "ran without it") {
+		t.Errorf("a different command was offered as the same one: %q", got)
+	}
+}


### PR DESCRIPTION
`missing_program.go` opens with the measurement that makes this line interesting: of the ten sessions told at session start that `timeout` was missing, nine ran it anyway. The pre-tool line moved that fact to the moment the command is about to run — and it is still only a fact. The store knows more than the fact: both fix pairs recorded for `timeout` on this machine are the same command with the wrapper taken out (`timeout 12 launchctl kickstart …` followed by `launchctl kickstart …`).

So the line says that:

```
timeout is not on this machine — 34 sessions ran into that. The same command ran without it.
```

Only that shape. A pair whose remedy runs a different program ("use python3") is a claim about the toolchain that one recorded run does not support, and a pair whose remedy is a diagnostic — `docker info | grep …`, which is what this store holds for docker — is not a remedy at all. Checked against the store: of `timeout`, `python`, `docker` and `shellcheck`, only `timeout` gains the clause, which is also the one with 34 sessions behind it.

The comparison is token-level: the failed command with the program and the argument a wrapper takes (`timeout 90`) removed has to equal the command that followed, so nothing else may have changed.

Tests: a store where the next command is the same one without the wrapper (clause present) and one where it is a different command (clause absent, the line stays a fact). Reverting the call turns the first red. `bench prompt` arms and `bench block` unchanged.
