### PR TITLE
feat(hook): the environment block says the command ran without the wrapper

### DIFF
--- a/cmd/deja/environment.go
+++ b/cmd/deja/environment.go
@@ -179,6 +179,9 @@ func environmentBlockFrom(dir, activation string) (string, []string) {
 		if fix := environmentRemedy(dir, w.Text, activation); fix != "" {
 			fmt.Fprintf(&b, "  what followed it: `%s`\n", fix)
 			knownRemedy = true
+		} else if note := environmentWrapperNote(dir, w.Text, activation); note != "" {
+			fmt.Fprintf(&b, "  %s\n", note)
+			knownRemedy = true
 		}
 	}
 	// Without this line the block reads as trivia. With it the model has
@@ -272,6 +275,48 @@ func environmentRemedy(dir, wall string, activation string) string {
 		return ""
 	}
 	return safeForStatusline(cmd, environmentMax)
+}
+
+// environmentWrapperNote is the remedy for a missing program, worded rather than
+// quoted.
+//
+// The most frequent wall on this machine — `command not found: timeout`, 34
+// sessions — had no remedy line at all, because the pairs recorded for it are
+// long commands from other work (`ssh -o ConnectTimeout=10 mini-ts 'cd … && …'`)
+// and environmentRemedy drops anything past the block's width. What those pairs
+// have in common is short enough to say: the same command ran with the wrapper
+// taken out. #3487 gave the pre-tool line that sentence; this is the same fact
+// at session start, where the note on missing_program.go says nine of ten
+// sessions told about a missing program ran it anyway.
+func environmentWrapperNote(dir, wall string, activation string) string {
+	prog, ok := missingProgramFromWall(wall)
+	if !ok {
+		return ""
+	}
+	pol := policy.Load()
+	for _, p := range index.FixesFor(dir, wall, 4, func(project string) bool {
+		return pol.Allows(activation, project)
+	}) {
+		if sameCommandWithout(p.Failed, p.Command, prog) {
+			return "what worked: the same command without `" + prog + "`"
+		}
+	}
+	return ""
+}
+
+// missingProgramFromWall reads the program out of a shell's own refusal, which
+// every shell words the same way at the end: "command not found: timeout".
+func missingProgramFromWall(wall string) (string, bool) {
+	const marker = "command not found: "
+	i := strings.LastIndex(wall, marker)
+	if i < 0 {
+		return "", false
+	}
+	prog := strings.TrimSpace(wall[i+len(marker):])
+	if prog == "" || strings.ContainsAny(prog, " \t/`'\"") {
+		return "", false
+	}
+	return prog, true
 }
 
 // environmentSpent is per process, which is what makes "once" countable on

--- a/cmd/deja/environment_wrapper_note_test.go
+++ b/cmd/deja/environment_wrapper_note_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/index"
+)
+
+// longWorkerCommand is past the block's width on purpose: the remedy recorded
+// for a missing wrapper is a real command from real work, and on this machine
+// every one of them is far longer than the ninety-six columns the block quotes
+// into. That is why the wall with 34 sessions behind it had no remedy line.
+const longWorkerCommand = "launchctl kickstart -k system/app.worker && launchctl print system/app.worker | grep -E 'state|pid' | head -5"
+
+// seedWrapperWall writes the same refusal in three projects, each session
+// running the wrapped command, being told the wrapper is missing, and then
+// running the same command without it.
+func seedWrapperWall(t *testing.T, remedy func(i int) string) string {
+	t.Helper()
+	tmp := hermeticEnv(t)
+	dir := filepath.Join(tmp, "index.db")
+	t.Setenv("DEJA_INDEX_DIR", dir)
+	root := os.Getenv("DEJA_CLAUDE_ROOT")
+	for i := range 3 {
+		project := fmt.Sprintf("app%d", i)
+		store := filepath.Join(root, "-work-"+project)
+		if err := os.MkdirAll(store, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		id := fmt.Sprintf("w%d", i)
+		rec := func(role string, content any, at string) string {
+			b, err := json.Marshal(map[string]any{
+				"type": role, "sessionId": id, "cwd": "/work/" + project, "timestamp": at,
+				"message": map[string]any{"role": role, "content": content},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			return string(b)
+		}
+		lines := []string{
+			rec("user", "restart the worker", "2026-04-0"+fmt.Sprint(i+1)+"T10:00:00Z"),
+			rec("assistant", []any{map[string]any{"type": "tool_use", "name": "Bash",
+				"input": map[string]any{"command": "timeout 12 " + longWorkerCommand}}},
+				"2026-04-0"+fmt.Sprint(i+1)+"T10:00:10Z"),
+			rec("user", []any{map[string]any{"type": "tool_result", "is_error": true,
+				"content": "zsh:1: command not found: timeout"}}, "2026-04-0"+fmt.Sprint(i+1)+"T10:00:20Z"),
+			rec("assistant", []any{map[string]any{"type": "tool_use", "name": "Bash",
+				"input": map[string]any{"command": remedy(i)}}}, "2026-04-0"+fmt.Sprint(i+1)+"T10:00:30Z"),
+			rec("user", []any{map[string]any{"type": "tool_result", "content": "ok"}},
+				"2026-04-0"+fmt.Sprint(i+1)+"T10:00:40Z"),
+		}
+		if err := os.WriteFile(filepath.Join(store, id+".jsonl"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := index.Ensure(dir, "", true, nil); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// The most frequent wall on this machine — `command not found: timeout`, 34
+// sessions — carried no remedy line, because every pair recorded for it is a
+// long command from other work and the block drops anything past its width.
+// What those pairs have in common is short enough to say.
+func TestTheEnvironmentBlockSaysTheCommandRanWithoutTheWrapper(t *testing.T) {
+	dir := seedWrapperWall(t, func(int) string { return longWorkerCommand })
+	block, _ := environmentBlockFrom(dir, "auto")
+	if !strings.Contains(block, "command not found: timeout") {
+		t.Fatalf("the wall itself is missing from the block:\n%s", block)
+	}
+	if !strings.Contains(block, "the same command without `timeout`") {
+		t.Errorf("the remedy every recorded pair agrees on is missing:\n%s", block)
+	}
+}
+
+// And when the pairs are something else, the wall stays a fact: the block does
+// not invent a remedy out of a command that merely followed.
+func TestTheEnvironmentBlockDoesNotInventAWrapperRemedy(t *testing.T) {
+	dir := seedWrapperWall(t, func(i int) string {
+		return fmt.Sprintf("launchctl print system/app.worker | grep state%d", i)
+	})
+	block, _ := environmentBlockFrom(dir, "auto")
+	if strings.Contains(block, "the same command without") {
+		t.Errorf("a remedy was claimed that no pair supports:\n%s", block)
+	}
+}


### PR DESCRIPTION
The session-start block's most frequent line on this machine is `- 34 separate sessions hit \`command not found: timeout\`` — and it was the one line with no remedy under it. `environmentRemedy` quotes the command that followed, capped at the block's 96 columns, and every pair recorded for that wall is a real command from real work: `ssh -o ConnectTimeout=10 mini-ts 'cd ~/… && venv/bin/python -m …'`. Too long, so nothing was said.

What those pairs have in common is short enough to say, and #3487 already words it for the pre-tool line:

```
- 34 separate sessions hit `command not found: timeout`
  what worked: the same command without `timeout`
```

Same predicate as #3487 (`sameCommandWithout`), so the two surfaces cannot disagree: the token-level comparison has to show the failed command with the program — and the argument a wrapper takes — removed and nothing else changed. A wall whose pairs are anything else keeps its old shape: a fact with no remedy, rather than an invented one.

This matters where `missing_program.go` says it matters: of the ten sessions told at session start that `timeout` was missing, nine ran it anyway. A fact with nothing to do is what that measured.

Tests: the same refusal in three projects (the block needs the spread) with a remedy past the width, which has to produce the worded line; and the same store with an unrelated next command, which must not. Reverting the branch turns the first red. `bench prompt` arms and `bench context` unchanged.
