### PR TITLE
test: a captured stdout is drained while the callback writes

### DIFF
--- a/cmd/deja/capture_drain_test.go
+++ b/cmd/deja/capture_drain_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The capture helpers have to drain the pipe while the callback is still
+// writing. A windows anonymous pipe buffers 4096 bytes, and `printSources`
+// crossed that at twenty-five harnesses — 4316 bytes — so the sequential
+// read-after-call in its test deadlocked the whole cmd/deja package on the
+// windows leg of main for twelve minutes before the timeout killed it.
+//
+// This pins the helper rather than the caller: a payload far past any
+// platform's buffer must come back whole. A helper that stops draining
+// concurrently fails here — verified by making it sequential, which hangs this
+// test until the package timeout rather than returning short, because the write
+// it blocks in cannot be abandoned.
+func TestCaptureStdoutOutlastsAPipeBuffer(t *testing.T) {
+	const lines = 20000
+	done := make(chan string, 1)
+	go func() {
+		done <- captureStdout(t, func() {
+			for i := range lines {
+				fmt.Printf("line %d of a payload no pipe buffer holds\n", i)
+			}
+		})
+	}()
+	select {
+	case out := <-done:
+		if got := strings.Count(out, "\n"); got != lines {
+			t.Fatalf("captured %d lines of %d", got, lines)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("captureStdout did not return: the callback is writing into a pipe nobody is reading")
+	}
+}

--- a/cmd/deja/coverage_final_test.go
+++ b/cmd/deja/coverage_final_test.go
@@ -95,18 +95,12 @@ func TestPrintSourcesAntigravityFallback(t *testing.T) {
 	hermeticEnv(t)
 	t.Setenv("DEJA_ANTIGRAVITY_ROOT", "")
 
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-	printSources(index.DefaultDir())
-	_ = w.Close()
-	os.Stdout = oldStdout
-	b, _ := io.ReadAll(r)
-	if !strings.Contains(string(b), "antigravity*") {
-		t.Fatalf("printSources fallback output = %q", string(b))
+	// Drained concurrently, because the source table prints one block per
+	// harness and outgrew a windows pipe's buffer: the sequential read after
+	// the call deadlocked the whole package at 25 harnesses.
+	out := captureStdout(t, func() { printSources(index.DefaultDir()) })
+	if !strings.Contains(out, "antigravity*") {
+		t.Fatalf("printSources fallback output = %q", out)
 	}
 }
 

--- a/cmd/deja/index_summary_test.go
+++ b/cmd/deja/index_summary_test.go
@@ -50,14 +50,21 @@ func TestRebuildOnATerminalSaysWhatItIndexed(t *testing.T) {
 		}
 		stderr := os.Stderr
 		os.Stderr = w
+		// Drained concurrently: a windows pipe buffers a few KB and a rebuild
+		// reports per file and per harness.
+		done := make(chan string, 1)
+		go func() {
+			b, _ := io.ReadAll(r)
+			done <- string(b)
+		}()
 		err = cmdIndex(dir, []string{"--rebuild"})
 		os.Stderr = stderr
 		_ = w.Close()
-		out, _ := io.ReadAll(r)
+		out := <-done
 		if err != nil {
 			t.Fatal(err)
 		}
-		return string(out)
+		return out
 	}
 
 	got := run(t)

--- a/cmd/deja/install_auto_test.go
+++ b/cmd/deja/install_auto_test.go
@@ -301,11 +301,17 @@ func TestPrintInstallProofListsDistinctProjects(t *testing.T) {
 	old := os.Stderr
 	r, w, _ := os.Pipe()
 	os.Stderr = w
+	// Drained concurrently: a windows pipe buffers a few KB and this report
+	// grows with what the install wrote.
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
 	printInstallProof(index.DefaultDir())
 	_ = w.Close()
 	os.Stderr = old
-	b, _ := io.ReadAll(r)
-	out := string(b)
+	out := <-done
 	if !strings.Contains(out, "deja already knows this machine:") ||
 		!strings.Contains(out, "tmp/beta") || !strings.Contains(out, "gamma") {
 		t.Fatalf("proof output = %q", out)


### PR DESCRIPTION
The windows leg of main went red on 0.20.0: `TestPrintSourcesAntigravityFallback` hung for 9m30s and took the whole `cmd/deja` package down with the 12m timeout.

Cause, measured: the test replaced `os.Stdout` with a pipe, called `printSources`, and only read after it returned. A windows anonymous pipe buffers 4096 bytes and that table is now **4316 bytes** — twenty-five harnesses, with Xcode's extra store paths (#3467) the ones that crossed the line. The write blocked, nobody was reading, and the stack in the failed run is `printSources` stuck in `syscall.WriteFile`.

Fixed by draining while the callback writes — the helper that already exists for this, with the same reason in a comment. Two other captures scale with the registry or with what an install wrote (`printInstallProof`, the rebuild summary) and got the same treatment before they cross too.

The guard is on the helper, not the callers: `TestCaptureStdoutOutlastsAPipeBuffer` pushes ~900 KB through it. Made the helper sequential again to check it fails — it does, by hanging until the package timeout, which is the same shape as the bug and is noted in the test.

Label `windows` so the leg runs on this PR.
