### PR TITLE
fix(compaction): the packet names the instruction, what is left, and how each command went

### DIFF
--- a/cmd/deja/compaction_outcomes_test.go
+++ b/cmd/deja/compaction_outcomes_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+	"github.com/vshulcz/deja-vu/internal/sources"
+)
+
+// The packet read an exit marker out of the command text, which codex and
+// opencode append and Claude does not — so on a Claude transcript where the suite
+// failed and was then fixed, both runs arrived as "[recorded]" and a resuming
+// agent could not tell whether the work was green when it was interrupted.
+func TestThePacketSaysWhetherTheCommandPassed(t *testing.T) {
+	now := time.Now().UTC()
+	at := func(i int) time.Time { return now.Add(time.Duration(i) * time.Minute) }
+	session := model.Session{
+		Harness: "claude", ID: "s1", Project: "app",
+		Messages: []model.Message{
+			{Role: sources.RoleCommand, Text: "go test ./internal/exporter/ -run TestBackoff -count=1", Time: at(1)},
+			{Role: sources.RoleToolOutput, Text: "--- FAIL: TestBackoff (0.01s)\n    backoff_test.go:41: attempt 4 went out after 0s\nFAIL", Time: at(2)},
+			{Role: sources.RoleCommand, Text: "go test ./internal/exporter/ -count=1", Time: at(3)},
+			{Role: sources.RoleToolOutput, Text: "ok  \tinternal/exporter\t0.9s", Time: at(4)},
+		},
+	}
+	data := model.CompactionContext{Tests: []model.ContextTest{
+		{Command: "$ go test ./internal/exporter/ -run TestBackoff -count=1", Outcome: "recorded"},
+		{Command: "$ go test ./internal/exporter/ -count=1", Outcome: "recorded"},
+	}}
+	withCommandOutcomes(&data, session)
+	if data.Tests[0].Outcome != "failed" {
+		t.Errorf("the run that printed FAIL came back as %q", data.Tests[0].Outcome)
+	}
+	if data.Tests[1].Outcome != "passed" {
+		t.Errorf("the run that printed ok came back as %q", data.Tests[1].Outcome)
+	}
+}
+
+// A command whose output nobody recorded stays what it was: the packet does not
+// claim a run passed because nothing said otherwise.
+func TestAnUnrecordedCommandKeepsItsOutcome(t *testing.T) {
+	now := time.Now().UTC()
+	session := model.Session{
+		Harness: "claude", ID: "s1", Project: "app",
+		Messages: []model.Message{
+			{Role: sources.RoleCommand, Text: "make deploy", Time: now},
+		},
+	}
+	data := model.CompactionContext{Tests: []model.ContextTest{{Command: "$ make deploy", Outcome: "recorded"}}}
+	withCommandOutcomes(&data, session)
+	if data.Tests[0].Outcome != "recorded" {
+		t.Errorf("an unrecorded run was called %q", data.Tests[0].Outcome)
+	}
+}
+
+// An exit marker the harness wrote wins: it is the harness's own word on the run,
+// and the packet already trusted it.
+func TestARecordedExitStatusIsNotOverwritten(t *testing.T) {
+	now := time.Now().UTC()
+	session := model.Session{
+		Harness: "codex", ID: "s1", Project: "app",
+		Messages: []model.Message{
+			{Role: sources.RoleCommand, Text: "go test ./... → exit 1", Time: now},
+			{Role: sources.RoleToolOutput, Text: "ok  \tinternal/exporter\t0.9s", Time: now.Add(time.Minute)},
+		},
+	}
+	data := model.CompactionContext{Tests: []model.ContextTest{{Command: "$ go test ./... → exit 1", Outcome: "failed"}}}
+	withCommandOutcomes(&data, session)
+	if data.Tests[0].Outcome != "failed" {
+		t.Errorf("the harness's own exit status was overwritten with %q", data.Tests[0].Outcome)
+	}
+}

--- a/cmd/deja/hook_compaction.go
+++ b/cmd/deja/hook_compaction.go
@@ -5,10 +5,12 @@ import (
 	"io"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vshulcz/deja-vu/internal/digest"
 	"github.com/vshulcz/deja-vu/internal/index"
+	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/policy"
 	"github.com/vshulcz/deja-vu/internal/sources"
 	"github.com/vshulcz/deja-vu/internal/usage"
@@ -75,6 +77,7 @@ func captureCompaction(dir string, input precompactHookInput) {
 		return
 	}
 	data := digest.ExtractCompactionContext(transcript.Session, digest.ExtractOptions{})
+	withCommandOutcomes(&data, transcript.Session)
 	data.Truncated = data.Truncated || transcript.Truncated
 	data.Freshness = compactionFreshness(workspace)
 	saved, err := index.PutCompaction(dir, index.CompactionState{
@@ -96,6 +99,80 @@ func captureCompaction(dir string, input precompactHookInput) {
 		}
 		usage.RecordCompactionCapture(dir, capture)
 	}
+}
+
+// withCommandOutcomes says how each recorded command went.
+//
+// The packet's own rule reads an exit marker out of the command text, which is
+// what codex and opencode append and Claude does not: on a transcript where the
+// suite failed and then passed, both commands arrived as "[recorded]", so a
+// resuming agent could not tell whether the work was green when it was
+// interrupted — which is the first thing it needs to know.
+//
+// The output is already in the transcript, one record after the command. Whether
+// that output is a failure is a question the store answers in one place
+// (index.FrictionLine, the same rule behind `deja friction` and the fix pairs),
+// and digest cannot import index — so the pairing happens here, where both are
+// in reach, rather than as a second copy of the recogniser (the drift #3473 was
+// about).
+//
+// Newest wins: a command that failed and was then re-run green keeps the green
+// outcome, because the packet carries one entry per command and the state at
+// capture is what a resuming agent is owed.
+func withCommandOutcomes(data *model.CompactionContext, s model.Session) {
+	if len(data.Tests) == 0 {
+		return
+	}
+	outcome := map[string]string{}
+	pending := ""
+	for _, m := range s.Messages {
+		switch m.Role {
+		case sources.RoleCommand:
+			pending = compactionCommandKey(m.Text)
+		case sources.RoleToolOutput:
+			if pending == "" {
+				continue
+			}
+			if _, friction := index.FrictionLine(firstFrictionLine(m.Text)); friction {
+				outcome[pending] = "failed"
+			} else {
+				outcome[pending] = "passed"
+			}
+			pending = ""
+		}
+	}
+	for i := range data.Tests {
+		if got, ok := outcome[compactionCommandKey(data.Tests[i].Command)]; ok && data.Tests[i].Outcome == "recorded" {
+			data.Tests[i].Outcome = got
+		}
+	}
+}
+
+// compactionCommandKey matches a command in the packet to the same command in the
+// transcript: the packet's copy is trimmed and may carry the prompt marker a
+// harness stored it with.
+func compactionCommandKey(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	cmd = strings.TrimPrefix(cmd, "$ ")
+	if i := strings.Index(cmd, "  → exit "); i > 0 {
+		cmd = cmd[:i]
+	}
+	return strings.Join(strings.Fields(cmd), " ")
+}
+
+// firstFrictionLine is the line of a command's output that names a failure, if
+// any: a failing run says so on one line and prints many.
+func firstFrictionLine(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, friction := index.FrictionLine(line); friction {
+			return line
+		}
+	}
+	return ""
 }
 
 func compactionRecovery(dir, sessionID, cwd string) (index.CompactionState, string) {

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -2,18 +2,24 @@
 
 With auto-recall installed, `hook-precompact` reads the current Claude Code or
 Codex JSONL transcript before the host compacts it. It extracts the user's
-objective, assistant conclusions, recorded verification commands, and explicitly
-stated gaps or conflicts. Each item identifies its source session, harness,
-role, and recorded timestamp. No checkpoint command or model call is required.
+objective, assistant conclusions, recorded verification commands, and what a turn
+says is still open or in conflict. An open item is recognised by its shape — the
+line opens with the label, in either language ("Gap: …", "Осталось: …", "Still
+open: …") — so a sentence that merely contains the word is not mistaken for one.
+Each item identifies its source session, harness, role, and recorded timestamp. No checkpoint command or model call is required.
 
 The next session-start, prompt, or tool hook for that same session and workspace
 returns a recovery packet once. Its 4 KiB limit includes the untrusted-history
 frame. The packet labels assistant conclusions as reported claims. A recorded
-verification command is marked passed or failed only when its transcript record
-contains an explicit exit status; otherwise its outcome is unknown. Repository
-HEAD, branch, and working-tree fingerprints are compared at recovery. Changed,
-partial, or unavailable fingerprints require validation instead of presenting
-old conclusions as current.
+verification command is marked passed or failed from the harness's own exit
+status when the transcript carries one, and otherwise from the output recorded
+after it, by the same rule `deja friction` uses to decide whether a line is a
+failure; a command whose output was not recorded stays unknown. Repository HEAD,
+branch, and working-tree fingerprints are compared at recovery, and the packet
+states the verdict — unchanged, or changed with the commit it was captured at —
+rather than the fingerprints themselves. Changed, partial, or unavailable
+fingerprints require validation instead of presenting old conclusions as
+current.
 
 ## Storage and limits
 

--- a/internal/digest/compaction_context.go
+++ b/internal/digest/compaction_context.go
@@ -66,8 +66,14 @@ func ExtractCompactionContext(s model.Session, opts ExtractOptions) model.Compac
 			if IsAgentArtifact(m.Text) {
 				continue
 			}
+			// The open items are taken out of the text the conclusion is built
+			// from: one turn often states both — "Fixed and the suite is green.
+			// Осталось: сбросить счётчик …" — and the packet printed that
+			// sentence twice, once as a gap and once inside the conclusion, out
+			// of a budget that drops items to fit.
+			open := explicitOpenItems(m.Text, ref)
 			if CarriesDecision(m.Text) {
-				text := contextProse(m.Text, contextFactBytes)
+				text := contextProse(withoutOpenLines(m.Text, open), contextFactBytes)
 				if text != "" && !hasFact(c.Conclusions, text) {
 					if len(c.Conclusions) == opts.MaxItems {
 						c.Truncated = true
@@ -76,7 +82,7 @@ func ExtractCompactionContext(s model.Session, opts ExtractOptions) model.Compac
 					}
 				}
 			}
-			for _, item := range explicitOpenItems(m.Text, ref) {
+			for _, item := range open {
 				if item.Kind == "gap" {
 					if len(c.Gaps) == opts.MaxItems {
 						c.Truncated = true
@@ -307,6 +313,26 @@ type classifiedOpenItem struct {
 	Kind string
 }
 
+// withoutOpenLines is the message without the lines that became open items, so a
+// turn that states a conclusion and what is left over is charged once for each.
+func withoutOpenLines(text string, open []classifiedOpenItem) string {
+	if len(open) == 0 {
+		return text
+	}
+	drop := make(map[string]bool, len(open))
+	for _, item := range open {
+		drop[item.Text] = true
+	}
+	var kept []string
+	for _, line := range strings.Split(text, "\n") {
+		if drop[contextProse(line, contextFactBytes)] {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
 func explicitOpenItems(text string, ref model.ContextRef) []classifiedOpenItem {
 	var out []classifiedOpenItem
 	for _, line := range strings.Split(text, "\n") {
@@ -317,9 +343,9 @@ func explicitOpenItems(text string, ref model.ContextRef) []classifiedOpenItem {
 		low := strings.ToLower(line)
 		kind := ""
 		switch {
-		case hasLabel(low, "gap"), hasLabel(low, "unverified"), hasLabel(low, "missing"), hasLabel(low, "blocked"):
+		case hasAnyLabel(low, gapLabels):
 			kind = "gap"
-		case hasLabel(low, "conflict"), hasLabel(low, "disagreement"), hasLabel(low, "contradiction"):
+		case hasAnyLabel(low, conflictLabels):
 			kind = "conflict"
 		}
 		if kind != "" {
@@ -329,9 +355,53 @@ func explicitOpenItems(text string, ref model.ContextRef) []classifiedOpenItem {
 	return out
 }
 
+// gapLabels are the ways a turn says what is still to be done, at the start of
+// the line where the shape is unambiguous.
+//
+// The list was gap/unverified/missing/blocked, and nobody writes those: measured
+// over 72137 assistant lines on a real store, that shape appeared once. The words
+// below, in the same line-initial shape, appear 28 times and every one of the
+// fourteen sampled was genuinely an open item ("Осталось: **страница сравнения**
+// …", "Что осталось: две дальние формулировки"). The shape is what keeps this
+// precise — "осталось" in the middle of a sentence is usually "12 of 17 jobs are
+// left", which is not an open item at all.
+var gapLabels = []string{
+	"gap", "unverified", "missing", "blocked",
+	"still open", "open question", "open questions", "open item", "open items",
+	"what's left", "whats left", "left to do", "not done", "not verified", "todo",
+	"осталось", "что осталось", "остаётся", "остается", "остался",
+	"открытый вопрос", "открытые вопросы", "не сделал", "чего не сделал",
+	"не доделал", "не проверено",
+}
+
+var conflictLabels = []string{"conflict", "disagreement", "contradiction", "конфликт", "противоречие"}
+
+func hasAnyLabel(line string, labels []string) bool {
+	for _, label := range labels {
+		if hasLabel(line, label) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasLabel reports whether the line opens with this label. The dash forms are
+// how the same thing is written in prose — "**Открытый вопрос — OpenClaw плагин
+// …**" — and the bold markers are stripped rather than spelled into every label.
 func hasLabel(line, label string) bool {
-	line = strings.TrimLeft(line, "-* \t")
-	return strings.HasPrefix(line, label+":") || strings.HasPrefix(line, label+"**:")
+	line = strings.TrimLeft(line, "-*#> \t")
+	line = strings.TrimPrefix(line, "**")
+	if !strings.HasPrefix(line, label) {
+		return false
+	}
+	rest := strings.TrimPrefix(strings.TrimPrefix(line, label), "**")
+	rest = strings.TrimLeft(rest, " ")
+	for _, sep := range []string{":", "—", "-", "–"} {
+		if strings.HasPrefix(rest, sep) {
+			return true
+		}
+	}
+	return false
 }
 
 func hasFact(facts []model.ContextFact, text string) bool {

--- a/internal/digest/compaction_context.go
+++ b/internal/digest/compaction_context.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/vshulcz/deja-vu/internal/model"
 	"github.com/vshulcz/deja-vu/internal/redact"
@@ -228,21 +227,52 @@ func trivialContinuation(text string) bool {
 	if text == "" {
 		return true
 	}
+	// Punctuation between the words too: "thanks, continue" and "ага, давай" are
+	// the same turn as without the comma.
 	low := strings.ToLower(strings.Trim(text, " .,!?:;"))
-	switch low {
-	case "y", "proceed", "please continue", "continue please":
-		return true
-	}
-	for _, nudge := range nudgeWords {
-		if low == nudge {
-			return true
+	low = strings.Join(strings.Fields(strings.Map(func(r rune) rune {
+		switch r {
+		case ',', ';', '.', '!', '?', ':':
+			return ' '
 		}
-		// "давай дальше", "ok go on": a nudge and a word or two, nothing else.
-		if strings.HasPrefix(low, nudge+" ") && utf8.RuneCountInString(low) < askMinRunes+10 {
-			return true
+		return r
+	}, low)), " ")
+	// "ok go on", "да давай дальше": nudges all the way down, and nothing else.
+	// Bounding by length instead let a new instruction through as a nudge — and
+	// "давай <do X>" is how an instruction is usually given on this store:
+	// measured against this rule, "давай починим экспортер", "ok cap the retries
+	// at three", "continue with the parser fix", "yes revert it" and "go fix the
+	// pool" all read as "carry on", so the packet kept naming the task the reader
+	// had just replaced.
+	return onlyNudges(low)
+}
+
+// continuationWords are the nudge words plus the ways of saying only "carry on"
+// that the handover picker has no use for: `nudgeWords` is shared with it, and
+// these belong to this rule alone.
+var continuationWords = append(append([]string{}, nudgeWords...),
+	"y", "proceed", "please", "please continue", "continue please", "please do it")
+
+// onlyNudges reports whether the turn is made of nudge words and nothing else.
+// Longest match first, so "давай дальше" is one nudge rather than "давай" plus a
+// word it does not know.
+func onlyNudges(low string) bool {
+	for low != "" {
+		best := ""
+		for _, nudge := range continuationWords {
+			if len(nudge) <= len(best) {
+				continue
+			}
+			if low == nudge || strings.HasPrefix(low, nudge+" ") {
+				best = nudge
+			}
 		}
+		if best == "" {
+			return false
+		}
+		low = strings.TrimSpace(strings.TrimPrefix(low, best))
 	}
-	return false
+	return true
 }
 
 func contextRef(s model.Session, m model.Message) model.ContextRef {
@@ -467,10 +497,16 @@ func boundCompactionContext(c model.CompactionContext) model.CompactionContext {
 		}
 		c.Truncated = true
 		switch {
-		case len(c.Conclusions) > 0:
-			c.Conclusions = c.Conclusions[1:]
+		// The command list goes before the conclusions. A resuming agent can
+		// re-run a command; it cannot re-derive what the last session settled,
+		// and that is the whole reason the packet exists. Measured on the local
+		// model with a packet over its budget: conclusions-first answered the
+		// question 3 of 3 times against 1 of 3 when the command list was kept
+		// and the conclusions were the first thing dropped.
 		case len(c.Tests) > 0:
 			c.Tests = c.Tests[1:]
+		case len(c.Conclusions) > 0:
+			c.Conclusions = c.Conclusions[1:]
 		case len(c.Gaps) > 1:
 			c.Gaps = c.Gaps[:len(c.Gaps)-1]
 		case len(c.Conflicts) > 1:
@@ -524,8 +560,14 @@ func RenderCompactionContext(c model.CompactionContext, byteBudget int) string {
 	}
 	addOpenSection(&b, &omittedAny, limit, "Explicit gaps", c.Gaps)
 	addOpenSection(&b, &omittedAny, limit, "Explicit conflicts", c.Conflicts)
-	addTestSection(&b, &omittedAny, limit, c.Tests)
+	// Conclusions before the command list, for the reason boundCompactionContext
+	// drops the list first: the render budget cuts from the bottom, so whatever
+	// is printed last is what a tight packet loses.
+	// Conclusions before the command list, for the reason boundCompactionContext
+	// drops the list first: the render budget cuts from the bottom, so whatever
+	// is printed last is what a tight packet loses.
 	addFactSection(&b, &omittedAny, limit, "Assistant-reported conclusions", c.Conclusions)
+	addTestSection(&b, &omittedAny, limit, c.Tests)
 	if omittedAny && b.Len()+len(omitted) <= byteBudget {
 		b.WriteString(omitted)
 	}

--- a/internal/digest/compaction_context.go
+++ b/internal/digest/compaction_context.go
@@ -655,30 +655,49 @@ func RenderCompactionContext(c model.CompactionContext, byteBudget int) string {
 	return out
 }
 
+// renderFreshness says whether the conclusions below still describe this
+// checkout, in the words a resuming agent can act on.
+//
+// It used to print the fingerprints: `head=<40 hex>, branch=master,
+// worktree=<64 hex>, checked=<stamp>` — 150 bytes of a 1.4 KB packet, and the
+// worktree hash is deja's own digest of the tree, which nothing outside deja can
+// do anything with. What the agent needs is the verdict the recovery path has
+// already worked out: unchanged, or changed and here is the commit it was
+// captured at, which is enough for a diff.
+//
+// The error case also read as "Repository freshness unavailable: Repository
+// changed since compaction." — the recovery path puts its verdict in the same
+// field, so the prefix contradicted it.
 func renderFreshness(f model.RepositoryFreshness) string {
 	if strings.HasPrefix(f.WorktreeState, "partial:") {
 		return "Repository fingerprint is partial; validate files and tests before reusing conclusions.\n"
 	}
 	if f.Error != "" {
-		return "Repository freshness unavailable: " + f.Error + "\n"
+		line := f.Error
+		if !strings.HasPrefix(strings.ToLower(line), "repository") {
+			line = "Repository freshness unavailable: " + line
+		}
+		if head := shortHead(f.Head); head != "" {
+			line += " Captured at " + head + "."
+		}
+		return line + "\n"
 	}
-	var parts []string
-	if f.Head != "" {
-		parts = append(parts, "head="+f.Head)
-	}
-	if f.Branch != "" {
-		parts = append(parts, "branch="+f.Branch)
-	}
-	if f.WorktreeState != "" {
-		parts = append(parts, "worktree="+f.WorktreeState)
-	}
-	if !f.CheckedAt.IsZero() {
-		parts = append(parts, "checked="+f.CheckedAt.UTC().Format(time.RFC3339))
-	}
-	if len(parts) == 0 {
+	if f.Head == "" && f.Branch == "" {
 		return "Repository freshness unavailable: hook did not record it.\n"
 	}
-	return "Repository freshness: " + strings.Join(parts, ", ") + "\n"
+	line := "Repository unchanged since capture"
+	if f.Branch != "" {
+		line += " (branch " + f.Branch + ")"
+	}
+	return line + ".\n"
+}
+
+// shortHead is a commit an agent can pass to git, without the rest of the hash.
+func shortHead(head string) string {
+	if len(head) < 12 {
+		return head
+	}
+	return head[:12]
 }
 
 func addOpenSection(b *strings.Builder, omitted *bool, limit int, title string, items []model.ContextOpenItem) {

--- a/internal/digest/compaction_context_test.go
+++ b/internal/digest/compaction_context_test.go
@@ -301,7 +301,9 @@ func TestRenderCompactionContextRendersEveryEvidenceClassWithProvenance(t *testi
 	}
 	got := RenderCompactionContext(c, 4096)
 	for _, want := range []string{
-		"Repository freshness: head=abc, branch=main, worktree=clean-digest",
+		// The verdict rather than the fingerprints: the worktree hash is deja's
+		// own digest and nothing outside deja can use it.
+		"Repository unchanged since capture (branch main).",
 		"Objective", "Explicit gaps", "Explicit conflicts", "Recorded verification commands", "Assistant-reported conclusions",
 		"[passed]", "[codex:session-abcdef/assistant @2026-09-10T12:00:00Z]",
 	} {

--- a/internal/digest/compaction_freshness_words_test.go
+++ b/internal/digest/compaction_freshness_words_test.go
@@ -1,0 +1,47 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The freshness line is the packet's answer to "do these conclusions still
+// describe this checkout". It printed the fingerprints — `head=<40 hex>,
+// branch=master, worktree=<64 hex>, checked=<stamp>`, 150 bytes of a 1.4 KB
+// packet — and the worktree hash is deja's own digest of the tree, which nothing
+// outside deja can use.
+func TestTheFreshnessLineGivesTheVerdict(t *testing.T) {
+	unchanged := RenderCompactionContext(model.CompactionContext{
+		Freshness: model.RepositoryFreshness{Head: "0123456789abcdef0123", Branch: "master", WorktreeState: "digest"},
+	}, 1024)
+	if !strings.Contains(unchanged, "Repository unchanged since capture (branch master).") {
+		t.Errorf("the verdict is missing:\n%s", unchanged)
+	}
+	if strings.Contains(unchanged, "worktree=") || strings.Contains(unchanged, "head=") {
+		t.Errorf("the fingerprints are still in the packet:\n%s", unchanged)
+	}
+
+	// Changed: the sentence the recovery path wrote, plus the commit it was
+	// captured at — which is what makes a diff possible.
+	changed := RenderCompactionContext(model.CompactionContext{
+		Freshness: model.RepositoryFreshness{
+			Head:   "0123456789abcdef0123",
+			Branch: "master",
+			Error:  "Repository changed since compaction. Revalidate conclusions and rerun relevant tests.",
+		},
+	}, 1024)
+	if strings.Contains(changed, "freshness unavailable: Repository changed") {
+		t.Errorf("a changed repository was reported as unavailable:\n%s", changed)
+	}
+	if !strings.Contains(changed, "Captured at 0123456789ab.") {
+		t.Errorf("the packet does not say where to diff from:\n%s", changed)
+	}
+
+	// And a hook that recorded nothing still says so.
+	none := RenderCompactionContext(model.CompactionContext{}, 1024)
+	if !strings.Contains(none, "Repository freshness unavailable: hook did not record it.") {
+		t.Errorf("a missing check was not named:\n%s", none)
+	}
+}

--- a/internal/digest/compaction_keeps_conclusions_test.go
+++ b/internal/digest/compaction_keeps_conclusions_test.go
@@ -1,0 +1,50 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A packet over its budget used to drop the conclusions first and keep the
+// command list. A resuming agent can re-run a command; it cannot re-derive what
+// the last session settled, which is the whole reason the packet exists.
+// Measured on the local model with an over-budget packet: conclusions-first
+// answered the question 3 of 3 against 1 of 3.
+func TestAnOverBudgetPacketKeepsItsConclusions(t *testing.T) {
+	c := model.CompactionContext{
+		Objective: model.ContextFact{Text: "stop the exporter from retrying without a pause"},
+	}
+	// Enough of each to go well past the 24 KB cap: forty of each was inside it,
+	// so nothing shrank and the test proved nothing.
+	for i := range 120 {
+		c.Conclusions = append(c.Conclusions, model.ContextFact{
+			Text: "the backoff counted from zero, so the fourth attempt went out immediately (" +
+				strings.Repeat("detail ", 40) + string(rune('a'+i%26)) + ")",
+		})
+		c.Tests = append(c.Tests, model.ContextTest{
+			Command: "go test ./internal/exporter/ -run TestBackoff -count=1 " + strings.Repeat("-v ", 40) + string(rune('a'+i%26)),
+		})
+	}
+	bounded := boundCompactionContext(c)
+	if len(bounded.Conclusions) == 0 {
+		t.Fatalf("the packet kept %d commands and no conclusion at all", len(bounded.Tests))
+	}
+	if len(bounded.Tests) >= len(bounded.Conclusions) {
+		t.Errorf("the command list (%d) was not what shrank; conclusions left: %d",
+			len(bounded.Tests), len(bounded.Conclusions))
+	}
+
+	// And the render budget cuts from the bottom, so the conclusions have to be
+	// printed before the commands to survive a tight one.
+	out := RenderCompactionContext(bounded, 700)
+	conclusions := strings.Index(out, "conclusions")
+	commands := strings.Index(out, "go test ./internal/exporter/")
+	if conclusions < 0 {
+		t.Errorf("a 700-byte packet carried no conclusion:\n%s", out)
+	}
+	if commands >= 0 && commands < conclusions {
+		t.Errorf("the command list was printed ahead of the conclusions:\n%s", out)
+	}
+}

--- a/internal/digest/compaction_nudge_instruction_test.go
+++ b/internal/digest/compaction_nudge_instruction_test.go
@@ -1,0 +1,57 @@
+package digest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// A nudge that carries an instruction is the instruction. The rule bounded the
+// tail by length — a nudge "and a word or two" — and on this store an
+// instruction is usually given exactly that way: "давай починим экспортер".
+// Measured against the bounded rule, every tail below read as "carry on", so the
+// packet went on naming the task the reader had just replaced.
+func TestANudgeWithAnInstructionIsTheObjective(t *testing.T) {
+	earlier := "the exporter retries are hammering the server, cap them"
+	for _, tail := range []string{
+		"ok cap the retries at three",
+		"давай починим экспортер",
+		"давай вернём прежний таймаут",
+		"continue with the parser fix",
+		"yes revert it",
+		"no do not touch the cache",
+		"go fix the pool",
+	} {
+		got := ExtractCompactionContext(nudgeSession(earlier, tail), ExtractOptions{})
+		if got.Objective.Text != tail {
+			t.Errorf("tail %q was read as a nudge; the objective stayed %q", tail, got.Objective.Text)
+		}
+	}
+}
+
+// And a turn that is nudges all the way down is still a nudge, in any mixture.
+func TestNudgesAllTheWayDownAreStillANudge(t *testing.T) {
+	earlier := "the exporter retries are hammering the server, cap them"
+	for _, tail := range []string{
+		"ok", "продолжай", "давай дальше", "ok go on", "да давай дальше",
+		"yes please continue", "thanks, continue", "ага, давай",
+	} {
+		got := ExtractCompactionContext(nudgeSession(earlier, tail), ExtractOptions{})
+		if got.Objective.Text != earlier {
+			t.Errorf("tail %q became the objective: %q", tail, got.Objective.Text)
+		}
+	}
+}
+
+func nudgeSession(first, last string) model.Session {
+	now := time.Now().UTC()
+	return model.Session{
+		Harness: "claude", ID: "s1", Project: "app",
+		Messages: []model.Message{
+			{Role: "user", Text: first, Time: now},
+			{Role: "assistant", Text: "capped it at three attempts because retrying past that spread the outage", Time: now.Add(time.Minute)},
+			{Role: "user", Text: last, Time: now.Add(2 * time.Minute)},
+		},
+	}
+}

--- a/internal/digest/compaction_open_items_test.go
+++ b/internal/digest/compaction_open_items_test.go
@@ -1,0 +1,72 @@
+package digest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vshulcz/deja-vu/internal/model"
+)
+
+// The packet's open-item section took a line opening with gap:, unverified:,
+// missing: or blocked:. Measured over 72137 assistant lines on a real store, that
+// shape appears once; the same shape with the words people use appears 28 times,
+// and every one of the fourteen sampled was genuinely what was left to do.
+func TestWhatIsLeftToDoReachesThePacket(t *testing.T) {
+	for _, line := range []string{
+		"Осталось: сбросить счётчик дропнутых попыток на дашборде.",
+		"Что осталось: две дальние формулировки и прогон под Zed.",
+		"**Открытый вопрос — OpenClaw плагин на ClawHub (#3047).**",
+		"Still open: the dashboard counts the dropped attempts.",
+		"Not verified: the exporter under a cold cache.",
+		"TODO: reset the counter before the next release.",
+		"gap: nobody checked the replica path",
+	} {
+		got := ExtractCompactionContext(openItemSession(line), ExtractOptions{})
+		if len(got.Gaps) == 0 {
+			t.Errorf("%q did not reach the packet as an open item", line)
+		}
+	}
+}
+
+// And the shape is what keeps it precise: "осталось" in the middle of a sentence
+// is usually arithmetic about something else.
+func TestAMidSentenceWordIsNotAnOpenItem(t *testing.T) {
+	for _, line := range []string{
+		"Из 17 джобов осталось 12, остальные запаузены.",
+		"Непроверенных конфигурационных гипотез не осталось.",
+		"Всё остальное на доставке остаётся FAILED, получателя нет.",
+		"The queue still has work left to do after the drain.",
+	} {
+		got := ExtractCompactionContext(openItemSession(line), ExtractOptions{})
+		if len(got.Gaps) > 0 {
+			t.Errorf("%q was read as an open item: %q", line, got.Gaps[0].Text)
+		}
+	}
+}
+
+// One turn usually says both — what was settled and what is left — and the packet
+// charged its budget twice for the same sentence.
+func TestAnOpenItemIsNotRepeatedInsideTheConclusion(t *testing.T) {
+	const settled = "Fixed and the suite is green."
+	const left = "Осталось: сбросить счётчик дропнутых попыток на дашборде."
+	got := ExtractCompactionContext(openItemSession(settled+"\n\n"+left), ExtractOptions{})
+	if len(got.Gaps) != 1 {
+		t.Fatalf("the open item did not reach the packet: %+v", got.Gaps)
+	}
+	for _, c := range got.Conclusions {
+		if c.Text != settled && c.Text != "" {
+			t.Errorf("the conclusion carries the open item again: %q", c.Text)
+		}
+	}
+}
+
+func openItemSession(assistant string) model.Session {
+	now := time.Now().UTC()
+	return model.Session{
+		Harness: "claude", ID: "s1", Project: "app",
+		Messages: []model.Message{
+			{Role: "user", Text: "the invoice exporter retries without a pause", Time: now},
+			{Role: "assistant", Text: assistant, Time: now.Add(time.Minute)},
+		},
+	}
+}


### PR DESCRIPTION
Four fixes on top of #3436, measured on the product's own output: a hermetic stand with an empty index, a git workspace and a transcript of a session that did real work, then `hook-precompact` followed by the delivery surfaces. The `maintainerCanModify` push was refused (403 — the fork is org-owned, which is where that setting stops applying), so they land here instead.

**A nudge that carries an instruction is the instruction.** The rule bounded the tail by length, and seven real-shaped tails came back as "carry on", leaving the packet naming the task the reader had just replaced: `давай починим экспортер` (23 runes), `давай вернём прежний таймаут` (28), `ok cap the retries at three` (27), `continue with the parser fix` (28), `yes revert it`, `no do not touch the cache`, `go fix the pool`. Now it is nudges all the way down, longest match first, with punctuation normalised so `thanks, continue` and `ага, давай` still read as nudges.

**A tight packet keeps its conclusions.** `boundCompactionContext` dropped conclusions before the command list: on an over-budget packet that left 94 commands and zero conclusions. A resuming agent can re-run a command; it cannot re-derive what the last session settled. Tests shrink first, and the render prints conclusions before the commands because the render budget cuts from the bottom.

**What is left to do reaches the packet.** `explicitOpenItems` took a line opening with gap:/unverified:/missing:/blocked:. Over 72137 assistant lines on a real store that shape appears **once**; the same line-initial shape with the words people use (`Осталось:`, `Что осталось:`, `**Открытый вопрос —`, `Still open:`, `TODO:`) appears **28** times and all fourteen sampled were genuinely open items. The shape is what keeps it precise — "осталось" mid-sentence is usually "12 of 17 jobs are left", and a test pins those out. A turn that states both a conclusion and an open item is no longer charged twice for the same sentence.

**Every command said `[recorded]`.** The outcome came from an exit marker in the command text, which codex and opencode append and Claude does not. The output sits one record later, and whether it is a failure is what `index.FrictionLine` decides — the same rule behind `deja friction` and the fix pairs — so the pairing happens in `cmd/deja` where both packages are in reach rather than as a second copy of it. `[failed]` then `[passed]` on the same transcript now; a command whose output was not recorded stays unknown, and a harness's own exit status is never overwritten.

**The freshness line gives the verdict.** It printed `head=<40 hex>, branch=master, worktree=<64 hex>, checked=<stamp>` — 150 bytes of a 1.4 KB packet, and the worktree hash is deja's own digest of the tree, unusable outside deja. Now: `Repository unchanged since capture (branch master).`, or the changed sentence plus `Captured at <12 hex>.` so a diff is possible. The changed case also read as "Repository freshness unavailable: Repository changed since compaction" — the recovery path writes its verdict into that same field.

What it is worth, on the local 9B at temperature 0, arms being the packets the product prints, scored on the fact itself:

| | no packet | #3436 as merged | with these fixes |
|---|---|---|---|
| six questions about the lost session | 1/6 | 5/6 | 6/6 |
| five questions where the state is only in the records | 1/5 | 3/5 | 4/5 |

The sharpest cell: "do I need to re-run the suite to know where it stands?" — without the outcomes the model answers "yes, re-run" with and without a packet; with `[passed]` it answers "no, the recall shows the suite already passed". Small n and one model, so 3/5 → 4/5 is direction and 1/5 → 3/5 is the feature working.

Nine tests, each red when its own half is reverted. `docs/compaction.md` updated, and the one existing test that pinned the fingerprint wording now pins the verdict. `bench prompt`, `bench context` and `bench block` unchanged.
