### PR TITLE
ci: the windows test timeout is 25m, not 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,14 @@ jobs:
       # race is caught on the linux and macOS legs above. Windows is in this
       # matrix for paths, file locking and case rules, and plain `go test`
       # exercises every one of those.
-      - run: go test -timeout 12m ./...
+      #
+      # The windows timeout is 25m rather than 12m because 12m stopped being a
+      # hang detector and started cutting honest work: run 34663347144 killed
+      # cmd/deja at 720.087s with the test it had just entered at 0s, so nothing
+      # was stuck — the package simply needs more than twelve minutes on a slow
+      # runner now. The job's own 60m cap is what bounds a real hang, and the go
+      # timeout still dies with every goroutine's stack well inside it.
+      - run: go test -timeout 25m ./...
         if: runner.os == 'Windows' && env.FULL == 'true'
         shell: bash
       - run: go build ./cmd/deja


### PR DESCRIPTION
main is red on the windows leg again, and this one is not a hang: run 34663347144 killed `cmd/deja` at 720.087s with the only listed running test at `0s` — the package had just entered it, so nothing was stuck. It needs more than twelve minutes on a slow runner now.

The 12m figure was set when the windows tests took 5m16s (#1229). The suite has roughly doubled since, and the same commit passed that leg on #3493 at 57m of job time, so it sits right on the line: one slow runner either side of it.

So the go timeout goes to 25m. What bounds a real hang is the job's own `timeout-minutes: 60`; the go timeout's job is to die with every goroutine's stack inside that cap, and 25m still does it with wide margin.

Label `windows` so the leg runs here.
