### PR TITLE
fix(copilot-chat): decode the edited-file URIs and read the older snapshot shape

### DIFF
--- a/internal/sources/copilot_chat.go
+++ b/internal/sources/copilot_chat.go
@@ -438,8 +438,7 @@ func copilotChatSession(path string, state map[string]any) ([]model.Session, err
 //
 // The transcript names a path only when the text does, so a chat that edited
 // eleven files left one `files` record. Measured on this machine: 48 of those
-// state files, and while `recentSnapshot.workingSet` is empty in every one of
-// them, their entries carry 145 resources between them (#3381).
+// state files, whose entries carry 145 resources between them (#3381).
 func appendChatEditedFiles(s *model.Session, path, id string) {
 	if !IndexToolPaths() || id == "" {
 		return
@@ -451,9 +450,6 @@ func appendChatEditedFiles(s *model.Session, path, id string) {
 	}
 	var state struct {
 		RecentSnapshot struct {
-			WorkingSet []struct {
-				Resource any `json:"resource"`
-			} `json:"workingSet"`
 			Entries []struct {
 				Resource any `json:"resource"`
 			} `json:"entries"`
@@ -472,9 +468,6 @@ func appendChatEditedFiles(s *model.Session, path, id string) {
 		seen[p] = true
 		paths = append(paths, p)
 	}
-	for _, e := range state.RecentSnapshot.WorkingSet {
-		add(e.Resource)
-	}
 	for _, e := range state.RecentSnapshot.Entries {
 		add(e.Resource)
 	}
@@ -485,23 +478,32 @@ func appendChatEditedFiles(s *model.Session, path, id string) {
 	s.Messages = append(s.Messages, model.Message{Role: RoleFiles, Text: strings.Join(paths, "\n"), Time: at})
 }
 
-// chatResourcePath reads the path out of a VS Code URI, which the state file
-// writes either as an object with `path` or as the string form of one.
+// chatResourcePath reads the path out of a VS Code URI. The state file writes
+// a percent-encoded URI string, decoded exactly once here, or an object whose
+// path is already decoded and is not decoded again.
 func chatResourcePath(res any) string {
+	var p string
 	switch v := res.(type) {
 	case string:
-		if i := strings.Index(v, "://"); i >= 0 {
-			v = v[i+3:]
-			if j := strings.IndexByte(v, '/'); j >= 0 {
-				v = v[j:]
+		if strings.Contains(v, "://") {
+			u, err := url.Parse(v)
+			if err != nil || u.Scheme == "" {
+				return ""
 			}
+			p = u.Path
+			if u.Scheme == "file" && u.Host != "" {
+				p = "//" + u.Host + u.Path
+			}
+		} else {
+			p = v
 		}
-		return strings.TrimSpace(v)
 	case map[string]any:
-		p, _ := v["path"].(string)
-		return strings.TrimSpace(p)
+		p, _ = v["path"].(string)
 	}
-	return ""
+	if strings.ContainsAny(p, "\n\r") {
+		return ""
+	}
+	return strings.TrimSpace(p)
 }
 
 func copilotChatTitle(state map[string]any) string {

--- a/internal/sources/copilot_chat_edited_files_test.go
+++ b/internal/sources/copilot_chat_edited_files_test.go
@@ -85,3 +85,120 @@ func TestACopilotChatWithoutEditStateIsUnchanged(t *testing.T) {
 		}
 	}
 }
+
+const copilotChatEditedFilesTestID = "bbbbbbbb-0000-4000-8000-bbbbbbbbbbbb"
+
+func copilotChatEditedFilesText(t *testing.T, state string) string {
+	t.Helper()
+	ws := filepath.Join(t.TempDir(), "workspaceStorage", "abc123")
+	chats := filepath.Join(ws, "chatSessions")
+	if err := os.MkdirAll(chats, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := `{"version":3,"sessionId":"` + copilotChatEditedFilesTestID +
+		`","creationDate":1767225600000,"requests":[{"message":{"text":"edit the files"},` +
+		`"response":[{"value":"done"}]}]}`
+	path := filepath.Join(chats, copilotChatEditedFilesTestID+".json")
+	if err := os.WriteFile(path, []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	edits := filepath.Join(ws, "chatEditingSessions", copilotChatEditedFilesTestID)
+	if err := os.MkdirAll(edits, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(edits, "state.json"), []byte(state), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := ParseCopilotChatFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ss) != 1 {
+		t.Fatalf("sessions = %d, want the one transcript", len(ss))
+	}
+	var records []string
+	for _, m := range ss[0].Messages {
+		if m.Role == RoleFiles {
+			records = append(records, m.Text)
+		}
+	}
+	if len(records) == 0 {
+		return ""
+	}
+	if len(records) != 1 {
+		t.Fatalf("files records = %d, want one: %q", len(records), records)
+	}
+	return records[0]
+}
+
+// VS Code writes string resources with URI.toString(), which percent-encodes
+// their paths, while UriComponents paths are already decoded.
+func TestACopilotChatDecodesThePercentEncodedResource(t *testing.T) {
+	state := `{"version":2,"sessionId":"` + copilotChatEditedFilesTestID +
+		`","recentSnapshot":{"entries":[` +
+		`{"resource":"file:///c%3A/Users/me/my%20app/main.go"},` +
+		`{"resource":{"scheme":"file","path":"/c:/Users/me/my app/other.go"}}]}}`
+	files := copilotChatEditedFilesText(t, state)
+
+	for _, want := range []string{
+		"/c:/Users/me/my app/main.go",
+		"/c:/Users/me/my app/other.go",
+	} {
+		if !strings.Contains(files, want) {
+			t.Errorf("the decoded files record does not name %s: %q", want, files)
+		}
+	}
+	for _, escaped := range []string{"%3A", "%20"} {
+		if strings.Contains(files, escaped) {
+			t.Errorf("the files record kept %s instead of decoding it: %q", escaped, files)
+		}
+	}
+}
+
+// VS Code's older snapshot stored workingSet as ResourceMapDTO pairs, while
+// its reader still took the edited files only from entries.
+func TestACopilotChatReadsTheOlderWorkingSetShape(t *testing.T) {
+	state := `{"version":1,"sessionId":"` + copilotChatEditedFilesTestID +
+		`","recentSnapshot":{"requestId":"r1",` +
+		`"workingSet":[["file:///work/app/a.go",{"state":0}]],` +
+		`"entries":[{"resource":"file:///work/app/b.go"}]}}`
+	files := copilotChatEditedFilesText(t, state)
+
+	if !strings.Contains(files, "/work/app/b.go") {
+		t.Errorf("the files record does not name the snapshot entry: %q", files)
+	}
+	if strings.Contains(files, "/work/app/a.go") {
+		t.Errorf("the files record misattributes a working-set key as edited: %q", files)
+	}
+}
+
+// The sidecar can carry an encoded newline inside one URI, while RoleFiles
+// uses literal newlines to separate resources.
+func TestACopilotChatDropsAResourceThatDecodesToANewline(t *testing.T) {
+	state := `{"version":2,"sessionId":"` + copilotChatEditedFilesTestID +
+		`","recentSnapshot":{"entries":[` +
+		`{"resource":"file:///work/app/x%0Ay.go"},` +
+		`{"resource":"file:///work/app/trailing.go%0A"},` +
+		`{"resource":"file:///work/app/cr.go%0D"},` +
+		`{"resource":"file:///work/app/ok.go"}]}}`
+	files := copilotChatEditedFilesText(t, state)
+	lines := strings.Split(files, "\n")
+
+	if len(lines) != 1 || lines[0] != "/work/app/ok.go" {
+		t.Fatalf("files lines = %q, want only /work/app/ok.go", lines)
+	}
+}
+
+// URI.toString() keeps a file URI's server in the authority rather than in
+// the decoded path.
+func TestACopilotChatKeepsAUNCResourceAuthority(t *testing.T) {
+	state := `{"version":2,"sessionId":"` + copilotChatEditedFilesTestID +
+		`","recentSnapshot":{"entries":[` +
+		`{"resource":"file://server/share/proj/f.go"}]}}`
+	files := copilotChatEditedFilesText(t, state)
+
+	if files != "//server/share/proj/f.go" {
+		t.Fatalf("files = %q, want //server/share/proj/f.go", files)
+	}
+}


### PR DESCRIPTION
Two problems in the sidecar reader that #3431 added to the VS Code Copilot Chat parser. Both were checked against the writer, `src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingSessionStorage.ts` in microsoft/vscode at `e4c7e7b1`.

The resource path was never percent-decoded. The reader accepts `recentSnapshot.entries[].resource` in two shapes. The current writer emits `URI.toString()` (line 176), which is percent-encoded. `chatResourcePath` took that string as-is, so a resource written as `file:///c%3A/work/my%20app/main.go` ended up in the files record as `/c%3A/work/my%20app/main.go`. This hits any path with a space or a non-ASCII character, so it is not limited to Windows drive letters. The string form is now parsed with `net/url`, which decodes once. The object shape (`UriComponents`, whose `path` is already decoded) is left as it was, so a literal `%25` in a path is not decoded twice. A file URI with an authority is kept as `//host/path`. Other schemes keep the path and drop the authority, as before.

The older snapshot shape failed to unmarshal. `recentSnapshot` is a union (line 283): v2 is `{stopId, entries}`, v1 is `{requestId, workingSet, entries}`, and `workingSet` in v1 is `ResourceMapDTO`, an array of `[uri, state]` pairs (line 275). The struct declared it as an array of objects, so `json.Unmarshal` failed on any v1 file whose working set was not empty, and the files record was silently dropped. The conversation itself was fine. Only the sidecar record went missing. VS Code's own reader takes `entries` from either shape and never reads `workingSet` (lines 66-68), so the struct now does the same. I have not measured how many v1 files exist on real installs. The state files on my machine are all v2.

A resource that decodes to a CR or LF is rejected before trimming, because the files record joins paths with newlines and a decoded `%0A` would otherwise split one resource into two lines. This mirrors the guard `copilotChatRefPath` already has.

Two side effects to be aware of:

- The sidecar file is not part of the transcript fingerprint, so sessions already indexed will keep the old paths until they are re-indexed for some other reason.
- A follow-up to the check on #3452, which said titles are unaffected. For a v1 transcript the parser has only `customTitle`, which as far as I can see the session storage writes only after a rename. Those sessions are named by the index from their user turns (a thin opener like "hi" gives way to the next substantial one). A session whose first turn was a background terminal completion used to be titled by that output. It is now titled by a turn the user wrote.

Tests: four new cases in `copilot_chat_edited_files_test.go` (percent-decoding, the v1 shape, decoded newlines including trailing ones, a file URI with an authority). All four fail against the previous `chatResourcePath` and struct, and pass with this change. `go vet` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
