### PR TITLE
chore: pin the manifests to 0.20.0

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/claude-plugin/plugin.json
+++ b/claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Claude Code: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/cmd/deja/kimi_plugin.go
+++ b/cmd/deja/kimi_plugin.go
@@ -12,7 +12,7 @@ import (
 // only offers an update for a plugin it installed from its own marketplace, so
 // for a repository or zip install nothing tells the user their copy is behind.
 // deja knows both numbers, and doctor is where someone looks.
-const kimiPluginVersion = "0.19.5"
+const kimiPluginVersion = "0.20.0"
 
 // kimiPluginInstalledVersion returns the version of the installed copy, or ""
 // when the plugin is not there.

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja-vu",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Codex: your own past sessions, from every coding agent on the machine, recalled before you ask.",
   "author": {
     "name": "vshulcz",

--- a/extensions/dsh/package.json
+++ b/extensions/dsh/package.json
@@ -50,7 +50,7 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.5"
+    "@vshulcz/deja-vu": "^0.20.0"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/kimi/kimi.plugin.json
+++ b/extensions/kimi/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/extensions/openclaw/package.json
+++ b/extensions/openclaw/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.5"
+    "@vshulcz/deja-vu": "^0.20.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.7.1"

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@opencode-ai/plugin": ">=1.0.0",
-    "@vshulcz/deja-vu": "^0.19.5"
+    "@vshulcz/deja-vu": "^0.20.0"
   },
   "scripts": {
     "test": "node --test test/*.test.js"

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -33,7 +33,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.5"
+    "@vshulcz/deja-vu": "^0.20.0"
   },
   "pi": {
     "extensions": ["./index.ts"],

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Gemini CLI: the coding sessions already on your disk — Gemini CLI, Claude Code, Codex, Cursor and twenty more — searchable and recalled, including work from before it was installed.",
   "contextFileName": "GEMINI.md",
   "mcpServers": {

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deja",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu memory for Kimi Code: recall the sessions your other coding agents already wrote — Claude Code, Codex, Cursor, opencode and twenty-one more, including work from before it was installed.",
   "keywords": [
     "memory",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     }
   },
   "dependencies": {
-    "@vshulcz/deja-vu": "^0.19.5"
+    "@vshulcz/deja-vu": "^0.20.0"
   }
 }

--- a/packaging/scoop/deja-vu.json
+++ b/packaging/scoop/deja-vu.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.19.5",
+    "version": "0.20.0",
     "description": "Search Claude Code, Codex and Cursor session history locally",
     "homepage": "https://github.com/vshulcz/deja-vu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_amd64.zip",
-            "hash": "59c071f22ec4d36a11513497f2d8eb8025aae0395447fce9df5f515ee69d7392"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.20.0/deja-vu_0.20.0_windows_amd64.zip",
+            "hash": "cc38a706c847edf96dfedbc7cafef7673a718ce56aafdc58bf9dfdbc7063e267"
         },
         "arm64": {
-            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_arm64.zip",
-            "hash": "87d6514436c2ffa34757b703021ba94769d14dcb53f10735bb8ee7cf524c62ac"
+            "url": "https://github.com/vshulcz/deja-vu/releases/download/v0.20.0/deja-vu_0.20.0_windows_arm64.zip",
+            "hash": "289afdba10cd9a023182f8749c74afa1eea95b0aec8ae616b7b80858c8ff81b9"
         }
     },
     "bin": "deja.exe",

--- a/packaging/winget/vshulcz.deja-vu.installer.yaml
+++ b/packaging/winget/vshulcz.deja-vu.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.5
+PackageVersion: 0.20.0
 InstallerType: zip
 NestedInstallerType: portable
 NestedInstallerFiles:
@@ -10,10 +10,10 @@ NestedInstallerFiles:
 UpgradeBehavior: install
 Installers:
 - Architecture: x64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_amd64.zip
-  InstallerSha256: 59C071F22EC4D36A11513497F2D8EB8025AAE0395447FCE9DF5F515EE69D7392
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.20.0/deja-vu_0.20.0_windows_amd64.zip
+  InstallerSha256: CC38A706C847EDF96DFEDBC7CAFEF7673A718CE56AAFDC58BF9DFDBC7063E267
 - Architecture: arm64
-  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.19.5/deja-vu_0.19.5_windows_arm64.zip
-  InstallerSha256: 87D6514436C2FFA34757B703021BA94769D14DCB53F10735BB8EE7CF524C62AC
+  InstallerUrl: https://github.com/vshulcz/deja-vu/releases/download/v0.20.0/deja-vu_0.20.0_windows_arm64.zip
+  InstallerSha256: 289AFDBA10CD9A023182F8749C74AFA1EEA95B0AEC8AE616B7B80858C8FF81B9
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
+++ b/packaging/winget/vshulcz.deja-vu.locale.en-US.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.5
+PackageVersion: 0.20.0
 PackageLocale: en-US
 Publisher: vshulcz
 PublisherUrl: https://github.com/vshulcz
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/vshulcz/deja-vu/issues
 PackageName: deja-vu
 PackageUrl: https://github.com/vshulcz/deja-vu
 License: MIT
-LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.19.5/LICENSE
+LicenseUrl: https://github.com/vshulcz/deja-vu/blob/v0.20.0/LICENSE
 ShortDescription: Search Claude Code, Codex and Cursor session history locally
 Tags:
 - aider
@@ -19,6 +19,6 @@ Tags:
 - cursor
 - mcp
 - memory
-ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.19.5
+ReleaseNotesUrl: https://github.com/vshulcz/deja-vu/releases/tag/v0.20.0
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/packaging/winget/vshulcz.deja-vu.yaml
+++ b/packaging/winget/vshulcz.deja-vu.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: vshulcz.deja-vu
-PackageVersion: 0.19.5
+PackageVersion: 0.20.0
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.12.0

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "deja-vu",
-  "version": "0.19.5",
+  "version": "0.20.0",
   "description": "deja-vu: memory for coding agents from the sessions already on your disk — Claude Code, Codex, Cursor, opencode and twenty-one more — including work from before it was installed.",
   "author": {
     "name": "vshulcz",


### PR DESCRIPTION
Post-release pin: scoop, winget and the plugin manifests now point at 0.20.0, with the hashes taken from the release's own `checksums.txt`. `pinmanifests -check` passes, which is the CI check that fails when they drift.
